### PR TITLE
Fix horizontal compact mode being unnecessarily enabled

### DIFF
--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -497,7 +497,6 @@ public class SidebarMatchModule implements MatchModule, Listener {
         rows.add(competitor.getStyledName(NameStyle.FANCY).render().toLegacyText());
 
         if (isCompactWool) {
-          String woolText = "";
           boolean firstWool = true;
 
           List<Goal> sortedWools = new ArrayList<>(gmm.getGoals(competitor));
@@ -512,7 +511,14 @@ public class SidebarMatchModule implements MatchModule, Listener {
 
           // Calculate whether having three spaces between each wool would fit on the scoreboard.
           boolean horizontalCompact =
-              !((MAX_PREFIX + MAX_SUFFIX) < sortedWools.size() + 3 * (sortedWools.size() - 1));
+              (MAX_PREFIX + MAX_SUFFIX)
+                  < (3 * sortedWools.size()) + (3 * (sortedWools.size() - 1)) + 1;
+          String woolText = "";
+          if (!horizontalCompact) {
+            // If there is extra room, add another space to the left of the wools to make them
+            // appear more centered.
+            woolText += " ";
+          }
 
           for (Goal goal : sortedWools) {
             if (goal instanceof MonumentWool && goal.isVisible()) {


### PR DESCRIPTION
The Horizontal Compact mode was being enabled when it should not have been. I have tested this fix on a 2 team, 4 team, and 8 team CTW, and all three maps have their correct scoreboards now.

Additionally, I have added an extra space to the left of non-horizontal-compact compact wools. This is how it was prior to the recent scoreboard changes, and looks better because the wools are more centered.

This fixes https://github.com/PGMDev/PGM/issues/509.

Signed-off-by: alexsosnovsky <60436249+alexsosnovsky@users.noreply.github.com>