### PR TITLE
Make minimal changes needed for Ingame to work in tournaments

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/graph/MatchPlayerProvider.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/MatchPlayerProvider.java
@@ -11,7 +11,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.util.text.TextException;
 
-final class MatchPlayerProvider implements BukkitProvider<MatchPlayer> {
+public final class MatchPlayerProvider implements BukkitProvider<MatchPlayer> {
 
   @Override
   public boolean isProvided() {

--- a/core/src/main/java/tc/oc/pgm/command/graph/MatchProvider.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/MatchProvider.java
@@ -9,7 +9,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.util.text.TextException;
 
-final class MatchProvider implements BukkitProvider<Match> {
+public final class MatchProvider implements BukkitProvider<Match> {
 
   @Override
   public boolean isProvided() {

--- a/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
@@ -9,6 +9,9 @@ import net.kyori.text.format.TextColor;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.bossbar.BossBarMatchModule;
+import tc.oc.pgm.events.CountdownCancelEvent;
+import tc.oc.pgm.events.CountdownEndEvent;
+import tc.oc.pgm.events.CountdownStartEvent;
 import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.bossbar.BossBarSource;
 import tc.oc.pgm.util.bossbar.DynamicBossBar;
@@ -83,6 +86,7 @@ public abstract class MatchCountdown extends Countdown {
 
     showOrHideBossBar();
 
+    match.callEvent(new CountdownStartEvent(match, this));
     super.onStart(remaining, total);
   }
 
@@ -113,12 +117,14 @@ public abstract class MatchCountdown extends Countdown {
 
   @Override
   public void onEnd(Duration total) {
+    match.callEvent(new CountdownEndEvent(match, this));
     bbmm.removeBossBar(bossBar);
   }
 
   @Override
   public void onCancel(Duration remaining, Duration total) {
     super.onCancel(remaining, total);
+    match.callEvent(new CountdownCancelEvent(match, this));
     bbmm.removeBossBar(bossBar);
   }
 
@@ -165,5 +171,9 @@ public abstract class MatchCountdown extends Countdown {
 
   protected float bossBarProgress(Duration remaining, Duration total) {
     return total.isZero() ? 0f : (float) remaining.toMillis() / total.toMillis();
+  }
+
+  public Duration getRemaining() {
+    return remaining;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/events/CountdownCancelEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/CountdownCancelEvent.java
@@ -1,0 +1,31 @@
+package tc.oc.pgm.events;
+
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.event.MatchEvent;
+import tc.oc.pgm.countdowns.Countdown;
+
+public class CountdownCancelEvent extends MatchEvent {
+
+  private final Countdown countdown;
+
+  private static final HandlerList handlers = new HandlerList();
+
+  public CountdownCancelEvent(Match match, Countdown countdown) {
+    super(match);
+    this.countdown = countdown;
+  }
+
+  public Countdown getCountdown() {
+    return countdown;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/events/CountdownEndEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/CountdownEndEvent.java
@@ -1,0 +1,31 @@
+package tc.oc.pgm.events;
+
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.event.MatchEvent;
+import tc.oc.pgm.countdowns.Countdown;
+
+public class CountdownEndEvent extends MatchEvent {
+
+  private final Countdown countdown;
+
+  private static final HandlerList handlers = new HandlerList();
+
+  public CountdownEndEvent(Match match, Countdown countdown) {
+    super(match);
+    this.countdown = countdown;
+  }
+
+  public Countdown getCountdown() {
+    return countdown;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/events/CountdownStartEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/CountdownStartEvent.java
@@ -1,0 +1,31 @@
+package tc.oc.pgm.events;
+
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.event.MatchEvent;
+import tc.oc.pgm.countdowns.Countdown;
+
+public class CountdownStartEvent extends MatchEvent {
+
+  private final Countdown countdown;
+
+  private static final HandlerList handlers = new HandlerList();
+
+  public CountdownStartEvent(Match match, Countdown countdown) {
+    super(match);
+    this.countdown = countdown;
+  }
+
+  public Countdown getCountdown() {
+    return countdown;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+}


### PR DESCRIPTION
Adds three new events (to support /ready and /unready);
- `CountdownStartEvent`
- `CountdownEndEvent`
- `CountdownCancelEvent`

Changes to `CountdownRunner` are not needed for tournaments.