### PR TITLE
Add old loadnewmaps aliases from OCN

### DIFF
--- a/core/src/main/java/tc/oc/pgm/commands/MapCommands.java
+++ b/core/src/main/java/tc/oc/pgm/commands/MapCommands.java
@@ -47,7 +47,7 @@ import tc.oc.pgm.util.text.TextTranslations;
 public class MapCommands {
 
   @Command(
-      aliases = {"loadnewmaps"},
+      aliases = {"loadnewmaps", "findnewmaps", "newmaps"},
       desc = "Loads new maps and outputs any errors")
   public static void loadNewMaps(MapLibrary library, @Switch('f') boolean force) {
     library.loadNewMaps(force); // MapLibrary will handle sending output asynchronously


### PR DESCRIPTION
When I test maps locally my muscle memory still forces me to type `newmaps` and every time I'm hit with the reality that that command just isn't a thing 😢.

I'm not sure if these aliases were removed from this version of if they just never existed but I'd appreciate their return. I'm losing valuable seconds every time I fall for the trap which forces me to prefix the command with `load`. 

I'm not as emotionally attached to the `findnewmaps` alias but maybe someone somewhere is.

Signed-off-by: Pugzy <pugzy@mail.com>