### PR TITLE
Fix bukkit command permissions not working

### DIFF
--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -143,9 +143,9 @@ groups:
     #  "-" denotes a negative permission.
     #  "+" denotes a positive permission.
     permissions:
-      - "-bukkit.command.kill"
-      - "-bukkit.command.me"
-      - "-bukkit.command.tell"
+      - "-minecraft.command.kill"
+      - "-minecraft.command.me"
+      - "-minecraft.command.tell"
       - "-worldedit.navigation.ceiling"
       - "-worldedit.navigation.up"
       - "-worldedit.calc"


### PR DESCRIPTION
The `bukkit.*` commands are not actually a thing and instead `minecraft.` should be used.