### PR TITLE
Fix start and cycle countdowns starting with negative durations

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
@@ -5,7 +5,6 @@ import app.ashcon.intake.parametric.annotation.Default;
 import app.ashcon.intake.parametric.annotation.Switch;
 import java.time.Duration;
 import javax.annotation.Nullable;
-import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
@@ -22,7 +21,6 @@ public final class CycleCommand {
       perms = Permissions.START)
   public void cycle(
       Match match,
-      Config config,
       MapOrder mapOrder,
       @Nullable Duration duration,
       @Default("next") MapInfo map,
@@ -35,9 +33,7 @@ public final class CycleCommand {
       mapOrder.setNextMap(map);
     }
 
-    match
-        .needModule(CycleMatchModule.class)
-        .startCountdown(duration == null ? config.getCycleTime() : duration);
+    match.needModule(CycleMatchModule.class).startCountdown(duration);
   }
 
   @Command(
@@ -47,11 +43,7 @@ public final class CycleCommand {
       flags = "f",
       perms = Permissions.START)
   public void recycle(
-      Match match,
-      Config config,
-      MapOrder mapOrder,
-      @Nullable Duration duration,
-      @Switch('f') boolean force) {
-    cycle(match, config, mapOrder, duration, match.getMap(), force);
+      Match match, MapOrder mapOrder, @Nullable Duration duration, @Switch('f') boolean force) {
+    cycle(match, mapOrder, duration, match.getMap(), force);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -32,6 +32,8 @@ public class CycleMatchModule implements MatchModule, Listener {
 
   public void startCountdown(@Nullable Duration duration) {
     if (duration == null) duration = PGM.get().getConfiguration().getCycleTime();
+    // In case the cycle config is set to -1 used to disable autocycle
+    if (duration.isNegative()) duration = Duration.ofSeconds(30);
     match.finish();
     match.getCountdown().start(new CycleCountdown(match), duration);
   }

--- a/core/src/main/java/tc/oc/pgm/start/StartMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/start/StartMatchModule.java
@@ -236,6 +236,8 @@ public class StartMatchModule implements MatchModule, Listener {
       @Nullable Duration duration, @Nullable Duration huddle, boolean force) {
     final Config config = PGM.get().getConfiguration();
     if (duration == null) duration = config.getStartTime();
+    // In case the start config is set to -1 used to disable autostart
+    if (duration.isNegative()) duration = Duration.ofSeconds(30);
     if (huddle == null) huddle = config.getHuddleTime();
 
     match.getLogger().fine("STARTING countdown");


### PR DESCRIPTION
Fixes #613 as explained in https://github.com/PGMDev/PGM/issues/613#issuecomment-674955359, hardcoding 30 seconds as the default start/cycle in case autostart is disabled is the easy fix.