### PR TITLE
Fix vanish chat formatting

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -473,6 +473,7 @@ public class ChatDispatcher implements Listener {
 
   private Component getChatFormat(@Nullable Component prefix, MatchPlayer player, String message) {
     Component msg = TextComponent.of(message != null ? message : "");
+    if (player.isVanished()) prefix = ADMIN_CHAT_PREFIX;
     if (prefix == null)
       return TextComponent.builder()
           .append("<", TextColor.WHITE)


### PR DESCRIPTION
# Fix vanish chat formatting
Another formatting fix related to the recent chat changes. While vanished, sending a message to global or team chat should re-format it as an admin chat message. While currently the message is still sent to the proper recipients, the formatting is not applying the admin chat prefix. This PR resolves that issue.

Signed-off-by: applenick <applenick@users.noreply.github.com>