### PR TITLE
Add Wool Flag Beams

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -43,6 +43,7 @@ import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.fireworks.FireworkMatchModule;
 import tc.oc.pgm.flag.FlagMatchModule;
 import tc.oc.pgm.flag.FlagModule;
+import tc.oc.pgm.flag.LegacyFlagBeamMatchModule;
 import tc.oc.pgm.gamerules.GameRulesMatchModule;
 import tc.oc.pgm.gamerules.GameRulesModule;
 import tc.oc.pgm.goals.GoalMatchModule;
@@ -158,6 +159,9 @@ public interface Modules {
     register(FireworkMatchModule.class, FireworkMatchModule::new);
     register(StatsMatchModule.class, StatsMatchModule::new);
     register(MapmakerMatchModule.class, MapmakerMatchModule::new);
+
+    // Modules that depend help older player versions
+    register(LegacyFlagBeamMatchModule.class, LegacyFlagBeamMatchModule::new);
 
     // Community MatchModules
     register(FreezeMatchModule.class, FreezeMatchModule::new);

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.flag;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -40,11 +41,7 @@ import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.flag.event.FlagCaptureEvent;
 import tc.oc.pgm.flag.event.FlagStateChangeEvent;
-import tc.oc.pgm.flag.state.BaseState;
-import tc.oc.pgm.flag.state.Captured;
-import tc.oc.pgm.flag.state.Completed;
-import tc.oc.pgm.flag.state.Returned;
-import tc.oc.pgm.flag.state.State;
+import tc.oc.pgm.flag.state.*;
 import tc.oc.pgm.goals.TouchableGoal;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalEvent;
@@ -199,6 +196,16 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
 
   public ItemStack getBannerItem() {
     return bannerItem;
+  }
+
+  public BaseState getState() {
+    return state;
+  }
+
+  public Optional<Location> getLocation() {
+    return this.state instanceof Spawned
+        ? Optional.of(((Spawned) state).getLocation())
+        : Optional.empty();
   }
 
   /** Owner is defined in XML, and does not change during a match */

--- a/core/src/main/java/tc/oc/pgm/flag/LegacyFlagBeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/LegacyFlagBeamMatchModule.java
@@ -1,0 +1,254 @@
+package tc.oc.pgm.flag;
+
+import static java.util.stream.IntStream.range;
+
+import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.match.event.MatchStartEvent;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.events.PlayerJoinMatchEvent;
+import tc.oc.pgm.events.PlayerJoinPartyEvent;
+import tc.oc.pgm.events.PlayerLeaveMatchEvent;
+import tc.oc.pgm.flag.event.FlagStateChangeEvent;
+import tc.oc.pgm.flag.state.Carried;
+import tc.oc.pgm.flag.state.Spawned;
+import tc.oc.pgm.util.inventory.ItemBuilder;
+import tc.oc.pgm.util.nms.NMSHacks;
+
+@ListenerScope(MatchScope.LOADED)
+public class LegacyFlagBeamMatchModule implements MatchModule, Listener {
+
+  private static int UPDATE_DELAY = 0;
+  private static int UPDATE_FREQUENCY = 50;
+
+  private UpdateTask task;
+  private final Match match;
+  private final Map<MatchPlayer, Map<Flag, Beam>> beams;
+
+  public LegacyFlagBeamMatchModule(Match match) {
+    this.match = match;
+    this.beams = new HashMap<>();
+  }
+
+  protected Stream<Flag> flags() {
+    FlagMatchModule module = match.getModule(FlagMatchModule.class);
+    return module == null ? Stream.empty() : module.getFlags().stream();
+  }
+
+  protected void retrackFlag(Flag flag) {
+    match.getParticipants().forEach(p -> retrackFlag(flag, p));
+  }
+
+  protected void retrackFlag(Flag flag, MatchPlayer player) {
+    untrackFlag(flag, player);
+    trackFlag(flag, player);
+  }
+
+  protected void trackFlag(Flag flag) {
+    match.getParticipants().forEach(p -> trackFlag(flag, p));
+  }
+
+  protected void trackFlag(Flag flag, MatchPlayer player) {
+    Map<Flag, Beam> flags = beams.containsKey(player) ? beams.get(player) : new HashMap<>();
+    if (flags.containsKey(flag)) {
+      return;
+    }
+
+    flags.put(flag, new Beam(flag, player.getBukkit()));
+
+    beams.put(player, flags);
+  }
+
+  protected void untrackFlag(Flag flag) {
+    match.getParticipants().forEach(p -> untrackFlag(flag, p));
+  }
+
+  protected void untrackFlag(Flag flag, MatchPlayer player) {
+    if (beams.containsKey(player)) {
+      Beam beam = beams.get(player).get(flag);
+      if (beam != null) {
+        beams.get(player).remove(flag).hide();
+      }
+    }
+  }
+
+  @Override
+  public void enable() {
+    flags().filter(flag -> flag.getState() instanceof Spawned).forEach(this::trackFlag);
+    this.task = new UpdateTask();
+  }
+
+  @Override
+  public void disable() {
+    flags().forEach(this::untrackFlag);
+    beams.clear();
+    this.task.stop();
+  }
+
+  // retrackFlags when players join a party so players are able to see the wool beams
+  // player join match event doesn't work at times.
+  @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+  public void onPlayerJoinParty(PlayerJoinPartyEvent event) {
+    flags()
+        .filter(flag -> flag.getState() instanceof Spawned)
+        .forEach(flag -> retrackFlag(flag, event.getPlayer()));
+  }
+
+  // retrackFlags when players switch worlds
+  // player join match event doesn't work at times.
+  @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+  public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+    try {
+      flags()
+          .filter(flag -> flag.getState() instanceof Spawned)
+          .forEach(flag -> retrackFlag(flag, match.getParticipant(event.getPlayer())));
+    } catch (NullPointerException e) {
+      /* ignore */
+    }
+  }
+
+  // retrackFlags when match starts to ensure all players can see flag beams
+  // player join match event doesn't work at times.
+  @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+  public void onMatchStart(MatchStartEvent event) {
+    flags().filter(flag -> flag.getState() instanceof Spawned).forEach(flag -> retrackFlag(flag));
+  }
+
+  @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+  public void onPlayerJoinMatch(PlayerJoinMatchEvent event) {
+    flags()
+        .filter(flag -> flag.getState() instanceof Spawned)
+        .forEach(flag -> trackFlag(flag, event.getPlayer()));
+  }
+
+  @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+  public void onPlayerLeaveMatch(PlayerLeaveMatchEvent event) {
+    flags()
+        .filter(flag -> flag.getState() instanceof Spawned)
+        .forEach(flag -> untrackFlag(flag, event.getPlayer()));
+  }
+
+  @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+  public void onFlagStateChange(FlagStateChangeEvent event) {
+    Flag flag = event.getFlag();
+    untrackFlag(flag);
+    if (event.getNewState() instanceof Spawned) {
+      trackFlag(flag);
+    }
+  }
+
+  private class UpdateTask implements Runnable {
+
+    private final Future<?> task;
+
+    private UpdateTask() {
+      this.task =
+          match
+              .getExecutor(MatchScope.RUNNING)
+              .scheduleAtFixedRate(this, UPDATE_DELAY, UPDATE_FREQUENCY, TimeUnit.MILLISECONDS);
+    }
+
+    public void stop() {
+      this.task.cancel(true);
+    }
+
+    @Override
+    public void run() {
+      ImmutableList.copyOf(beams.values()).forEach(flags -> flags.forEach((f, b) -> b.update()));
+    }
+  }
+
+  class Beam {
+
+    final Flag flag;
+    final Player bukkit;
+    final List<NMSHacks.FakeZombie> segments;
+
+    Beam(Flag flag, Player bukkit) {
+      this.flag = flag;
+      this.bukkit = bukkit;
+      this.segments =
+          range(0, 32)
+              .mapToObj(i -> new NMSHacks.FakeZombie(match.getWorld(), true, false))
+              .collect(Collectors.toList());
+      show();
+    }
+
+    Optional<Player> carrier() {
+      return Optional.ofNullable(
+          flag.getState() instanceof Carried
+              ? ((Carried) flag.getState()).getCarrier().getBukkit()
+              : null);
+    }
+
+    Optional<Location> location() {
+      if (!flag.getLocation().isPresent()) {
+        return Optional.empty();
+      }
+
+      Location location = flag.getLocation().get().clone();
+      location.setPitch(0);
+      return Optional.of(location);
+    }
+
+    ItemStack wool() {
+      return new ItemBuilder()
+          .material(Material.WOOL)
+          .enchant(Enchantment.DURABILITY, 1)
+          .color(flag.getDyeColor())
+          .build();
+    }
+
+    void show() {
+      if (carrier().map(carrier -> carrier.equals(bukkit)).orElse(false)) return;
+      segments.forEach(
+          segment -> {
+            location().ifPresent(l -> segment.spawn(bukkit, l.clone()));
+            segment.wear(bukkit, 4, wool()); // Head slot
+          });
+      range(1, segments.size())
+          .forEachOrdered(
+              i -> {
+                segments.get(i - 1).ride(bukkit, segments.get(i).entity());
+              });
+      update();
+    }
+
+    void update() {
+      Optional<Player> carrier = carrier();
+      NMSHacks.FakeZombie base = segments.get(0);
+      if (carrier.isPresent()) {
+        base.mount(bukkit, carrier.get());
+      } else {
+        base.entity().eject();
+        location().ifPresent(l -> base.teleport(bukkit, l));
+      }
+    }
+
+    void hide() {
+      for (int i = segments.size() - 1; i >= 0; i--) {
+        segments.get(i).destroy(bukkit);
+      }
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -269,6 +269,10 @@ public class Carried extends Spawned implements Missing {
     this.flag.getMatch().callEvent(event);
   }
 
+  public MatchPlayer getCarrier() {
+    return this.carrier;
+  }
+
   protected boolean isCarrier(MatchPlayer player) {
     return this.carrier == player;
   }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/ItemBuilder.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/ItemBuilder.java
@@ -1,12 +1,15 @@
 package tc.oc.pgm.util.inventory;
 
 import java.util.Arrays;
+import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.material.Dye;
 import org.bukkit.material.MaterialData;
+import org.bukkit.material.Wool;
 
 /** A nice way to build {@link ItemStack}s. */
 public class ItemBuilder {
@@ -79,6 +82,26 @@ public class ItemBuilder {
 
   public ItemBuilder enchant(Enchantment enchantment, int level) {
     meta().addEnchant(enchantment, level, true);
+    return this;
+  }
+
+  public ItemBuilder color(DyeColor color) {
+    final Material type = item.getType();
+    switch (type) {
+      case INK_SACK:
+        item.setData(new Dye(color));
+        break;
+
+      case WOOL:
+        item.setData(new Wool(color));
+        break;
+
+      default:
+        // banners/other colored blocks
+        item.setData(new MaterialData(type, color.getWoolData()));
+        break;
+    }
+    item.setDurability(item.getData().getData());
     return this;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -27,6 +27,7 @@ import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.material.MaterialData;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.NameTagVisibility;
+import org.bukkit.util.Vector;
 import tc.oc.pgm.util.reflect.ReflectionUtils;
 
 public interface NMSHacks {
@@ -457,5 +458,114 @@ public interface NMSHacks {
 
   static int getProtocolVersion(Player player) {
     return ((CraftPlayer) player).getHandle().playerConnection.networkManager.protocolVersion;
+  }
+
+  static Packet setPassengerPacket(int riderId, int vehicleId) {
+    return new PacketPlayOutAttachEntity(riderId, vehicleId, false);
+  }
+
+  static Packet entityEquipmentPacket(
+      int entityId, int slot, org.bukkit.inventory.ItemStack armor) {
+    return new PacketPlayOutEntityEquipment(entityId, slot, CraftItemStack.asNMSCopy(armor));
+  }
+
+  interface FakeEntity {
+    int entityId();
+
+    Entity entity();
+
+    void spawn(Player viewer, Location location, org.bukkit.util.Vector velocity);
+
+    default void spawn(Player viewer, Location location) {
+      spawn(viewer, location, new org.bukkit.util.Vector(0, 0, 0));
+    }
+
+    default void destroy(Player viewer) {
+      sendPacket(viewer, destroyEntitiesPacket(entityId()));
+    }
+
+    default void teleport(Player viewer, Location location) {
+      sendPacket(viewer, teleportEntityPacket(entityId(), location));
+    }
+
+    default void ride(Player viewer, Entity rider) {
+      sendPacket(viewer, setPassengerPacket(rider.getEntityId(), entityId()));
+    }
+
+    default void mount(Player viewer, Entity vehicle) {
+      sendPacket(viewer, setPassengerPacket(entityId(), vehicle.getEntityId()));
+    }
+
+    default void wear(Player viewer, int slot, org.bukkit.inventory.ItemStack item) {
+      sendPacket(viewer, entityEquipmentPacket(entityId(), slot, item));
+    }
+  }
+
+  abstract class FakeEntityImpl<T extends net.minecraft.server.v1_8_R3.Entity>
+      implements FakeEntity {
+    protected final T entity;
+
+    protected FakeEntityImpl(T entity) {
+      this.entity = entity;
+    }
+
+    @Override
+    public Entity entity() {
+      return entity.getBukkitEntity();
+    }
+
+    @Override
+    public int entityId() {
+      return entity.getId();
+    }
+  }
+
+  class FakeLivingEntity<T extends EntityLiving> extends FakeEntityImpl<T> {
+
+    protected FakeLivingEntity(T entity) {
+      super(entity);
+    }
+
+    @Override
+    public void spawn(Player viewer, Location location, Vector velocity) {
+      entity.setPositionRotation(
+          location.getX(),
+          location.getY(),
+          location.getZ(),
+          location.getYaw(),
+          location.getPitch());
+      entity.motX = velocity.getX();
+      entity.motY = velocity.getY();
+      entity.motZ = velocity.getZ();
+      sendPacket(viewer, spawnPacket());
+    }
+
+    protected Packet<?> spawnPacket() {
+      return new PacketPlayOutSpawnEntityLiving(entity);
+    }
+  }
+
+  class FakeZombie extends FakeLivingEntity<EntityZombie> {
+
+    public FakeZombie(World world, boolean invisible) {
+      this(world, invisible, false);
+    }
+
+    public FakeZombie(World world, boolean invisible, boolean baby) {
+      super(new EntityZombie(((CraftWorld) world).getHandle()));
+
+      entity.setInvisible(invisible);
+      entity.setBaby(baby);
+      NBTTagCompound tag = entity.getNBTTag();
+      if (tag == null) {
+        tag = new NBTTagCompound();
+      }
+      entity.c(tag);
+      tag.setBoolean("Silent", true);
+      tag.setBoolean("Invulnerable", true);
+      tag.setBoolean("NoGravity", true);
+      tag.setBoolean("NoAI", true);
+      entity.f(tag);
+    }
   }
 }


### PR DESCRIPTION
Adds the `LegacyFlagBeamMatchModule` which renders wool blocks (using fake zombies) over flags so that all players can see the beams. Currently renders wool beams for all player versions for continuity. 

Code originally written by @Electroid [here](https://github.com/StratusNetwork/projectares/commit/52c82a81e7c12722e9c644d526b227dcce373f06#diff-59b90ff90f481d22f799020fdd02c882) and modified by @jasoryeh and @ShinyDialga