### PR TITLE
Add leak completion to cores

### DIFF
--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -8,34 +8,42 @@ import javax.annotation.Nullable;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.material.MaterialData;
 import org.bukkit.util.Vector;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayerState;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.goals.Contribution;
+import tc.oc.pgm.goals.IncrementalGoal;
 import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.TouchableGoal;
 import tc.oc.pgm.modes.ModeUtils;
 import tc.oc.pgm.regions.CuboidRegion;
 import tc.oc.pgm.regions.FiniteBlockRegion;
 import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.material.matcher.SingleMaterialMatcher;
 import tc.oc.pgm.util.named.NameStyle;
 
 // TODO: Consider making Core extend Destroyable
-public class Core extends TouchableGoal<CoreFactory> implements ModeChangeGoal<CoreFactory> {
+public class Core extends TouchableGoal<CoreFactory>
+    implements IncrementalGoal<CoreFactory>, ModeChangeGoal<CoreFactory> {
 
   protected final FiniteBlockRegion casingRegion;
   protected final FiniteBlockRegion lavaRegion;
   protected final Region leakRegion;
+  protected final int leakRequired;
 
   protected MaterialData material;
+  protected int leak = 0;
   protected boolean leaked = false;
   protected Iterable<Location> proximityLocations;
 
@@ -74,6 +82,8 @@ public class Core extends TouchableGoal<CoreFactory> implements ModeChangeGoal<C
     Vector max = region.getBounds().getMax().add(new Vector(15, 0, 15));
     max.setY(region.getBounds().getMin().getY() - definition.getLeakLevel());
     this.leakRegion = new CuboidRegion(min, max);
+
+    this.leakRequired = lavaRegion.getBounds().getMin().getBlockY() - max.getBlockY() + 1;
   }
 
   // Remove @Nullable
@@ -137,6 +147,15 @@ public class Core extends TouchableGoal<CoreFactory> implements ModeChangeGoal<C
     return this.leakRegion;
   }
 
+  public boolean updateLeak(int yLevel) {
+    int newLeak = Math.min(lavaRegion.getBounds().getMin().getBlockY() - yLevel, leakRequired);
+    if (newLeak > this.leak) {
+      this.leak = newLeak;
+      return true;
+    }
+    return false;
+  }
+
   public void markLeaked() {
     this.leaked = true;
   }
@@ -168,6 +187,43 @@ public class Core extends TouchableGoal<CoreFactory> implements ModeChangeGoal<C
   @Override
   public boolean isAffectedByModeChanges() {
     return this.definition.hasModeChanges();
+  }
+
+  @Override
+  public boolean getShowProgress() {
+    return this.definition.getShowProgress();
+  }
+
+  @Override
+  public double getCompletion() {
+    return (double) this.leak / this.leakRequired;
+  }
+
+  @Override
+  public String renderCompletion() {
+    return StringUtils.percentage(this.getCompletion());
+  }
+
+  @Nullable
+  @Override
+  public String renderPreciseCompletion() {
+    return this.leak + "/" + this.leakRequired;
+  }
+
+  @Override
+  public String renderSidebarStatusText(@Nullable Competitor competitor, Party viewer) {
+    if (this.getShowProgress() || viewer.isObserving()) {
+      String text = this.renderCompletion();
+      if (PGM.get().getConfiguration().showProximity()) {
+        String precise = this.renderPreciseCompletion();
+        if (precise != null) {
+          text += " " + ChatColor.GRAY + precise;
+        }
+      }
+      return text;
+    } else {
+      return super.renderSidebarStatusText(competitor, viewer);
+    }
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
@@ -14,6 +14,7 @@ public class CoreFactory extends ProximityGoalDefinition {
   protected final MaterialData material;
   protected final int leakLevel;
   protected final boolean modeChanges;
+  protected final boolean showProgress;
 
   public CoreFactory(
       @Nullable String id,
@@ -25,13 +26,15 @@ public class CoreFactory extends ProximityGoalDefinition {
       Region region,
       MaterialData material,
       int leakLevel,
-      boolean modeChanges) {
+      boolean modeChanges,
+      boolean showProgress) {
 
     super(id, name, required, visible, owner, proximityMetric);
     this.region = region;
     this.material = material;
     this.leakLevel = leakLevel;
     this.modeChanges = modeChanges;
+    this.showProgress = showProgress;
   }
 
   public Region getRegion() {
@@ -48,5 +51,9 @@ public class CoreFactory extends ProximityGoalDefinition {
 
   public boolean hasModeChanges() {
     return this.modeChanges;
+  }
+
+  public boolean getShowProgress() {
+    return this.showProgress;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -116,6 +116,7 @@ public class CoreModule implements MapModule {
         }
 
         boolean modeChanges = XMLUtils.parseBoolean(coreEl.getAttribute("mode-changes"), false);
+        boolean showProgress = XMLUtils.parseBoolean(coreEl.getAttribute("show-progress"), false);
         boolean visible = XMLUtils.parseBoolean(coreEl.getAttribute("show"), true);
         Boolean required = XMLUtils.parseBoolean(coreEl.getAttribute("required"), null);
         ProximityMetric proximityMetric =
@@ -133,7 +134,8 @@ public class CoreModule implements MapModule {
                 region,
                 material,
                 leakLevel,
-                modeChanges);
+                modeChanges,
+                showProgress);
         context.getFeatures().addFeature(coreEl, factory);
         coreFactories.add(factory);
       }

--- a/util/src/main/java/tc/oc/pgm/util/LegacyFormatUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/LegacyFormatUtils.java
@@ -572,6 +572,7 @@ public final class LegacyFormatUtils {
     for (int i = 0; i < chars.length; i++) {
       switch (chars[i]) {
         case '.':
+        case ',': // Some locales will use , as the decimal separator
           chars[i] = '\u2024';
           break;
         default:


### PR DESCRIPTION
The description says it all, now cores will no longer be just a touch scoring as 50% of an objective, instead, they will have a % of completion based on how far down the lava flows.
The amount required to flow is from the lowest lava block in the core, to the y level of the leak, wich is the bottom of the core region - leak distance, and the one extra block for the actual leak