### PR TITLE
Add legacy support for warnings

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -14,6 +14,7 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.setting.Settings;
 import tc.oc.pgm.filters.query.Query;
 import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.chat.Audience;
 import tc.oc.pgm.util.named.Named;
 
@@ -143,6 +144,15 @@ public interface MatchPlayer extends Audience, Named, Tickable, InventoryHolder 
    * @return Whether the {@link MatchPlayer} is vanished.
    */
   boolean isVanished();
+
+  /**
+   * Get whether the {@link MatchPlayer} is using a legacy version (1.7.X)
+   *
+   * @return Whether the {@link MatchPlayer} is using a legacy version
+   */
+  default boolean isLegacy() {
+    return getProtocolVersion() <= ViaUtils.VERSION_1_7;
+  }
 
   /**
    * Get whether the {@link MatchPlayer} can interact with things in the {@link Match}.

--- a/core/src/main/java/tc/oc/pgm/community/command/ModerationCommand.java
+++ b/core/src/main/java/tc/oc/pgm/community/command/ModerationCommand.java
@@ -50,6 +50,7 @@ import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.util.LegacyFormatUtils;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
 import tc.oc.pgm.util.UsernameFormatUtils;
+import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.chat.Audience;
 import tc.oc.pgm.util.chat.Sound;
 import tc.oc.pgm.util.named.NameStyle;
@@ -809,7 +810,25 @@ public class ModerationCommand implements Listener {
         TextComponent.builder().append(WARN_SYMBOL).append(titleWord).append(WARN_SYMBOL).build();
     Component subtitle = formatPunishmentReason(reason).color(TextColor.GOLD);
 
-    target.showTitle(title, subtitle, 5, 200, 10);
+    // Legacy support - Displays a chat message instead of title
+    if (ViaUtils.getProtocolVersion(target.getBukkit()) <= ViaUtils.VERSION_1_7) {
+      target.sendMessage(
+          TextFormatter.horizontalLineHeading(target.getBukkit(), title, TextColor.GRAY));
+      target.sendMessage(TextComponent.empty());
+      target.sendMessage(
+          TextFormatter.horizontalLineHeading(
+              target.getBukkit(),
+              subtitle,
+              TextColor.YELLOW,
+              TextDecoration.OBFUSCATED,
+              LegacyFormatUtils.MAX_CHAT_WIDTH));
+      target.sendMessage(TextComponent.empty());
+      target.sendMessage(
+          TextFormatter.horizontalLineHeading(target.getBukkit(), title, TextColor.GRAY));
+
+    } else {
+      target.showTitle(title, subtitle, 5, 200, 10);
+    }
     target.playSound(WARN_SOUND);
   }
 

--- a/core/src/main/java/tc/oc/pgm/community/command/ModerationCommand.java
+++ b/core/src/main/java/tc/oc/pgm/community/command/ModerationCommand.java
@@ -50,7 +50,6 @@ import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.util.LegacyFormatUtils;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
 import tc.oc.pgm.util.UsernameFormatUtils;
-import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.chat.Audience;
 import tc.oc.pgm.util.chat.Sound;
 import tc.oc.pgm.util.named.NameStyle;
@@ -811,7 +810,7 @@ public class ModerationCommand implements Listener {
     Component subtitle = formatPunishmentReason(reason).color(TextColor.GOLD);
 
     // Legacy support - Displays a chat message instead of title
-    if (ViaUtils.getProtocolVersion(target.getBukkit()) <= ViaUtils.VERSION_1_7) {
+    if (target.isLegacy()) {
       target.sendMessage(
           TextFormatter.horizontalLineHeading(target.getBukkit(), title, TextColor.GRAY));
       target.sendMessage(TextComponent.empty());

--- a/core/src/main/java/tc/oc/pgm/flag/LegacyFlagBeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/LegacyFlagBeamMatchModule.java
@@ -33,7 +33,6 @@ import tc.oc.pgm.events.PlayerLeaveMatchEvent;
 import tc.oc.pgm.flag.event.FlagStateChangeEvent;
 import tc.oc.pgm.flag.state.Carried;
 import tc.oc.pgm.flag.state.Spawned;
-import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.inventory.ItemBuilder;
 import tc.oc.pgm.util.nms.NMSHacks;
 
@@ -74,8 +73,7 @@ public class LegacyFlagBeamMatchModule implements MatchModule, Listener {
     Map<Flag, Beam> flags = beams.containsKey(player) ? beams.get(player) : new HashMap<>();
     if (flags.containsKey(flag) // beam duplication check
         || !flag.getDefinition().showBeam() // considers the flag definition's flag beam setting.
-        || (ViaUtils.getProtocolVersion(player.getBukkit())
-                > ViaUtils.VERSION_1_7 // version greater than 1.7 &
+        || (!player.isLegacy() // version greater than 1.7 &
             && !PGM.get()
                 .getConfiguration()
                 .useLegacyFlagBeams())) { // we shouldn't show to >1.7 players

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -204,7 +204,7 @@ public class MatchPlayerImpl implements MatchPlayer, PlayerAudience, Comparable<
   @Override
   public void resetGamemode() {
     boolean participating = canInteract(),
-        allowFlight = !participating && !(isDead() && getProtocolVersion() <= ViaUtils.VERSION_1_7);
+        allowFlight = !participating && !(isDead() && isLegacy());
     logger.fine("Refreshing gamemode as " + (participating ? "participant" : "observer"));
 
     if (!participating) getBukkit().leaveVehicle();

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoll.java
@@ -32,7 +32,6 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
-import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.named.MapNameStyle;
 import tc.oc.pgm.util.nms.NMSHacks;
 import tc.oc.pgm.util.text.TextTranslations;
@@ -143,7 +142,7 @@ public class MapPoll {
   }
 
   public void sendBook(MatchPlayer viewer, boolean forceOpen) {
-    if (viewer.getProtocolVersion() <= ViaUtils.VERSION_1_7) {
+    if (viewer.isLegacy()) {
       // Must use separate sendMessages, since 1.7 clients do not like the newline character
       viewer.sendMessage(TranslatableComponent.of("vote.header.map", TextColor.DARK_PURPLE));
       for (MapInfo pgmMap : votes.keySet()) viewer.sendMessage(getMapBookComponent(viewer, pgmMap));

--- a/core/src/main/java/tc/oc/pgm/tablist/LegacyMatchTabDisplay.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/LegacyMatchTabDisplay.java
@@ -192,7 +192,7 @@ public class LegacyMatchTabDisplay implements Listener {
   }
 
   private void render(MatchPlayer viewer) {
-    if (viewer.getProtocolVersion() > ViaUtils.VERSION_1_7) return;
+    if (!viewer.isLegacy()) return;
 
     Player bukkit = viewer.getBukkit();
     MapInfo mapInfo = viewer.getMatch().getMap();

--- a/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
@@ -106,15 +106,24 @@ public final class TextFormatter {
    */
   public static Component horizontalLineHeading(
       CommandSender sender, Component text, TextColor lineColor, int width) {
+    return horizontalLineHeading(sender, text, lineColor, TextDecoration.STRIKETHROUGH, width);
+  }
+
+  public static Component horizontalLineHeading(
+      CommandSender sender,
+      Component text,
+      TextColor lineColor,
+      TextDecoration decoration,
+      int width) {
     text = TextComponent.builder().append(" ").append(text).append(" ").build();
     int textWidth = LegacyFormatUtils.pixelWidth(TextTranslations.translateLegacy(text, sender));
     int spaceCount =
         Math.max(0, ((width - textWidth) / 2 + 1) / (LegacyFormatUtils.SPACE_PIXEL_WIDTH + 1));
     String line = Strings.repeat(" ", spaceCount);
     return TextComponent.builder()
-        .append(line, lineColor, TextDecoration.STRIKETHROUGH)
+        .append(line, lineColor, decoration)
         .append(text)
-        .append(line, lineColor, TextDecoration.STRIKETHROUGH)
+        .append(line, lineColor, decoration)
         .build();
   }
 


### PR DESCRIPTION
# Add legacy support for warnings
Atm `/warn` does not display the title to 1.7 users. To resolve that, this PR sends a nicely formatted text warning to 1.7 clients.

## Screenshot
![Screen Shot 2020-08-13 at 1 36 59 AM](https://user-images.githubusercontent.com/3377659/90113249-e8e33200-dd05-11ea-94c1-321451df9d53.png)


Signed-off-by: applenick <applenick@users.noreply.github.com>