### PR TITLE
Add default-maps to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,5 @@ match-*/
 maps.zip
 maps/
 maps-default/
+default-maps/
 


### PR DESCRIPTION
Ever since #579 the default repo if you don't setup config will be `default-maps` instead of `maps-default`, wich means setting up a new dev enviroment and running the server will cause that folder to appear