### PR TITLE
Fix mode change bossbar percentage

### DIFF
--- a/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
@@ -32,7 +32,7 @@ public abstract class MatchCountdown extends Countdown {
 
     @Override
     public float getMeter(Player viewer) {
-      return total.isZero() ? 0f : (float) remaining.toMillis() / total.toMillis();
+      return bossBarProgress(remaining, total);
     }
   };
 


### PR DESCRIPTION
# Monument mode bossbar fixes 🕙 
One of the biggest changes to PGM since release.

Since the dawn of time, this bug has existed, overlooked and unreported. Only those with the sharpest of eyes and greatest minds were able to discover what follows. I'm about to blow the bloody doors right off this mystery machine and crack the case wide open.

Basically monument mode boss bars are displaying incorrectly. The health percentage is displaying the `remaining time / match length`, however, unlike regular countdowns monument mode ones do not start displaying until `x` seconds (defined either by XML or 60 seconds default). Its a bit hard to explain so see the screenshots section.. 

The code that takes this special monument modes bar into account is present, however, never gets used as the method that normally gets overridden is ignored completely with an exact copy. 

[This line](https://github.com/PGMDev/PGM/blob/master/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java#L35) (A) is doing the job of [this line](https://github.com/PGMDev/PGM/blob/master/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java#L167) (B) which would then allow [this line](https://github.com/PGMDev/PGM/blob/master/core/src/main/java/tc/oc/pgm/modes/ModeChangeCountdown.java#L65) (C) to do the correct logic. This pull request points A to B (vs replicating it) which allows C to work. Just trust me I'm a doctor.

Screenshots taken when using an XML like below.
```xml
<mode after="20s" show-before="10s" material="gold block" name="GOLD CORE MODE"/>
```

### Screenshots

*Before*... the boss bar percentage is all off, what is this mess? The duration of the boss bar is added together with the match time which makes the display wrong 😿 showing as 9/20.

![image](https://user-images.githubusercontent.com/8608892/83336603-c025d180-a2ac-11ea-98a6-c077e2decbdb.png)

*After*... you can see the boss bar shows the correct health value/percentage 90% 🥂 9/10
![image](https://user-images.githubusercontent.com/8608892/83335687-5a364b80-a2a6-11ea-84c7-650b83eb7ebb.png)

This is easier to see when mode changes start a little bit later than 20 seconds into the match but I don't fancy sitting around whilst debugging waiting to get a better screenshot.


Signed-off-by: Pugzy <pugzy@mail.com>