### PR TITLE
Allow customization of tablist footer

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -88,6 +88,10 @@ public final class PGMConfig implements Config {
   private final Component header;
   private final Component footer;
 
+  // tablist.*
+  private final Component rightTablistText;
+  private final Component leftTablistText;
+
   // community.*
   private final boolean communityMode;
 
@@ -172,6 +176,11 @@ public final class PGMConfig implements Config {
     this.header = header == null || header.isEmpty() ? null : parseComponent(header);
     final String footer = config.getString("sidebar.footer");
     this.footer = footer == null || footer.isEmpty() ? null : parseComponent(footer);
+    final String leftText = config.getString("tablist.left");
+    this.leftTablistText = leftText == null || leftText.isEmpty() ? null : parseComponent(leftText);
+    final String rightText = config.getString("tablist.right");
+    this.rightTablistText =
+        rightText == null || rightText.isEmpty() ? null : parseComponent(rightText);
 
     this.communityMode = parseBoolean(config.getString("community.enabled", "true"));
 
@@ -508,6 +517,16 @@ public final class PGMConfig implements Config {
   @Override
   public Component getMatchFooter() {
     return footer;
+  }
+
+  @Override
+  public Component getLeftTablistText() {
+    return leftTablistText;
+  }
+
+  @Override
+  public Component getRightTablistText() {
+    return rightTablistText;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -161,6 +161,22 @@ public interface Config {
   Component getMatchFooter();
 
   /**
+   * Gets the left side text for the Tablist.
+   *
+   * @return The left side component, or null for none.
+   */
+  @Nullable
+  Component getLeftTablistText();
+
+  /**
+   * Gets the right side text for the Tablist.
+   *
+   * @return The right side component, or null for none.
+   */
+  @Nullable
+  Component getRightTablistText();
+
+  /**
    * Gets whether the tab list is rendered.
    *
    * @return If the tab list is rendered.

--- a/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
@@ -3,10 +3,12 @@ package tc.oc.pgm.tablist;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
 import net.md_5.bungee.api.chat.BaseComponent;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -60,12 +62,25 @@ public class MatchFooterTabEntry extends DynamicTabEntry {
       content.append("\n");
     }
 
+    final Component leftContent = PGM.get().getConfiguration().getLeftTablistText();
+    final Component rightContent = PGM.get().getConfiguration().getRightTablistText();
+
+    if (leftContent != null) {
+      content.append(leftContent.colorIfAbsent(TextColor.WHITE)).append(" - ", TextColor.DARK_GRAY);
+    }
+
     content
         .append(TranslatableComponent.of("match.info.time", TextColor.GRAY))
         .append(": ", TextColor.GRAY)
         .append(
             TimeUtils.formatDuration(match.getDuration()),
             this.match.isRunning() ? TextColor.GREEN : TextColor.GOLD);
+
+    if (rightContent != null) {
+      content
+          .append(" - ", TextColor.DARK_GRAY)
+          .append(rightContent.colorIfAbsent(TextColor.WHITE));
+    }
 
     return TextTranslations.toBaseComponent(
         content.colorIfAbsent(TextColor.DARK_GRAY).build(), view.getViewer());

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -78,6 +78,13 @@ ui:
 sidebar:
   header: "" # A header, disabled if empty.
   footer: "" # A footer, disabled if empty.
+  
+# Customize text displayed in the footer of the tablist.
+# Color codes can be used ex. "&aHello World"  
+# To disable, set to an empty string.
+tablist:
+  left: ""
+  right: ""
 
 # Overrides the server MoTD.
 #


### PR DESCRIPTION
# Custom Tablist Footer

Resolves #573 

New config section:
```yaml
tablist:
  left: ""
  right: ""

```
## Screenshots
Example of footer shown with additional stats
![footer-match](https://user-images.githubusercontent.com/3377659/88989660-f96cc480-d290-11ea-83c9-67396f49e170.png)

Example of footer shown as an observer
![footer-hello-world](https://user-images.githubusercontent.com/3377659/88989710-17d2c000-d291-11ea-98f4-1f40abcf00ca.png)



Signed-off-by: applenick <applenick@users.noreply.github.com>