### PR TITLE
Fix author name NPE on 1.7 tablist

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/LegacyMatchTabDisplay.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/LegacyMatchTabDisplay.java
@@ -186,6 +186,7 @@ public class LegacyMatchTabDisplay implements Listener {
     // If there is exactly one map author, show their name in the top middle slot.
     // Multiple names will surely not fit, so showing none of them is the only fair thing.
     if (mapInfo.getAuthors().size() == 1) {
+      String author = mapInfo.getAuthors().iterator().next().getNameLegacy();
       this.tabDisplay.set(
           bukkit,
           1,
@@ -194,8 +195,10 @@ public class LegacyMatchTabDisplay implements Listener {
               TranslatableComponent.of(
                   "misc.by",
                   TextColor.DARK_GRAY,
-                  TextComponent.of(
-                      mapInfo.getAuthors().iterator().next().getNameLegacy(), TextColor.GRAY)),
+                  (author == null)
+                      ? TranslatableComponent.of(
+                          "misc.unknown", TextColor.GRAY, TextDecoration.ITALIC)
+                      : TextComponent.of(author, TextColor.GRAY)),
               bukkit));
     } else {
       this.tabDisplay.set(


### PR DESCRIPTION
For maps with a single author, if the author's data hasn't been loaded from the database or Mojang API when the legacy tablist is rendered, the text library throws an exception as the author's legacy name is null. This causes the tablist to stop updating.

If the legacy name is null, this will show an italicised 'Unknown', similar to the modern tablist.

Next time the tablist renders, the author's name should appear as normal, as it will have been loaded.

Signed-off-by: Ian <46601096+iangbb@users.noreply.github.com>