### PR TITLE
Prevent match scheduler being used when match is unloaded

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
@@ -30,7 +30,7 @@ public class MatchFooterTabEntry extends DynamicTabEntry {
   @Override
   public void addToView(TabView view) {
     super.addToView(view);
-    if (this.tickTask == null) {
+    if (this.tickTask == null && match.isLoaded()) {
       Runnable tick = MatchFooterTabEntry.this::invalidate;
       this.tickTask =
           match


### PR DESCRIPTION
This is a major issue, i am unsure under what case this occurs, but it will completely break the tab:

```
java.util.concurrent.RejectedExecutionException
       at tc.oc.pgm.util.concurrent.TaskExecutorService$Task.<init>(TaskExecutorService.java:191)
       at tc.oc.pgm.util.concurrent.TaskExecutorService$Task.<init>(TaskExecutorService.java:209)
       at tc.oc.pgm.util.concurrent.TaskExecutorService$Task.<init>(TaskExecutorService.java:184)
       at tc.oc.pgm.util.concurrent.TaskExecutorService.scheduleWithFixedDelay(TaskExecutorService.java:127)
       at tc.oc.pgm.tablist.MatchFooterTabEntry.addToView(MatchFooterTabEntry.java:40)
       at tc.oc.pgm.util.tablist.TabView.setSlot(TabView.java:154)
       at tc.oc.pgm.util.tablist.TabView.setFooter(TabView.java:176)
       at tc.oc.pgm.tablist.MatchTabView.render(MatchTabView.java:107)
       at tc.oc.pgm.util.tablist.TabManager.render(TabManager.java:109)
       at tc.oc.pgm.tablist.MatchTabManager$1.run(MatchTabManager.java:89)
       at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
       at tc.oc.pgm.util.concurrent.TaskExecutorService$Task.run(TaskExecutorService.java:228)
       at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:64)
       at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:412)
       at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:893)
       at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:365)
       at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:823)
       at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:724)
       at java.lang.Thread.run(Thread.java:748)
```
The execution is rejected because the match was no longer loaded
