### PR TITLE
Fix a few text related issues

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/MapTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MapTabEntry.java
@@ -5,7 +5,6 @@ import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
 import net.kyori.text.format.TextDecoration;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.match.Match;
@@ -32,9 +31,6 @@ public class MapTabEntry extends DynamicTabEntry {
             TextComponent.of(map.getName(), TextColor.AQUA, TextDecoration.BOLD),
             TextFormatter.nameList(map.getAuthors(), NameStyle.FANCY, TextColor.GRAY));
 
-    return net.md_5.bungee.api.chat.TextComponent.fromLegacyToComponent(
-        LegacyComponentSerializer.legacy()
-            .serialize(TextTranslations.translate(text, view.getViewer().getLocale())),
-        false);
+    return TextTranslations.toBaseComponent(text, view.getViewer());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/teams/Team.java
+++ b/core/src/main/java/tc/oc/pgm/teams/Team.java
@@ -37,8 +37,6 @@ public class Team extends SimpleParty implements Competitor, Feature<TeamFactory
   private TeamMatchModule tmm;
   private JoinMatchModule jmm;
   protected @Nullable String name = null;
-  protected @Nullable Component componentName;
-  protected Component chatPrefix;
   protected Integer minPlayers, maxPlayers, maxOverfill;
 
   // Recorded in the match document, Tourney plugin sets this
