### PR TITLE
Fix vanish chat

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -114,6 +114,11 @@ public class ChatDispatcher implements Listener {
       desc = "Send a message to everyone",
       usage = "[message]")
   public void sendGlobal(Match match, MatchPlayer sender, @Nullable @Text String message) {
+    if (sender != null && sender.isVanished()) {
+      sendAdmin(match, sender, message);
+      return;
+    }
+
     if (checkMute(sender)) {
       send(
           match,
@@ -131,6 +136,11 @@ public class ChatDispatcher implements Listener {
       desc = "Send a message to your team",
       usage = "[message]")
   public void sendTeam(Match match, MatchPlayer sender, @Nullable @Text String message) {
+    if (sender != null && sender.isVanished()) {
+      sendAdmin(match, sender, message);
+      return;
+    }
+
     final Party party = sender == null ? match.getDefaultParty() : sender.getParty();
 
     // No team chat when playing free-for-all or match end, default to global chat
@@ -171,7 +181,7 @@ public class ChatDispatcher implements Listener {
     send(
         match,
         sender,
-        message != null ? BukkitUtils.colorize(message) : message,
+        message != null ? BukkitUtils.colorize(message) : null,
         AC_FORMAT,
         getChatFormat(ADMIN_CHAT_PREFIX, sender, message),
         AC_FILTER,
@@ -380,18 +390,16 @@ public class ChatDispatcher implements Listener {
           .getAsyncExecutor()
           .execute(
               () -> {
-                final Predicate<MatchPlayer> finalFilter = sender.isVanished() ? AC_FILTER : filter;
-                final String finalFormat = sender.isVanished() ? AC_FORMAT : format;
                 final AsyncPlayerChatEvent event =
                     new AsyncPlayerChatEvent(
                         false,
                         sender.getBukkit(),
                         message,
                         match.getPlayers().stream()
-                            .filter(finalFilter)
+                            .filter(filter)
                             .map(MatchPlayer::getBukkit)
                             .collect(Collectors.toSet()));
-                event.setFormat(finalFormat);
+                event.setFormat(format);
                 CHAT_EVENT_CACHE.put(event, true);
                 match.callEvent(event);
 


### PR DESCRIPTION
Makes it so chatting while vanished forces you thru the admin chat method, instead of chaning the prefix and the sender in two different places.
Makes it so if you don't have permission for adminchat it will not let you chat there

Replaces the need for #623 