### PR TITLE
Fix alt account broadcast issues

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/command/ModerationCommand.java
+++ b/core/src/main/java/tc/oc/pgm/community/command/ModerationCommand.java
@@ -869,13 +869,15 @@ public class ModerationCommand implements Listener {
 
     Component reasonMsg = formatPunishmentReason(reason);
     Component formattedMsg =
-        UsernameFormatUtils.formatStaffName(sender, match)
+        TextComponent.builder()
+            .append(UsernameFormatUtils.formatStaffName(sender, match))
             .append(BROADCAST_DIV)
             .append(prefix)
             .append(BROADCAST_DIV)
             .append(target)
             .append(BROADCAST_DIV)
-            .append(reasonMsg);
+            .append(reasonMsg)
+            .build();
 
     if (!silent) {
       match.sendMessage(formattedMsg);
@@ -943,7 +945,7 @@ public class ModerationCommand implements Listener {
 
     ban.ifPresent(
         info -> {
-          if (!isBanStillValid(event.getPlayer())) {
+          if (!isBanStillValid(info.getUserName())) {
             removeCachedBan(info);
             return;
           }
@@ -989,17 +991,15 @@ public class ModerationCommand implements Listener {
     return Bukkit.getBanList(BanList.Type.NAME).isBanned(name);
   }
 
-  private boolean isBanStillValid(Player player) {
-    return isBanStillValid(player.getName());
-  }
-
   private Component formatAltAccountBroadcast(BannedAccountInfo info, MatchPlayer player) {
-    Component message =
-        TranslatableComponent.of(
-            "moderation.similarIP.loginEvent",
-            player.getName(NameStyle.FANCY),
-            TextComponent.of(info.getUserName(), TextColor.DARK_AQUA));
-    return message.hoverEvent(HoverEvent.of(Action.SHOW_TEXT, info.getHoverMessage()));
+    return TextComponent.builder()
+        .append(
+            TranslatableComponent.of(
+                "moderation.similarIP.loginEvent",
+                player.getName(NameStyle.FANCY),
+                TextComponent.of(info.getUserName(), TextColor.DARK_AQUA)))
+        .hoverEvent(HoverEvent.of(Action.SHOW_TEXT, info.getHoverMessage()))
+        .build();
   }
 
   // Force vanished players to silent broadcast


### PR DESCRIPTION
# Fix alt account broadcast issues
It was brought to my attention today that the alternate account detection had a few issues.

This PR resolves two main issues, first was console ban broadcasts including empty statements. Second and the more pressing issue, was of the alt account alert not being broadcasted at all. The logic was incorrect as it was removing the cached account info based on the player who was joining, rather than the username of the player who was previously banned.

I tested this locally and should resolve both of those issues 👍  

Signed-off-by: applenick <applenick@users.noreply.github.com>