### PR TITLE
Fix several tablist issues

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -72,6 +72,7 @@ public class MatchPlayerImpl implements MatchPlayer, PlayerAudience, Comparable<
   private final AtomicBoolean frozen;
   private final AtomicBoolean dead;
   private final AtomicBoolean visible;
+  private final AtomicBoolean protocolReady;
   private final AtomicInteger protocolVersion;
   private final AtomicBoolean vanished;
 
@@ -88,6 +89,7 @@ public class MatchPlayerImpl implements MatchPlayer, PlayerAudience, Comparable<
     this.dead = new AtomicBoolean(false);
     this.visible = new AtomicBoolean(false);
     this.vanished = new AtomicBoolean(false);
+    this.protocolReady = new AtomicBoolean(ViaUtils.isReady(player));
     this.protocolVersion = new AtomicInteger(ViaUtils.getProtocolVersion(player));
   }
 
@@ -378,6 +380,10 @@ public class MatchPlayerImpl implements MatchPlayer, PlayerAudience, Comparable<
 
   @Override
   public int getProtocolVersion() {
+    if (!protocolReady.get()) {
+      protocolReady.set(ViaUtils.isReady(getBukkit()));
+      protocolVersion.set(ViaUtils.getProtocolVersion(getBukkit()));
+    }
     return protocolVersion.get();
   }
 

--- a/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
@@ -56,9 +56,10 @@ public class MatchFooterTabEntry extends DynamicTabEntry {
 
     MatchPlayer viewer = match.getPlayer(view.getViewer());
 
-    if (viewer.getCompetitor() != null
+    if (viewer != null
+        && viewer.isParticipating()
         && viewer.getSettings().getValue(SettingKey.STATS).equals(SettingValue.STATS_ON)) {
-      content.append(match.getModule(StatsMatchModule.class).getBasicStatsMessage(viewer.getId()));
+      content.append(match.needModule(StatsMatchModule.class).getBasicStatsMessage(viewer.getId()));
       content.append("\n");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>us.myles</groupId>
             <artifactId>viaversion</artifactId>
-            <version>2.2.2</version>
+            <version>3.0.2-SNAPSHOT</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
@@ -42,6 +42,10 @@ public class ViaUtils {
     }
   }
 
+  public static boolean isReady(Player player) {
+    return !enabled() || Via.getAPI().isInjected(player.getUniqueId());
+  }
+
   public static BossBar<?> createBossBar() {
     return enabled() ? Via.getAPI().createBossBar("", BossColor.BLUE, BossStyle.SOLID) : null;
   }


### PR DESCRIPTION
 - Resolves a NPE on footer entry when player is in no match (happens during cycle)
 - Fixes 1.8 tablist sometimes being sent to 1.7 clients, resulting in them seeing many random names
 - Fixes 1.7 tablist sometimes not being rendered for 1.7 clients, resulting them in seeing an empty tab with only time updates