### PR TITLE
Prevent empty repo from cloning default maps

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -128,33 +128,7 @@ public final class PGMConfig implements Config {
     }
 
     for (Map<?, ?> repository : repositories) {
-      final URI uri = parseUri(String.valueOf(repository.get("uri")));
-
-      String branch = String.valueOf(repository.get("branch"));
-      if (branch.isEmpty() || branch.equals("null")) {
-        branch = null;
-      }
-
-      String path = String.valueOf(repository.get("path"));
-      final File folder;
-      if (path.isEmpty() || path.equals("null")) {
-        folder =
-            new File(
-                "maps", (uri.getHost() + uri.getPath()).replaceAll("[/._]", "-").toLowerCase());
-      } else {
-        folder = new File(path);
-      }
-
-      this.mapSourceFactories.add(new GitMapSourceFactory(folder, uri, branch));
-
-      final Object subFolders = repository.get("folders");
-      if (subFolders instanceof List) {
-        for (Object subFolder : (List) subFolders) {
-          folders.add(new File(folder, subFolder.toString()).getAbsolutePath());
-        }
-      } else {
-        folders.add(folder.getAbsolutePath());
-      }
+      registerRemoteMapSource(mapSourceFactories, repository);
     }
 
     for (String folder : folders) {
@@ -211,6 +185,46 @@ public final class PGMConfig implements Config {
     this.experiments = experiments == null ? ImmutableMap.of() : experiments.getValues(false);
   }
 
+  public static final Map<?, ?> DEFAULT_REMOTE_REPO =
+      ImmutableMap.of("uri", "https://github.com/PGMDev/Maps", "path", "default-maps");
+
+  public static void registerRemoteMapSource(
+      List<MapSourceFactory> mapSources, Map<?, ?> repository) {
+    final URI uri = parseUri(String.valueOf(repository.get("uri")));
+
+    String branch = String.valueOf(repository.get("branch"));
+    if (branch.isEmpty() || branch.equals("null")) {
+      branch = null;
+    }
+
+    String path = String.valueOf(repository.get("path"));
+    final File folder;
+    if (path.isEmpty() || path.equals("null")) {
+      folder =
+          new File("maps", (uri.getHost() + uri.getPath()).replaceAll("[/._]", "-").toLowerCase());
+    } else {
+      folder = new File(path);
+    }
+
+    mapSources.add(new GitMapSourceFactory(folder, uri, branch));
+
+    TreeSet<File> folders = new TreeSet<>();
+    final Object subFolders = repository.get("folders");
+    if (subFolders instanceof List) {
+      for (Object subFolder : (List) subFolders) {
+        folders.add(new File(folder, subFolder.toString()));
+      }
+    } else {
+      folders.add(folder);
+    }
+
+    for (File folderFile : folders) {
+      mapSources.add(
+          new SystemMapSourceFactory(
+              folderFile.isAbsolute() ? folderFile : folderFile.getAbsoluteFile()));
+    }
+  }
+
   // TODO: Can be removed after 1.0 release
   private static void handleLegacyConfig(FileConfiguration config, File dataFolder) {
     // v0.9 uses map.folders instead of map.sources
@@ -218,10 +232,7 @@ public final class PGMConfig implements Config {
       renameKey(config, "map.sources", "map.folders");
 
       if (config.getStringList("map.folders").contains("default")) {
-        config.set(
-            "map.repositories",
-            ImmutableList.of(
-                ImmutableMap.of("uri", "https://github.com/PGMDev/Maps", "path", "default-maps")));
+        config.set("map.repositories", ImmutableList.of(DEFAULT_REMOTE_REPO));
       }
 
       try {

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -156,8 +156,17 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     }
 
     if (!mapLibrary.getMaps().hasNext()) {
-      getServer().getPluginManager().disablePlugin(this);
-      return;
+      PGMConfig.registerRemoteMapSource(mapSourceFactories, PGMConfig.DEFAULT_REMOTE_REPO);
+      try {
+        mapLibrary.loadNewMaps(false).get(30, TimeUnit.SECONDS);
+      } catch (ExecutionException | InterruptedException | TimeoutException e) {
+        e.printStackTrace();
+      } finally {
+        if (!mapLibrary.getMaps().hasNext()) {
+          getServer().getPluginManager().disablePlugin(this);
+          return;
+        }
+      }
     }
 
     if (config.getMapPoolFile() == null) {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -25,9 +25,9 @@ map:
     #    folders:
     #    - "tournament"
     #
-    # To disable the default maps, remove the repository below.
-    - uri: "https://github.com/PGMDev/Maps"
-      path: "maps-default"
+    # To enable the default maps, uncomment the repository below.
+    # - uri: "https://github.com/PGMDev/Maps"
+    #  path: "maps-default"
 
   # A path to a map pools file, or empty to disable map pools.
   pools: "map-pools.yml"


### PR DESCRIPTION
# Prevent empty repo from cloning default maps when disabled
Resolves #574 
Please see my comment under the original issues for the cause and explanation.

## Solution
 I moved some logic around in `PGMConfig` to accommodate registering the default repo when no maps are found. This prevents users from starting the server with 0 maps (providing a good user experience), also allows the fix to work as intended. This was the best solution I could think of that resulted in the least amount of changes, if there are any suggestions on how to improve this please let me know 😄 

As always this was tested and no bugs were found as far as I could tell 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>