### PR TITLE
Fix vanished name rendering

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
@@ -346,7 +346,7 @@ public class FreezeMatchModule implements MatchModule, Listener {
               "moderation.freeze.broadcast.frozen",
               TextColor.GRAY,
               senderName,
-              freezee.getName(NameStyle.FANCY)),
+              freezee.getName(NameStyle.CONCISE)),
           match);
     }
 
@@ -370,7 +370,7 @@ public class FreezeMatchModule implements MatchModule, Listener {
               "moderation.freeze.broadcast.thaw",
               TextColor.GRAY,
               senderName,
-              freezee.getName(NameStyle.FANCY)),
+              freezee.getName(NameStyle.CONCISE)),
           match);
     }
 

--- a/core/src/main/java/tc/oc/pgm/util/UsernameFormatUtils.java
+++ b/core/src/main/java/tc/oc/pgm/util/UsernameFormatUtils.java
@@ -24,7 +24,7 @@ public class UsernameFormatUtils {
   public static Component formatStaffName(CommandSender sender, Match match) {
     if (sender != null && sender instanceof Player) {
       MatchPlayer matchPlayer = match.getPlayer((Player) sender);
-      if (matchPlayer != null) return matchPlayer.getName(NameStyle.FANCY);
+      if (matchPlayer != null) return matchPlayer.getName(NameStyle.CONCISE);
     }
     return CONSOLE_NAME;
   }

--- a/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
@@ -65,7 +65,7 @@ public interface PlayerComponent {
         builder = formatTeleport(formatColor(player), player.getName());
         break;
       case CONCISE:
-        builder = formatConcise(player);
+        builder = formatConcise(player, false);
         break;
       case FANCY:
         builder = formatFancy(player);
@@ -132,12 +132,12 @@ public interface PlayerComponent {
     return prefix.append(colorName);
   }
 
-  // Color, flair, and vanish status
-  static TextComponent.Builder formatConcise(Player player) {
+  // Color and flair with optional vanish
+  static TextComponent.Builder formatConcise(Player player, boolean vanish) {
     TextComponent.Builder prefix = getPrefixComponent(player);
     TextComponent.Builder colorName = formatColor(player);
 
-    if (isVanished(player)) {
+    if (isVanished(player) && vanish) {
       colorName = formatVanished(colorName);
     }
 
@@ -146,7 +146,7 @@ public interface PlayerComponent {
 
   // Color, flair, vanished, and teleport
   static TextComponent.Builder formatVerbose(Player player) {
-    return formatTeleport(formatConcise(player), player.getName());
+    return formatTeleport(formatConcise(player, true), player.getName());
   }
 
   /**


### PR DESCRIPTION
# Fix vanished name rendering

This PR resolves an issue from the recent redesign of `PlayerComponent` that caused vanished names to be rendered as offline even though the message viewers are those who should bypass it (staff). The solution was to modify the concise name style to allow vanished names to render properly.

## Screenshots
Example of location where staff should see the name rendered as online instead of offline.
![Screen Shot 2020-06-23 at 6 05 30 PM](https://user-images.githubusercontent.com/3377659/85485329-5d5ae980-b57d-11ea-94d4-d26797f12e7a.png)

What it looks like fixed:
![Screen Shot 2020-06-23 at 6 06 03 PM](https://user-images.githubusercontent.com/3377659/85485392-7a8fb800-b57d-11ea-90fd-33d9d487c2d3.png)




Signed-off-by: applenick <applenick@users.noreply.github.com>