### PR TITLE
Make changes needed for Ingame & fix cycling bugs

### DIFF
--- a/core/src/main/java/InitiateMatchStartCountdown/InitiateMatchStartCountdown.java
+++ b/core/src/main/java/InitiateMatchStartCountdown/InitiateMatchStartCountdown.java
@@ -1,0 +1,31 @@
+package InitiateMatchStartCountdown;
+
+import java.time.Duration;
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.event.MatchEvent;
+
+public class InitiateMatchStartCountdown extends MatchEvent {
+
+  private final Duration duration;
+
+  public InitiateMatchStartCountdown(Match match, Duration duration) {
+    super(match);
+    this.duration = duration;
+  }
+
+  public Duration duration() {
+    return duration;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/graph/MatchPlayerProvider.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/MatchPlayerProvider.java
@@ -11,7 +11,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.util.text.TextException;
 
-final class MatchPlayerProvider implements BukkitProvider<MatchPlayer> {
+public final class MatchPlayerProvider implements BukkitProvider<MatchPlayer> {
 
   @Override
   public boolean isProvided() {

--- a/core/src/main/java/tc/oc/pgm/command/graph/MatchProvider.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/MatchProvider.java
@@ -9,7 +9,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.util.text.TextException;
 
-final class MatchProvider implements BukkitProvider<Match> {
+public final class MatchProvider implements BukkitProvider<Match> {
 
   @Override
   public boolean isProvided() {

--- a/core/src/main/java/tc/oc/pgm/countdowns/CountdownRunner.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/CountdownRunner.java
@@ -65,7 +65,7 @@ public class CountdownRunner extends BukkitRunnable {
     if (this.task == null && count > 0) {
       this.count = count;
       this.interval = interval;
-      this.start = match.getTick().instant;
+      this.start = Instant.now();
       this.end = this.start.plus(remaining);
       this.secondsRemaining = remaining.getSeconds();
       this.countdown.onStart(remaining, this.getTotalTime());
@@ -81,7 +81,7 @@ public class CountdownRunner extends BukkitRunnable {
       logger.fine("Cancelling countdown " + countdown);
 
       this.stop();
-      Duration remaining = Duration.between(match.getTick().instant, this.end);
+      Duration remaining = Duration.between(Instant.now(), this.end);
       this.countdown.onCancel(
           TimeUtils.isShorterThan(remaining, Duration.ZERO) ? Duration.ZERO : remaining,
           this.getTotalTime());
@@ -117,7 +117,7 @@ public class CountdownRunner extends BukkitRunnable {
     if (this.end == null || this.secondsRemaining < 0) return;
 
     // Get the total ticks remaining in the countdown
-    long ticksRemaining = TimeUtils.toTicks(Duration.between(match.getTick().instant, this.end));
+    long ticksRemaining = TimeUtils.toTicks(Duration.between(Instant.now(), this.end));
 
     // Handle any cycles since the last one
     for (;

--- a/core/src/main/java/tc/oc/pgm/events/CancelMatchStartCountdownEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/CancelMatchStartCountdownEvent.java
@@ -1,0 +1,31 @@
+package tc.oc.pgm.events;
+
+import java.time.Duration;
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.event.MatchEvent;
+
+public class CancelMatchStartCountdownEvent extends MatchEvent {
+
+  private final Duration remaining;
+
+  public CancelMatchStartCountdownEvent(Match match, Duration remaining) {
+    super(match);
+    this.remaining = remaining;
+  }
+
+  public Duration remaining() {
+    return remaining;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
@@ -2,12 +2,15 @@ package tc.oc.pgm.start;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import InitiateMatchStartCountdown.InitiateMatchStartCountdown;
 import java.time.Duration;
 import javax.annotation.Nullable;
 import net.kyori.text.Component;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
+import org.bukkit.Bukkit;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.events.CancelMatchStartCountdownEvent;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.TimeUtils;
@@ -49,11 +52,11 @@ public class StartCountdown extends PreMatchCountdown {
   @Override
   public void onStart(Duration remaining, Duration total) {
     super.onStart(remaining, total);
+    Bukkit.getPluginManager().callEvent(new InitiateMatchStartCountdown(match, remaining));
     this.autoBalanced = false;
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   public void onTick(Duration remaining, Duration total) {
     super.onTick(remaining, total);
 
@@ -81,6 +84,12 @@ public class StartCountdown extends PreMatchCountdown {
         this.getMatch().playSound(COUNT_SOUND);
       }
     }
+  }
+
+  @Override
+  public void onCancel(Duration remaining, Duration total) {
+    super.onCancel(remaining, total);
+    Bukkit.getPluginManager().callEvent(new CancelMatchStartCountdownEvent(match, remaining));
   }
 
   @Override


### PR DESCRIPTION
Ingame is a plugin that manages tournaments and ranked matches. It automatically cycles to matches (even when no players are online hence the changes to CountdownRunner), assigns players to teams and supports customisable vetoes.

Ingame is still a WIP and will be open-sourced in the coming days.

Signed-off-by: William Jeffcock <jeffcockw@gmail.com>