### PR TITLE
Add /votebook command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
@@ -284,21 +284,36 @@ public final class MapPoolCommand {
       @Switch('o') boolean forceOpen,
       @Text MapInfo map)
       throws CommandException {
+    MapPoll poll = getVotingPool(player, sender, mapOrder);
+    if (poll != null) {
+      boolean voteResult = poll.toggleVote(map, ((Player) sender).getUniqueId());
+      Component voteAction =
+          TranslatableComponent.of(
+              voteResult ? "vote.for" : "vote.abstain",
+              voteResult ? TextColor.GREEN : TextColor.RED,
+              map.getStyledName(MapNameStyle.COLOR));
+      player.sendMessage(voteAction);
+      poll.sendBook(player, forceOpen);
+    }
+  }
+
+  @Command(aliases = "votebook", desc = "Spawn a vote book")
+  public void voteBook(MatchPlayer player, CommandSender sender, MapOrder mapOrder)
+      throws CommandException {
+    MapPoll poll = getVotingPool(player, sender, mapOrder);
+    if (poll != null) {
+      poll.sendBook(player, false);
+    }
+  }
+
+  private static MapPoll getVotingPool(MatchPlayer player, CommandSender sender, MapOrder mapOrder)
+      throws CommandException {
     MapPool pool = getMapPoolManager(sender, mapOrder).getActiveMapPool();
     MapPoll poll = pool instanceof VotingPool ? ((VotingPool) pool).getCurrentPoll() : null;
     if (poll == null) {
       player.sendWarning(TranslatableComponent.of("vote.noVote"));
-      return;
     }
-    boolean voteResult = poll.toggleVote(map, ((Player) sender).getUniqueId());
-
-    Component voteAction =
-        TranslatableComponent.of(
-            voteResult ? "vote.for" : "vote.abstain",
-            voteResult ? TextColor.GREEN : TextColor.RED,
-            map.getStyledName(MapNameStyle.COLOR));
-    player.sendMessage(voteAction);
-    poll.sendBook(player, forceOpen);
+    return poll;
   }
 
   public static MapPoolManager getMapPoolManager(CommandSender sender, MapOrder mapOrder)


### PR DESCRIPTION
# Add a vote book command

This PR introduces a new command, `/votebook`, which allows for players who have lost the current voting book or who have joined after a vote has begun to receive the item again.

## Screenshot
![votebook](https://user-images.githubusercontent.com/3377659/94775578-f2d3f980-0374-11eb-9ed7-8b25a1a50804.gif)


## Feedback
While there is already the `/votenext -o` flag, I felt that method of forcing open the vote book to not be as intuitive. And this command solves that by simply giving another book. 

If you have any further suggestions just let me know :+1:

Signed-off-by: applenick <applenick@users.noreply.github.com>