### PR TITLE
Fix error message sent after cycle

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
@@ -55,7 +55,8 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
       // Match creation was cancelled, no need to show an error
       if (e.getCause() instanceof InterruptedException) throw e;
 
-      PGM.get().getGameLogger().log(Level.SEVERE, e.getMessage(), e.getCause());
+      Throwable err = e.getCause();
+      PGM.get().getGameLogger().log(Level.SEVERE, err.getMessage(), err.getCause());
       throw e;
     }
   }


### PR DESCRIPTION
# Fix error message sent after cycle
This is a small fix to remove the error that’s sent after a match cycles.

## Screenshot
Currently this is what is displayed when a cycle completes
![Screen Shot 2020-05-26 at 12 52 42 AM](https://user-images.githubusercontent.com/3377659/82939762-a56bf980-9f48-11ea-97ce-1f1cb49ed681.png)


Signed-off-by: applenick <applenick@users.noreply.github.com>