### PR TITLE
Use correct materials when filtering fluids

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -298,9 +298,24 @@ public class BlockTransformListener implements Listener {
       newState.setType(event.getBlock().getType());
       newState.setRawData(event.getBlock().getData());
 
+      // When lava flows into water, it creates stone or cobblestone
+      if (isWater(oldState.getMaterial()) && isLava(newState.getMaterial())) {
+        newState.setMaterial(
+            event.getFace() == BlockFace.DOWN ? Material.STONE : Material.COBBLESTONE);
+        newState.setRawData((byte) 0);
+      }
+
       // Check for lava ownership
       this.callEvent(event, oldState, newState, Trackers.getOwner(event.getBlock()));
     }
+  }
+
+  private boolean isWater(Material material) {
+    return material == Material.WATER || material == Material.STATIONARY_WATER;
+  }
+
+  private boolean isLava(Material material) {
+    return material == Material.LAVA || material == Material.STATIONARY_LAVA;
   }
 
   @EventWrapper


### PR DESCRIPTION
Currently, if you wanted to prevent a cobblestone  generator, you would need to filter preventing certain blockstates of lava being created, this is annoying and buggy since those states may be used in certain flows.
This makes it so you're able to deny stone/cobble being placed and it prevents "cobblestone generator" behaviour