### PR TITLE
Restore /recycle and /cycle [map]

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
@@ -1,11 +1,14 @@
 package tc.oc.pgm.command;
 
 import app.ashcon.intake.Command;
+import app.ashcon.intake.parametric.annotation.Default;
 import app.ashcon.intake.parametric.annotation.Switch;
 import java.time.Duration;
 import javax.annotation.Nullable;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.cycle.CycleMatchModule;
 import tc.oc.pgm.util.text.TextException;
@@ -18,13 +21,37 @@ public final class CycleCommand {
       flags = "f",
       perms = Permissions.START)
   public void cycle(
-      Match match, Config config, @Nullable Duration duration, @Switch('f') boolean force) {
+      Match match,
+      Config config,
+      MapOrder mapOrder,
+      @Nullable Duration duration,
+      @Default("next") MapInfo map,
+      @Switch('f') boolean force) {
     if (match.isRunning() && !force) {
       throw TextException.of("admin.matchRunning.cycle");
+    }
+
+    if (map != null && mapOrder.getNextMap() != map) {
+      mapOrder.setNextMap(map);
     }
 
     match
         .needModule(CycleMatchModule.class)
         .startCountdown(duration == null ? config.getCycleTime() : duration);
+  }
+
+  @Command(
+      aliases = {"recycle", "rematch"},
+      desc = "Reload (cycle to) the current map",
+      usage = "[seconds]",
+      flags = "f",
+      perms = Permissions.START)
+  public void recycle(
+      Match match,
+      Config config,
+      MapOrder mapOrder,
+      @Nullable Duration duration,
+      @Switch('f') boolean force) {
+    cycle(match, config, mapOrder, duration, match.getMap(), force);
   }
 }


### PR DESCRIPTION
# Restore /recycle and /cycle [map]

Resolves #532 

Made possible by @Pablete1234’s solution for Electroid/Intake#24 and related PR Electroid/Intake#25
Note: mentioned Intake PR must be approved before this one for this to work 😄 

Once approved this PR will restore the `/recycle [duration]` and `/cycle [duration] [map]` commands to their former functionality. 


## Screenshots
Example of using cycle command with a target map
![cycle](https://user-images.githubusercontent.com/3377659/89078329-1066f180-d339-11ea-8bbd-0e4ab6b2b308.gif)

Example of recycle command
![recycle](https://user-images.githubusercontent.com/3377659/89078336-13fa7880-d339-11ea-9e3f-bb3498541ee7.gif)


Signed-off-by: applenick <applenick@users.noreply.github.com>