### PR TITLE
Add option to show kill count next to names on death messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -18,6 +18,7 @@ public enum SettingKey {
   CHAT("chat", CHAT_TEAM, CHAT_GLOBAL, CHAT_ADMIN), // Changes the default chat channel
   DEATH(
       Arrays.asList("death", "dms"), DEATH_ALL, DEATH_OWN), // Changes which death messages are seen
+  KILLS("kills", KILL_COUNT_ON, KILL_COUNT_OFF),
   PICKER("picker", PICKER_AUTO, PICKER_ON, PICKER_OFF), // Changes when the picker is displayed
   JOIN(Arrays.asList("join", "jms"), JOIN_ON, JOIN_OFF), // Changes if join messages are seen
   MESSAGE(

--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -21,6 +21,9 @@ public enum SettingValue {
   DEATH_OWN("death", "own"), // Only send death messages involving self
   DEATH_ALL("death", "all"), // Send all death messages, highlight your own
 
+  KILL_COUNT_ON("kills", "on"), // Show the amount of kills a player has in death messages
+  KILL_COUNT_OFF("kills", "off"), // Don't show the amount of kills a player has in death messages
+
   PICKER_AUTO("picker", "auto"), // Display after cycle, or with permissions.
   PICKER_ON("picker", "on"), // Display the picker GUI always
   PICKER_OFF("picker", "off"), // Never display the picker GUI

--- a/core/src/main/java/tc/oc/pgm/death/DeathMessageMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/death/DeathMessageMatchModule.java
@@ -15,6 +15,7 @@ import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
 import tc.oc.pgm.api.setting.SettingKey;
+import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.events.ListenerScope;
 
 @ListenerScope(MatchScope.RUNNING)
@@ -36,9 +37,15 @@ public class DeathMessageMatchModule implements MatchModule, Listener {
     if (!event.getMatch().isRunning()) return;
 
     DeathMessageBuilder builder = new DeathMessageBuilder(event, logger);
-    Component message = builder.getMessage().color(TextColor.GRAY);
-
+    Component baseMessage = builder.getMessage().color(TextColor.GRAY);
+    Component killCountMessage = builder.getMessage(true).color(TextColor.GRAY);
     for (MatchPlayer viewer : event.getMatch().getPlayers()) {
+      Component message;
+      if (viewer.getSettings().getValue(SettingKey.KILLS).equals(SettingValue.KILL_COUNT_ON)) {
+        message = killCountMessage;
+      } else {
+        message = baseMessage;
+      }
       switch (viewer.getSettings().getValue(SettingKey.DEATH)) {
         case DEATH_OWN:
           if (event.isInvolved(viewer)) {

--- a/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/StatsMatchModule.java
@@ -248,4 +248,9 @@ public class StatsMatchModule implements MatchModule, Listener {
     if (hasNoStats(player)) return putNewPlayer(player).getBasicStatsMessage();
     return allPlayerStats.get(player).getBasicStatsMessage();
   }
+
+  public int getPlayerKills(UUID player) {
+    if (hasNoStats(player)) return 0;
+    return allPlayerStats.get(player).kills;
+  }
 }


### PR DESCRIPTION
This is a feature to show a person's kills next to his/her name on death messages. It can be turned off in settings, but defaults to true.
Here is an example:

![2020-07-12_12 25 18](https://user-images.githubusercontent.com/28692086/87251795-5c123380-c43c-11ea-96c1-5f5dcefeb4a2.png)

Notes: 
If the person has `/toggle stats` set to false, then when that person is involved in a death message, his/her kill count is not included in the message for everybody. 
Also, if a person dies to the void/lava/etc. it works correctly. 
Signed-off-by: mrcookie