### PR TITLE
Add flair hover to join/leave broadcast

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -35,6 +35,7 @@ import org.bukkit.event.vehicle.VehicleUpdateEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.match.Match;
@@ -205,9 +206,10 @@ public class PGMListener implements Listener {
       SettingValue option = viewer.getSettings().getValue(SettingKey.JOIN);
       if (option.equals(SettingValue.JOIN_ON)) {
         Component name =
-            TextComponent.of(
-                player.getBukkit().getDisplayName(viewer.getBukkit()) + ChatColor.YELLOW);
-        Component component = TranslatableComponent.of(key, name);
+            PGM.get()
+                .getNameDecorationRegistry()
+                .getDecoratedNameComponent(player.getBukkit(), player.getParty());
+        Component component = TranslatableComponent.of(key, TextColor.YELLOW, name);
         viewer.sendMessage(
             staffOnly
                 ? ChatDispatcher.ADMIN_CHAT_PREFIX.append(component.color(TextColor.YELLOW))


### PR DESCRIPTION
# Add flair hover to join/leave broadcast

Resolves #635, super simple fix that enables hovering over flairs sent in join/leave messages.

Should be good to go 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>