### PR TITLE
Fix a vanished broadcast bug

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -179,6 +179,10 @@ public class VanishManagerImpl implements VanishManager, Listener {
     // If player is vanished & joined via "vanish" subdomain. Remove vanish status on quit
     if (isVanished(player.getId()) && tempVanish.contains(player.getId())) {
       setVanished(player, false, true);
+      // Temporary vanish status is removed before quit,
+      // so prevent regular quit msg and forces a staff only broadcast
+      event.setQuitMessage(null);
+      PGMListener.announceJoinOrLeave(player, false, true, true);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -189,6 +189,11 @@ public class PGMListener implements Listener {
   }
 
   public static void announceJoinOrLeave(MatchPlayer player, boolean join, boolean staffOnly) {
+    announceJoinOrLeave(player, join, staffOnly, false);
+  }
+
+  public static void announceJoinOrLeave(
+      MatchPlayer player, boolean join, boolean staffOnly, boolean force) {
     checkNotNull(player);
     Collection<MatchPlayer> viewers =
         player.getMatch().getPlayers().stream()
@@ -201,7 +206,8 @@ public class PGMListener implements Listener {
         continue; // Skip staff during fake broadcast
 
       final String key =
-          (join ? "misc.join" : "misc.leave") + (staffOnly && player.isVanished() ? ".quiet" : "");
+          (join ? "misc.join" : "misc.leave")
+              + (staffOnly && (player.isVanished() || force) ? ".quiet" : "");
 
       SettingValue option = viewer.getSettings().getValue(SettingKey.JOIN);
       if (option.equals(SettingValue.JOIN_ON)) {


### PR DESCRIPTION
# Fix a vanished broadcast bug
I caught this bug earlier today. Basically when a staff member joins via a `vanish` subdomain and opts not to toggle their vanish status while online, upon leaving PGM will broadcast the regular quit message instead of the staff only one. Thus exposing vanished staff members to everyone online :scream:

This PR resolves that issue. I tested this and since it’s a small fix should be good to go 👍 
Let me know if there is anything that could be adjusted.

Signed-off-by: applenick <applenick@users.noreply.github.com>