### PR TITLE
Resolve current VictoryCondition correctly

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/graph/VictoryConditionProvider.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/VictoryConditionProvider.java
@@ -34,7 +34,7 @@ public class VictoryConditionProvider implements BukkitProvider<VictoryCondition
   public VictoryCondition get(
       CommandSender sender, CommandArgs args, List<? extends Annotation> list)
       throws MissingArgumentException, ProvisionException {
-    final String text = args.next();
+    final String text = args.hasNext() ? args.next() : null;
 
     final Match match = PGM.get().getMatchManager().getMatch(sender);
     if (match == null) {


### PR DESCRIPTION
When running the timelimit command in game `tl 30s` with no condition as a third argument it should automatically populate that argument (when setting the timelimit) with the existing victory condition if one is set (via XML or previous usage of command). This allows for a timelimit to be set without altering the win condition.

The way the current VictoryConditionProvider is setup a `MissingArgumentException`is thrown in the `args.next()` method if the argument is null causing the following message to occur and setting an empty/default victory condition.

![image](https://user-images.githubusercontent.com/8608892/95264132-c0b81100-0826-11eb-8ef4-9efc0f927cc0.png)

This check ensures the exception is not thrown at this location by checking for its existence which then allows the proceeding code to establish and pass back the existing victory condition from the match. Like so:

![image](https://user-images.githubusercontent.com/8608892/95264182-cf062d00-0826-11eb-80bc-7d39f0bc0274.png)


Signed-off-by: Pugzy <pugzy@mail.com>