### PR TITLE
Add option to show ping in tablist

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -79,6 +79,7 @@ public final class PGMConfig implements Config {
   // ui.*
   private final boolean showSideBar;
   private final boolean showTabList;
+  private final boolean showTabListPing;
   private final boolean showProximity;
   private final boolean showFireworks;
   private final boolean participantsSeeObservers;
@@ -163,6 +164,7 @@ public final class PGMConfig implements Config {
     this.showProximity = parseBoolean(config.getString("ui.proximity", "false"));
     this.showSideBar = parseBoolean(config.getString("ui.sidebar", "true"));
     this.showTabList = parseBoolean(config.getString("ui.tablist", "true"));
+    this.showTabListPing = parseBoolean(config.getString("ui.ping", "true"));
     this.participantsSeeObservers =
         parseBoolean(config.getString("ui.participants-see-observers", "true"));
     this.showFireworks = parseBoolean(config.getString("ui.fireworks", "true"));
@@ -511,6 +513,11 @@ public final class PGMConfig implements Config {
   @Override
   public boolean showTabList() {
     return showTabList;
+  }
+
+  @Override
+  public boolean showTabListPing() {
+    return showTabListPing;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -168,6 +168,13 @@ public interface Config {
   boolean showTabList();
 
   /**
+   * Gets whether the tab list is should show real ping.
+   *
+   * @return If the tab list should show real ping.
+   */
+  boolean showTabListPing();
+
+  /**
    * Gets whether observers are shown to participants in the tab list.
    *
    * @return If observers should be visible to participants.

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -69,6 +69,7 @@ gameplay:
 ui:
   sidebar: true    # Enable the side bar?
   tablist: true    # Enable the tab list?
+  ping: false      # Should tab list show real ping?
   proximity: false # Should the proximity of objectives be visible?
   fireworks: true  # Spawn fireworks after objectives are completed?
   participants-see-observers: true # Can participants see observers in the tab list?

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -92,6 +92,11 @@ public interface NMSHacks {
     return playerListPacketData(packet, uuid, null, null, 0, null);
   }
 
+  static PacketPlayOutPlayerInfo.PlayerInfoData playerListPacketData(
+      PacketPlayOutPlayerInfo packet, UUID uuid, int ping) {
+    return playerListPacketData(packet, uuid, uuid.toString().substring(0, 16), null, ping, null);
+  }
+
   static Packet teamPacket(
       int operation,
       String name,
@@ -477,5 +482,9 @@ public interface NMSHacks {
 
   static int getProtocolVersion(Player player) {
     return ((CraftPlayer) player).getHandle().playerConnection.networkManager.protocolVersion;
+  }
+
+  static int getPing(Player player) {
+    return ((CraftPlayer) player).getHandle().ping;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/tablist/PlayerTabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/PlayerTabEntry.java
@@ -20,6 +20,12 @@ import tc.oc.pgm.util.text.types.PlayerComponent;
  */
 public class PlayerTabEntry extends DynamicTabEntry {
 
+  private static boolean showPing = false;
+
+  public static void setShowRealPing(boolean showPing) {
+    PlayerTabEntry.showPing = showPing;
+  }
+
   private static UUID randomUUIDVersion2SameDefaultSkin(UUID original) {
     // Parity of UUID.hashCode determines if the player's default skin is Steve/Alex
     // To make the player list match, we generate a random UUID with the same hashCode parity.
@@ -63,6 +69,12 @@ public class PlayerTabEntry extends DynamicTabEntry {
   @Override
   public @Nullable Skin getSkin(TabView view) {
     return this.player.getSkin();
+  }
+
+  @Override
+  public int getPing() {
+    if (showPing) return NMSHacks.getPing(this.player);
+    return super.getPing();
   }
 
   // Dispatched by TabManager

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabManager.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabManager.java
@@ -43,7 +43,7 @@ public class TabManager implements Listener {
   protected final Plugin plugin;
   final DefaultMapAdapter<Player, TabView> enabledViews;
 
-  final DefaultMapAdapter<Player, TabEntry> playerEntries;
+  protected final DefaultMapAdapter<Player, TabEntry> playerEntries;
   final Map<Integer, TabEntry> blankEntries =
       new DefaultMapAdapter<Integer, TabEntry>(key -> new BlankTabEntry(), true);
 

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
@@ -17,6 +17,7 @@ public class TabRender {
   private final PacketPlayOutPlayerInfo removePacket;
   private final PacketPlayOutPlayerInfo addPacket;
   private final PacketPlayOutPlayerInfo updatePacket;
+  private final PacketPlayOutPlayerInfo updatePingPacket;
   private final List<Packet> deferredPackets;
 
   public TabRender(TabView view) {
@@ -29,6 +30,8 @@ public class TabRender {
     this.updatePacket =
         this.createPlayerInfoPacket(
             PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
+    this.updatePingPacket =
+        this.createPlayerInfoPacket(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_LATENCY);
     this.deferredPackets = new ArrayList<>();
   }
 
@@ -96,6 +99,7 @@ public class TabRender {
     if (!this.removePacket.b.isEmpty()) this.send(this.removePacket);
     if (!this.addPacket.b.isEmpty()) this.send(this.addPacket);
     if (!this.updatePacket.b.isEmpty()) this.send(this.updatePacket);
+    if (!this.updatePingPacket.b.isEmpty()) this.send(this.updatePingPacket);
 
     for (Packet packet : this.deferredPackets) {
       this.send(packet);
@@ -145,6 +149,8 @@ public class TabRender {
     this.updatePacket.b.add(
         NMSHacks.playerListPacketData(
             this.updatePacket, entry.getId(), this.getContent(entry, index)));
+    this.updatePingPacket.b.add(
+        NMSHacks.playerListPacketData(this.updatePingPacket, entry.getId(), entry.getPing()));
   }
 
   public void setHeaderFooter(TabEntry header, TabEntry footer) {


### PR DESCRIPTION
Adds a config option to enable displaying real players' ping on the tablist, will not work on the 1.7 legacy tablist and there are no plans to ever port it there