### PR TITLE
Add custom vote management 

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
@@ -2,8 +2,6 @@ package tc.oc.pgm.command;
 
 import app.ashcon.intake.Command;
 import app.ashcon.intake.CommandException;
-import app.ashcon.intake.bukkit.parametric.Type;
-import app.ashcon.intake.bukkit.parametric.annotation.Fallback;
 import app.ashcon.intake.parametric.annotation.Default;
 import app.ashcon.intake.parametric.annotation.Switch;
 import app.ashcon.intake.parametric.annotation.Text;
@@ -26,14 +24,12 @@ import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.cycle.CycleCountdown;
-import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.rotation.MapPoll;
 import tc.oc.pgm.rotation.MapPool;
 import tc.oc.pgm.rotation.MapPoolManager;
 import tc.oc.pgm.rotation.Rotation;
 import tc.oc.pgm.rotation.VotingPool;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
-import tc.oc.pgm.util.UsernameFormatUtils;
 import tc.oc.pgm.util.chat.Audience;
 import tc.oc.pgm.util.named.MapNameStyle;
 import tc.oc.pgm.util.text.TextFormatter;
@@ -278,118 +274,6 @@ public final class MapPoolCommand {
             .build();
 
     viewer.sendMessage(message);
-  }
-
-  @Command(
-      aliases = {"setvote", "sv"},
-      desc = "Set maps for a custom poll",
-      flags = "rcl",
-      usage = "[map name] -r (remove) -c (clear) -l (list)",
-      perms = Permissions.SETNEXT)
-  public void setVote(
-      Audience viewer,
-      CommandSender sender,
-      @Fallback(Type.NULL) @Text MapInfo map,
-      MapOrder mapOrder,
-      Match match,
-      @Switch('c') boolean clear,
-      @Switch('r') boolean remove,
-      @Switch('l') boolean list)
-      throws CommandException {
-    MapPool pool = getMapPoolManager(sender, mapOrder).getActiveMapPool();
-    VotingPool vote = (pool instanceof VotingPool ? ((VotingPool) pool) : null);
-
-    if (vote == null) {
-      viewer.sendWarning(TranslatableComponent.of("vote.disabled"));
-      return;
-    }
-
-    if (list) {
-      int currentMaps = vote.getCustomVoteMaps().size();
-      TextColor listNumColor =
-          currentMaps > 1 ? currentMaps < 5 ? TextColor.GREEN : TextColor.YELLOW : TextColor.RED;
-      Component listMsg =
-          TextComponent.builder()
-              .append(TranslatableComponent.of("map.setVote.list"))
-              .append(": (")
-              .append(Integer.toString(currentMaps), listNumColor)
-              .append("/")
-              .append(Integer.toString(VotingPool.MAX_VOTE_OPTIONS), TextColor.RED)
-              .append(")")
-              .color(TextColor.GRAY)
-              .build();
-      viewer.sendMessage(listMsg);
-
-      int index = 1;
-      for (MapInfo mi : vote.getCustomVoteMaps()) {
-        Component indexedName =
-            TextComponent.builder()
-                .append(Integer.toString(index), TextColor.YELLOW)
-                .append(". ", TextColor.GRAY)
-                .append(mi.getStyledName(MapNameStyle.COLOR_WITH_AUTHORS))
-                .build();
-        viewer.sendMessage(indexedName);
-        index++;
-      }
-      return;
-    }
-
-    // Clear all custom vote maps
-    if (clear) {
-      Component current =
-          TextComponent.of(Integer.toString(vote.getCustomVoteMaps().size()), TextColor.RED);
-      vote.getCustomVoteMaps().clear();
-      Component clearedMsg =
-          TranslatableComponent.of(
-              "map.setVote.clear",
-              TextColor.GRAY,
-              UsernameFormatUtils.formatStaffName(sender, match));
-      clearedMsg =
-          clearedMsg.append(
-              TextComponent.builder()
-                  .append(" (")
-                  .append(current)
-                  .append(")")
-                  .color(TextColor.GRAY)
-                  .build());
-      ChatDispatcher.broadcastAdminChatMessage(clearedMsg, match);
-      return;
-    }
-
-    // Remove a single custom vote map
-    if (remove) {
-      if (vote.isCustomVote(map)) {
-        vote.removeCustomVote(map);
-        ChatDispatcher.broadcastAdminChatMessage(
-            TranslatableComponent.of(
-                "map.setVote.removeMap",
-                TextColor.GRAY,
-                UsernameFormatUtils.formatStaffName(sender, match),
-                map.getStyledName(MapNameStyle.COLOR)),
-            match);
-        return;
-      }
-    }
-
-    // Check if map is already added
-    if (vote.isCustomVote(map)) {
-      viewer.sendWarning(
-          TranslatableComponent.of(
-              "map.setVote.existing", TextColor.GRAY, map.getStyledName(MapNameStyle.COLOR)));
-      return;
-    }
-
-    if (vote.addCustomVoteMap(map)) {
-      ChatDispatcher.broadcastAdminChatMessage(
-          TranslatableComponent.of(
-              "map.setVote.addMap",
-              TextColor.GRAY,
-              UsernameFormatUtils.formatStaffName(sender, match),
-              map.getStyledName(MapNameStyle.COLOR)),
-          match);
-    } else {
-      viewer.sendWarning(TranslatableComponent.of("map.setVote.limit", TextColor.RED));
-    }
   }
 
   @Command(aliases = "votenext", desc = "Vote for the next map", usage = "map")

