### PR TITLE
Improve freeze alert broadcast

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
@@ -12,6 +12,8 @@ import javax.annotation.Nullable;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
+import net.kyori.text.event.ClickEvent;
+import net.kyori.text.event.HoverEvent;
 import net.kyori.text.format.TextColor;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
@@ -345,11 +347,8 @@ public class FreezeMatchModule implements MatchModule, Listener {
       freezee.playSound(FREEZE_SOUND);
 
       ChatDispatcher.broadcastAdminChatMessage(
-          TranslatableComponent.of(
-              "moderation.freeze.broadcast.frozen",
-              TextColor.GRAY,
-              senderName,
-              freezee.getName(NameStyle.CONCISE)),
+          createInteractiveBroadcast(
+              freezee.getName(NameStyle.CONCISE), senderName, freezee.getBukkit().getName(), true),
           match);
     }
 
@@ -369,12 +368,25 @@ public class FreezeMatchModule implements MatchModule, Listener {
       freezee.sendMessage(thawedTitle.color(TextColor.GREEN).build());
 
       ChatDispatcher.broadcastAdminChatMessage(
-          TranslatableComponent.of(
-              "moderation.freeze.broadcast.thaw",
-              TextColor.GRAY,
-              senderName,
-              freezee.getName(NameStyle.CONCISE)),
+          createInteractiveBroadcast(
+              freezee.getName(NameStyle.CONCISE), senderName, freezee.getBukkit().getName(), false),
           match);
+    }
+
+    private Component createInteractiveBroadcast(
+        Component senderName, Component targetName, String username, boolean frozen) {
+      return TextComponent.builder()
+          .append(
+              TranslatableComponent.of(
+                  String.format("moderation.freeze.broadcast.%s", frozen ? "frozen" : "thaw"),
+                  TextColor.GRAY,
+                  senderName,
+                  targetName))
+          .hoverEvent(
+              HoverEvent.showText(
+                  TranslatableComponent.of("moderation.freeze.broadcast.hover", TextColor.GRAY)))
+          .clickEvent(ClickEvent.runCommand("/f " + username))
+          .build();
     }
 
     // Borrowed from WorldEdit

--- a/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
@@ -347,9 +347,7 @@ public class FreezeMatchModule implements MatchModule, Listener {
       freezee.playSound(FREEZE_SOUND);
 
       ChatDispatcher.broadcastAdminChatMessage(
-          createInteractiveBroadcast(
-              freezee.getName(NameStyle.CONCISE), senderName, freezee.getBukkit().getName(), true),
-          match);
+          createInteractiveBroadcast(senderName, freezee, true), match);
     }
 
     private void thaw(MatchPlayer freezee, Component senderName, boolean silent) {
@@ -368,24 +366,22 @@ public class FreezeMatchModule implements MatchModule, Listener {
       freezee.sendMessage(thawedTitle.color(TextColor.GREEN).build());
 
       ChatDispatcher.broadcastAdminChatMessage(
-          createInteractiveBroadcast(
-              freezee.getName(NameStyle.CONCISE), senderName, freezee.getBukkit().getName(), false),
-          match);
+          createInteractiveBroadcast(senderName, freezee, false), match);
     }
 
     private Component createInteractiveBroadcast(
-        Component senderName, Component targetName, String username, boolean frozen) {
+        Component senderName, MatchPlayer freezee, boolean frozen) {
       return TextComponent.builder()
           .append(
               TranslatableComponent.of(
                   String.format("moderation.freeze.broadcast.%s", frozen ? "frozen" : "thaw"),
                   TextColor.GRAY,
                   senderName,
-                  targetName))
+                  freezee.getName(NameStyle.CONCISE)))
           .hoverEvent(
               HoverEvent.showText(
                   TranslatableComponent.of("moderation.freeze.broadcast.hover", TextColor.GRAY)))
-          .clickEvent(ClickEvent.runCommand("/f " + username))
+          .clickEvent(ClickEvent.runCommand("/f " + freezee.getBukkit().getName()))
           .build();
     }
 

--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -144,6 +144,8 @@ moderation.freeze.broadcast.frozen = {0} has frozen {1}
 # {1} = target player name
 moderation.freeze.broadcast.thaw = {0} has unfrozen {1}
 
+moderation.freeze.broadcast.hover = Click to reverse action
+
 moderation.defuse.water = You may not defuse TNT in water.
 
 moderation.defuse.enemy = You may not defuse enemy TNT.


### PR DESCRIPTION
# Improve Freeze Broadcast

This is just a small feature I found would be useful for staff members. Now when a freeze message is sent to the admin chat, clicking the broadcast will allow a staff member to reverse the action done. 

Signed-off-by: applenick <applenick@users.noreply.github.com>