### PR TITLE
Fix mercy rules when leader scores 0 points

### DIFF
--- a/core/src/main/java/tc/oc/pgm/score/MercyRule.java
+++ b/core/src/main/java/tc/oc/pgm/score/MercyRule.java
@@ -68,7 +68,9 @@ public class MercyRule {
 
     // Score larger than trailing score
     if (event.getNewScore() > getTrailerScore()) {
-      setTrailer(event.getCompetitor(), event.getNewScore());
+      if (!isLeader(event.getCompetitor())) {
+        setTrailer(event.getCompetitor(), event.getNewScore());
+      }
       return;
     }
 
@@ -97,7 +99,7 @@ public class MercyRule {
       }
     }
 
-    setLeader(lead.getKey(), lead.getValue());
-    setTrailer(trail.getKey(), trail.getValue());
+    setLeader(lead.getKey(), lead.getKey() == null ? 0 : lead.getValue());
+    setTrailer(trail.getKey(), trail.getKey() == null ? 0 : trail.getValue());
   }
 }


### PR DESCRIPTION
Fixes bugs with mercy rules, one that causes mercy rules to overlap leader and trailer if the leader got 0 points, completely breaking mercy rules. 

The other is on cycle sometimes negative infinity was displayed as score limit