### PR TITLE
Mitigate client autocompletion being flooded by tab entries

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -84,7 +84,7 @@ public interface NMSHacks {
   static PacketPlayOutPlayerInfo.PlayerInfoData playerListPacketData(
       PacketPlayOutPlayerInfo packet, UUID uuid, BaseComponent... displayName) {
     return playerListPacketData(
-        packet, uuid, uuid.toString().substring(0, 16), null, 0, null, displayName);
+        packet, uuid, "|" + uuid.toString().substring(0, 15), null, 0, null, displayName);
   }
 
   static PacketPlayOutPlayerInfo.PlayerInfoData playerListPacketData(

--- a/util/src/main/java/tc/oc/pgm/util/tablist/SimpleTabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/SimpleTabEntry.java
@@ -27,7 +27,8 @@ public abstract class SimpleTabEntry implements TabEntry {
     this.uuid = uuid;
 
     String name = this.uuid.toString();
-    this.name = name.substring(name.length() - 16); // Use last 16 chars, most likely to be unique
+    // Use a | and the last 15 chars, most likely to be unique, and appear sorted at the end
+    this.name = "|" + name.substring(name.length() - 15);
   }
 
   protected SimpleTabEntry() {


### PR DESCRIPTION
Solves #416 , basically appends a `|` character before the fake names, wich makes them sort always on the bottom
![image](https://user-images.githubusercontent.com/11789291/89117793-e7fa0700-d4a0-11ea-86a4-ce097676c0f5.png)
