### PR TITLE
Add mercy option to score module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/score/MercyRule.java
+++ b/core/src/main/java/tc/oc/pgm/score/MercyRule.java
@@ -1,0 +1,103 @@
+package tc.oc.pgm.score;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.api.party.event.CompetitorScoreChangeEvent;
+
+public class MercyRule {
+
+  private final ScoreMatchModule scoreMatchModule;
+  private final int scoreLimit;
+  private final int mercyLimit;
+
+  private Map.Entry<Competitor, Double> leader;
+  private Map.Entry<Competitor, Double> trailer;
+
+  public MercyRule(ScoreMatchModule scoreMatchModule, int scoreLimit, int mercyLimit) {
+    this.scoreMatchModule = scoreMatchModule;
+    this.scoreLimit = scoreLimit;
+    this.mercyLimit = mercyLimit;
+
+    calculateLeaders();
+  }
+
+  private double getLeaderScore() {
+    return leader.getValue();
+  }
+
+  private double getTrailerScore() {
+    return trailer.getValue();
+  }
+
+  private void setLeader(Competitor competitor, Double score) {
+    leader = new AbstractMap.SimpleEntry<>(competitor, score);
+  }
+
+  private void setTrailer(Competitor competitor, Double score) {
+    trailer = new AbstractMap.SimpleEntry<>(competitor, score);
+  }
+
+  private boolean isLeader(Competitor competitor) {
+    return competitor.equals(leader.getKey());
+  }
+
+  private boolean isTrailer(Competitor competitor) {
+    return competitor.equals(trailer.getKey());
+  }
+
+  public int getScoreLimit() {
+    int scoreBaseline = (int) getTrailerScore();
+
+    if (scoreLimit < 0) {
+      return scoreBaseline + mercyLimit;
+    }
+
+    return Math.min(scoreBaseline + mercyLimit, scoreLimit);
+  }
+
+  public void handleEvent(CompetitorScoreChangeEvent event) {
+    // Score is larger than leading score
+    if (event.getNewScore() > getLeaderScore()) {
+      if (!isLeader(event.getCompetitor())) {
+        trailer = leader;
+      }
+      setLeader(event.getCompetitor(), event.getNewScore());
+      return;
+    }
+
+    // Score larger than trailing score
+    if (event.getNewScore() > getTrailerScore()) {
+      setTrailer(event.getCompetitor(), event.getNewScore());
+      return;
+    }
+
+    // Score is going down
+    if (event.getOldScore() > event.getNewScore()) {
+      if (isLeader(event.getCompetitor())
+          || isTrailer(event.getCompetitor())
+          || trailer.getKey() == null) {
+        calculateLeaders();
+      }
+    }
+  }
+
+  private void calculateLeaders() {
+    Map.Entry<Competitor, Double> lead =
+        new AbstractMap.SimpleEntry<>(null, Double.NEGATIVE_INFINITY);
+    Map.Entry<Competitor, Double> trail =
+        new AbstractMap.SimpleEntry<>(null, Double.NEGATIVE_INFINITY);
+
+    for (Map.Entry<Competitor, Double> entry : scoreMatchModule.getScores().entrySet()) {
+      if (entry.getValue() > lead.getValue()) {
+        trail = lead;
+        lead = entry;
+      } else if (entry.getValue() > trail.getValue()) {
+        trail = entry;
+      }
+    }
+
+    setLeader(lead.getKey(), lead.getValue());
+    setTrailer(trail.getKey(), trail.getValue());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/score/ScoreConfig.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreConfig.java
@@ -4,4 +4,5 @@ public class ScoreConfig {
   public int scoreLimit = -1;
   public int deathScore;
   public int killScore;
+  public int mercyLimit;
 }

--- a/core/src/main/java/tc/oc/pgm/score/ScoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreModule.java
@@ -98,6 +98,7 @@ public class ScoreModule implements MapModule {
 
       for (Element scoreEl : scoreElements) {
         config.scoreLimit = XMLUtils.parseNumber(scoreEl.getChild("limit"), Integer.class, -1);
+        config.mercyLimit = XMLUtils.parseNumber(scoreEl.getChild("mercy"), Integer.class, -1);
 
         // For backwards compatibility, default kill/death points to 1 if proto is old and <king/>
         // tag


### PR DESCRIPTION
Allow a `mercy` option within the score module. This can be used alongside a `limit` or standalone. As referenced in #250. 

### Example

This XML example will result in a match that progresses like the scoreboard screenshots. 
The winner is the first team to get a mercy lead of 5 or reach the limit of 10.

```xml
<score>
    <mercy>5</mercy>
    <limit>10</limit>
</score>
```

![image](https://user-images.githubusercontent.com/8608892/89710319-cce43700-d979-11ea-85da-c8e65db12480.png)

*Blue team take a storming lead with just one flag away from the win, but wait, red team pulls it back and forces the score limit. 
What an epic gamer moment, so glad I got to watch this historic match on Nartica ™️ .*

### Notes

If a `limit` is not set then a team will need to lead by the set mercy amount or fallback on another condition such as time.

The example above uses CTF but as it is the `ScoreModule` it would work with TDMs and Hills.

This just hooks into the scoring module so no changes to the scoreboard etc. I'd imagine this feature only being used in competitive environments where teams are aware of the score limit and mercy rules (from scrimming), otherwise, the scoreboard limit changing "randomly" may be a bit confusing. Maybe some UI work could be done to make this clearer.

### Code

I have toyed around with the idea of including the feature directly in the score module but decided to separate it out into its own `MercyRule` class so I can have a few helper methods to make it a bit more readable. The topic of micro optimisation was mentioned in the linked issue, the current implementation only re-sorts all team scores if the lead or trail have their score decreased.

Wanted to get the PR made for this for feedback rather than having a useless finished branch that I had not touched in 3 months. 

Signed-off-by: Pugzy <pugzy@mail.com>