--- a/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
@@ -37,10 +37,9 @@ public class VotingCommand {
       MapOrder mapOrder,
       Match match)
       throws CommandException {
-
     VotingPool vote = getVotingPool(sender, mapOrder);
 
-    if (vote.isCustomVote(map)) {
+    if (vote.isCustomMapSelected(map)) {
       viewer.sendWarning(
           TranslatableComponent.of(
               "map.setVote.existing", TextColor.GRAY, map.getStyledName(MapNameStyle.COLOR)));
@@ -156,7 +155,8 @@ public class VotingCommand {
       if (manager.getActiveMapPool() instanceof VotingPool) {
         VotingPool votePool = (VotingPool) manager.getActiveMapPool();
         if (votePool.getCurrentPoll() != null) {
-          throw new CommandException(ChatColor.RED + TextTranslations.translate("map.setVote.existing", sender));
+          throw new CommandException(
+              ChatColor.RED + TextTranslations.translate("map.setVote.inProgress", sender));
         }
         return votePool;
       }

--- a/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
@@ -1,0 +1,170 @@
+package tc.oc.pgm.command;
+
+import app.ashcon.intake.Command;
+import app.ashcon.intake.CommandException;
+import app.ashcon.intake.bukkit.parametric.Type;
+import app.ashcon.intake.bukkit.parametric.annotation.Fallback;
+import app.ashcon.intake.parametric.annotation.Text;
+import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
+import net.kyori.text.TranslatableComponent;
+import net.kyori.text.format.TextColor;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.api.map.MapOrder;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.listeners.ChatDispatcher;
+import tc.oc.pgm.rotation.MapPoolManager;
+import tc.oc.pgm.rotation.VotingPool;
+import tc.oc.pgm.util.UsernameFormatUtils;
+import tc.oc.pgm.util.chat.Audience;
+import tc.oc.pgm.util.named.MapNameStyle;
+import tc.oc.pgm.util.text.TextTranslations;
+
+public class VotingCommand {
+
+  @Command(
+      aliases = {"add", "set"},
+      desc = "Add a custom map to the next vote",
+      usage = "[map name]",
+      perms = Permissions.SETNEXT)
+  public void addMap(
+      Audience viewer,
+      CommandSender sender,
+      @Fallback(Type.NULL) @Text MapInfo map,
+      MapOrder mapOrder,
+      Match match)
+      throws CommandException {
+
+    VotingPool vote = getVotingPool(sender, mapOrder);
+
+    if (vote.isCustomVote(map)) {
+      viewer.sendWarning(
+          TranslatableComponent.of(
+              "map.setVote.existing", TextColor.GRAY, map.getStyledName(MapNameStyle.COLOR)));
+      return;
+    }
+
+    if (vote.addCustomVoteMap(map)) {
+      ChatDispatcher.broadcastAdminChatMessage(
+          TranslatableComponent.of(
+              "map.setVote.addMap",
+              TextColor.GRAY,
+              UsernameFormatUtils.formatStaffName(sender, match),
+              map.getStyledName(MapNameStyle.COLOR)),
+          match);
+    } else {
+      viewer.sendWarning(TranslatableComponent.of("map.setVote.limit", TextColor.RED));
+    }
+  }
+
+  @Command(
+      aliases = {"remove", "rm"},
+      desc = "Remove a custom map from the next vote",
+      usage = "[map name]",
+      perms = Permissions.SETNEXT)
+  public void removeMap(
+      Audience viewer,
+      CommandSender sender,
+      @Fallback(Type.NULL) @Text MapInfo map,
+      MapOrder mapOrder,
+      Match match)
+      throws CommandException {
+    VotingPool vote = getVotingPool(sender, mapOrder);
+    if (vote.removeCustomVote(map)) {
+      ChatDispatcher.broadcastAdminChatMessage(
+          TranslatableComponent.of(
+              "map.setVote.removeMap",
+              TextColor.GRAY,
+              UsernameFormatUtils.formatStaffName(sender, match),
+              map.getStyledName(MapNameStyle.COLOR)),
+          match);
+    } else {
+      viewer.sendWarning(
+          TranslatableComponent.of("map.setVote.notFound", map.getStyledName(MapNameStyle.COLOR)));
+    }
+  }
+
+  @Command(
+      aliases = {"clear"},
+      desc = "Clear all custom map selections from the next vote",
+      perms = Permissions.SETNEXT)
+  public void clearMaps(CommandSender sender, Match match, MapOrder mapOrder)
+      throws CommandException {
+    VotingPool vote = getVotingPool(sender, mapOrder);
+
+    Component current =
+        TextComponent.of(Integer.toString(vote.getCustomVoteMaps().size()), TextColor.RED);
+    vote.getCustomVoteMaps().clear();
+    Component clearedMsg =
+        TranslatableComponent.of(
+            "map.setVote.clear",
+            TextColor.GRAY,
+            UsernameFormatUtils.formatStaffName(sender, match));
+    clearedMsg =
+        clearedMsg.append(
+            TextComponent.builder()
+                .append(" (")
+                .append(current)
+                .append(")")
+                .color(TextColor.GRAY)
+                .build());
+    ChatDispatcher.broadcastAdminChatMessage(clearedMsg, match);
+  }
+
+  @Command(
+      aliases = {"list", "ls"},
+      desc = "View a list of maps that have been selected for the next vote")
+  public void listMaps(CommandSender sender, Audience viewer, MapOrder mapOrder)
+      throws CommandException {
+    VotingPool vote = getVotingPool(sender, mapOrder);
+
+    int currentMaps = vote.getCustomVoteMaps().size();
+    TextColor listNumColor =
+        currentMaps > 1 ? currentMaps < 5 ? TextColor.GREEN : TextColor.YELLOW : TextColor.RED;
+    Component listMsg =
+        TextComponent.builder()
+            .append(TranslatableComponent.of("map.setVote.list"))
+            .append(": (")
+            .append(Integer.toString(currentMaps), listNumColor)
+            .append("/")
+            .append(Integer.toString(VotingPool.MAX_VOTE_OPTIONS), TextColor.RED)
+            .append(")")
+            .color(TextColor.GRAY)
+            .build();
+    viewer.sendMessage(listMsg);
+
+    int index = 1;
+    for (MapInfo mi : vote.getCustomVoteMaps()) {
+      Component indexedName =
+          TextComponent.builder()
+              .append(Integer.toString(index), TextColor.YELLOW)
+              .append(". ", TextColor.WHITE)
+              .append(mi.getStyledName(MapNameStyle.COLOR_WITH_AUTHORS))
+              .build();
+      viewer.sendMessage(indexedName);
+      index++;
+    }
+  }
+
+  public static VotingPool getVotingPool(CommandSender sender, MapOrder mapOrder)
+      throws CommandException {
+    if (mapOrder instanceof MapPoolManager) {
+      MapPoolManager manager = (MapPoolManager) mapOrder;
+      if (manager.getActiveMapPool() instanceof VotingPool) {
+        VotingPool votePool = (VotingPool) manager.getActiveMapPool();
+        if (votePool.getCurrentPoll() != null) {
+          throw new CommandException(ChatColor.RED + TextTranslations.translate("map.setVote.existing", sender));
+        }
+        return votePool;
+      }
+      throw new CommandException(
+          ChatColor.RED + TextTranslations.translate("vote.disabled", sender));
+    }
+
+    throw new CommandException(
+        ChatColor.RED + TextTranslations.translate("pool.mapPoolsDisabled", sender));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
@@ -26,7 +26,7 @@ import tc.oc.pgm.util.text.TextTranslations;
 public class VotingCommand {
 
   @Command(
-      aliases = {"add", "set"},
+      aliases = {"add"},
       desc = "Add a custom map to the next vote",
       usage = "[map name]",
       perms = Permissions.SETNEXT)
@@ -42,20 +42,20 @@ public class VotingCommand {
     if (vote.isCustomMapSelected(map)) {
       viewer.sendWarning(
           TranslatableComponent.of(
-              "map.setVote.existing", TextColor.GRAY, map.getStyledName(MapNameStyle.COLOR)));
+              "vote.custom.existing", TextColor.GRAY, map.getStyledName(MapNameStyle.COLOR)));
       return;
     }
 
     if (vote.addCustomVoteMap(map)) {
       ChatDispatcher.broadcastAdminChatMessage(
           TranslatableComponent.of(
-              "map.setVote.addMap",
+              "vote.custom.add",
               TextColor.GRAY,
               UsernameFormatUtils.formatStaffName(sender, match),
               map.getStyledName(MapNameStyle.COLOR)),
           match);
     } else {
-      viewer.sendWarning(TranslatableComponent.of("map.setVote.limit", TextColor.RED));
+      viewer.sendWarning(TranslatableComponent.of("vote.custom.limit", TextColor.RED));
     }
   }
 
@@ -75,14 +75,14 @@ public class VotingCommand {
     if (vote.removeCustomVote(map)) {
       ChatDispatcher.broadcastAdminChatMessage(
           TranslatableComponent.of(
-              "map.setVote.removeMap",
+              "vote.custom.remove",
               TextColor.GRAY,
               UsernameFormatUtils.formatStaffName(sender, match),
               map.getStyledName(MapNameStyle.COLOR)),
           match);
     } else {
       viewer.sendWarning(
-          TranslatableComponent.of("map.setVote.notFound", map.getStyledName(MapNameStyle.COLOR)));
+          TranslatableComponent.of("vote.custom.notFound", map.getStyledName(MapNameStyle.COLOR)));
     }
   }
 
@@ -99,7 +99,7 @@ public class VotingCommand {
     vote.getCustomVoteMaps().clear();
     Component clearedMsg =
         TranslatableComponent.of(
-            "map.setVote.clear",
+            "vote.custom.clear",
             TextColor.GRAY,
             UsernameFormatUtils.formatStaffName(sender, match));
     clearedMsg =
@@ -125,7 +125,7 @@ public class VotingCommand {
         currentMaps > 1 ? currentMaps < 5 ? TextColor.GREEN : TextColor.YELLOW : TextColor.RED;
     Component listMsg =
         TextComponent.builder()
-            .append(TranslatableComponent.of("map.setVote.list"))
+            .append(TranslatableComponent.of("vote.custom.list"))
             .append(": (")
             .append(Integer.toString(currentMaps), listNumColor)
             .append("/")
@@ -156,7 +156,7 @@ public class VotingCommand {
         VotingPool votePool = (VotingPool) manager.getActiveMapPool();
         if (votePool.getCurrentPoll() != null) {
           throw new CommandException(
-              ChatColor.RED + TextTranslations.translate("map.setVote.inProgress", sender));
+              ChatColor.RED + TextTranslations.translate("vote.custom.inProgress", sender));
         }
         return votePool;
       }

--- a/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
@@ -94,8 +94,7 @@ public class VotingCommand {
       throws CommandException {
     VotingPool vote = getVotingPool(sender, mapOrder);
 
-    Component current =
-        TextComponent.of(Integer.toString(vote.getCustomVoteMaps().size()), TextColor.RED);
+    Component current = TextComponent.of(vote.getCustomVoteMaps().size(), TextColor.RED);
     vote.getCustomVoteMaps().clear();
     Component clearedMsg =
         TranslatableComponent.of(
@@ -122,7 +121,9 @@ public class VotingCommand {
 
     int currentMaps = vote.getCustomVoteMaps().size();
     TextColor listNumColor =
-        currentMaps > 1 ? currentMaps < 5 ? TextColor.GREEN : TextColor.YELLOW : TextColor.RED;
+        currentMaps >= VotingPool.MIN_CUSTOM_VOTE_OPTIONS
+            ? currentMaps < VotingPool.MAX_VOTE_OPTIONS ? TextColor.GREEN : TextColor.YELLOW
+            : TextColor.RED;
     Component listMsg =
         TextComponent.builder()
             .append(TranslatableComponent.of("vote.custom.list"))

--- a/core/src/main/java/tc/oc/pgm/command/graph/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/CommandGraph.java
@@ -45,6 +45,7 @@ import tc.oc.pgm.command.StartCommand;
 import tc.oc.pgm.command.StatsCommand;
 import tc.oc.pgm.command.TeamCommand;
 import tc.oc.pgm.command.TimeLimitCommand;
+import tc.oc.pgm.command.VotingCommand;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.chat.Audience;
 
@@ -82,6 +83,7 @@ public class CommandGraph extends BasicBukkitCommandGraph {
     register(new StatsCommand());
     register(new TeamCommand(), "team");
     register(new TimeLimitCommand());
+    register(new VotingCommand(), "vote", "votes");
   }
 
   public void register(Object command, String... aliases) {

--- a/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
@@ -125,7 +125,7 @@ public class VotingPool extends MapPool {
     return customVoteMaps;
   }
 
-  public boolean isCustomVote(MapInfo info) {
+  public boolean isCustomMapSelected(MapInfo info) {
     return customVoteMaps.stream().anyMatch(s -> s.getName().equalsIgnoreCase(info.getName()));
   }
 

--- a/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
@@ -1,7 +1,10 @@
 package tc.oc.pgm.rotation;
 
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.bukkit.configuration.ConfigurationSection;
 import tc.oc.pgm.api.map.MapInfo;
@@ -12,7 +15,7 @@ import tc.oc.pgm.restart.RestartManager;
 public class VotingPool extends MapPool {
 
   // Number of maps in the vote, unless not enough maps in pool
-  private static final int MAX_VOTE_OPTIONS = 5;
+  public static final int MAX_VOTE_OPTIONS = 5;
   // If maps were single voted, it would avg to this default
   private static final double DEFAULT_WEIGHT = 1d / MAX_VOTE_OPTIONS;
 
@@ -22,6 +25,9 @@ public class VotingPool extends MapPool {
   private final Map<MapInfo, Double> mapScores = new HashMap<>();
 
   private MapPoll currentPoll;
+
+  /** Override pool is used when custom maps are defined, does not count for regular vote score * */
+  private Set<MapInfo> customVoteMaps = Sets.newHashSet();
 
   public VotingPool(MapPoolManager manager, ConfigurationSection section, String name) {
     super(manager, section, name);
@@ -58,6 +64,7 @@ public class VotingPool extends MapPool {
     if (currentPoll == null) return getRandom();
 
     MapInfo map = currentPoll.finishVote();
+    customVoteMaps.clear();
     currentPoll = null;
     return map != null ? map : getRandom();
   }
@@ -88,10 +95,47 @@ public class VotingPool extends MapPool {
               if (manager.getOverriderMap() != null) return;
               // If there is a restart queued, don't start a vote
               if (RestartManager.isQueued()) return;
-              currentPoll = new MapPoll(match, mapScores, VOTE_SIZE);
+              currentPoll =
+                  shouldCustomVote()
+                      ? new MapPoll(
+                          match,
+                          getCustomVoteMapWeighted(),
+                          Math.min(MAX_VOTE_OPTIONS, customVoteMaps.size()))
+                      : new MapPoll(match, mapScores, VOTE_SIZE);
+
               match.getPlayers().forEach(viewer -> currentPoll.sendBook(viewer, false));
             },
             5,
             TimeUnit.SECONDS);
+  }
+
+  public boolean addCustomVoteMap(MapInfo info) {
+    if (customVoteMaps.size() < MAX_VOTE_OPTIONS) {
+      this.customVoteMaps.add(info);
+      return true;
+    }
+    return false;
+  }
+
+  public boolean removeCustomVote(MapInfo map) {
+    return this.customVoteMaps.remove(map);
+  }
+
+  public Set<MapInfo> getCustomVoteMaps() {
+    return customVoteMaps;
+  }
+
+  public boolean isCustomVote(MapInfo info) {
+    return customVoteMaps.stream().anyMatch(s -> s.getName().equalsIgnoreCase(info.getName()));
+  }
+
+  private boolean shouldCustomVote() {
+    return customVoteMaps.size() > 1;
+  }
+
+  private Map<MapInfo, Double> getCustomVoteMapWeighted() {
+    Map<MapInfo, Double> maps = Maps.newHashMap();
+    customVoteMaps.forEach(map -> maps.put(map, DEFAULT_WEIGHT));
+    return maps;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
@@ -16,6 +16,8 @@ public class VotingPool extends MapPool {
 
   // Number of maps in the vote, unless not enough maps in pool
   public static final int MAX_VOTE_OPTIONS = 5;
+  // Number of maps required for a custom vote (/vote)
+  public static final int MIN_CUSTOM_VOTE_OPTIONS = 2;
   // If maps were single voted, it would avg to this default
   private static final double DEFAULT_WEIGHT = 1d / MAX_VOTE_OPTIONS;
 
@@ -130,7 +132,7 @@ public class VotingPool extends MapPool {
   }
 
   private boolean shouldCustomVote() {
-    return customVoteMaps.size() > 1;
+    return customVoteMaps.size() >= MIN_CUSTOM_VOTE_OPTIONS;
   }
 
   private Map<MapInfo, Double> getCustomVoteMapWeighted() {

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -71,7 +71,7 @@ map.setVote.clear = {0} has cleared the custom vote selection
 # {0} = map name
 map.setVote.notFound = {0} could not be removed since it was never added
 
-map.setVote.existing = Voting selection can not be modified at this time
+map.setVote.inProgress = Voting selection can not be modified at this time
 
 map.setVote.limit = Map limit for the custom vote has been reached
 

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -68,6 +68,11 @@ map.setVote.existing = {0} has already been added to the custom vote
 # {0} = player name (who cleared the map selection)
 map.setVote.clear = {0} has cleared the custom vote selection
 
+# {0} = map name
+map.setVote.notFound = {0} could not be removed since it was never added
+
+map.setVote.existing = Voting selection can not be modified at this time
+
 map.setVote.limit = Map limit for the custom vote has been reached
 
 map.setVote.list = Selected Maps

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -54,6 +54,24 @@ map.setNext.confirm = You may not set the next map when a restart is queued. Use
 # {1} = name of map that was unset
 map.setNext.revert = {0} has removed {1} as the next map
 
+# {0} = player name (who added the map)
+# {1} = map name 
+map.setVote.addMap = {0} added {1} to the custom vote
+
+# {0} = player name (who removed the map)
+# {1} = map name 
+map.setVote.removeMap = {0} removed {1} from the custom vote
+
+# {0} = map name
+map.setVote.existing = {0} has already been added to the custom vote
+
+# {0} = player name (who cleared the map selection)
+map.setVote.clear = {0} has cleared the custom vote selection
+
+map.setVote.limit = Map limit for the custom vote has been reached
+
+map.setVote.list = Selected Maps
+
 map.noNextMap = No next map
 
 # {0} = map name
@@ -119,3 +137,5 @@ vote.against = Voted against {0}
 
 # {0} = option name (e.g. "Airship Battle")
 vote.abstain = Removed your vote for {0}
+
+vote.disabled = Voting is disabled

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -54,29 +54,6 @@ map.setNext.confirm = You may not set the next map when a restart is queued. Use
 # {1} = name of map that was unset
 map.setNext.revert = {0} has removed {1} as the next map
 
-# {0} = player name (who added the map)
-# {1} = map name 
-map.setVote.addMap = {0} added {1} to the custom vote
-
-# {0} = player name (who removed the map)
-# {1} = map name 
-map.setVote.removeMap = {0} removed {1} from the custom vote
-
-# {0} = map name
-map.setVote.existing = {0} has already been added to the custom vote
-
-# {0} = player name (who cleared the map selection)
-map.setVote.clear = {0} has cleared the custom vote selection
-
-# {0} = map name
-map.setVote.notFound = {0} could not be removed since it was never added
-
-map.setVote.inProgress = Voting selection can not be modified at this time
-
-map.setVote.limit = Map limit for the custom vote has been reached
-
-map.setVote.list = Selected Maps
-
 map.noNextMap = No next map
 
 # {0} = map name
@@ -144,3 +121,27 @@ vote.against = Voted against {0}
 vote.abstain = Removed your vote for {0}
 
 vote.disabled = Voting is disabled
+
+# {0} = player name (who added the map)
+# {1} = map name 
+vote.custom.add = {0} added {1} to the custom vote
+
+# {0} = player name (who removed the map)
+# {1} = map name 
+vote.custom.remove = {0} removed {1} from the custom vote
+
+# {0} = map name
+vote.custom.existing = {0} has already been added to the custom vote
+
+# {0} = player name (who cleared the map selection)
+vote.custom.clear = {0} has cleared the custom vote selection
+
+# {0} = map name
+vote.custom.notFound = {0} could not be removed since it was never added
+
+vote.custom.inProgress = Voting selection can not be modified at this time
+
+vote.custom.limit = Map limit for the custom vote has been reached
+
+vote.custom.list = Selected Maps
+


### PR DESCRIPTION
# Add custom vote management 

This PR adds a new command (`/vote`) which allows for up to 5 custom maps to be added by staff to override the next map vote. 

## Command
`/vote add [map name]` Adds the specified map to the selection
`/vote remove [map name]`Removes specified map from the selection
`/vote clear` Removes all maps that were added
` /vote list` Displays a list of selected maps

## Screenshots:

Command feedback when a map is added or removed from the selection
![Screen Shot 2020-06-22 at 12 16 44 AM](https://user-images.githubusercontent.com/3377659/85261754-7f3f5980-b421-11ea-90a2-328ebbedd198.png)

List format when using `/vote list` ( the first number’s color changes depending on how many maps are in the selection)
![Screen Shot 2020-06-22 at 12 17 40 AM](https://user-images.githubusercontent.com/3377659/85261751-7ea6c300-b421-11ea-9ba2-87aef24e1fda.png)

Command feedback when using `/vote clear` to clear entire selection
![Screen Shot 2020-06-22 at 12 17 00 AM](https://user-images.githubusercontent.com/3377659/85261752-7f3f5980-b421-11ea-9b62-a1e1e3a8f1ae.png)

Error when trying to add maps over the limit (5)
![Screen Shot 2020-06-22 at 12 23 36 AM](https://user-images.githubusercontent.com/3377659/85261750-7e0e2c80-b421-11ea-8692-34e7fb72d959.png)

Example of voting book when custom selection is active and was provided with 3 maps:
![Screen Shot 2020-06-22 at 9 34 44 AM](https://user-images.githubusercontent.com/3377659/85312467-b89cb700-b46b-11ea-96b9-aa9a7658aa4c.png)


## Feedback
I rewrote this command from originally being `/setvote` into `/vote`, allowing for a more organized and standard command structure. If anyone had additional features that would fit the scope of adjusting votes, please let me know!

As always this was tested and should be good to go if no changes are requested 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>