### PR TITLE
XML option to show where a flag will respawn at next.

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -88,6 +88,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
   private final Set<Team> completers;
   private BaseState state;
   private boolean transitioning;
+  private @Nullable Post predeterminedPost;
 
   protected Flag(Match match, FlagDefinition definition, ImmutableSet<Net> nets)
       throws ModuleLoadException {
@@ -235,11 +236,15 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
   }
 
   private int sequentialPostCounter = 1;
-  private Post returnPost;
 
   public Post getReturnPost(Post post) {
     if (post.isSpecifiedPost()) {
       return post;
+    }
+    if (predeterminedPost != null) {
+      Post returnPost = predeterminedPost;
+      predeterminedPost = null;
+      return returnPost;
     }
     if (definition.isSequential()) {
       sequentialPostCounter %= definition.getPosts().size();
@@ -250,8 +255,13 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
   }
 
   public Location getReturnPoint(Post post) {
-    returnPost = getReturnPost(post);
+    Post returnPost = getReturnPost(post);
     return returnPost.getReturnPoint(this, this.bannerYawProvider).clone();
+  }
+
+  public String predeterminePost(Post post) {
+    predeterminedPost = getReturnPost(post);
+    return predeterminedPost.getPostName();
   }
 
   public AngleProvider getBannerYawProvider() {

--- a/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
@@ -46,6 +46,9 @@ public class FlagDefinition extends ProximityGoalDefinition {
   private final boolean dropOnWater; // Flag can freeze water to drop on it
   private final boolean showBeam;
   private final boolean sequential;
+  private boolean
+      showRespawnOnPickup; // When a flag is picked up, if true, it will display where it will
+  // respawn. Will be set to false if a net defines a different respawn post.
 
   public FlagDefinition(
       @Nullable String id,
@@ -69,7 +72,8 @@ public class FlagDefinition extends ProximityGoalDefinition {
       boolean showBeam,
       ProximityMetric flagProximityMetric,
       ProximityMetric netProximityMetric,
-      boolean sequential) {
+      boolean sequential,
+      boolean showRespawnOnPickup) {
 
     // We can't use the owner field in OwnedGoal because our owner
     // is a reference that can't be resolved until after parsing.
@@ -98,6 +102,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
     this.dropOnWater = dropOnWater;
     this.showBeam = showBeam;
     this.sequential = sequential;
+    this.showRespawnOnPickup = showRespawnOnPickup;
   }
 
   public @Nullable DyeColor getColor() {
@@ -179,6 +184,14 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
   public boolean isSequential() {
     return sequential;
+  }
+
+  public boolean willShowRespawnOnPickup() {
+    return showRespawnOnPickup;
+  }
+
+  public void setShowRespawnOnPickup(boolean value) {
+    this.showRespawnOnPickup = value;
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
@@ -158,6 +158,14 @@ public class FlagParser {
       capturableFlags = ImmutableSet.copyOf(this.flags);
     }
 
+    if (capturableFlags.size() != 0 && returnPost != null) {
+      for (FlagDefinition flagDef : flags) {
+        if (capturableFlags.contains(flagDef)) {
+          flagDef.setShowRespawnOnPickup(false);
+        }
+      }
+    }
+
     ImmutableSet<FlagDefinition> returnableFlags;
     Node returnableNode = Node.fromAttr(el, "rescue", "return");
     if (returnableNode != null) {
@@ -211,6 +219,8 @@ public class FlagParser {
     boolean multiCarrier = XMLUtils.parseBoolean(el.getAttribute("shared"), false);
     boolean sequential = XMLUtils.parseBoolean(el.getAttribute("sequential"), false);
     Component carryMessage = XMLUtils.parseFormattedText(el, "carry-message");
+    boolean showRespawnOnPickup =
+        XMLUtils.parseBoolean(el.getAttribute("show-respawn-on-pickup"), true);
     boolean dropOnWater = XMLUtils.parseBoolean(el.getAttribute("drop-on-water"), true);
     boolean showBeam = XMLUtils.parseBoolean(el.getAttribute("beam"), true);
     ProximityMetric flagProximityMetric =
@@ -260,7 +270,8 @@ public class FlagParser {
             showBeam,
             flagProximityMetric,
             netProximityMetric,
-            sequential);
+            sequential,
+            showRespawnOnPickup);
     flags.add(flag);
     factory.getFeatures().addFeature(el, flag);
 

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -59,6 +59,18 @@ public class Carried extends Spawned implements Missing {
     this.carrier = carrier;
     this.dropLocations.add(
         dropLocation); // Need an initial dropLocation in case the carrier never generates ones
+    if (this.flag.getDefinition().willShowRespawnOnPickup()) {
+      String postName = this.flag.predeterminePost(this.post);
+      if (postName != null) { // The post needs a name in order to display the message.
+        this.flag
+            .getMatch()
+            .sendMessage(
+                TranslatableComponent.of(
+                    "flag.willRespawn.next",
+                    this.flag.getComponentName(),
+                    TextComponent.of(postName, TextColor.AQUA)));
+      }
+    }
   }
 
   @Override

--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -217,6 +217,10 @@ flag.willRespawn = {0} will respawn in {1}
 flag.willRespawn.named = {0} will respawn at {1} in {2}
 
 # {0} = flag name
+# {1} = post name
+flag.willRespawn.next = {0} will respawn next at {1}
+
+# {0} = flag name
 flag.respawn = {0} has respawned
 
 # {0} = flag name


### PR DESCRIPTION
This change is intended to help king of the flag play better (ie desert sanctuary). With this change, as soon as the flag is picked up, if show-respawn-on-pickup="true", it will say in chat where the flag will respawn at next.

I added the attribute show-respawn-on-pickup to <flag>. It defaults to false. Also, the chosen post must have a name in order for the chat message to display.

Signed-off-by: mrcookie 