### PR TITLE
Support modifybowprojectile in 1.4 protocol

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
@@ -9,7 +9,6 @@ import org.bukkit.potion.PotionEffect;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import tc.oc.pgm.api.map.MapModule;
-import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
@@ -45,12 +44,6 @@ public class ModifyBowProjectileModule implements MapModule {
       Set<PotionEffect> potionEffects = new HashSet<>();
 
       for (Element parent : doc.getRootElement().getChildren("modifybowprojectile")) {
-        if (factory.getProto().isNoOlderThan(MapProtos.FILTER_FEATURES)) {
-          throw new InvalidXMLException(
-              "Module is discontinued as of " + MapProtos.FILTER_FEATURES.toString(),
-              doc.getRootElement().getChild("modifybowprojectile"));
-        }
-
         Element projectileElement = parent.getChild("projectile");
         if (projectileElement != null) {
           projectile = XMLUtils.parseEntityType(projectileElement);


### PR DESCRIPTION
Modifybowprojectile was deprecated in 1.4 proto for no apparent good reason, there's no valid replacement for it and it just means if anyone wants to use it they have to downgrade their map xml to 1.3.x, for no real reason.

Until there's a better alternative, maps should be allowed to use it