### PR TITLE
Improve tablist perf: cache header/foot & avoid ping

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/LegacyMatchTabDisplay.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/LegacyMatchTabDisplay.java
@@ -85,7 +85,13 @@ public class LegacyMatchTabDisplay implements Listener {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerJoin(PlayerJoinEvent event) {
-    tryEnable(event.getPlayer());
+    if (ViaUtils.isReady(event.getPlayer())) tryEnable(event.getPlayer());
+    else {
+      // Player connection hasn't been setup yet, try next tick
+      PGM.get()
+          .getExecutor()
+          .schedule(() -> tryEnable(event.getPlayer()), 50, TimeUnit.MILLISECONDS);
+    }
   }
 
   /**
@@ -97,11 +103,6 @@ public class LegacyMatchTabDisplay implements Listener {
    */
   private void tryEnable(Player player) {
     if (!player.isOnline()) return;
-    if (!ViaUtils.isReady(player)) {
-      // Player connection hasn't been setup yet, try next tick
-      PGM.get().getExecutor().schedule(() -> tryEnable(player), 50, TimeUnit.MILLISECONDS);
-      return;
-    }
     if (ViaUtils.getProtocolVersion(player) >= ViaUtils.VERSION_1_8) return;
     this.tabDisplay.addViewer(player);
   }

--- a/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
@@ -35,9 +35,7 @@ public class MatchFooterTabEntry extends DynamicTabEntry {
     if (this.tickTask == null && match.isLoaded()) {
       Runnable tick = MatchFooterTabEntry.this::invalidate;
       this.tickTask =
-          match
-              .getExecutor(MatchScope.LOADED)
-              .scheduleWithFixedDelay(tick, 0, TimeUtils.TICK * 5, TimeUnit.MILLISECONDS);
+          match.getExecutor(MatchScope.LOADED).scheduleWithFixedDelay(tick, 0, 1, TimeUnit.SECONDS);
     }
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/tablist/DynamicTabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/DynamicTabEntry.java
@@ -28,6 +28,19 @@ public abstract class DynamicTabEntry extends SimpleTabEntry {
     cleanViews.clear();
   }
 
+  /** Mark all {@link TabView}s containing this entry dirty for both content and ping */
+  public void invalidatePing() {
+    if (cleanViews.isEmpty()) return;
+
+    for (TabView view : cleanViews) {
+      view.invalidateContent(this);
+      view.invalidatePing();
+    }
+
+    dirtyViews.addAll(cleanViews);
+    cleanViews.clear();
+  }
+
   @Override
   public boolean isDirty(TabView view) {
     return dirtyViews.contains(view);

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabDisplay.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabDisplay.java
@@ -12,6 +12,7 @@ import net.kyori.text.format.TextColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.minecraft.server.v1_8_R3.Packet;
 import net.minecraft.server.v1_8_R3.PacketPlayOutPlayerInfo;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -170,6 +171,15 @@ public class TabDisplay {
       String[] names = new String[this.slots];
       Arrays.fill(names, "");
       this.viewers.put(viewer, names);
+
+      // Force removing and re-adding all players, because tab list is FIFO in 1.7, re-adding
+      // players makes them append at the end
+      for (Player player : Bukkit.getOnlinePlayers()) {
+        if (viewer.canSee(player)) {
+          viewer.hidePlayer(player);
+          viewer.showPlayer(player);
+        }
+      }
     }
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
@@ -149,12 +149,15 @@ public class TabRender {
     this.updatePacket.b.add(
         NMSHacks.playerListPacketData(
             this.updatePacket, entry.getId(), this.getContent(entry, index)));
+  }
+
+  public void updatePing(TabEntry entry, int index) {
     this.updatePingPacket.b.add(
         NMSHacks.playerListPacketData(this.updatePingPacket, entry.getId(), entry.getPing()));
   }
 
-  public void setHeaderFooter(TabEntry header, TabEntry footer) {
-    view.getViewer().setPlayerListHeaderFooter(header.getContent(view), footer.getContent(view));
+  public void setHeaderFooter(BaseComponent header, BaseComponent footer) {
+    view.getViewer().setPlayerListHeaderFooter(header, footer);
   }
 
   public void updateFakeEntity(TabEntry entry, boolean create) {

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabView.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabView.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.util.tablist;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -26,8 +27,9 @@ public class TabView {
   protected @Nullable TabManager manager;
 
   // True when any slots/header/footer have been changed but not rendered
-  private boolean dirtyLayout, dirtyContent, dirtyHeaderFooter;
+  private boolean dirtyLayout, dirtyContent, dirtyHeader, dirtyFooter, dirtyPing;
   private final TabEntry[] slots, rendered;
+  private BaseComponent header, footer;
 
   public TabView(Player viewer) {
     this.viewer = viewer;
@@ -69,7 +71,9 @@ public class TabView {
 
     this.invalidateLayout();
     this.invalidateContent();
-    this.invalidateHeaderFooter();
+    this.invalidatePing();
+    this.invalidateHeader();
+    this.invalidateFooter();
   }
 
   /** Tear down the display and return control the the viewer's player list to settings */
@@ -108,16 +112,28 @@ public class TabView {
 
   protected void invalidateContent(TabEntry entry) {
     int slot = getSlot(entry);
-    if (slot >= this.size) {
-      this.invalidateHeaderFooter();
-    } else if (slot >= 0) {
-      this.invalidateContent();
+    if (slot == this.headerSlot) this.invalidateHeader();
+    else if (slot == this.footerSlot) this.invalidateFooter();
+    else if (slot >= 0) this.invalidateContent();
+  }
+
+  protected void invalidateHeader() {
+    if (!this.dirtyHeader) {
+      this.dirtyHeader = true;
+      this.invalidateManager();
     }
   }
 
-  protected void invalidateHeaderFooter() {
-    if (!this.dirtyHeaderFooter) {
-      this.dirtyHeaderFooter = true;
+  protected void invalidateFooter() {
+    if (!this.dirtyFooter) {
+      this.dirtyFooter = true;
+      this.invalidateManager();
+    }
+  }
+
+  protected void invalidatePing() {
+    if (!this.dirtyPing) {
+      this.dirtyPing = true;
       this.invalidateManager();
     }
   }
@@ -158,8 +174,10 @@ public class TabView {
 
       if (slot < this.size) {
         this.invalidateLayoutAndContent();
-      } else {
-        this.invalidateHeaderFooter();
+      } else if (slot == this.headerSlot) {
+        this.invalidateHeader();
+      } else if (slot == this.footerSlot) {
+        this.invalidateFooter();
       }
     }
   }
@@ -186,6 +204,7 @@ public class TabView {
     TabRender render = new TabRender(this);
     this.renderLayout(render);
     this.renderContent(render);
+    this.renderPing(render);
     this.markSlotsClean();
     this.renderHeaderFooter(render, false);
     render.finish();
@@ -255,6 +274,19 @@ public class TabView {
     }
   }
 
+  public void renderPing(TabRender render) {
+    if (this.dirtyPing) {
+      this.dirtyPing = false;
+
+      // Build the update packet from entries with updated ping that are not being added or removed
+      for (int i = 0; i < this.size; i++) {
+        if (this.slots[i].isDirty(this)) {
+          render.updatePing(this.slots[i], i);
+        }
+      }
+    }
+  }
+
   public void markSlotsClean() {
     for (TabEntry entry : slots) {
       entry.markClean(this);
@@ -264,11 +296,17 @@ public class TabView {
   public void renderHeaderFooter(TabRender render, boolean force) {
     if (this.manager == null) return;
 
-    if (force || this.dirtyHeaderFooter) {
-      this.dirtyHeaderFooter = false;
-      render.setHeaderFooter(
-          this.rendered[this.headerSlot] = this.slots[this.headerSlot],
-          this.rendered[this.footerSlot] = this.slots[this.footerSlot]);
+    if (force || this.dirtyHeader || this.dirtyFooter) {
+      if (force || this.dirtyHeader) {
+        this.dirtyHeader = false;
+        header = (this.rendered[this.headerSlot] = this.slots[this.headerSlot]).getContent(this);
+      }
+      if (force || this.dirtyFooter) {
+        this.dirtyFooter = false;
+        footer = (this.rendered[this.footerSlot] = this.slots[this.footerSlot]).getContent(this);
+      }
+
+      render.setHeaderFooter(header, footer);
       this.slots[this.headerSlot].markClean(this);
       this.slots[this.footerSlot].markClean(this);
     }
@@ -299,7 +337,8 @@ public class TabView {
     TabRender render = new TabRender(this);
 
     render.setHeaderFooter(
-        this.manager.getBlankEntry(this.headerSlot), this.manager.getBlankEntry(this.footerSlot));
+        this.manager.getBlankEntry(this.headerSlot).getContent(this),
+        this.manager.getBlankEntry(this.footerSlot).getContent(this));
 
     for (int index = 0; index < this.size; index++) {
       render.destroySlot(this.rendered[index], index);


### PR DESCRIPTION
 - Removed recursion on trying to late-enable tab. While it was originally intentional, i'd rather break tab than potentially recurse delayed executions
 - Tab rendering is now defered 250ms instead of only 50ms (used to be 1s and was lowered)
 - Header & Footer entries now render separately and are cached by viewer
 - Header & Footer are now invalidated separately
 - Match footer (with match timer) now invalidates every second instead of every 5 ticks
 - Ping will no longer always be updated alongside content, only will update if explicitly marked dirty (scheduled every 15 seconds)
 - When 1.7 tab list is enabled it will remove all earlier visible clients. Allows it to be enabled a tick later without (due to FIFO) having other (real) player entries show at the very start