@@ -128,10 +126,7 @@ public class Team extends SimpleParty implements Competitor, Feature<TeamFactory
 
   @Override
   public Component getName(NameStyle style) {
-    if (componentName == null) {
-      this.componentName = TextComponent.of(getNameLegacy(), TextFormatter.convert(getColor()));
-    }
-    return componentName;
+    return TextComponent.of(getNameLegacy(), TextFormatter.convert(getColor()));
   }
 
   /**
@@ -166,7 +161,6 @@ public class Team extends SimpleParty implements Competitor, Feature<TeamFactory
     if (Objects.equals(this.name, newName) || this.getNameLegacy().equals(newName)) return;
     String oldName = this.getNameLegacy();
     this.name = newName;
-    this.componentName = null;
     this.match.callEvent(new PartyRenameEvent(this, oldName, this.getNameLegacy()));
   }
 
@@ -182,11 +176,7 @@ public class Team extends SimpleParty implements Competitor, Feature<TeamFactory
 
   @Override
   public Component getChatPrefix() {
-    if (chatPrefix == null) {
-      this.chatPrefix =
-          TextComponent.of("(" + getShortName() + ") ", TextFormatter.convert(getColor()));
-    }
-    return chatPrefix;
+    return TextComponent.of("(" + getShortName() + ") ", TextFormatter.convert(getColor()));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/teams/Team.java
+++ b/core/src/main/java/tc/oc/pgm/teams/Team.java
@@ -37,6 +37,8 @@ public class Team extends SimpleParty implements Competitor, Feature<TeamFactory
   private TeamMatchModule tmm;
   private JoinMatchModule jmm;
   protected @Nullable String name = null;
+  protected @Nullable Component componentName;
+  protected @Nullable Component chatPrefix;
   protected Integer minPlayers, maxPlayers, maxOverfill;
 
   // Recorded in the match document, Tourney plugin sets this
@@ -126,7 +128,10 @@ public class Team extends SimpleParty implements Competitor, Feature<TeamFactory
 
   @Override
   public Component getName(NameStyle style) {
-    return TextComponent.of(getNameLegacy(), TextFormatter.convert(getColor()));
+    if (componentName == null) {
+      this.componentName = TextComponent.of(getNameLegacy(), TextFormatter.convert(getColor()));
+    }
+    return componentName;
   }
 
   /**
@@ -161,6 +166,8 @@ public class Team extends SimpleParty implements Competitor, Feature<TeamFactory
     if (Objects.equals(this.name, newName) || this.getNameLegacy().equals(newName)) return;
     String oldName = this.getNameLegacy();
     this.name = newName;
+    this.componentName = null;
+    this.chatPrefix = null;
     this.match.callEvent(new PartyRenameEvent(this, oldName, this.getNameLegacy()));
   }
 
@@ -176,7 +183,11 @@ public class Team extends SimpleParty implements Competitor, Feature<TeamFactory
 
   @Override
   public Component getChatPrefix() {
-    return TextComponent.of("(" + getShortName() + ") ", TextFormatter.convert(getColor()));
+    if (chatPrefix == null) {
+      this.chatPrefix =
+          TextComponent.of("(" + getShortName() + ") ", TextFormatter.convert(getColor()));
+    }
+    return chatPrefix;
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -80,15 +80,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Compile-time library used to generate "Delegate" classes -->
-        <!-- TODO: remove after deprecation of tc.oc.util.bukkit.Component -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- XML parsing library used for all "map.xml" configuration loading -->
         <dependency>
             <groupId>org.jdom</groupId>

--- a/util/src/main/java/tc/oc/pgm/util/named/NameStyle.java
+++ b/util/src/main/java/tc/oc/pgm/util/named/NameStyle.java
@@ -5,43 +5,27 @@ package tc.oc.pgm.util.named;
  * only by context, and is independent of the viewer.
  */
 public enum NameStyle {
-  PLAIN(false, false, false, false, false, false, false, false, false), // No formatting
-  COLOR(true, false, false, false, false, false, false, true, false), // Color only
-  FANCY(
-      true, true, true, true, true, false, false, true,
-      false), // Color, flair, friend status, nick status, vanish status
-  TAB(
-      true, true, true, true, true, false, true, true,
-      true), // Color, flair, friend status, nick status, death status, and vanish status
-  VERBOSE(true, true, true, true, true, true, false, true, true), // Fancy plus nickname
-  CONCISE(true, true, true, true, true, true, false, false, true); // Verbose, but removes teleport
+  PLAIN(false, false, false, false, false), // No formatting
+  COLOR(true, false, false, true, false), // Color and teleport
+  FANCY(true, true, false, true, false), // Color, flair, and teleport
+  TAB(true, true, true, false, true), // Color, flair, death status, and vanish
+  VERBOSE(true, true, false, true, true), // Color, flair, teleport, and vanish
+  CONCISE(true, true, false, false, true); // Color, flair, and vanish
 
   public final boolean isColor;
   public final boolean showPrefix;
-  public final boolean showSelf; // Bold if self
-  public final boolean showFriend; // Italic if friend
-  public final boolean showDisguise; // Strikethrough if disguised
-  public final boolean showNickname; // Show nickname after real name
   public final boolean showDeath; // Grey out name if dead
   public final boolean teleport; // Click name to teleport
-  public final boolean showVanish; // Italic if vanished
+  public final boolean showVanish; // Whether to render name as online or not
 
   NameStyle(
       boolean isColor,
       boolean showPrefix,
-      boolean showSelf,
-      boolean showFriend,
-      boolean showDisguise,
-      boolean showNickname,
       boolean showDeath,
       boolean teleport,
       boolean showVanish) {
     this.isColor = isColor;
     this.showPrefix = showPrefix;
-    this.showSelf = showSelf;
-    this.showFriend = showFriend;
-    this.showDisguise = showDisguise;
-    this.showNickname = showNickname;
     this.showDeath = showDeath;
     this.teleport = teleport;
     this.showVanish = showVanish;

--- a/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
@@ -127,6 +127,12 @@ public final class TextFormatter {
    * Convert ChatColor -> TextColor
    */
   public static TextColor convert(Enum<?> color) {
-    return TextColor.valueOf(color.name());
+    TextColor textColor = TextColor.WHITE;
+    try {
+      textColor = TextColor.valueOf(color.name());
+    } catch (IllegalArgumentException e) {
+      // If not found use default
+    }
+    return textColor;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
@@ -23,40 +23,6 @@ public interface PlayerComponent {
   static Component UNKNOWN =
       TranslatableComponent.of("misc.unknown", TextColor.DARK_AQUA, TextDecoration.ITALIC);
 
-  static Component of(Player player, NameStyle style) {
-    return of(player, "", style);
-  }
-
-  static Component of(@Nullable Player player, String defName, NameStyle style) {
-
-    // Offline player or not visible
-    if ((player == null || !player.isOnline())) {
-      return formatOffline(defName, style == NameStyle.PLAIN);
-    }
-
-    // For name styles that don't allow vanished, make vanished appear offline
-    if (!style.showVanish && isVanished(player)) {
-      return formatOffline(player.getName(), style == NameStyle.PLAIN);
-    }
-
-    switch (style) {
-      case COLOR:
-        return formatTeleport(formatColor(player), player.getName());
-      case CONCISE:
-        return formatConcise(player);
-      case FANCY:
-        return formatFancy(player);
-      case PLAIN:
-        return formatPlain(player);
-      case TAB:
-        return formatTab(player);
-      case VERBOSE:
-        return formatVerbose(player);
-      default:
-        return formatPlain(player);
-    }
-  }
-
   static Component of(UUID playerId, NameStyle style) {
     Player player = Bukkit.getPlayer(playerId);
     return player != null ? of(player, style) : UNKNOWN;
@@ -68,63 +34,105 @@ public interface PlayerComponent {
         : TranslatableComponent.of("misc.console", TextColor.DARK_AQUA);
   }
 
+  static Component of(Player player, NameStyle style) {
+    return of(player, "", style);
+  }
+
+  static Component of(@Nullable Player player, String defName, NameStyle style) {
+    // Offline player or not visible
+    if ((player == null || !player.isOnline())) {
+      return formatOffline(defName, style == NameStyle.PLAIN).build();
+    }
+
+    // For name styles that don't allow vanished, make vanished appear offline
+    if (!style.showVanish && isVanished(player)) {
+      return formatOffline(player.getName(), style == NameStyle.PLAIN).build();
+    }
+
+    TextComponent.Builder builder = TextComponent.builder();
+
+    switch (style) {
+      case COLOR:
+        builder = formatTeleport(formatColor(player), player.getName());
+        break;
+      case CONCISE:
+        builder = formatConcise(player);
+        break;
+      case FANCY:
+        builder = formatFancy(player);
+        break;
+      case TAB:
+        builder = formatTab(player);
+        break;
+      case VERBOSE:
+        builder = formatVerbose(player);
+        break;
+      default:
+        builder = formatPlain(player);
+        break;
+    }
+
+    return builder.build();
+  }
+
   // What an offline or vanished username renders as
-  static Component formatOffline(String name, boolean plain) {
-    TextComponent component = TextComponent.of(name);
-    if (!plain) component = component.color(TextColor.DARK_AQUA);
+  static TextComponent.Builder formatOffline(String name, boolean plain) {
+    TextComponent.Builder component = TextComponent.builder().append(name);
+    if (!plain) component.color(TextColor.DARK_AQUA);
     return component;
   }
 
   // No color or formatting, simply the name
-  static Component formatPlain(Player player) {
-    return TextComponent.of(player.getName());
+  static TextComponent.Builder formatPlain(Player player) {
+    return TextComponent.builder().append(player.getName());
   }
 
   // Color only
-  static Component formatColor(Player player) {
+  static TextComponent.Builder formatColor(Player player) {
     String displayName = player.getDisplayName();
     char colorChar = displayName.charAt((displayName.indexOf(player.getName()) - 1));
     TextColor color = TextFormatter.convert(ChatColor.getByChar(colorChar));
-    return TextComponent.of(player.getName(), color);
+    return TextComponent.builder().append(player.getName(), color);
   }
 
   // Color, flair & teleport
-  static Component formatFancy(Player player) {
-    Component prefix = getPrefixComponent(player);
-    Component colorName = formatColor(player);
+  static TextComponent.Builder formatFancy(Player player) {
+    TextComponent.Builder prefix = getPrefixComponent(player);
+    TextComponent.Builder colorName = formatColor(player);
+
     return formatTeleport(prefix.append(colorName), player.getName());
   }
 
   // Color, flair, death status, and vanish
-  static Component formatTab(Player player) {
-    Component prefix = getPrefixComponent(player);
-    Component colorName = formatColor(player);
+  static TextComponent.Builder formatTab(Player player) {
+    TextComponent.Builder prefix = getPrefixComponent(player);
+    TextComponent.Builder colorName = formatColor(player);
 
     if (isDead(player)) {
-      colorName = colorName.color(TextColor.DARK_GRAY);
+      colorName.color(TextColor.DARK_GRAY);
     }
 
     if (isVanished(player)) {
-      colorName = colorName.decoration(TextDecoration.STRIKETHROUGH, true);
+      colorName = formatVanished(colorName);
     }
 
     return prefix.append(colorName);
   }
 
   // Color, flair, and vanish status
-  static Component formatConcise(Player player) {
-    Component prefix = getPrefixComponent(player);
-    Component colorName = formatColor(player);
+  static TextComponent.Builder formatConcise(Player player) {
+    TextComponent.Builder prefix = getPrefixComponent(player);
+    TextComponent.Builder colorName = formatColor(player);
 
     if (isVanished(player)) {
-      colorName = colorName.decoration(TextDecoration.STRIKETHROUGH, true);
+      colorName = formatVanished(colorName);
     }
 
     return prefix.append(colorName);
   }
 
   // Color, flair, vanished, and teleport
-  static Component formatVerbose(Player player) {
+  static TextComponent.Builder formatVerbose(Player player) {
     return formatTeleport(formatConcise(player), player.getName());
   }
 
@@ -134,7 +142,7 @@ public interface PlayerComponent {
    * @param player The player
    * @return a component with a player's prefix
    */
-  static Component getPrefixComponent(Player player) {
+  static TextComponent.Builder getPrefixComponent(Player player) {
     String realName = player.getName();
     String displayName = player.getDisplayName();
     String prefix = displayName.substring(0, displayName.indexOf(realName) - 2);
@@ -157,17 +165,22 @@ public interface PlayerComponent {
       }
     }
 
-    return prefixComponent.build();
+    return prefixComponent;
   }
 
   // Format component to have teleport click/hover
-  static Component formatTeleport(Component username, String name) {
+  static TextComponent.Builder formatTeleport(TextComponent.Builder username, String name) {
     return username
         .hoverEvent(
             HoverEvent.of(
                 Action.SHOW_TEXT,
-                TranslatableComponent.of("misc.teleportTo", TextColor.GRAY, username)))
+                TranslatableComponent.of("misc.teleportTo", TextColor.GRAY, username.build())))
         .clickEvent(ClickEvent.runCommand("/tp " + name));
+  }
+
+  // Format for visible vanished players
+  static TextComponent.Builder formatVanished(TextComponent.Builder builder) {
+    return builder.decoration(TextDecoration.STRIKETHROUGH, true);
   }
 
   // Player state checks

--- a/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
@@ -15,7 +15,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.util.named.NameStyle;
-import tc.oc.pgm.util.text.TextParser;
+import tc.oc.pgm.util.text.TextFormatter;
 
 /** PlayerComponent is used to format player names in a consistent manner with optional styling */
 public interface PlayerComponent {
@@ -38,32 +38,49 @@ public interface PlayerComponent {
       return component.build();
     }
 
-    Component usernameComponent;
+    // For name styles that don't allow vanished, make vanished appear offline
+    if (!style.showVanish && isVanished(player)) {
+      TextComponent name = TextComponent.of(player.getName());
+      if (style != NameStyle.PLAIN) name = name.color(TextColor.DARK_AQUA);
+      component.append(name);
+      return component.build();
+    }
+
     String realName = player.getName();
     String displayName = player.getDisplayName();
+    String prefix = displayName.replace(realName, "");
+
+    char colorChar = displayName.charAt((displayName.indexOf(realName) - 1));
+    TextColor color =
+        style != NameStyle.PLAIN
+            ? TextFormatter.convert(ChatColor.getByChar(colorChar))
+            : TextColor.WHITE;
+
+    Component prefixComponent = TextComponent.of(prefix);
+    Component usernameComponent = TextComponent.of(realName, color);
 
     if (!style.showPrefix) {
-      displayName = displayName.substring(displayName.indexOf(realName) - 2);
+      prefixComponent = TextComponent.empty();
     }
 
     if (style.showDeath && isDead(player)) {
-      displayName =
-          displayName.replaceFirst(realName, ChatColor.DARK_GRAY + realName + ChatColor.RESET);
+      usernameComponent = usernameComponent.color(TextColor.DARK_GRAY);
     }
 
     if (style.showVanish && isVanished(player)) {
-      displayName =
-          displayName.replaceFirst(realName, ChatColor.STRIKETHROUGH + realName + ChatColor.RESET);
+      usernameComponent = usernameComponent.decoration(TextDecoration.STRIKETHROUGH, true);
     }
 
-    usernameComponent = TextParser.parseComponent(displayName);
-    component.append(usernameComponent);
+    Component formattedUsername =
+        TextComponent.builder().append(prefixComponent).append(usernameComponent).build();
+
+    component.append(formattedUsername);
 
     if (style.teleport) {
       component.hoverEvent(
           HoverEvent.of(
               Action.SHOW_TEXT,
-              TranslatableComponent.of("misc.teleportTo", TextColor.GRAY).args(usernameComponent)));
+              TranslatableComponent.of("misc.teleportTo", TextColor.GRAY).args(formattedUsername)));
       component.clickEvent(ClickEvent.runCommand("/tp " + player.getName()));
     }
 

--- a/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
@@ -28,63 +28,33 @@ public interface PlayerComponent {
   }
 
   static Component of(@Nullable Player player, String defName, NameStyle style) {
-    TextComponent.Builder component = TextComponent.builder();
 
-    // Offline player
-    if (player == null || !player.isOnline()) {
-      TextComponent name = TextComponent.of(defName);
-      if (style != NameStyle.PLAIN) name = name.color(TextColor.DARK_AQUA);
-      component.append(name);
-      return component.build();
+    // Offline player or not visible
+    if ((player == null || !player.isOnline())) {
+      return formatOffline(defName, style == NameStyle.PLAIN);
     }
 
     // For name styles that don't allow vanished, make vanished appear offline
     if (!style.showVanish && isVanished(player)) {
-      TextComponent name = TextComponent.of(player.getName());
-      if (style != NameStyle.PLAIN) name = name.color(TextColor.DARK_AQUA);
-      component.append(name);
-      return component.build();
+      return formatOffline(player.getName(), style == NameStyle.PLAIN);
     }
 
-    String realName = player.getName();
-    String displayName = player.getDisplayName();
-    String prefix = displayName.replace(realName, "");
-
-    char colorChar = displayName.charAt((displayName.indexOf(realName) - 1));
-    TextColor color =
-        style != NameStyle.PLAIN
-            ? TextFormatter.convert(ChatColor.getByChar(colorChar))
-            : TextColor.WHITE;
-
-    Component prefixComponent = TextComponent.of(prefix);
-    Component usernameComponent = TextComponent.of(realName, color);
-
-    if (!style.showPrefix) {
-      prefixComponent = TextComponent.empty();
+    switch (style) {
+      case COLOR:
+        return formatTeleport(formatColor(player), player.getName());
+      case CONCISE:
+        return formatConcise(player);
+      case FANCY:
+        return formatFancy(player);
+      case PLAIN:
+        return formatPlain(player);
+      case TAB:
+        return formatTab(player);
+      case VERBOSE:
+        return formatVerbose(player);
+      default:
+        return formatPlain(player);
     }
-
-    if (style.showDeath && isDead(player)) {
-      usernameComponent = usernameComponent.color(TextColor.DARK_GRAY);
-    }
-
-    if (style.showVanish && isVanished(player)) {
-      usernameComponent = usernameComponent.decoration(TextDecoration.STRIKETHROUGH, true);
-    }
-
-    Component formattedUsername =
-        TextComponent.builder().append(prefixComponent).append(usernameComponent).build();
-
-    component.append(formattedUsername);
-
-    if (style.teleport) {
-      component.hoverEvent(
-          HoverEvent.of(
-              Action.SHOW_TEXT,
-              TranslatableComponent.of("misc.teleportTo", TextColor.GRAY).args(formattedUsername)));
-      component.clickEvent(ClickEvent.runCommand("/tp " + player.getName()));
-    }
-
-    return component.build();
   }
 
   static Component of(UUID playerId, NameStyle style) {
@@ -98,6 +68,109 @@ public interface PlayerComponent {
         : TranslatableComponent.of("misc.console", TextColor.DARK_AQUA);
   }
 
+  // What an offline or vanished username renders as
+  static Component formatOffline(String name, boolean plain) {
+    TextComponent component = TextComponent.of(name);
+    if (!plain) component = component.color(TextColor.DARK_AQUA);
+    return component;
+  }
+
+  // No color or formatting, simply the name
+  static Component formatPlain(Player player) {
+    return TextComponent.of(player.getName());
+  }
+
+  // Color only
+  static Component formatColor(Player player) {
+    String displayName = player.getDisplayName();
+    char colorChar = displayName.charAt((displayName.indexOf(player.getName()) - 1));
+    TextColor color = TextFormatter.convert(ChatColor.getByChar(colorChar));
+    return TextComponent.of(player.getName(), color);
+  }
+
+  // Color, flair & teleport
+  static Component formatFancy(Player player) {
+    Component prefix = getPrefixComponent(player);
+    Component colorName = formatColor(player);
+    return formatTeleport(prefix.append(colorName), player.getName());
+  }
+
+  // Color, flair, death status, and vanish
+  static Component formatTab(Player player) {
+    Component prefix = getPrefixComponent(player);
+    Component colorName = formatColor(player);
+
+    if (isDead(player)) {
+      colorName = colorName.color(TextColor.DARK_GRAY);
+    }
+
+    if (isVanished(player)) {
+      colorName = colorName.decoration(TextDecoration.STRIKETHROUGH, true);
+    }
+
+    return prefix.append(colorName);
+  }
+
+  // Color, flair, and vanish status
+  static Component formatConcise(Player player) {
+    Component prefix = getPrefixComponent(player);
+    Component colorName = formatColor(player);
+
+    if (isVanished(player)) {
+      colorName = colorName.decoration(TextDecoration.STRIKETHROUGH, true);
+    }
+
+    return prefix.append(colorName);
+  }
+
+  // Color, flair, vanished, and teleport
+  static Component formatVerbose(Player player) {
+    return formatTeleport(formatConcise(player), player.getName());
+  }
+
+  /**
+   * Get the player's prefix as a {@link Component}
+   *
+   * @param player The player
+   * @return a component with a player's prefix
+   */
+  static Component getPrefixComponent(Player player) {
+    String realName = player.getName();
+    String displayName = player.getDisplayName();
+    String prefix = displayName.substring(0, displayName.indexOf(realName) - 2);
+
+    TextComponent.Builder prefixComponent = TextComponent.builder();
+    boolean isColor = false;
+    TextColor color = null;
+    for (int i = 0; i < prefix.length(); i++) {
+      if (prefix.charAt(i) == ChatColor.COLOR_CHAR) {
+        isColor = true;
+        continue;
+      }
+
+      if (isColor) {
+        color = TextFormatter.convert(ChatColor.getByChar(prefix.charAt(i)));
+        isColor = false;
+      } else {
+        prefixComponent.append(
+            String.valueOf(prefix.charAt(i)), color != null ? color : TextColor.WHITE);
+      }
+    }
+
+    return prefixComponent.build();
+  }
+
+  // Format component to have teleport click/hover
+  static Component formatTeleport(Component username, String name) {
+    return username
+        .hoverEvent(
+            HoverEvent.of(
+                Action.SHOW_TEXT,
+                TranslatableComponent.of("misc.teleportTo", TextColor.GRAY, username)))
+        .clickEvent(ClickEvent.runCommand("/tp " + name));
+  }
+
+  // Player state checks
   static boolean isVanished(Player player) {
     return player.hasMetadata("isVanished");
   }


### PR DESCRIPTION
# Fix a few text related issues
Most of these issues come from the recent text refactor, all of which are resolved by this PR 🎉 

* Vanished mapmakers are no longer exposed via various map info locations
* Fixed issue related to names not rendering decorations (death message bug)
* Resolve team chat prefix not using proper aliased name (resolves #534)

## Screenshot
![Screen Shot 2020-06-14 at 1 11 40 AM](https://user-images.githubusercontent.com/3377659/84588529-0dda2800-addd-11ea-8cd1-48a2ebe20583.png)

![Screen Shot 2020-06-14 at 12 34 22 AM](https://user-images.githubusercontent.com/3377659/84588535-13377280-addd-11ea-89fd-544bf6f6edfa.png)

Signed-off-by: applenick <applenick@users.noreply.github.com>