### PR TITLE
Fix control points with names not being named

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -61,7 +61,7 @@ public abstract class ControlPointParser {
     Attribute attrName = elControlPoint.getAttribute("name");
 
     if (attrName != null) {
-      name = attrName.getName();
+      name = attrName.getValue();
     } else {
       int serial = serialNumber.getAndIncrement();
       name = "Hill";


### PR DESCRIPTION
Fixes #653 , currently all control points with a name are displayed as `name` instead of the proper name. Hills without a name are already properly named `Hill`, `Hill 2` etc