### PR TITLE
Force users to always use JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,28 @@
                     <includeDependencySources>true</includeDependencySources>
                 </configuration>
             </plugin>
+
+            <!-- Make sure people are compiling against the correct JDK -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <!-- Fuzzy match -->
+                                    <version>[${maven.compiler.target},)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Maven source/target compilation configuration options only make a best effort attempt to compile for the specified version and won't always compile working code if libraries from different java versions are used. This forces users to only compile against JDK 8. 