### PR TITLE
Further tablist performance improvements & fixes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
@@ -29,9 +29,7 @@ import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.teams.events.TeamResizeEvent;
 import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.collection.DefaultMapAdapter;
-import tc.oc.pgm.util.tablist.DynamicTabEntry;
 import tc.oc.pgm.util.tablist.PlayerTabEntry;
-import tc.oc.pgm.util.tablist.TabEntry;
 import tc.oc.pgm.util.tablist.TabManager;
 
 public class MatchTabManager extends TabManager implements Listener {
@@ -53,11 +51,9 @@ public class MatchTabManager extends TabManager implements Listener {
 
     if (PGM.get().getConfiguration().showTabListPing()) {
       PlayerTabEntry.setShowRealPing(true);
-      // If ping is shown, invalidate player entries to force-update them every so often
+      // If ping is shown, update all views every 30 seconds like vanilla does
       pingUpdateTask =
-          PGM.get()
-              .getExecutor()
-              .scheduleWithFixedDelay(this::invalidatePlayers, 5, 15, TimeUnit.SECONDS);
+          PGM.get().getExecutor().scheduleWithFixedDelay(this::renderPing, 5, 30, TimeUnit.SECONDS);
     } else {
       PlayerTabEntry.setShowRealPing(false);
     }
@@ -135,13 +131,6 @@ public class MatchTabManager extends TabManager implements Listener {
         if (mapEntry != null) mapEntry.invalidate();
         break;
       }
-    }
-  }
-
-  /** Invalidates all player entries, used for ping to update */
-  private void invalidatePlayers() {
-    for (TabEntry value : playerEntries.values()) {
-      if (value instanceof DynamicTabEntry) ((DynamicTabEntry) value).invalidatePing();
     }
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -98,6 +98,28 @@ public interface NMSHacks {
     return playerListPacketData(packet, uuid, uuid.toString().substring(0, 16), null, ping, null);
   }
 
+  /**
+   * Removes all players from the tab for the viewer and re-adds them
+   *
+   * @param viewer The viewer to send the packets to
+   */
+  static void removeAndAddAllTabPlayers(Player viewer) {
+    List<EntityPlayer> players = new ArrayList<>();
+    for (Player player : Bukkit.getOnlinePlayers()) {
+      if (viewer.canSee(player) || player == viewer)
+        players.add(((CraftPlayer) player).getHandle());
+    }
+
+    sendPacket(
+        viewer,
+        new PacketPlayOutPlayerInfo(
+            PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, players));
+    sendPacket(
+        viewer,
+        new PacketPlayOutPlayerInfo(
+            PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, players));
+  }
+
   static Packet teamPacket(
       int operation,
       String name,

--- a/util/src/main/java/tc/oc/pgm/util/tablist/DynamicTabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/DynamicTabEntry.java
@@ -28,19 +28,6 @@ public abstract class DynamicTabEntry extends SimpleTabEntry {
     cleanViews.clear();
   }
 
-  /** Mark all {@link TabView}s containing this entry dirty for both content and ping */
-  public void invalidatePing() {
-    if (cleanViews.isEmpty()) return;
-
-    for (TabView view : cleanViews) {
-      view.invalidateContent(this);
-      view.invalidatePing();
-    }
-
-    dirtyViews.addAll(cleanViews);
-    cleanViews.clear();
-  }
-
   @Override
   public boolean isDirty(TabView view) {
     return dirtyViews.contains(view);

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabDisplay.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabDisplay.java
@@ -12,7 +12,6 @@ import net.kyori.text.format.TextColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.minecraft.server.v1_8_R3.Packet;
 import net.minecraft.server.v1_8_R3.PacketPlayOutPlayerInfo;
-import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -174,12 +173,7 @@ public class TabDisplay {
 
       // Force removing and re-adding all players, because tab list is FIFO in 1.7, re-adding
       // players makes them append at the end
-      for (Player player : Bukkit.getOnlinePlayers()) {
-        if (viewer.canSee(player)) {
-          viewer.hidePlayer(player);
-          viewer.showPlayer(player);
-        }
-      }
+      NMSHacks.removeAndAddAllTabPlayers(viewer);
     }
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabManager.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabManager.java
@@ -113,6 +113,12 @@ public class TabManager implements Listener {
     }
   }
 
+  public void renderPing() {
+    for (TabView view : this.enabledViews.values()) {
+      if (view != null) view.renderPing();
+    }
+  }
+
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onQuit(PlayerQuitEvent event) {
     TabView view = this.getViewOrNull(event.getPlayer());


### PR DESCRIPTION
- Fix 1.7 players sometimes seeing themselves at the top of the list if viaversion injected late
- Ping now updates every 30 seconds instead of 15, to match vanilla (600 ticks)
- Ping updating is no longer defered via player entry invalidating, and avoids re-rendering player names
- List of viewed observers is now in sync with vanished status, and no longer filtered at render time