### PR TITLE
Reintroduce projectile trails

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -77,6 +77,7 @@ import tc.oc.pgm.modules.MobsModule;
 import tc.oc.pgm.modules.ModifyBowProjectileMatchModule;
 import tc.oc.pgm.modules.ModifyBowProjectileModule;
 import tc.oc.pgm.modules.MultiTradeMatchModule;
+import tc.oc.pgm.modules.ProjectileTrailMatchModule;
 import tc.oc.pgm.modules.SoundsMatchModule;
 import tc.oc.pgm.modules.StatsMatchModule;
 import tc.oc.pgm.modules.TimeLockModule;
@@ -159,6 +160,7 @@ public interface Modules {
     register(FireworkMatchModule.class, FireworkMatchModule::new);
     register(StatsMatchModule.class, StatsMatchModule::new);
     register(MapmakerMatchModule.class, MapmakerMatchModule::new);
+    register(ProjectileTrailMatchModule.class, ProjectileTrailMatchModule::new);
 
     // Modules that help older player versions
     register(LegacyFlagBeamMatchModule.class, LegacyFlagBeamMatchModule::new);

--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -33,7 +33,8 @@ public enum SettingKey {
   SOUNDS("sounds", SOUNDS_ALL, SOUNDS_DM, SOUNDS_NONE), // Changes when sounds are played
   VOTE("vote", VOTE_ON, VOTE_OFF), // Changes if the vote book is shown on cycle
   STATS("stats", STATS_ON, STATS_OFF), // Changes if stats are tracked
-  ;
+  EFFECTS("effects", EFFECTS_ON, EFFECTS_OFF) // Changes if special particle effects are shown
+;
 
   private final List<String> aliases;
   private final SettingValue[] values;

--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -43,6 +43,9 @@ public enum SettingValue {
 
   STATS_ON("stats", "on"), // Track stats
   STATS_OFF("stats", "off"), // Don't track stats
+
+  EFFECTS_ON("effects", "on"), // Display special particle effects
+  EFFECTS_OFF("effects", "off"); // Don't display special particle effects
   ;
 
   private final String key;

--- a/core/src/main/java/tc/oc/pgm/modules/ProjectileTrailMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ProjectileTrailMatchModule.java
@@ -1,0 +1,110 @@
+package tc.oc.pgm.modules;
+
+import java.util.concurrent.TimeUnit;
+import org.bukkit.Color;
+import org.bukkit.Effect;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.setting.SettingKey;
+import tc.oc.pgm.api.setting.SettingValue;
+import tc.oc.pgm.events.ListenerScope;
+
+@ListenerScope(MatchScope.RUNNING)
+public class ProjectileTrailMatchModule implements MatchModule, Listener {
+
+  private static final String TRAIL_META = "projectile_trail_color";
+  private static final String CRITICAL_META = "arrow_is_critical";
+
+  private final Match match;
+
+  public ProjectileTrailMatchModule(Match match) {
+    this.match = match;
+    match
+        .getExecutor(MatchScope.RUNNING)
+        .scheduleAtFixedRate(this::checkMatchProjectiles, 0l, 50, TimeUnit.MILLISECONDS);
+  }
+
+  public void checkMatchProjectiles() {
+    match.getWorld().getEntitiesByClass(Projectile.class).stream()
+        .filter(projectile -> projectile.hasMetadata(TRAIL_META))
+        .forEach(
+            projectile -> {
+              if (projectile.isDead() || projectile.isOnGround()) {
+                projectile.removeMetadata(TRAIL_META, PGM.get());
+              } else {
+                final Color color = (Color) projectile.getMetadata(TRAIL_META, PGM.get()).value();
+
+                match.getPlayers().stream()
+                    .filter(
+                        pl ->
+                            pl.getSettings().getValue(SettingKey.EFFECTS)
+                                == SettingValue.EFFECTS_ON)
+                    .forEach(
+                        player -> {
+                          player
+                              .getBukkit()
+                              .spigot()
+                              .playEffect(
+                                  projectile.getLocation(),
+                                  Effect.COLOURED_DUST,
+                                  0,
+                                  0,
+                                  rgbToParticle(color.getRed()),
+                                  rgbToParticle(color.getGreen()),
+                                  rgbToParticle(color.getBlue()),
+                                  1,
+                                  0,
+                                  50);
+                        });
+              }
+            });
+  }
+
+  private float rgbToParticle(int rgb) {
+    return Math.max(0.001f, (rgb / 255.0f));
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void onProjectileLaunch(ProjectileLaunchEvent event) {
+    MatchPlayer player = match.getPlayer(event.getActor());
+    if (player != null) {
+      final Projectile projectile = event.getEntity();
+      projectile.setMetadata(
+          TRAIL_META, new FixedMetadataValue(PGM.get(), player.getParty().getFullColor()));
+      // Set critical metadata to false in order to remove default particle trail.
+      // The metadata will be restored just before the arrow hits something.
+      if (projectile instanceof Arrow) {
+        final Arrow arrow = (Arrow) projectile;
+        arrow.setMetadata(CRITICAL_META, new FixedMetadataValue(PGM.get(), arrow.isCritical()));
+        arrow.setCritical(false);
+      }
+    }
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+  public void onProjectileHit(ProjectileHitEvent event) {
+    MatchPlayer player = match.getPlayer(event.getActor());
+    if (player != null) {
+      final Projectile projectile = event.getEntity();
+      projectile.removeMetadata(TRAIL_META, PGM.get());
+      // Restore critical metadata to arrows if applicable
+      if (projectile instanceof Arrow) {
+        final Arrow arrow = (Arrow) projectile;
+        if (arrow.hasMetadata(CRITICAL_META)) {
+          arrow.setCritical(arrow.getMetadata(CRITICAL_META, PGM.get()).asBoolean());
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Reintroduce Projectile trails

This PR reintroduces a fun feature from the old PGM. Arrow trails spawn a small particle trail matching your teams color. I adapted the code that made this possible from the old PGM as well as added the ability to toggle the arrow trails on and off via a new setting`/toggle effects` Note: I also made the setting “effects” that way in the future if we choose to allow more customized effects they can fall under this setting category. 

## Screenshot
![arrowsyay](https://user-images.githubusercontent.com/3377659/94775458-b1434e80-0374-11eb-8241-ac8e39db2a52.gif)


## Feedback
This is a feature I personally enjoy and adds a bit of uniqueness to PGM. However if desired I can add an option to the config to completely disable this feature. However I felt that having simply the new setting toggle would be enough. 

Any feedback is appreciated :+1:

Signed-off-by: applenick <applenick@users.noreply.github.com>