### PR TITLE
Prevent team griefing on scored matches

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -11,6 +11,7 @@ import static tc.oc.pgm.util.text.TextParser.parseUri;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Range;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -67,7 +68,7 @@ public final class PGMConfig implements Config {
 
   // gameplay.*
   private final boolean woolRefill;
-  private final boolean flagBeams;
+  private final int griefScore;
 
   // join.*
   private final long minPlayers;
@@ -76,6 +77,7 @@ public final class PGMConfig implements Config {
   private final boolean balanceJoin;
   private final boolean queueJoin;
   private final boolean anytimeJoin;
+  private final boolean flagBeams;
 
   // ui.*
   private final boolean showSideBar;
@@ -158,6 +160,8 @@ public final class PGMConfig implements Config {
     this.matchLimit = parseInteger(config.getString("restart.match-limit", "30"));
 
     this.woolRefill = parseBoolean(config.getString("gameplay.refill-wool", "true"));
+    this.griefScore =
+        parseInteger(config.getString("gameplay.grief-score", "-10"), Range.atMost(0));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));
@@ -505,6 +509,11 @@ public final class PGMConfig implements Config {
   @Override
   public boolean shouldRefillWool() {
     return woolRefill;
+  }
+
+  @Override
+  public int getGriefScore() {
+    return griefScore;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -234,6 +234,13 @@ public interface Config {
   boolean shouldRefillWool();
 
   /**
+   * Gets at which score players should be no longer allowed to keep playing TDM
+   *
+   * @return The minimum score they must hold
+   */
+  int getGriefScore();
+
+  /**
    * Gets a group of players, used for prefixes and player sorting.
    *
    * @return A list of groups.

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -64,6 +64,7 @@ join:
 # Changes various gameplay mechanics.
 gameplay:
   refill-wool: true # Should wool in wool rooms be automatically refilled?
+  grief-score: -10 # Score under which players should be kept out of the match
 
 # Toggles various user interfaces.
 ui:

--- a/util/src/main/i18n/templates/join.properties
+++ b/util/src/main/i18n/templates/join.properties
@@ -35,6 +35,8 @@ join.err.noPermission = You are not allowed to join this match
 
 join.err.alreadyJoined = You have already joined the match
 
+join.err.teamGrief = You made a negative impact for your team and can no longer play this match
+
 # {0} = team name (e.g. "Observers")
 join.err.alreadyJoined.team = You have already joined {0}
 

--- a/util/src/main/i18n/templates/join.properties
+++ b/util/src/main/i18n/templates/join.properties
@@ -35,7 +35,7 @@ join.err.noPermission = You are not allowed to join this match
 
 join.err.alreadyJoined = You have already joined the match
 
-join.err.teamGrief = You made a negative impact for your team and can no longer play this match
+join.err.teamGrief = You caused too much negative impact to play this match
 
 # {0} = team name (e.g. "Observers")
 join.err.alreadyJoined.team = You have already joined {0}


### PR DESCRIPTION
A new config option for under how many (negative) points, a player should be kicked out of the match and not allowed to rejoin. This prevents team griefing in TDM dying to the enemy team doesn't substract score so that won't affect this, only purposely suiciding will end up triggering it

![image](https://user-images.githubusercontent.com/11789291/89862037-66446080-dba7-11ea-92c3-3c484a4a3ff7.png)
