### PR TITLE
Add names to posts. Add support for multiple posts for one flag.

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.flag;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Iterator;
+import java.util.Random;
 import java.util.Set;
 import javax.annotation.Nullable;
 import net.kyori.text.Component;
@@ -233,8 +234,31 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     }
   }
 
+  private int sequentialPostCounter = 0;
+  private Post returnPost;
+
+  public Post getReturnPost(Post post) {
+    if (post.isSpecifiedPost()) {
+      return post;
+    }
+    if (definition.isSequential()) {
+      Post returnPost = definition.getPosts().get(sequentialPostCounter++);
+      if (sequentialPostCounter == definition.getPosts().size()) {
+        sequentialPostCounter = 0;
+      }
+      return returnPost;
+    }
+    Random random = match.getRandom();
+    return definition.getPosts().get(random.nextInt(definition.getPosts().size()));
+  }
+
   public Location getReturnPoint(Post post) {
-    return post.getReturnPoint(this, this.bannerYawProvider).clone();
+    returnPost = getReturnPost(post);
+    return returnPost.getReturnPoint(this, this.bannerYawProvider).clone();
+  }
+
+  public AngleProvider getBannerYawProvider() {
+    return bannerYawProvider;
   }
 
   // Touchable

--- a/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.flag;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import javax.annotation.Nullable;
 import net.kyori.text.Component;
@@ -28,6 +29,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
   private final @Nullable DyeColor
       color; // Flag color, null detects color from the banner at match load time
   private final Post defaultPost; // Flag starts the match at this post
+  private final ImmutableList<Post> posts;
   private final @Nullable FeatureReference<TeamFactory>
       owner; // Team that owns the flag, affects various things
   private final double
@@ -43,6 +45,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
   private final @Nullable Component carryMessage; // Custom message to show flag carrier
   private final boolean dropOnWater; // Flag can freeze water to drop on it
   private final boolean showBeam;
+  private final boolean sequential;
 
   public FlagDefinition(
       @Nullable String id,
@@ -51,6 +54,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
       boolean visible,
       @Nullable DyeColor color,
       Post defaultPost,
+      ImmutableList<Post> posts,
       @Nullable FeatureReference<TeamFactory> owner,
       double pointsPerCapture,
       double pointsPerSecond,
@@ -64,7 +68,8 @@ public class FlagDefinition extends ProximityGoalDefinition {
       boolean dropOnWater,
       boolean showBeam,
       ProximityMetric flagProximityMetric,
-      ProximityMetric netProximityMetric) {
+      ProximityMetric netProximityMetric,
+      boolean sequential) {
 
     // We can't use the owner field in OwnedGoal because our owner
     // is a reference that can't be resolved until after parsing.
@@ -79,6 +84,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
     this.color = color;
     this.defaultPost = defaultPost;
+    this.posts = posts;
     this.owner = owner;
     this.pointsPerCapture = pointsPerCapture;
     this.pointsPerSecond = pointsPerSecond;
@@ -91,6 +97,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
     this.carryMessage = carryMessage;
     this.dropOnWater = dropOnWater;
     this.showBeam = showBeam;
+    this.sequential = sequential;
   }
 
   public @Nullable DyeColor getColor() {
@@ -108,6 +115,10 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
   public Post getDefaultPost() {
     return this.defaultPost;
+  }
+
+  public ImmutableList<Post> getPosts() {
+    return this.posts;
   }
 
   @Override
@@ -164,6 +175,10 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
   public boolean showBeam() {
     return showBeam;
+  }
+
+  public boolean isSequential() {
+    return sequential;
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/tc/oc/pgm/flag/Post.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Post.java
@@ -38,9 +38,14 @@ public class Post extends SelfIdentifyingFeatureDefinition {
   private final boolean permanent; // Flag enters Completed state when at this post
   private final double pointsPerSecond; // Points awarded while any flag is at this post
   private final Filter pickupFilter; // Filter players who can pickup a flag at this post
+  private final @Nullable String
+      postName; // The name of the post to be shown in chat when the flag is respawning
+
+  private boolean specifiedPost = false;
 
   public Post(
       @Nullable String id,
+      @Nullable String name,
       @Nullable FeatureReference<TeamFactory> owner,
       Duration recoverTime,
       @Nullable Duration respawnTime,
@@ -64,6 +69,11 @@ public class Post extends SelfIdentifyingFeatureDefinition {
     this.permanent = permanent;
     this.pointsPerSecond = pointsPerSecond;
     this.pickupFilter = pickupFilter;
+    this.postName = name;
+  }
+
+  public @Nullable String getPostName() {
+    return this.postName;
   }
 
   public @Nullable TeamFactory getOwner() {
@@ -114,6 +124,14 @@ public class Post extends SelfIdentifyingFeatureDefinition {
       location.setYaw(yawProvider.getAngle(location.toVector()));
     }
     return location;
+  }
+
+  public boolean isSpecifiedPost() {
+    return this.specifiedPost;
+  }
+
+  public void setSpecifiedPost(boolean value) {
+    this.specifiedPost = value;
   }
 
   private Location getReturnPoint(Flag flag) {

--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -212,6 +212,11 @@ flag.return = {0} has been returned
 flag.willRespawn = {0} will respawn in {1}
 
 # {0} = flag name
+# {1} = post name
+# {2} = duration
+flag.willRespawn.named = {0} will respawn at {1} in {2}
+
+# {0} = flag name
 flag.respawn = {0} has respawned
 
 # {0} = flag name


### PR DESCRIPTION
Fix for #359 

I added a name attribute to posts. When the flag is respawning, if a name is specified, it will say which post the flag will respawn to.


Also, I added support for a flag to have multiple posts. Each post can still have multiple blocks, so all previous xmls should still work. Also, the flag element now has an attribute called sequential. If sequential="true", when the flag respawns, it will cycle through the posts; if false, it will randomly choose a post to respawn to. When a flag is respawning, it will first choose a post, and then choose one of the post's points.

Signed-off-by: mrcookie_13 batbmrcookie@gmail.com