### PR TITLE
Color the team picker

### DIFF
--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -50,6 +50,7 @@ import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.join.GenericJoinResult;
 import tc.oc.pgm.join.JoinMatchModule;
 import tc.oc.pgm.join.JoinResult;
+import tc.oc.pgm.match.Observers;
 import tc.oc.pgm.spawns.events.DeathKitApplyEvent;
 import tc.oc.pgm.spawns.events.ObserverKitApplyEvent;
 import tc.oc.pgm.teams.Team;
@@ -237,6 +238,13 @@ public class PickerMatchModule implements MatchModule, Listener {
         Lists.newArrayList(
             ChatColor.DARK_PURPLE
                 + TextTranslations.translate("picker.tooltip", player.getBukkit())));
+
+    // Color the leather helmet to match player team
+    if (!(player.getParty() instanceof Observers)) {
+      LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
+      armorMeta.setColor(player.getParty().getFullColor());
+      meta = armorMeta;
+    }
 
     stack.setItemMeta(meta);
     return stack;


### PR DESCRIPTION
# Color the team picker 🎨 

Just a minor visual update I thought would look neat and be helpful for users. Now the team picker item will be dyed the same color as the team you have chosen. 

## Screenshot
![colors](https://user-images.githubusercontent.com/3377659/91537573-5f1d9200-e8cb-11ea-9a30-638aa9a7a322.gif)


Signed-off-by: applenick <applenick@users.noreply.github.com>