### PR TITLE
Add group hover info to chat

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -584,18 +584,14 @@ public final class PGMConfig implements Config {
 
   private static class Group implements Config.Group {
     private final String id;
-    private final String prefix;
-    private final String suffix;
+    private final Flair flair;
     private final Permission permission;
     private final Permission observerPermission;
     private final Permission participantPermission;
 
     public Group(ConfigurationSection config) throws TextException {
       this.id = config.getName();
-      final String prefix = config.getString("prefix");
-      this.prefix = prefix == null ? null : parseComponentLegacy(prefix);
-      final String suffix = config.getString("suffix");
-      this.suffix = suffix == null ? null : parseComponentLegacy(suffix);
+      this.flair = new Flair(config);
       final PermissionDefault def =
           id.equalsIgnoreCase("op")
               ? PermissionDefault.OP
@@ -651,6 +647,37 @@ public final class PGMConfig implements Config {
     }
 
     @Override
+    public Flair getFlair() {
+      return flair;
+    }
+  }
+
+  private static class Flair implements Config.Flair {
+
+    private String prefix;
+    private String suffix;
+    private String displayName;
+    private String description;
+    private String clickLink;
+
+    public Flair(ConfigurationSection config) {
+      final String prefix = config.getString("prefix");
+      this.prefix = prefix == null ? null : parseComponentLegacy(prefix);
+
+      final String suffix = config.getString("suffix");
+      this.suffix = suffix == null ? null : parseComponentLegacy(suffix);
+
+      final String name = config.getString("display-name");
+      this.displayName = name == null ? null : parseComponentLegacy(name);
+
+      final String desc = config.getString("description");
+      this.description = desc == null ? null : parseComponentLegacy(desc);
+
+      final String link = config.getString("click-link");
+      this.clickLink = link == null ? null : parseComponentLegacy(link);
+    }
+
+    @Override
     public String getPrefix() {
       return prefix;
     }
@@ -658,6 +685,21 @@ public final class PGMConfig implements Config {
     @Override
     public String getSuffix() {
       return suffix;
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+
+    @Override
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    @Override
+    public String getClickLink() {
+      return clickLink;
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -659,6 +659,8 @@ public final class PGMConfig implements Config {
     private String displayName;
     private String description;
     private String clickLink;
+    private Component prefixOverride;
+    private Component suffixOverride;
 
     public Flair(ConfigurationSection config) {
       final String prefix = config.getString("prefix");
@@ -675,6 +677,14 @@ public final class PGMConfig implements Config {
 
       final String link = config.getString("click-link");
       this.clickLink = link == null ? null : parseComponentLegacy(link);
+
+      final String prefixComp = config.getString("prefix-component");
+      this.prefixOverride =
+          prefixComp == null || prefixComp.isEmpty() ? null : parseComponent(prefixComp);
+
+      final String suffixComp = config.getString("suffix-component");
+      this.suffixOverride =
+          suffixComp == null || suffixComp.isEmpty() ? null : parseComponent(suffixComp);
     }
 
     @Override
@@ -700,6 +710,16 @@ public final class PGMConfig implements Config {
     @Override
     public String getClickLink() {
       return clickLink;
+    }
+
+    @Override
+    public Component getPrefixOverride() {
+      return prefixOverride;
+    }
+
+    @Override
+    public Component getSuffixOverride() {
+      return suffixOverride;
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -317,7 +317,14 @@ public interface Config {
 
     String getClickLink();
 
+    Component getPrefixOverride();
+
+    Component getSuffixOverride();
+
     default Component getComponent(boolean prefix) {
+      if (prefix ? getPrefixOverride() != null : getSuffixOverride() != null) {
+        return prefix ? getPrefixOverride() : getSuffixOverride();
+      }
       TextComponent.Builder hover = TextComponent.builder().append(getDisplayName());
       if (getDescription() != null && !getDescription().isEmpty()) {
         hover.append("\n").append(getDescription());

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -6,6 +6,12 @@ import java.util.Map;
 import java.util.logging.Level;
 import javax.annotation.Nullable;
 import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
+import net.kyori.text.TranslatableComponent;
+import net.kyori.text.event.ClickEvent;
+import net.kyori.text.event.HoverEvent;
+import net.kyori.text.format.TextColor;
+import net.kyori.text.format.TextDecoration;
 import org.bukkit.permissions.Permission;
 import tc.oc.pgm.api.map.factory.MapSourceFactory;
 
@@ -251,12 +257,21 @@ public interface Config {
     String getId();
 
     /**
+     * Gets a flair object which holds all prefix/suffix related data
+     *
+     * @return A {@link Flair} for this group
+     */
+    Flair getFlair();
+
+    /**
      * Gets the prefix to show next to each player's name.
      *
      * @return A chat prefix, or null for none.
      */
     @Nullable
-    String getPrefix();
+    default String getPrefix() {
+      return getFlair().getPrefix();
+    }
 
     /**
      * Gets the suffix to show next to each player's name.
@@ -264,7 +279,9 @@ public interface Config {
      * @return A chat suffix, or null for none.
      */
     @Nullable
-    String getSuffix();
+    default String getSuffix() {
+      return getFlair().getSuffix();
+    }
 
     /**
      * Gets the permission node required to be included in this group.
@@ -286,6 +303,46 @@ public interface Config {
      * @return A permissions map.
      */
     Permission getParticipantPermission();
+  }
+
+  interface Flair {
+
+    String getPrefix();
+
+    String getSuffix();
+
+    String getDescription();
+
+    String getDisplayName();
+
+    String getClickLink();
+
+    default Component getComponent(boolean prefix) {
+      TextComponent.Builder hover = TextComponent.builder().append(getDisplayName());
+      if (getDescription() != null && !getDescription().isEmpty()) {
+        hover.append("\n").append(getDescription());
+      }
+
+      if (getClickLink() != null && !getClickLink().isEmpty()) {
+        Component clickLink =
+            TranslatableComponent.of(
+                "chat.clickLink",
+                TextColor.DARK_AQUA,
+                TextComponent.of(getClickLink(), TextColor.AQUA, TextDecoration.UNDERLINED));
+        hover.append("\n").append(clickLink);
+      }
+
+      TextComponent.Builder component =
+          TextComponent.builder()
+              .append(prefix ? getPrefix() : getSuffix())
+              .hoverEvent(HoverEvent.showText(hover.build()));
+
+      if (getClickLink() != null && !getClickLink().isEmpty()) {
+        component.clickEvent(ClickEvent.openUrl(getClickLink()));
+      }
+
+      return component.build();
+    }
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/namedecorations/ConfigDecorationProvider.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/ConfigDecorationProvider.java
@@ -3,6 +3,8 @@ package tc.oc.pgm.namedecorations;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.api.Config;
@@ -28,6 +30,25 @@ public class ConfigDecorationProvider implements NameDecorationProvider {
         .filter(g -> g.getSuffix() != null)
         .map(Config.Group::getSuffix)
         .collect(Collectors.joining());
+  }
+
+  @Override
+  public Component getPrefixComponent(UUID uuid) {
+    return generateFlair(groups(uuid), true);
+  }
+
+  @Override
+  public Component getSuffixComponent(UUID uuid) {
+    return generateFlair(groups(uuid), false);
+  }
+
+  private Component generateFlair(Stream<? extends Config.Group> flairs, boolean prefix) {
+    TextComponent.Builder builder = TextComponent.builder();
+    flairs
+        .filter(p -> prefix ? p.getPrefix() != null : p.getSuffix() != null)
+        .map(Config.Group::getFlair)
+        .forEach(flair -> builder.append(flair.getComponent(prefix)));
+    return builder.build();
   }
 
   private Stream<? extends Config.Group> groups(UUID uuid) {

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationProvider.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationProvider.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.namedecorations;
 
 import java.util.UUID;
 import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
 
 /** This interface is intended to return what prefix and suffix a player should have */
 public interface NameDecorationProvider {
@@ -10,7 +11,11 @@ public interface NameDecorationProvider {
 
   String getSuffix(UUID uuid);
 
-  Component getPrefixComponent(UUID uuid);
+  default Component getPrefixComponent(UUID uuid) {
+    return TextComponent.of(getPrefix(uuid));
+  }
 
-  Component getSuffixComponent(UUID uuid);
+  default Component getSuffixComponent(UUID uuid) {
+    return TextComponent.of(getSuffix(uuid));
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationProvider.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationProvider.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.namedecorations;
 
 import java.util.UUID;
+import net.kyori.text.Component;
 
 /** This interface is intended to return what prefix and suffix a player should have */
 public interface NameDecorationProvider {
@@ -8,4 +9,8 @@ public interface NameDecorationProvider {
   String getPrefix(UUID uuid);
 
   String getSuffix(UUID uuid);
+
+  Component getPrefixComponent(UUID uuid);
+
+  Component getSuffixComponent(UUID uuid);
 }

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistry.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistry.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.namedecorations;
 
 import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import tc.oc.pgm.api.party.Party;
@@ -25,7 +26,9 @@ public interface NameDecorationRegistry extends Listener {
    * @param party The party this player is currently in
    * @return The name, decorated, in component form
    */
-  Component getDecoratedNameComponent(Player player, Party party);
+  default Component getDecoratedNameComponent(Player player, Party party) {
+    return TextComponent.of(getDecoratedName(player, party));
+  }
 
   /**
    * Set what name decoration provider this registry should use

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistry.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistry.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.namedecorations;
 
+import net.kyori.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import tc.oc.pgm.api.party.Party;
@@ -14,6 +15,17 @@ public interface NameDecorationRegistry extends Listener {
    * @return The name, decorated
    */
   String getDecoratedName(Player player, Party party);
+
+  /**
+   * Get the fully decorated name as a Component
+   *
+   * <p>Note: Allows for prefix/suffix hover events
+   *
+   * @param player The player to decorate
+   * @param party The party this player is currently in
+   * @return The name, decorated, in component form
+   */
+  Component getDecoratedNameComponent(Player player, Party party);
 
   /**
    * Set what name decoration provider this registry should use

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
@@ -2,6 +2,9 @@ package tc.oc.pgm.namedecorations;
 
 import java.util.UUID;
 import javax.annotation.Nullable;
+import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
+import net.kyori.text.format.TextColor;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -13,6 +16,7 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.PlayerJoinMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
+import tc.oc.pgm.util.text.TextFormatter;
 
 public class NameDecorationRegistryImpl implements NameDecorationRegistry, Listener {
 
@@ -54,12 +58,31 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
         + ChatColor.WHITE;
   }
 
+  @Override
+  public Component getDecoratedNameComponent(Player player, Party party) {
+    return TextComponent.builder()
+        .append(getPrefixComponent(player.getUniqueId()))
+        .append(
+            player.getName(),
+            party == null ? TextColor.WHITE : TextFormatter.convert(party.getColor()))
+        .append(getSuffixComponent(player.getUniqueId()))
+        .build();
+  }
+
   public String getPrefix(UUID uuid) {
     return provider != null ? provider.getPrefix(uuid) : "";
   }
 
   public String getSuffix(UUID uuid) {
     return provider != null ? provider.getSuffix(uuid) : "";
+  }
+
+  public Component getPrefixComponent(UUID uuid) {
+    return provider != null ? provider.getPrefixComponent(uuid) : TextComponent.empty();
+  }
+
+  public Component getSuffixComponent(UUID uuid) {
+    return provider != null ? provider.getSuffixComponent(uuid) : TextComponent.empty();
   }
 
   @Override

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -113,7 +113,12 @@ groups:
     # Description of group - Displayed when hovering over prefix/suffix
     description: "&7Administrator of the server"
     # URL shown below description when hovering over prefix/suffix
-    click-link: "&bhttps://pgm.dev/"
+    click-link: "https://pgm.dev/"
+    
+    # If you want to further customize prefix/suffix flairs, provide components here to override format
+    # Only use if you know what you're doing
+    prefix-component: ""
+    suffix-component: ""
 
   # customgroup:
   #   prefix: ""

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -107,9 +107,20 @@ groups:
   # A special group for server operators.
   op:
     prefix: "&6❖"
+    suffix: ""
+    # Display name of the group - Displayed when hovering over prefix/suffix              
+    display-name: "&6Server Operator"
+    # Description of group - Displayed when hovering over prefix/suffix
+    description: "&7Administrator of the server"
+    # URL shown below description when hovering over prefix/suffix
+    click-link: "&bhttps://pgm.dev/"
 
   # customgroup:
   #   prefix: ""
+  #   suffix: ""
+  #   display-name: ""
+  #   description: ""
+  #   click-link: ""
   #   permissions:
   #    - "+pgm.premium"
   #   observer-permissions: []

--- a/util/src/main/i18n/templates/misc.properties
+++ b/util/src/main/i18n/templates/misc.properties
@@ -191,3 +191,6 @@ type.uri = url
 type.team = team
 
 type.settingkey = setting
+
+# {0} = a URL (e.g. "https://oc.tc")
+chat.clickLink = More info at {0}

--- a/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
@@ -6,11 +6,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import javax.annotation.Nullable;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
 import net.kyori.text.format.TextDecoration;
+import net.kyori.text.format.TextFormat;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import tc.oc.pgm.util.LegacyFormatUtils;
 import tc.oc.pgm.util.named.NameStyle;
@@ -134,5 +137,36 @@ public final class TextFormatter {
       // If not found use default
     }
     return textColor;
+  }
+
+  public static TextFormat convertFormat(Enum<?> color) {
+    TextFormat textColor = TextColor.WHITE;
+    try {
+      textColor = TextColor.valueOf(color.name());
+    } catch (IllegalArgumentException e) {
+      // If not found use default
+      if ((color instanceof ChatColor) && convertDecoration((ChatColor) color) != null) {
+        textColor = convertDecoration((ChatColor) color);
+      }
+    }
+    return textColor;
+  }
+
+  @Nullable
+  public static TextDecoration convertDecoration(ChatColor color) {
+    switch (color) {
+      case BOLD:
+        return TextDecoration.BOLD;
+      case ITALIC:
+        return TextDecoration.ITALIC;
+      case MAGIC:
+        return TextDecoration.OBFUSCATED;
+      case STRIKETHROUGH:
+        return TextDecoration.STRIKETHROUGH;
+      case UNDERLINE:
+        return TextDecoration.UNDERLINED;
+      default:
+        return null;
+    }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.util.text.types;
 
+import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import net.kyori.text.Component;
@@ -10,6 +12,7 @@ import net.kyori.text.event.HoverEvent;
 import net.kyori.text.event.HoverEvent.Action;
 import net.kyori.text.format.TextColor;
 import net.kyori.text.format.TextDecoration;
+import net.kyori.text.format.TextFormat;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -200,21 +203,32 @@ public interface PlayerComponent {
   static TextComponent.Builder stringToComponent(String str) {
     TextComponent.Builder component = TextComponent.builder();
     boolean isColor = false;
-    TextColor color = null;
+    TextFormat color = null;
+    List<TextFormat> decorations = Lists.newArrayList();
     for (int i = 0; i < str.length(); i++) {
       if (str.charAt(i) == ChatColor.COLOR_CHAR) {
         isColor = true;
         continue;
       }
-
       if (isColor) {
-        color = TextFormatter.convert(ChatColor.getByChar(str.charAt(i)));
+        TextFormat formatting = TextFormatter.convertFormat(ChatColor.getByChar(str.charAt(i)));
+        if (formatting instanceof TextColor) {
+          color = formatting;
+          decorations.clear();
+        } else {
+          decorations.add(formatting);
+        }
         isColor = false;
       } else {
-        component.append(String.valueOf(str.charAt(i)), color != null ? color : TextColor.WHITE);
+        TextComponent part =
+            TextComponent.of(
+                String.valueOf(str.charAt(i)),
+                (color != null ? TextColor.class.cast(color) : TextColor.WHITE));
+        for (TextFormat decoration : decorations)
+          part = part.decoration(TextDecoration.class.cast(decoration), true);
+        component.append(part);
       }
     }
-
     return component;
   }
 


### PR DESCRIPTION
# Add group hover info to chat

This PR resolves #603 and resolves #615 

A brief overview, now when a user hovers over a flair (if defined) information explaining what the rank is will be shown.

To add this feature I did a few things. First created a new `Flair` class in the config to hold info related to prefix/suffix including the attributes for the hover message. Then the main change was made in `ChatDispatcher`, where now instead of sending a formatted string, a component message is created and sent to players. Allowing for the hover/click events to work as intended. 

## Config
New configurations values added:
```yaml
groups:
  # A special group for server operators.
  op:
    prefix: "&6❖"
    suffix: ""
    # Display name of the group - Displayed when hovering over prefix/suffix              
    display-name: "&6Server Operator"
    # Description of group - Displayed when hovering over prefix/suffix
    description: "&7Administrator of the server"
    # URL shown below description when hovering over prefix/suffix
    click-link: "&bhttps://pgm.dev/"

    # If you want to further customize prefix/suffix flairs, provide components here to override format
    # Only use if you know what you're doing
    prefix-component: ""
    suffix-component: “"
```

## Screenshots
Example of defining just a `display-name`
![hello-1](https://user-images.githubusercontent.com/3377659/90108665-8129e880-dcff-11ea-8caf-5d45bd1fe1cf.gif)
Example of defining a `display-name` and `description`
![hello-2](https://user-images.githubusercontent.com/3377659/90108820-bb938580-dcff-11ea-8658-888f87e528a2.gif)
Example using all hover attributes including `click-link`
![hello-3](https://user-images.githubusercontent.com/3377659/90108834-bf270c80-dcff-11ea-88c1-a714da1d122c.gif)

## Suggestions
I applied the feedback given in #603 regarding the config layout, if there are any other suggestions just let me know here and I’ll be glad to adjust this. 

As always this PR was tested and all features work as intended 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>