### PR TITLE
Rework /vote logic

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
@@ -157,7 +157,7 @@ public class VotingCommand {
 
     Component listMsg =
         TextComponent.builder()
-            .append(TranslatableComponent.of("vote.title.map"))
+            .append(TranslatableComponent.of("vote.title.selection"))
             .append(": (")
             .append(Integer.toString(currentMaps), listNumColor)
             .append("/")

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
@@ -45,13 +45,15 @@ public class MapPoll {
 
   private final WeakReference<Match> match;
   private final Map<MapInfo, Double> mapScores;
+  private final Set<MapInfo> overrides;
   private final int voteSize;
 
   private final Map<MapInfo, Set<UUID>> votes = new HashMap<>();
 
-  MapPoll(Match match, Map<MapInfo, Double> mapScores, int voteSize) {
+  MapPoll(Match match, Map<MapInfo, Double> mapScores, Set<MapInfo> overrides, int voteSize) {
     this.match = new WeakReference<>(match);
     this.mapScores = mapScores;
+    this.overrides = overrides;
     this.voteSize = voteSize;
 
     selectMaps();
@@ -68,7 +70,10 @@ public class MapPoll {
     NavigableMap<Double, MapInfo> cumulativeScores = new TreeMap<>();
     double maxWeight = cummulativeMap(0, sortedDist, cumulativeScores);
 
-    for (int i = 0; i < voteSize; i++) {
+    // Add all override maps before selecting random
+    overrides.forEach(map -> votes.put(map, new HashSet<>()));
+
+    for (int i = overrides.size(); i < voteSize; i++) {
       NavigableMap<Double, MapInfo> subMap =
           cumulativeScores.tailMap(Math.random() * maxWeight, true);
       Map.Entry<Double, MapInfo> selected = subMap.pollFirstEntry();

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -134,3 +134,13 @@ vote.limit = Selection limit for the vote has been reached
 
 vote.title.map = Selected Maps
 
+# {0} = player name (who toggled mode)
+# {1} = mode name
+vote.toggle = {0} toggled vote mode to {1}
+
+vote.mode.replace = Replace
+
+vote.mode.create = Create
+
+vote.mode.hover = Click to toggle vote mode
+

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -132,7 +132,7 @@ vote.remove = {0} removed {1} from the vote
 
 vote.limit = Selection limit for the vote has been reached
 
-vote.title.map = Selected Maps
+vote.title.selection = Selected Maps
 
 # {0} = player name (who toggled mode)
 # {1} = mode name


### PR DESCRIPTION
# Rework /vote logic

This PR started out as a new command (`/vote fill`) but has since removed that command in favor of implementing both a `Replacement` and `Override` selection mode.


## `Replacement`
When vote selection is in the replacement mode, maps added to the selection will replace maps that are provided by the current pool.

Example:
Let’s say we wanted to add three maps to the vote `The Nile`, `Ozone`, and `Sand Wars`. Since three maps are added, two will be provided based on the pool. 

Using `/vote list` (As you can see, there is now an indicator of what mode is active, in this case Replace)
![Screen Shot 2020-07-07 at 11 16 45 AM](https://user-images.githubusercontent.com/3377659/86826206-428c7880-c045-11ea-80fb-066d78d95162.png)

When the vote is ready, you’ll notice that 2 additional maps from the current pool were added. 
![Screen Shot 2020-07-07 at 11 17 06 AM](https://user-images.githubusercontent.com/3377659/86826303-6223a100-c045-11ea-842c-d612fbe5a6eb.png)


## `Create`
Create preserves the current functionality, where the selected maps will be the **only**  maps provided in the poll.

Using `/vote list` again, we can see the three selected maps. Also pictured is the hover message that is displayed over the mode indicator. Note: you can click the status to run `/vote mode` to toggle the mode. 
![Screen Shot 2020-07-07 at 11 20 59 AM](https://user-images.githubusercontent.com/3377659/86826663-e70eba80-c045-11ea-8e3d-e63092281660.png)

When the vote is ready, only the selected maps will be visible. 
![Screen Shot 2020-07-07 at 11 18 30 AM](https://user-images.githubusercontent.com/3377659/86826710-f55cd680-c045-11ea-87a4-7cd20c527e15.png)

Also here is the formatting used when executing `/vote mode` twice.
![Screen Shot 2020-07-07 at 11 20 15 AM](https://user-images.githubusercontent.com/3377659/86826810-0f96b480-c046-11ea-80c3-d134cc4556d6.png)


Signed-off-by: applenick <applenick@users.noreply.github.com>