### PR TITLE
Remove id attribute from spawner module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -11,7 +11,6 @@ import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.CoarsePlayerMoveEvent;
-import tc.oc.pgm.api.feature.Feature;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.Tickable;
 import tc.oc.pgm.api.match.event.MatchFinishEvent;
@@ -20,7 +19,7 @@ import tc.oc.pgm.api.time.Tick;
 import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.bukkit.OnlinePlayerMapAdapter;
 
-public class Spawner implements Feature<SpawnerDefinition>, Listener, Tickable {
+public class Spawner implements Listener, Tickable {
 
   public static final String METADATA_KEY = "spawner";
 
@@ -39,16 +38,6 @@ public class Spawner implements Feature<SpawnerDefinition>, Listener, Tickable {
     this.lastTick = match.getTick().tick;
     this.players = new OnlinePlayerMapAdapter<>(PGM.get());
     calculateDelay();
-  }
-
-  @Override
-  public String getId() {
-    return definition.id;
-  }
-
-  @Override
-  public SpawnerDefinition getDefinition() {
-    return definition;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
@@ -11,7 +11,6 @@ import tc.oc.pgm.api.region.Region;
 public class SpawnerDefinition implements FeatureDefinition {
 
   public final Region spawnRegion;
-  public final String id;
   public final Region playerRegion;
   public final int maxEntities;
   public final Duration minDelay, maxDelay, delay;
@@ -19,7 +18,6 @@ public class SpawnerDefinition implements FeatureDefinition {
   public final Filter playerFilter;
 
   public SpawnerDefinition(
-      String id,
       List<Spawnable> objects,
       Region spawnRegion,
       Region playerRegion,
@@ -29,7 +27,6 @@ public class SpawnerDefinition implements FeatureDefinition {
       Duration maxDelay,
       int maxEntities) {
     this.spawnRegion = spawnRegion;
-    this.id = id;
     this.playerRegion = playerRegion;
     this.maxEntities = maxEntities;
     this.minDelay = minDelay;

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -54,7 +54,6 @@ public class SpawnerModule implements MapModule {
           XMLUtils.flattenElements(doc.getRootElement(), "spawners", "spawner")) {
         Region spawnRegion = regionParser.parseRequiredRegionProperty(element, "spawn-region");
         Region playerRegion = regionParser.parseRequiredRegionProperty(element, "player-region");
-        String id = element.getAttributeValue("id");
         Attribute delayAttr = element.getAttribute("delay");
         Attribute minDelayAttr = element.getAttribute("min-delay");
         Attribute maxDelayAttr = element.getAttribute("max-delay");
@@ -89,7 +88,6 @@ public class SpawnerModule implements MapModule {
 
         SpawnerDefinition spawnerDefinition =
             new SpawnerDefinition(
-                id,
                 objects,
                 spawnRegion,
                 playerRegion,


### PR DESCRIPTION
The [spawner module](https://pgm.dev/docs/modules/mechanics/spawners/) was added in such a way that required each spawner to be given an ID.
The few times that I have seen the module used I've seen IDs like `spawner1`, `spawner2`... as there's no purpose to them.

These IDs can not be referenced anywhere and are completely useless. If there ever comes a time when there becomes a need to reference spawners by ID then I'm sure this could be added back but until then its extra XML fodder.

Other similar modules (think [portals](https://pgm.dev/docs/modules/mechanics/portals/), [renewables](https://pgm.dev/docs/modules/blocks/renewables/)) do not have IDs making this an odd one out.

