### PR TITLE
Disable arbitrary sorting of sidebar competitors

### DIFF
--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.scoreboard;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Ordering;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -462,8 +461,6 @@ public class SidebarMatchModule implements MatchModule, Listener {
       sortedCompetitors.retainAll(competitorsWithGoals);
 
       if (viewingParty instanceof Competitor) {
-        // Participants see competitors in arbitrary order, with their own at the top
-        sortedCompetitors.sort(Ordering.arbitrary());
 
         // Bump viewing party to the top of the list
         if (sortedCompetitors.remove(viewingParty)) {


### PR DESCRIPTION
This change enables teams to be sorted by objective completion on the scoreboard for everyone, not just observers. Of course, players on a team will still see their own team at the top.

This solves the issue on many-team maps where sometimes the winning team is not seen on the scoreboard by any other teams, and is therefore not seen as a threat.