### PR TITLE
Allow blockdrop trample on survival mode

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/event/AdventureModeInteractEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/event/AdventureModeInteractEvent.java
@@ -1,8 +1,5 @@
 package tc.oc.pgm.api.event;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import org.bukkit.GameMode;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -10,7 +7,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerActionBase;
 
 /**
- * An extended {@link Block} interact event for {@link Player}s in {@link
+ * An extended {@link Block} interact event for {@link Player}s sometimes in {@link
  * org.bukkit.GameMode#ADVENTURE} mode.
  */
 public abstract class AdventureModeInteractEvent extends PlayerActionBase implements Cancellable {
@@ -20,9 +17,6 @@ public abstract class AdventureModeInteractEvent extends PlayerActionBase implem
 
   public AdventureModeInteractEvent(Player player, Block block) {
     super(player);
-    checkArgument(
-        player.getGameMode() == GameMode.ADVENTURE,
-        "adventure interact event for non-adventure player");
     this.block = block;
   }
 

--- a/core/src/main/java/tc/oc/pgm/api/event/BlockTrampleEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/event/BlockTrampleEvent.java
@@ -5,8 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
 /**
- * Called when a {@link Player} tramples over a {@link Block} in {@link
- * org.bukkit.GameMode#ADVENTURE} mode.
+ * Called when a {@link Player} tramples over a {@link Block}.
  *
  * @see AdventureModeInteractEvent
  */

--- a/core/src/main/java/tc/oc/pgm/listeners/GeneralizingListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/GeneralizingListener.java
@@ -226,7 +226,6 @@ public class GeneralizingListener implements Listener {
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void detectBlockTrample(CoarsePlayerMoveEvent event) {
     if (!event.getPlayer().isOnGround()) return;
-    if (event.getPlayer().getGameMode() != GameMode.ADVENTURE) return;
 
     Block block = event.getBlockTo().getBlock();
     if (!block.getType().isSolid()) {


### PR DESCRIPTION
Currently blockdrops trample only works if you're on adventure mode. This, while looks to be intended code-wise, makes little to no sense mapmaking-wise.
The same change was made in 1.9+ PGM, see: https://github.com/OvercastNetwork/ProjectAres/blob/7484cb81fcc33814fe26812684660da4e0dbd671/Util/bukkit/src/main/java/tc/oc/commons/bukkit/listeners/PlayerMovementListener.java#L242