### PR TITLE
Fix spawners not spawning items randomly

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -115,8 +115,7 @@ public class Spawner implements Feature<SpawnerDefinition>, Listener, Tickable {
   public void onPlayerMove(CoarsePlayerMoveEvent event) {
     final MatchPlayer player = match.getParticipant(event.getPlayer());
     if (player == null) return;
-    if (definition.playerRegion.contains(event.getPlayer())
-        && players.get(event.getPlayer()) == null) {
+    if (definition.playerRegion.contains(event.getPlayer())) {
       players.putIfAbsent(event.getPlayer(), player);
     } else {
       players.remove(event.getPlayer());


### PR DESCRIPTION
Currently spawners update the players in the region in a way that every-other block movement while inside the region will add or remove you from it. This is incredibly weird behaviour as it can happen that you are standing still and nothing will ever spawn, until you cross one block then it starts spawning normally. Move another block and it will stop again.