### PR TITLE
Dont carry over chunks from old matches

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -295,15 +295,13 @@ public class PGMListener implements Listener {
   @EventHandler
   public void freezeWorld(final BlockTransformEvent event) {
     Match match = this.mm.getMatch(event.getWorld());
-    if (match != null && match.isFinished()) {
-      event.setCancelled(true);
-    }
+    if (match == null || match.isFinished()) event.setCancelled(true);
   }
 
   @EventHandler
   public void freezeVehicle(final VehicleUpdateEvent event) {
     Match match = this.mm.getMatch(event.getWorld());
-    if (match != null && match.isFinished()) {
+    if (match == null || match.isFinished()) {
       event.getVehicle().setVelocity(new Vector());
     }
   }

--- a/core/src/main/java/tc/oc/pgm/snapshot/SnapshotMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/snapshot/SnapshotMatchModule.java
@@ -14,6 +14,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.material.MaterialData;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -104,6 +105,11 @@ public class SnapshotMatchModule implements MatchModule, Listener {
   // event
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onBlockChange(BlockTransformEvent event) {
+    Match match = PGM.get().getMatchManager().getMatch(event.getWorld());
+
+    // Dont carry over old chunks into a new match
+    if (match == null || match.isFinished()) return;
+
     Chunk chunk = event.getOldState().getChunk();
     ChunkVector chunkVector = ChunkVector.of(chunk);
     if (!chunkSnapshots.containsKey(chunkVector)) {


### PR DESCRIPTION
- Also made freezeWorld/freezeVehicle more robust

Fixes #408 

This was caused by `SnapshotMatchModule` reacting to `BlockTransformEvent`s from an old match. How does this happen you ask?

If you read through the steps over at [MatchFactoryImpl](https://github.com/PGMDev/PGM/blob/master/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java) you will notice that the new match is loaded (Stage 4) before the old match is unloaded(Stage 5). This means that in the moment between https://github.com/PGMDev/PGM/blob/6bb95c9f700a87a8aa27ca91d656c29ed8f0bd69/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java#L311 and https://github.com/PGMDev/PGM/blob/6bb95c9f700a87a8aa27ca91d656c29ed8f0bd69/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java#L378 both worlds are active!

 But does not https://github.com/PGMDev/PGM/blob/6bb95c9f700a87a8aa27ca91d656c29ed8f0bd69/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java#L295-L301 cancel all `BlockTransformEvent`s? 


Yes it does, but `SnapshotMatchModule` has [ignoreCancelled = true](https://github.com/PGMDev/PGM/blob/6bb95c9f700a87a8aa27ca91d656c29ed8f0bd69/core/src/main/java/tc/oc/pgm/snapshot/SnapshotMatchModule.java#L105) so it does not care about that. 

The fix for this problem is that you need to check if the event is fired from an old match(`match == null || match#isFinished`)

If you for some reason want to replicate this, i advise you to set `match-teleports-per-second` and `match-preload-seconds` to some semi-high value to simulate the time it takes with more players. (Very hard to replicate without some "lag")

Signed-off-by: SimonIMac <simonmorland@gmail.com>