### PR TITLE
Add map author prefix/permission

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -70,6 +70,7 @@ import tc.oc.pgm.modules.ItemDestroyMatchModule;
 import tc.oc.pgm.modules.ItemDestroyModule;
 import tc.oc.pgm.modules.ItemKeepMatchModule;
 import tc.oc.pgm.modules.ItemKeepModule;
+import tc.oc.pgm.modules.MapmakerMatchModule;
 import tc.oc.pgm.modules.MobsMatchModule;
 import tc.oc.pgm.modules.MobsModule;
 import tc.oc.pgm.modules.ModifyBowProjectileMatchModule;
@@ -156,6 +157,7 @@ public interface Modules {
     register(ObserverToolsMatchModule.class, new ObserverToolsMatchModule.Factory());
     register(FireworkMatchModule.class, FireworkMatchModule::new);
     register(StatsMatchModule.class, StatsMatchModule::new);
+    register(MapmakerMatchModule.class, MapmakerMatchModule::new);
 
     // Community MatchModules
     register(FreezeMatchModule.class, FreezeMatchModule::new);

--- a/core/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/core/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -38,6 +38,8 @@ public interface Permissions {
   String FREEZE = ROOT + ".freeze"; // Access to the /freeze command
   String VANISH = ROOT + ".vanish"; // Access to /vanish command
 
+  String MAPMAKER = GROUP + ".mapmaker"; // Permission group for mapmakers, defined in config.yml
+
   // Role-specific permission nodes
   Permission DEFAULT =
       new Permission(

--- a/core/src/main/java/tc/oc/pgm/modules/MapmakerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/MapmakerMatchModule.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -27,7 +28,7 @@ public class MapmakerMatchModule implements MatchModule, Listener {
         .getBukkit()
         .addAttachment(
             PGM.get(),
-            "pgm.group.mapmaker",
+            Permissions.MAPMAKER,
             authors.stream().anyMatch(c -> c.isPlayer(player.getId())));
     PGM.get().getPrefixRegistry().removePlayer(player.getId()); // Refresh prefixes for the player
   }

--- a/core/src/main/java/tc/oc/pgm/modules/MapmakerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/MapmakerMatchModule.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.modules;
 
-import org.bukkit.entity.Player;
+import java.util.Collection;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import tc.oc.pgm.api.PGM;
@@ -8,27 +8,27 @@ import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
-import tc.oc.pgm.api.match.event.MatchUnloadEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerAddEvent;
 import tc.oc.pgm.events.ListenerScope;
 
-import java.util.Collection;
-
 @ListenerScope(MatchScope.LOADED)
 public class MapmakerMatchModule implements MatchModule, Listener {
-    private final Collection<Contributor> authors;
+  private final Collection<Contributor> authors;
 
-    public MapmakerMatchModule(Match match) {
-        this.authors = match.getMap().getAuthors();
-    }
+  public MapmakerMatchModule(Match match) {
+    this.authors = match.getMap().getAuthors();
+  }
 
-    @EventHandler(ignoreCancelled = true)
-    public void onPlayerAddEvent(final MatchPlayerAddEvent event) {
-        MatchPlayer player = event.getPlayer();
-        player.getBukkit().addAttachment(PGM.get(), "pgm.group.mapmaker", authors.stream().anyMatch(c -> c.isPlayer(player.getId())));
-        PGM.get().getPrefixRegistry().removePlayer(player.getId()); //Refresh prefixes for the player
-    }
-
-
+  @EventHandler(ignoreCancelled = true)
+  public void onPlayerAddEvent(final MatchPlayerAddEvent event) {
+    MatchPlayer player = event.getPlayer();
+    player
+        .getBukkit()
+        .addAttachment(
+            PGM.get(),
+            "pgm.group.mapmaker",
+            authors.stream().anyMatch(c -> c.isPlayer(player.getId())));
+    PGM.get().getPrefixRegistry().removePlayer(player.getId()); // Refresh prefixes for the player
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/modules/MapmakerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/MapmakerMatchModule.java
@@ -1,0 +1,34 @@
+package tc.oc.pgm.modules;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.map.Contributor;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.match.event.MatchUnloadEvent;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.player.event.MatchPlayerAddEvent;
+import tc.oc.pgm.events.ListenerScope;
+
+import java.util.Collection;
+
+@ListenerScope(MatchScope.LOADED)
+public class MapmakerMatchModule implements MatchModule, Listener {
+    private final Collection<Contributor> authors;
+
+    public MapmakerMatchModule(Match match) {
+        this.authors = match.getMap().getAuthors();
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerAddEvent(final MatchPlayerAddEvent event) {
+        MatchPlayer player = event.getPlayer();
+        player.getBukkit().addAttachment(PGM.get(), "pgm.group.mapmaker", authors.stream().anyMatch(c -> c.isPlayer(player.getId())));
+        PGM.get().getPrefixRegistry().removePlayer(player.getId()); //Refresh prefixes for the player
+    }
+
+
+}

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -140,7 +140,7 @@ groups:
   mapmaker:
     prefix: "&9*"
     permissions:
-      - "pgm.premium"
+      - "+pgm.premium"
 
 # Enables "community mode" with features such as /report, /freeze, /warn, and /ban.
 community:

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -136,6 +136,12 @@ groups:
       - "-worldedit.navigation.jumpto.tool"
       - "-commandbook.teleport"
 
+  # A special group for authors of the playing map
+  mapmaker:
+    prefix: "&9*"
+    permissions:
+      - "pgm.premium"
+
 # Enables "community mode" with features such as /report, /freeze, /warn, and /ban.
 community:
   enabled: true   # Is community mode enabled?


### PR DESCRIPTION
Adds a special permission for map authors!

Requires any users of the current version of PGM to add the section in the config manually

Thanks to: @Pablete1234 
Pair programming partners: @BGMP and @Pugzy 

Closes #152


Signed-off-by: SimonIMac <simonmorland@gmail.com>