### PR TITLE
Update running instructions

### DIFF
--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -13,14 +13,14 @@ cd /path/to/folder
 
 2. Download the latest version of [SportPaper](https://github.com/Electroid/SportPaper), a fork of the Minecraft 1.8 server.
 ```bash
-curl https://pkg.ashcon.app/sportpaper -Lo sportpaper.jar
+curl https://github.com/PGMDev/PGM/releases/download/v0.8/SportPaper.jar -Lo sportpaper.jar
 curl https://pkg.ashcon.app/sportpaper-config -Lo sportpaper.yml
 ```
 
 3. Create a plugins folder and download the latest version of PGM.
 ```bash
 mkdir plugins
-curl https://pkg.ashcon.app/pgm -Lo plugins/pgm.jar
+curl https://github.com/PGMDev/PGM/releases/download/v0.8/PGM.jar -Lo plugins/pgm.jar
 ```
 
 4. Run the server and enjoy playing PvP games with your friends!

--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -14,7 +14,7 @@ cd /path/to/folder
 2. Download the latest version of [SportPaper](https://github.com/Electroid/SportPaper), a fork of the Minecraft 1.8 server.
 ```bash
 curl https://github.com/PGMDev/PGM/releases/download/v0.8/SportPaper.jar -Lo sportpaper.jar
-curl https://pkg.ashcon.app/sportpaper-config -Lo sportpaper.yml
+curl https://raw.githubusercontent.com/PGMDev/PGM/dev/server/src/main/jib/server/sportpaper.yml -Lo sportpaper.yml
 ```
 
 3. Create a plugins folder and download the latest version of PGM.


### PR DESCRIPTION
The current running instructions gives you very old SportPaper and PGM versions, and the `sportpaper.yml` 404's.

This PR "fixes" that but it's not optimal since it's "hardcoding" v0.8, and would become outdated when a new version is released. But it's better than how it is currently.