### PR TITLE
Start sequential posts from 1

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -242,9 +242,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
       return post;
     }
     if (definition.isSequential()) {
-      if (sequentialPostCounter == definition.getPosts().size()) {
-        sequentialPostCounter = 0;
-      }
+      sequentialPostCounter %= definition.getPosts().size();
       return definition.getPosts().get(sequentialPostCounter++);
     }
     Random random = match.getRandom();

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -234,7 +234,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     }
   }
 
-  private int sequentialPostCounter = 0;
+  private int sequentialPostCounter = 1;
   private Post returnPost;
 
   public Post getReturnPost(Post post) {
@@ -242,11 +242,10 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
       return post;
     }
     if (definition.isSequential()) {
-      Post returnPost = definition.getPosts().get(sequentialPostCounter++);
       if (sequentialPostCounter == definition.getPosts().size()) {
         sequentialPostCounter = 0;
       }
-      return returnPost;
+      return definition.getPosts().get(sequentialPostCounter++);
     }
     Random random = match.getRandom();
     return definition.getPosts().get(random.nextInt(definition.getPosts().size()));


### PR DESCRIPTION
As the default flag post is post 0, we should start from 1 when iterating sequential posts, as otherwise post 0 is duplicated in the sequence.

For three posts A, B, C, the current situation: A -> A -> B -> C -> A -> B -> C -> ...

Starting from 1: A -> B -> C -> A -> B -> C -> ...

Signed-off-by: Ian <46601096+iangbb@users.noreply.github.com>