### PR TITLE
Fix formatting of hover messages & prevent NPE when missing display name

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -332,18 +332,27 @@ public interface Config {
       if (prefix ? getPrefixOverride() != null : getSuffixOverride() != null) {
         return prefix ? getPrefixOverride() : getSuffixOverride();
       }
-      TextComponent.Builder hover = TextComponent.builder().append(getDisplayName());
+      TextComponent.Builder hover = TextComponent.builder();
+      boolean addNewline = false;
+      if (getDisplayName() != null && !getDisplayName().isEmpty()) {
+        addNewline = true;
+        hover.append(getDisplayName());
+      }
       if (getDescription() != null && !getDescription().isEmpty()) {
-        hover.append("\n").append(getDescription());
+        if (addNewline) hover.append(TextComponent.newline());
+        addNewline = true;
+        hover.append(getDescription());
       }
 
       if (getClickLink() != null && !getClickLink().isEmpty()) {
+        if (addNewline) hover.append(TextComponent.newline());
+
         Component clickLink =
             TranslatableComponent.of(
                 "chat.clickLink",
                 TextColor.DARK_AQUA,
                 TextComponent.of(getClickLink(), TextColor.AQUA, TextDecoration.UNDERLINED));
-        hover.append("\n").append(clickLink);
+        hover.append(clickLink);
       }
 
       TextComponent.Builder component =


### PR DESCRIPTION
```
Caused by: java.lang.NullPointerException
	at tc.oc.pgm.lib.net.kyori.text.TextComponent.of(TextComponent.java:108)
	at tc.oc.pgm.lib.net.kyori.text.ComponentBuilder.append(ComponentBuilder.java:52)
	at tc.oc.pgm.api.Config$Flair.getComponent(Config.java:335)
	at tc.oc.pgm.namedecorations.ConfigDecorationProvider.lambda$generateFlair$3(ConfigDecorationProvider.java:50)
```

When no display name was configured it would throw a NPE whenever anyone with the role tried to talk in chat. Additionally, prevented random newlines if some part of the hover wasn't there, since it's all optional