### PR TITLE
Fix FFA matches being unplayable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
+++ b/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
@@ -100,7 +100,7 @@ public class Tribute implements Competitor, MultiAudience {
 
   @Override
   public Component getName(NameStyle style) {
-    return PlayerComponent.of(player.getBukkit(), style);
+    return PlayerComponent.of(player != null ? player.getBukkit() : null, style);
   }
 
   @Override


### PR DESCRIPTION
# Fix FFA matches being unplayable
Due to the recent large text refactor (#519), FFA matches are currently unplayable due to a small check that causes a NPE leaving players unable to damage one another. 

This resolves that issue 🎉 

Signed-off-by: applenick <applenick@users.noreply.github.com>