### PR TITLE
Reintroduce /velocity command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/core/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -93,6 +93,7 @@ public interface Permissions {
               .put(GAMEPLAY, true)
               .put(DEBUG, true)
               .put(RELOAD, true)
+              .put(MAPDEV, true)
               .build());
 
   Permission ALL =

--- a/core/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/core/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -37,6 +37,7 @@ public interface Permissions {
   String BAN = ROOT + ".ban"; // Access to the /ban command
   String FREEZE = ROOT + ".freeze"; // Access to the /freeze command
   String VANISH = ROOT + ".vanish"; // Access to /vanish command
+  String MAPDEV = ROOT + ".mapdev"; // Access to mapdev related commands
 
   String MAPMAKER = GROUP + ".mapmaker"; // Permission group for mapmakers, defined in config.yml
 

--- a/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
@@ -1,0 +1,49 @@
+package tc.oc.pgm.command;
+
+import app.ashcon.intake.Command;
+import app.ashcon.intake.CommandException;
+import net.kyori.text.TextComponent;
+import net.kyori.text.TranslatableComponent;
+import net.kyori.text.format.TextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.util.chat.Audience;
+import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.text.types.PlayerComponent;
+
+public class MapDevCommand {
+
+  @Command(
+      aliases = {"velocity", "vel"},
+      desc = "Apply a velocity to a player",
+      perms = Permissions.MAPDEV)
+  public void velocity(
+      Audience viewer, CommandSender sender, Player target, Double x, Double y, Double z)
+      throws CommandException {
+    boolean self = (sender instanceof Player) && ((Player) sender).equals(target);
+    Vector velocity = new Vector(x, y, z);
+    TextComponent.Builder message =
+        TextComponent.builder().append(TranslatableComponent.of("command.mapdev.velocity"));
+    if (!self) {
+      message.append(TextComponent.space()).append(PlayerComponent.of(target, NameStyle.FANCY));
+    }
+    message
+        .append(" (")
+        .append(String.format("%.2f", velocity.getX()), getVelocityColor(velocity.getX()))
+        .append(", ")
+        .append(String.format("%.2f", velocity.getY()), getVelocityColor(velocity.getY()))
+        .append(", ")
+        .append(String.format("%.2f", velocity.getZ()), getVelocityColor(velocity.getZ()))
+        .append(")")
+        .color(TextColor.GRAY)
+        .build();
+    viewer.sendMessage(message.build());
+    target.setVelocity(velocity);
+  }
+
+  private TextColor getVelocityColor(Double value) {
+    return value > 0 ? TextColor.GREEN : TextColor.RED;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/graph/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/CommandGraph.java
@@ -35,6 +35,7 @@ import tc.oc.pgm.command.InventoryCommand;
 import tc.oc.pgm.command.JoinCommand;
 import tc.oc.pgm.command.ListCommand;
 import tc.oc.pgm.command.MapCommand;
+import tc.oc.pgm.command.MapDevCommand;
 import tc.oc.pgm.command.MapOrderCommand;
 import tc.oc.pgm.command.MapPoolCommand;
 import tc.oc.pgm.command.MatchCommand;
@@ -85,6 +86,7 @@ public class CommandGraph extends BasicBukkitCommandGraph {
     register(new TeamCommand(), "team");
     register(new TimeLimitCommand());
     register(new VotingCommand(), "vote", "votes");
+    register(new MapDevCommand());
   }
 
   public void register(Object command, String... aliases) {

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -81,3 +81,5 @@ command.message.blocked = {0} is not accepting messages at this time.
 
 # {0} = map name
 command.maps.hover = Click to view {0}
+
+command.mapdev.velocity = Applying Velocity


### PR DESCRIPTION
# Reintroduce /velocity command

In an effort to make PGM more useful for map developers, I've reintroduced the `/velocity` which can be used to test features such as jump-pads and allow for the mapmaking process to progress more efficiently. 

I hope to bring a number of other map dev specific commands into PGM, but decided to start with this one. 

## Screenshot
![velocity](https://user-images.githubusercontent.com/3377659/94775641-15661280-0375-11eb-9a94-814da34c2998.gif)

## Feedback/Suggestions
Once again always open to feedback and look forward to any ideas people may have for other mapmaking commands/features that would prove useful :+1:

Signed-off-by: applenick <applenick@users.noreply.github.com>