### PR TITLE
Allow tab to be extended & fix cycle white names

### DIFF
--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistry.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistry.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.namedecorations;
 
-import java.util.UUID;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import tc.oc.pgm.api.party.Party;
@@ -15,13 +14,6 @@ public interface NameDecorationRegistry extends Listener {
    * @return The name, decorated
    */
   String getDecoratedName(Player player, Party party);
-
-  /**
-   * Force-refresh this player's decoration
-   *
-   * @param uuid UUID of the player to refresh
-   */
-  void refreshPlayer(UUID uuid);
 
   /**
    * Set what name decoration provider this registry should use

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
@@ -13,8 +13,6 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.PlayerJoinMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
-import tc.oc.pgm.tablist.MatchTabManager;
-import tc.oc.pgm.util.tablist.PlayerTabEntry;
 
 public class NameDecorationRegistryImpl implements NameDecorationRegistry, Listener {
 
@@ -38,7 +36,13 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
 
   @EventHandler
   public void onNameDecorationChange(NameDecorationChangeEvent event) {
-    refreshPlayer(event.getUUID());
+    if (event.getUUID() == null) return;
+
+    final Player player = Bukkit.getPlayer(event.getUUID());
+    final MatchPlayer matchPlayer = PGM.get().getMatchManager().getPlayer(player);
+    if (matchPlayer == null) return;
+
+    matchPlayer.getBukkit().setDisplayName(getDecoratedName(player, matchPlayer.getParty()));
   }
 
   @Override
@@ -56,23 +60,6 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
 
   public String getSuffix(UUID uuid) {
     return provider != null ? provider.getSuffix(uuid) : "";
-  }
-
-  @Override
-  public void refreshPlayer(UUID uuid) {
-    if (uuid == null) return;
-
-    final Player player = Bukkit.getPlayer(uuid);
-    final MatchPlayer matchPlayer = PGM.get().getMatchManager().getPlayer(player);
-    if (matchPlayer == null) return;
-
-    matchPlayer.getBukkit().setDisplayName(getDecoratedName(player, matchPlayer.getParty()));
-
-    final MatchTabManager tabManager = PGM.get().getMatchTabManager();
-    if (tabManager != null) {
-      final PlayerTabEntry tabEntry = (PlayerTabEntry) tabManager.getPlayerEntryOrNull(player);
-      if (tabEntry != null) tabEntry.invalidate();
-    }
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/tablist/FreeForAllTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/FreeForAllTabEntry.java
@@ -20,7 +20,7 @@ public class FreeForAllTabEntry extends DynamicTabEntry {
   }
 
   @Override
-  public BaseComponent getContent(TabView view) {
+  public BaseComponent[] getContent(TabView view) {
     Component content =
         TextComponent.builder()
             .append(String.valueOf(match.getParticipants().size()), TextColor.WHITE)
@@ -31,6 +31,6 @@ public class FreeForAllTabEntry extends DynamicTabEntry {
                 TranslatableComponent.of(
                     "match.info.players", TextColor.YELLOW, TextDecoration.BOLD))
             .build();
-    return TextTranslations.toBaseComponent(content, view.getViewer());
+    return TextTranslations.toBaseComponentArray(content, view.getViewer());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/tablist/MapTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MapTabEntry.java
@@ -18,12 +18,12 @@ public class MapTabEntry extends DynamicTabEntry {
 
   private final MapInfo map;
 
-  protected MapTabEntry(Match match) {
+  public MapTabEntry(Match match) {
     this.map = match.getMap();
   }
 
   @Override
-  public BaseComponent getContent(TabView view) {
+  public BaseComponent[] getContent(TabView view) {
     final Component text =
         TranslatableComponent.of(
             "misc.authorship",
@@ -31,6 +31,6 @@ public class MapTabEntry extends DynamicTabEntry {
             TextComponent.of(map.getName(), TextColor.AQUA, TextDecoration.BOLD),
             TextFormatter.nameList(map.getAuthors(), NameStyle.FANCY, TextColor.GRAY));
 
-    return TextTranslations.toBaseComponent(text, view.getViewer());
+    return TextTranslations.toBaseComponentArray(text, view.getViewer());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
@@ -11,6 +11,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
@@ -49,16 +50,17 @@ public class MatchFooterTabEntry extends DynamicTabEntry {
   }
 
   @Override
-  public BaseComponent getContent(TabView view) {
+  public BaseComponent[] getContent(TabView view) {
     TextComponent.Builder content = TextComponent.builder();
 
     MatchPlayer viewer = match.getPlayer(view.getViewer());
 
     if (viewer != null
-        && viewer.isParticipating()
+        && viewer.getParty() instanceof Competitor
+        && (match.isRunning() || match.isFinished())
         && viewer.getSettings().getValue(SettingKey.STATS).equals(SettingValue.STATS_ON)) {
       content.append(match.needModule(StatsMatchModule.class).getBasicStatsMessage(viewer.getId()));
-      content.append("\n");
+      content.append(TextComponent.newline());
     }
 
     final Component leftContent = PGM.get().getConfiguration().getLeftTablistText();
@@ -81,7 +83,7 @@ public class MatchFooterTabEntry extends DynamicTabEntry {
           .append(rightContent.colorIfAbsent(TextColor.WHITE));
     }
 
-    return TextTranslations.toBaseComponent(
+    return TextTranslations.toBaseComponentArray(
         content.colorIfAbsent(TextColor.DARK_GRAY).build(), view.getViewer());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/tablist/TeamTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/TeamTabEntry.java
@@ -20,7 +20,7 @@ public class TeamTabEntry extends DynamicTabEntry {
   }
 
   @Override
-  public BaseComponent getContent(TabView view) {
+  public BaseComponent[] getContent(TabView view) {
     Component content =
         TextComponent.builder()
             .append(String.valueOf(team.getPlayers().size()), TextColor.WHITE)
@@ -31,6 +31,6 @@ public class TeamTabEntry extends DynamicTabEntry {
                 team.getShortName(), TextFormatter.convert(team.getColor()), TextDecoration.BOLD)
             .build();
 
-    return TextTranslations.toBaseComponent(content, view.getViewer());
+    return TextTranslations.toBaseComponentArray(content, view.getViewer());
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -42,6 +42,12 @@ public interface NMSHacks {
     return getTrackerEntry(((CraftEntity) entity).getHandle());
   }
 
+  static void sendPacket(Object packet) {
+    for (Player pl : Bukkit.getOnlinePlayers()) {
+      sendPacket(pl, packet);
+    }
+  }
+
   static void sendPacket(Player bukkitPlayer, Object packet) {
     if (bukkitPlayer.isOnline()) {
       EntityPlayer nmsPlayer = ((CraftPlayer) bukkitPlayer).getHandle();

--- a/util/src/main/java/tc/oc/pgm/util/tablist/PlayerTabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/PlayerTabEntry.java
@@ -51,8 +51,8 @@ public class PlayerTabEntry extends DynamicTabEntry {
   }
 
   @Override
-  public BaseComponent getContent(TabView view) {
-    return TextTranslations.toBaseComponent(
+  public BaseComponent[] getContent(TabView view) {
+    return TextTranslations.toBaseComponentArray(
         PlayerComponent.of(player, NameStyle.TAB, view.getViewer()), view.getViewer());
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/tablist/StaticTabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/StaticTabEntry.java
@@ -27,7 +27,7 @@ public class StaticTabEntry extends SimpleTabEntry {
   public void markClean(TabView view) {}
 
   @Override
-  public BaseComponent getContent(TabView view) {
-    return TextTranslations.toBaseComponent(content, view.getViewer());
+  public BaseComponent[] getContent(TabView view) {
+    return TextTranslations.toBaseComponentArray(content, view.getViewer());
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabEntry.java
@@ -52,7 +52,7 @@ public interface TabEntry {
    *
    * @return
    */
-  BaseComponent getContent(TabView view);
+  BaseComponent[] getContent(TabView view);
 
   /**
    * Gamemode for the entry. If the entry is linked to a real player, this will change the client's

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
@@ -50,12 +50,12 @@ public class TabRender {
     return packet;
   }
 
-  private BaseComponent getContent(TabEntry entry, int index) {
+  private BaseComponent[] getContent(TabEntry entry, int index) {
     return entry.getContent(this.view);
   }
 
   private void appendAddition(TabEntry entry, int index) {
-    BaseComponent displayName = this.getContent(entry, index);
+    BaseComponent[] displayName = this.getContent(entry, index);
     this.addPacket.b.add(
         NMSHacks.playerListPacketData(
             this.addPacket,
@@ -156,7 +156,7 @@ public class TabRender {
         NMSHacks.playerListPacketData(this.updatePingPacket, entry.getId(), entry.getPing()));
   }
 
-  public void setHeaderFooter(BaseComponent header, BaseComponent footer) {
+  public void setHeaderFooter(BaseComponent[] header, BaseComponent[] footer) {
     view.getViewer().setPlayerListHeaderFooter(header, footer);
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabView.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabView.java
@@ -29,7 +29,7 @@ public class TabView {
   // True when any slots/header/footer have been changed but not rendered
   private boolean dirtyLayout, dirtyContent, dirtyHeader, dirtyFooter;
   private final TabEntry[] slots, rendered;
-  private BaseComponent header, footer;
+  private BaseComponent[] header, footer;
 
   public TabView(Player viewer) {
     this.viewer = viewer;

--- a/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
@@ -104,7 +104,7 @@ public interface PlayerComponent {
     String displayName = player.getDisplayName();
     char colorChar = displayName.charAt((displayName.indexOf(player.getName()) - 1));
     TextColor color = TextFormatter.convert(ChatColor.getByChar(colorChar));
-    return TextComponent.builder().append(player.getName()).color(color);
+    return TextComponent.builder(player.getName(), color);
   }
 
   // Color, flair & teleport


### PR DESCRIPTION
- Adds constructors that allow subclassing of tab entries, wich means other plugins can render them differently if they wish

- Fixes the bug where during cycle you'll see a list of white players on top left of the tab, making it all look displaced
(I'm unsure if there's a better way to do this one, launching an event from match factory impl just to move that code away seems to over-engineer it)

- Fixes a hidden CME that would always happen on match unload, and would make the `return null` on `advanceSync` never be reached

- Fixes stats not showing on tab for players after match

 - Name decoration provider shouldn't be responsible for updating the tablist entries, and no longer is, just launch the event when name decorations change

- Flatten a nesting level added on all tablist entries when rendered to json text (comparison: https://gist.github.com/Pablete1234/a9f8b88f38117863e6df34c10275df6b) to optimize serialization