### PR TITLE
Improvements to custom voting options

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
@@ -132,7 +132,7 @@ public class VotingCommand {
     vote.getOptions().clear();
 
     if (maps.isEmpty()) {
-      viewer.sendWarning(TranslatableComponent.of("map.noMapsFound"));
+      viewer.sendWarning(TranslatableComponent.of("vote.noMapsFound"));
     } else {
       ChatDispatcher.broadcastAdminChatMessage(clearedMsg, match);
     }

--- a/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
@@ -52,12 +52,12 @@ public class VotingCommand {
             UsernameFormatUtils.formatStaffName(sender, match),
             map.getStyledName(MapNameStyle.COLOR));
 
-    if (vote.isCustomMapSelected(map)) {
+    if (vote.getOptions().isAdded(map)) {
       viewer.sendWarning(addMessage);
       return;
     }
 
-    if (vote.addCustomVoteMap(map)) {
+    if (vote.getOptions().addVote(map)) {
       ChatDispatcher.broadcastAdminChatMessage(addMessage, match);
     } else {
       viewer.sendWarning(TranslatableComponent.of("vote.limit", TextColor.RED));
@@ -77,7 +77,7 @@ public class VotingCommand {
       Match match)
       throws CommandException {
     VotingPool vote = getVotingPool(sender, mapOrder);
-    if (vote.removeCustomVote(map)) {
+    if (vote.getOptions().removeMap(map)) {
       ChatDispatcher.broadcastAdminChatMessage(
           TranslatableComponent.of(
               "vote.remove",
@@ -99,7 +99,7 @@ public class VotingCommand {
     VotingPool vote = getVotingPool(sender, mapOrder);
     Component voteModeName =
         TranslatableComponent.of(
-            vote.toggleVoteMode() ? "vote.mode.replace" : "vote.mode.create",
+            vote.getOptions().toggleMode() ? "vote.mode.replace" : "vote.mode.create",
             TextColor.LIGHT_PURPLE);
     ChatDispatcher.broadcastAdminChatMessage(
         TranslatableComponent.of(
@@ -114,12 +114,12 @@ public class VotingCommand {
       aliases = {"clear"},
       desc = "Clear all custom map selections from the next vote",
       perms = Permissions.SETNEXT)
-  public void clearMaps(CommandSender sender, Match match, MapOrder mapOrder)
+  public void clearMaps(Audience viewer, CommandSender sender, Match match, MapOrder mapOrder)
       throws CommandException {
     VotingPool vote = getVotingPool(sender, mapOrder);
 
     List<Component> maps =
-        vote.getCustomVoteMaps().stream()
+        vote.getOptions().getCustomVoteMaps().stream()
             .map(mi -> mi.getStyledName(MapNameStyle.COLOR))
             .collect(Collectors.toList());
     Component clearedMsg =
@@ -129,9 +129,13 @@ public class VotingCommand {
             UsernameFormatUtils.formatStaffName(sender, match),
             TextFormatter.list(maps, TextColor.GRAY));
 
-    vote.getCustomVoteMaps().clear();
+    vote.getOptions().clear();
 
-    ChatDispatcher.broadcastAdminChatMessage(clearedMsg, match);
+    if (maps.isEmpty()) {
+      viewer.sendWarning(TranslatableComponent.of("map.noMapsFound"));
+    } else {
+      ChatDispatcher.broadcastAdminChatMessage(clearedMsg, match);
+    }
   }
 
   @Command(
@@ -141,13 +145,13 @@ public class VotingCommand {
       throws CommandException {
     VotingPool vote = getVotingPool(sender, mapOrder);
 
-    int currentMaps = vote.getCustomVoteMaps().size();
+    int currentMaps = vote.getOptions().getCustomVoteMaps().size();
     TextColor listNumColor =
         currentMaps >= VotingPool.MIN_CUSTOM_VOTE_OPTIONS
             ? currentMaps < VotingPool.MAX_VOTE_OPTIONS ? TextColor.GREEN : TextColor.YELLOW
             : TextColor.RED;
 
-    String modeKey = vote.getVoteMode() ? "replace" : "create";
+    String modeKey = vote.getOptions().isReplace() ? "replace" : "create";
     Component mode =
         TranslatableComponent.of(String.format("vote.mode.%s", modeKey), TextColor.LIGHT_PURPLE)
             .hoverEvent(
@@ -172,7 +176,7 @@ public class VotingCommand {
     viewer.sendMessage(listMsg);
 
     int index = 1;
-    for (MapInfo mi : vote.getCustomVoteMaps()) {
+    for (MapInfo mi : vote.getOptions().getCustomVoteMaps()) {
       Component indexedName =
           TextComponent.builder()
               .append(Integer.toString(index), TextColor.YELLOW)
@@ -192,7 +196,7 @@ public class VotingCommand {
         VotingPool votePool = (VotingPool) manager.getActiveMapPool();
         if (votePool.getCurrentPoll() != null) {
           throw new CommandException(
-              ChatColor.RED + TextTranslations.translate("vote.disabled", sender));
+              ChatColor.RED + TextTranslations.translate("vote.modify.disallow", sender));
         }
         return votePool;
       }

--- a/core/src/main/java/tc/oc/pgm/rotation/CustomVotingPoolOptions.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/CustomVotingPoolOptions.java
@@ -1,12 +1,12 @@
 package tc.oc.pgm.rotation;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import tc.oc.pgm.api.map.MapInfo;
 
-public class VotingPoolOptions {
+public class CustomVotingPoolOptions {
 
   // Set of maps to be used in custom vote selection
   private Set<MapInfo> customVoteMaps;
@@ -14,7 +14,7 @@ public class VotingPoolOptions {
   // Whether custom map selection should replace existing entries
   private boolean replace;
 
-  public VotingPoolOptions() {
+  public CustomVotingPoolOptions() {
     this.customVoteMaps = Sets.newHashSet();
     this.replace = true;
   }
@@ -57,8 +57,7 @@ public class VotingPoolOptions {
   }
 
   public Map<MapInfo, Double> getCustomVoteMapWeighted() {
-    Map<MapInfo, Double> maps = Maps.newHashMap();
-    customVoteMaps.forEach(map -> maps.put(map, VotingPool.DEFAULT_WEIGHT));
-    return maps;
+    return customVoteMaps.stream()
+        .collect(Collectors.toMap(map -> map, x -> VotingPool.DEFAULT_WEIGHT));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -52,7 +52,7 @@ public class MapPoolManager implements MapOrder {
   private MapInfo overriderMap;
 
   /** Options related to voting pools, allows for custom voting @see {@link VotingPool} * */
-  private VotingPoolOptions options;
+  private CustomVotingPoolOptions options;
 
   private Datastore database;
 
@@ -60,7 +60,7 @@ public class MapPoolManager implements MapOrder {
     this.logger = logger;
     this.mapPoolsFile = mapPoolsFile;
     this.database = database;
-    this.options = new VotingPoolOptions();
+    this.options = new CustomVotingPoolOptions();
 
     if (!mapPoolsFile.exists()) {
       try {
@@ -216,7 +216,7 @@ public class MapPoolManager implements MapOrder {
     return overriderMap;
   }
 
-  public VotingPoolOptions getCustomVoteOptions() {
+  public CustomVotingPoolOptions getCustomVoteOptions() {
     return options;
   }
 

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -51,12 +51,16 @@ public class MapPoolManager implements MapOrder {
   /** When a {@link MapInfo} is manually set next, it overrides the rotation order * */
   private MapInfo overriderMap;
 
+  /** Options related to voting pools, allows for custom voting @see {@link VotingPool} * */
+  private VotingPoolOptions options;
+
   private Datastore database;
 
   public MapPoolManager(Logger logger, File mapPoolsFile, Datastore database) {
     this.logger = logger;
     this.mapPoolsFile = mapPoolsFile;
     this.database = database;
+    this.options = new VotingPoolOptions();
 
     if (!mapPoolsFile.exists()) {
       try {
@@ -210,6 +214,10 @@ public class MapPoolManager implements MapOrder {
 
   protected MapInfo getOverriderMap() {
     return overriderMap;
+  }
+
+  public VotingPoolOptions getCustomVoteOptions() {
+    return options;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
@@ -35,7 +35,7 @@ public class VotingPool extends MapPool {
       MapPoolManager manager,
       ConfigurationSection section,
       String name,
-      @Nullable VotingPoolOptions existingOptions) {
+      @Nullable CustomVotingPoolOptions existingOptions) {
     super(manager, section, name);
     VOTE_SIZE = Math.min(MAX_VOTE_OPTIONS, maps.size() - 1);
     ADJUST_FACTOR = 1d / (maps.size() * MAX_VOTE_OPTIONS);
@@ -117,7 +117,7 @@ public class VotingPool extends MapPool {
             TimeUnit.SECONDS);
   }
 
-  public VotingPoolOptions getOptions() {
+  public CustomVotingPoolOptions getOptions() {
     return manager.getCustomVoteOptions();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/VotingPool.java
@@ -1,12 +1,10 @@
 package tc.oc.pgm.rotation;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.bukkit.configuration.ConfigurationSection;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.match.Match;
@@ -20,7 +18,7 @@ public class VotingPool extends MapPool {
   // Number of maps required for a custom vote (/vote)
   public static final int MIN_CUSTOM_VOTE_OPTIONS = 2;
   // If maps were single voted, it would avg to this default
-  private static final double DEFAULT_WEIGHT = 1d / MAX_VOTE_OPTIONS;
+  public static final double DEFAULT_WEIGHT = 1d / MAX_VOTE_OPTIONS;
 
   // Amount of maps to display on vote
   private final int VOTE_SIZE;
@@ -29,13 +27,15 @@ public class VotingPool extends MapPool {
 
   private MapPoll currentPoll;
 
-  /** Override pool is used when custom maps are defined, does not count for regular vote score * */
-  private Set<MapInfo> customVoteMaps = Sets.newHashSet();
-
-  /** Whether custom vote should replace existing maps or override the poll * */
-  private boolean replaceMaps = true;
-
   public VotingPool(MapPoolManager manager, ConfigurationSection section, String name) {
+    this(manager, section, name, null);
+  }
+
+  public VotingPool(
+      MapPoolManager manager,
+      ConfigurationSection section,
+      String name,
+      @Nullable VotingPoolOptions existingOptions) {
     super(manager, section, name);
     VOTE_SIZE = Math.min(MAX_VOTE_OPTIONS, maps.size() - 1);
     ADJUST_FACTOR = 1d / (maps.size() * MAX_VOTE_OPTIONS);
@@ -70,7 +70,7 @@ public class VotingPool extends MapPool {
     if (currentPoll == null) return getRandom();
 
     MapInfo map = currentPoll.finishVote();
-    customVoteMaps.clear();
+    manager.getCustomVoteOptions().clear();
     currentPoll = null;
     return map != null ? map : getRandom();
   }
@@ -101,14 +101,15 @@ public class VotingPool extends MapPool {
               if (manager.getOverriderMap() != null) return;
               // If there is a restart queued, don't start a vote
               if (RestartManager.isQueued()) return;
+
               currentPoll =
-                  shouldOverride()
+                  getOptions().shouldOverride()
                       ? new MapPoll(
                           match,
-                          getCustomVoteMapWeighted(),
+                          getOptions().getCustomVoteMapWeighted(),
                           Collections.emptySet(),
-                          Math.min(MAX_VOTE_OPTIONS, customVoteMaps.size()))
-                      : new MapPoll(match, mapScores, customVoteMaps, VOTE_SIZE);
+                          Math.min(MAX_VOTE_OPTIONS, getOptions().getCustomVoteMaps().size()))
+                      : new MapPoll(match, mapScores, getOptions().getCustomVoteMaps(), VOTE_SIZE);
 
               match.getPlayers().forEach(viewer -> currentPoll.sendBook(viewer, false));
             },
@@ -116,43 +117,7 @@ public class VotingPool extends MapPool {
             TimeUnit.SECONDS);
   }
 
-  public boolean addCustomVoteMap(MapInfo info) {
-    if (customVoteMaps.size() < MAX_VOTE_OPTIONS) {
-      this.customVoteMaps.add(info);
-      return true;
-    }
-    return false;
-  }
-
-  public boolean removeCustomVote(MapInfo map) {
-    return this.customVoteMaps.remove(map);
-  }
-
-  public Set<MapInfo> getCustomVoteMaps() {
-    return customVoteMaps;
-  }
-
-  public boolean isCustomMapSelected(MapInfo info) {
-    return customVoteMaps.stream().anyMatch(s -> s.getName().equalsIgnoreCase(info.getName()));
-  }
-
-  private boolean shouldOverride() {
-    return customVoteMaps.size() >= MIN_CUSTOM_VOTE_OPTIONS && !getVoteMode();
-  }
-
-  public boolean toggleVoteMode() {
-    this.replaceMaps = !replaceMaps;
-    return replaceMaps;
-  }
-
-  /** @return true if replace, false if override */
-  public boolean getVoteMode() {
-    return replaceMaps;
-  }
-
-  private Map<MapInfo, Double> getCustomVoteMapWeighted() {
-    Map<MapInfo, Double> maps = Maps.newHashMap();
-    customVoteMaps.forEach(map -> maps.put(map, DEFAULT_WEIGHT));
-    return maps;
+  public VotingPoolOptions getOptions() {
+    return manager.getCustomVoteOptions();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/VotingPoolOptions.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/VotingPoolOptions.java
@@ -1,0 +1,64 @@
+package tc.oc.pgm.rotation;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.util.Map;
+import java.util.Set;
+import tc.oc.pgm.api.map.MapInfo;
+
+public class VotingPoolOptions {
+
+  // Set of maps to be used in custom vote selection
+  private Set<MapInfo> customVoteMaps;
+
+  // Whether custom map selection should replace existing entries
+  private boolean replace;
+
+  public VotingPoolOptions() {
+    this.customVoteMaps = Sets.newHashSet();
+    this.replace = true;
+  }
+
+  public boolean shouldOverride() {
+    return customVoteMaps.size() >= VotingPool.MIN_CUSTOM_VOTE_OPTIONS && !replace;
+  }
+
+  public boolean isReplace() {
+    return replace;
+  }
+
+  public boolean toggleMode() {
+    this.replace = !replace;
+    return replace;
+  }
+
+  public boolean addVote(MapInfo map) {
+    if (customVoteMaps.size() < VotingPool.MAX_VOTE_OPTIONS) {
+      this.customVoteMaps.add(map);
+      return true;
+    }
+    return false;
+  }
+
+  public boolean removeMap(MapInfo map) {
+    return this.customVoteMaps.remove(map);
+  }
+
+  public Set<MapInfo> getCustomVoteMaps() {
+    return customVoteMaps;
+  }
+
+  public boolean isAdded(MapInfo info) {
+    return customVoteMaps.stream().anyMatch(s -> s.getName().equalsIgnoreCase(info.getName()));
+  }
+
+  public void clear() {
+    customVoteMaps.clear();
+  }
+
+  public Map<MapInfo, Double> getCustomVoteMapWeighted() {
+    Map<MapInfo, Double> maps = Maps.newHashMap();
+    customVoteMaps.forEach(map -> maps.put(map, VotingPool.DEFAULT_WEIGHT));
+    return maps;
+  }
+}

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -58,6 +58,8 @@ map.setNext.revert = {0} has removed {1} as the next map
 
 map.noNextMap = No next map
 
+map.noMapsFound = No maps found
+
 map.info.commandHint = Type {0} for info
 
 # {0} = map name
@@ -125,6 +127,8 @@ vote.against = Voted against {0}
 vote.abstain = Removed your vote for {0}
 
 vote.disabled = Voting is disabled
+
+vote.modify.disallow = Unable to modify vote at this time
 
 # {0} = player name (who added the map)
 # {1} = map name 

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -58,8 +58,6 @@ map.setNext.revert = {0} has removed {1} as the next map
 
 map.noNextMap = No next map
 
-map.noMapsFound = No maps found
-
 map.info.commandHint = Type {0} for info
 
 # {0} = map name
@@ -152,3 +150,4 @@ vote.mode.create = Create
 
 vote.mode.hover = Click to toggle vote mode
 
+vote.noMapsFound = No maps to clear from the vote


### PR DESCRIPTION
# Improvements to custom voting options

Recently some staff on OCC have reported some issues with maps added via the `/vote` command not showing up in the current poll. The main source of this issue stems from the custom map vote selection data being stored in the individual VotingPool instances rather than the MapPoolManager. As when the server switches pools to accommodate player sizes, the custom vote will not carry over. Instead, the selected maps will not show up until the server switches back to the pool in which the maps were selected.

To resolve this I refactored the custom vote code into a `VotingPoolOptions` class, and an instance of that is created and stored in `MapPoolManager`

Also included are several small text fixes that improve some error commands that staff were confused by. An example being attempting to use any `/vote` command while a vote was in progress would display a disabled message, instead I’ve adjusted that to `Unable to modify vote at this time`

This should resolve all issues that have been reported regarding the `/vote` command, however if there are any other suggestions just let me know 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>