### PR TITLE
Implement overtime

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/match/Match.java
+++ b/core/src/main/java/tc/oc/pgm/api/match/Match.java
@@ -329,6 +329,13 @@ public interface Match extends MatchPlayerResolver, MultiAudience, ModuleContext
   Collection<Competitor> getCompetitors();
 
   /**
+   * Get all the currently winning {@link Competitor}s in the {@link Match}.
+   *
+   * @return All the winning {@link Competitor}s.
+   */
+  Collection<Competitor> getWinners();
+
+  /**
    * Set or change the {@link Party} of a {@link MatchPlayer}.
    *
    * @param player The {@link MatchPlayer}.

--- a/core/src/main/java/tc/oc/pgm/command/graph/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/CommandGraph.java
@@ -21,6 +21,7 @@ import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.api.party.VictoryCondition;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
@@ -110,6 +111,7 @@ public class CommandGraph extends BasicBukkitCommandGraph {
       bind(MapInfo.class, new MapInfoParser());
       bind(Party.class, new PartyProvider());
       bind(TeamMatchModule.class, new TeamsProvider());
+      bind(VictoryCondition.class, new VictoryConditionProvider());
       bind(SettingKey.class, new SettingKeyParser());
       bind(SettingValue.class, new EnumProvider<>(SettingValue.class));
     }

--- a/core/src/main/java/tc/oc/pgm/command/graph/VictoryConditionProvider.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/VictoryConditionProvider.java
@@ -1,0 +1,76 @@
+package tc.oc.pgm.command.graph;
+
+import app.ashcon.intake.argument.CommandArgs;
+import app.ashcon.intake.argument.MissingArgumentException;
+import app.ashcon.intake.argument.Namespace;
+import app.ashcon.intake.bukkit.parametric.provider.BukkitProvider;
+import app.ashcon.intake.parametric.ProvisionException;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.VictoryCondition;
+import tc.oc.pgm.result.VictoryConditions;
+import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.teams.TeamMatchModule;
+import tc.oc.pgm.timelimit.TimeLimit;
+import tc.oc.pgm.timelimit.TimeLimitMatchModule;
+import tc.oc.pgm.util.text.TextException;
+
+public class VictoryConditionProvider implements BukkitProvider<VictoryCondition> {
+
+  @Override
+  public String getName() {
+    return "victory condition";
+  }
+
+  @Nullable
+  @Override
+  public VictoryCondition get(
+      CommandSender sender, CommandArgs args, List<? extends Annotation> list)
+      throws MissingArgumentException, ProvisionException {
+    final String text = args.next();
+
+    final Match match = PGM.get().getMatchManager().getMatch(sender);
+    if (match == null) {
+      throw TextException.of("command.onlyPlayers");
+    }
+
+    // Default to current tl victory condition
+    if (text == null) {
+      final TimeLimitMatchModule time = match.needModule(TimeLimitMatchModule.class);
+      final TimeLimit existing = time.getTimeLimit();
+      return existing == null ? null : existing.getResult();
+    }
+
+    return VictoryConditions.parse(match, text);
+  }
+
+  private static final List<String> BASE_SUGGESTIONS =
+      Arrays.asList("default", "tie", "objectives", "score");
+
+  @Override
+  public List<String> getSuggestions(
+      String prefix,
+      CommandSender sender,
+      Namespace namespace,
+      List<? extends Annotation> modifiers) {
+    final Match match = PGM.get().getMatchManager().getMatch(sender);
+    if (match == null) return BASE_SUGGESTIONS;
+
+    TeamMatchModule tmm = match.getModule(TeamMatchModule.class);
+    if (tmm == null) return BASE_SUGGESTIONS;
+
+    return Stream.concat(
+            BASE_SUGGESTIONS.stream(),
+            tmm.getParticipatingTeams().stream()
+                .map(Team::getNameLegacy)
+                .map(name -> name.replace(" ", "")))
+        .collect(Collectors.toList());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/countdowns/SingleCountdownContext.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/SingleCountdownContext.java
@@ -14,7 +14,7 @@ public class SingleCountdownContext extends CountdownContext {
   @Override
   public void start(
       Countdown countdown, Duration duration, @Nullable Duration interval, int count) {
-    this.cancelAll();
+    this.cancelOthers(countdown);
     super.start(countdown, duration, interval, count);
   }
 

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -641,6 +641,12 @@ public class MatchImpl implements Match {
   }
 
   @Override
+  public Collection<Competitor> getWinners() {
+    competitors.invalidateRanking();
+    return ImmutableList.copyOf(competitors.getRank(0));
+  }
+
+  @Override
   public void addParty(Party party) {
     logger.fine("Adding party " + party);
     checkNotNull(party);

--- a/core/src/main/java/tc/oc/pgm/result/VictoryConditions.java
+++ b/core/src/main/java/tc/oc/pgm/result/VictoryConditions.java
@@ -37,19 +37,13 @@ public class VictoryConditions {
       case "score":
         return new ScoreVictoryCondition();
       default:
-        if (match != null) {
-          TeamFactory winner = Teams.getTeam(raw, match);
-          if (winner == null) {
-            throw TextException.invalidFormat(raw, Team.class, null);
-          }
-          return new TeamVictoryCondition(winner);
-        } else {
-          TeamFactory winner = Teams.getTeam(raw, factory);
-          if (winner == null) {
-            throw TextException.invalidFormat(raw, Team.class, null);
-          }
-          return new TeamVictoryCondition(winner);
+        TeamFactory winner;
+        if (match != null) winner = Teams.getTeam(raw, match);
+        else winner = Teams.getTeam(raw, factory);
+        if (winner == null) {
+          throw TextException.invalidFormat(raw, Team.class, null);
         }
+        return new TeamVictoryCondition(winner);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/timelimit/OvertimeCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/OvertimeCountdown.java
@@ -1,0 +1,102 @@
+package tc.oc.pgm.timelimit;
+
+import java.time.Duration;
+import java.time.Instant;
+import javax.annotation.Nullable;
+import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
+import net.kyori.text.TranslatableComponent;
+import net.kyori.text.format.TextColor;
+import net.kyori.text.format.TextDecoration;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.util.text.PeriodFormats;
+
+public class OvertimeCountdown extends TimeLimitCountdown {
+
+  private @Nullable Instant maxRefresh;
+  private @Nullable Competitor winner;
+
+  public OvertimeCountdown(Match match, TimeLimit timeLimit) {
+    super(match, timeLimit);
+  }
+
+  public @Nullable Duration getRemaining() {
+    return remaining;
+  }
+
+  @Override
+  protected TextColor urgencyColor() {
+    long seconds = remaining.getSeconds();
+    if (seconds > 20) {
+      return TextColor.GREEN;
+    } else if (seconds > 10) {
+      return TextColor.YELLOW;
+    } else if (seconds > 5) {
+      return TextColor.GOLD;
+    } else {
+      return TextColor.DARK_RED;
+    }
+  }
+
+  @Override
+  protected Component formatText() {
+    return TranslatableComponent.of(
+            "misc.overtime",
+            TextColor.YELLOW,
+            TextComponent.of(colonTime(), urgencyColor()).decoration(TextDecoration.BOLD, false))
+        .decoration(TextDecoration.BOLD, true);
+  }
+
+  @Override
+  protected boolean showChat() {
+    return false;
+  }
+
+  @Override
+  protected boolean playSounds() {
+    // Play sounds on the last 5 seconds, but only if overtime isn't super short
+    return remaining.getSeconds() <= 5 && total.getSeconds() >= 10;
+  }
+
+  @Override
+  public void onStart(Duration remaining, Duration total) {
+    super.onStart(remaining, total);
+
+    // Should never happen, but rather play safe
+    if (timeLimit.getOvertime() == null) return;
+
+    match.sendMessage(TranslatableComponent.of("broadcast.overtime", TextColor.YELLOW));
+    if (timeLimit.getMaxOvertime() != null) {
+      match.sendMessage(
+          TranslatableComponent.of(
+              "broadcast.overtime.limit",
+              TextColor.YELLOW,
+              PeriodFormats.briefNaturalApproximate(timeLimit.getMaxOvertime())
+                  .color(TextColor.AQUA)));
+
+      maxRefresh = Instant.now().plus(timeLimit.getMaxOvertime()).minus(timeLimit.getOvertime());
+    }
+  }
+
+  @Override
+  public void onTick(Duration remaining, Duration total) {
+    Competitor newWinner = timeLimit.currentWinner(match);
+
+    if ((newWinner == null || this.winner != newWinner)
+        && (maxRefresh == null || !Instant.now().isAfter(maxRefresh))) {
+      this.winner = newWinner;
+      start(); // Force the countdown to be re-scheduled
+      remaining = total;
+    }
+    super.onTick(remaining, total);
+  }
+
+  protected boolean mayEnd() {
+    return true;
+  }
+
+  public void start() {
+    this.getMatch().getCountdown().start(this, this.timeLimit.getOvertime());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.timelimit;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.time.Duration;
+import java.util.Collection;
 import javax.annotation.Nullable;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
@@ -13,23 +14,39 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.VictoryCondition;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.util.TimeUtils;
+import tc.oc.pgm.util.collection.RankedSet;
 
 @FeatureInfo(name = "time-limit")
 public class TimeLimit extends SelfIdentifyingFeatureDefinition implements VictoryCondition {
-  private final Duration duration;
+  private final Duration duration, overtime, maxOvertime;
   private final @Nullable VictoryCondition result;
   private final boolean show;
 
   public TimeLimit(
-      @Nullable String id, Duration duration, @Nullable VictoryCondition result, boolean show) {
+      @Nullable String id,
+      Duration duration,
+      @Nullable Duration overtime,
+      @Nullable Duration maxOvertime,
+      @Nullable VictoryCondition result,
+      boolean show) {
     super(id);
     this.duration = checkNotNull(duration);
+    this.overtime = overtime;
+    this.maxOvertime = maxOvertime;
     this.result = result;
     this.show = show;
   }
 
   public Duration getDuration() {
     return duration;
+  }
+
+  public @Nullable Duration getOvertime() {
+    return overtime;
+  }
+
+  public @Nullable Duration getMaxOvertime() {
+    return maxOvertime;
   }
 
   public @Nullable VictoryCondition getResult() {
@@ -58,6 +75,18 @@ public class TimeLimit extends SelfIdentifyingFeatureDefinition implements Victo
   public boolean isCompleted(Match match) {
     TimeLimitCountdown countdown = match.needModule(TimeLimitMatchModule.class).getCountdown();
     return countdown != null && match.getCountdown().isFinished(countdown);
+  }
+
+  public @Nullable Competitor currentWinner(Match match) {
+    Collection<Competitor> winners;
+    if (result == null) winners = match.getWinners();
+    else {
+      RankedSet<Competitor> comp = new RankedSet<>(result);
+      comp.addAll(match.getCompetitors());
+      winners = comp.getRank(0);
+    }
+    if (winners.size() == 1) return winners.iterator().next();
+    return null;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
@@ -19,7 +19,7 @@ public class TimeLimitCountdown extends MatchCountdown {
   private static final Sound CRESCENDO_SOUND =
       new Sound("portal.trigger", 1f, 0.78f); // Last few seconds
 
-  private final TimeLimit timeLimit;
+  protected final TimeLimit timeLimit;
 
   public TimeLimitCountdown(Match match, TimeLimit timeLimit) {
     super(match);
@@ -46,11 +46,15 @@ public class TimeLimitCountdown extends MatchCountdown {
     return this.timeLimit.getShow() && super.showBossBar();
   }
 
+  protected boolean playSounds() {
+    return this.timeLimit.getShow();
+  }
+
   @Override
   public void onTick(Duration remaining, Duration total) {
     super.onTick(remaining, total);
 
-    if (this.timeLimit.getShow()) {
+    if (this.playSounds()) {
       long secondsLeft = remaining.getSeconds();
       if (secondsLeft > 30) {
         // Beep for chat messages before the last 30 seconds
@@ -73,10 +77,19 @@ public class TimeLimitCountdown extends MatchCountdown {
     invalidateBossBar();
   }
 
+  protected boolean mayEnd() {
+    return timeLimit.getOvertime() == null || timeLimit.currentWinner(match) != null;
+  }
+
   @Override
   public void onEnd(Duration total) {
     super.onEnd(total);
-    this.getMatch().calculateVictory();
+    if (mayEnd()) {
+      this.getMatch().calculateVictory();
+    } else {
+      TimeLimitMatchModule tl = this.getMatch().getModule(TimeLimitMatchModule.class);
+      if (tl != null) tl.startOvertime();
+    }
     this.freeze(Duration.ZERO);
   }
 

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitMatchModule.java
@@ -11,6 +11,7 @@ public class TimeLimitMatchModule implements MatchModule {
   private final TimeLimit defaultTimeLimit;
   private @Nullable TimeLimit timeLimit;
   private @Nullable TimeLimitCountdown countdown;
+  private @Nullable OvertimeCountdown overtime;
 
   public TimeLimitMatchModule(Match match, @Nullable TimeLimit timeLimit) {
     this.match = match;
@@ -48,7 +49,7 @@ public class TimeLimitMatchModule implements MatchModule {
   }
 
   public @Nullable TimeLimitCountdown getCountdown() {
-    return countdown;
+    return countdown != null ? countdown : overtime;
   }
 
   public @Nullable Duration getFinalRemaining() {
@@ -56,6 +57,8 @@ public class TimeLimitMatchModule implements MatchModule {
   }
 
   public void start() {
+    cancel();
+
     // Match.finish() will cancel this, so we don't have to
     if (this.timeLimit != null && match.isRunning()) {
       this.countdown = new TimeLimitCountdown(match, this.timeLimit);
@@ -63,10 +66,22 @@ public class TimeLimitMatchModule implements MatchModule {
     }
   }
 
+  public void startOvertime() {
+    cancel();
+    if (this.timeLimit != null && this.timeLimit.getOvertime() != null && match.isRunning()) {
+      this.overtime = new OvertimeCountdown(match, this.timeLimit);
+      this.overtime.start();
+    }
+  }
+
   public void cancel() {
     if (this.countdown != null) {
       this.countdown.cancel();
       this.countdown = null;
+    }
+    if (this.overtime != null) {
+      this.overtime.cancel();
+      this.overtime = null;
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
@@ -84,6 +84,8 @@ public class TimeLimitModule implements MapModule {
       return new TimeLimit(
           el.getAttributeValue("id"),
           TextParser.parseDuration(el.getTextNormalize()),
+          XMLUtils.parseDuration(el.getAttribute("overtime")),
+          XMLUtils.parseDuration(el.getAttribute("max-overtime")),
           parseVictoryCondition(factory, el.getAttribute("result")),
           XMLUtils.parseBoolean(el.getAttribute("show"), true));
     }

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -111,8 +111,8 @@ broadcast.matchStart = The match has started!
 
 broadcast.startCancel = Match start cancelled
 
-broadcast.overtime = The match was tied, overtime has started, once the tie is broken time will start ticking
-broadcast.overtime.limit = If the match is still tied after {0} it will result in a tie.
+broadcast.overtime = Overtime! The timer will start after the tie is broken
+broadcast.overtime.limit = If there is no winner after {0}, the match will be tied.
 
 broadcast.gameOver = Game over!
 

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -111,6 +111,9 @@ broadcast.matchStart = The match has started!
 
 broadcast.startCancel = Match start cancelled
 
+broadcast.overtime = The match was tied, overtime has started, once the tie is broken time will start ticking
+broadcast.overtime.limit = If the match is still tied after {0} it will result in a tie.
+
 broadcast.gameOver = Game over!
 
 broadcast.gameOver.teamWon = Your team won!

--- a/util/src/main/i18n/templates/misc.properties
+++ b/util/src/main/i18n/templates/misc.properties
@@ -54,6 +54,8 @@ misc.timeAgo = {0} ago
 # {0} = duration (e.g. "1:00" for 1 minute left, "15:25" for 15 minutes and 25 seconds left)
 misc.timeRemaining = Time Remaining: {0}
 
+misc.overtime = Overtime {0}
+
 # {0} = player name
 misc.createdBy = Created by {0}
 


### PR DESCRIPTION
Addresses https://github.com/PGMDev/PGM/issues/473#issuecomment-626084693 , and fixes #547 & fixes #529 

Maps can define a overtime as well as a max-overtime on their timelimit, it can also be defined via the `/tl` command, once the time limit runs out, if no team is winning (there's a tie) overtime starts.

As soon as one team breaks the tie time starts ticking down, if a tie or a comeback (other team starts winning) the time refreshes back to start ticking down from full overtime.

Once max overtime has passed, time will no longer keep refreshing, this avoids infinite matches.

Has been tested and works correctly, there is *one* known bug, if you're approaching the max overtime limit, time may not refresh if it had started ticking down already (even if it should refresh, but to less than the overtime value).
Eg: max-overtime 15m, overtime 1m, at 13:45 overtime starts ticking down, at 14:15, overtime is at 30 seconds left, and a tie occurs again or one team makes a comeback, overtime will not refresh, but it should have refreshed to 0:45.

Some refactoring of countdowns was required or otherwise this "continuously-refreshing-countdown" would cause the bossbar/countdown (including wither packets) to keep on being re-created