### PR TITLE
Allow voting book to be forced open

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
@@ -275,7 +275,11 @@ public final class MapPoolCommand {
 
   @Command(aliases = "votenext", desc = "Vote for the next map", usage = "map")
   public static void voteNext(
-      MatchPlayer player, CommandSender sender, MapOrder mapOrder, @Text MapInfo map)
+      MatchPlayer player,
+      CommandSender sender,
+      MapOrder mapOrder,
+      @Switch('o') boolean forceOpen,
+      @Text MapInfo map)
       throws CommandException {
     MapPool pool = getMapPoolManager(sender, mapOrder).getActiveMapPool();
     MapPoll poll = pool instanceof VotingPool ? ((VotingPool) pool).getCurrentPoll() : null;
@@ -291,7 +295,7 @@ public final class MapPoolCommand {
             voteResult ? TextColor.GREEN : TextColor.RED,
             map.getStyledName(MapNameStyle.COLOR));
     player.sendMessage(voteAction);
-    poll.sendBook(player);
+    poll.sendBook(player, forceOpen);
   }
 
   public static MapPoolManager getMapPoolManager(CommandSender sender, MapOrder mapOrder)

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
@@ -136,7 +136,7 @@ public class MapPoll {
         .build();
   }
 
-  public void sendBook(MatchPlayer viewer) {
+  public void sendBook(MatchPlayer viewer, boolean forceOpen) {
     String title = ChatColor.GOLD + "" + ChatColor.BOLD;
     title += TextTranslations.translate("vote.title.map", viewer.getBukkit());
 
@@ -162,7 +162,7 @@ public class MapPoll {
     }
     viewer.getInventory().setItemInHand(is);
 
-    if (viewer.getSettings().getValue(SettingKey.VOTE) == SettingValue.VOTE_ON)
+    if (forceOpen || viewer.getSettings().getValue(SettingKey.VOTE) == SettingValue.VOTE_ON)
       NMSHacks.openBook(is, viewer.getBukkit());
   }
 
@@ -180,7 +180,7 @@ public class MapPoll {
                 TextComponent.of(
                     map.getTags().stream().map(MapTag::toString).collect(Collectors.joining(" ")),
                     TextColor.YELLOW)))
-        .clickEvent(ClickEvent.runCommand("/votenext " + map.getName()))
+        .clickEvent(ClickEvent.runCommand("/votenext -o " + map.getName()))
         .build();
   }
 

--- a/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
@@ -89,7 +89,7 @@ public class VotingPool extends MapPool {
               // If there is a restart queued, don't start a vote
               if (RestartManager.isQueued()) return;
               currentPoll = new MapPoll(match, mapScores, VOTE_SIZE);
-              match.getPlayers().forEach(currentPoll::sendBook);
+              match.getPlayers().forEach(viewer -> currentPoll.sendBook(viewer, false));
             },
             5,
             TimeUnit.SECONDS);


### PR DESCRIPTION
When the setting `vote` is set to `off` the voting book does not popup when given to the player, great.

BUT I believe that once you interact with the book (opening and clicking a map) the book should reopen for you to vote for another map until you close the book manually. ATM it's a bit of a faff to have the `vote` `off` as you need to manually open the book each time you select more than one map.

This adds a forced argument to the `sendBook` method which if set to true will force the book open. If false it will use the player's settings. This is then used via a command flag `-f` when a book is voted for by clicking its name in the book.

Signed-off-by: Pugzy <pugzy@mail.com>