### PR TITLE
Fix empty message sent to observers on match finish

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
@@ -62,7 +62,7 @@ public class MatchAnnouncer implements Listener {
 
     // broadcast match finish message
     for (MatchPlayer viewer : match.getPlayers()) {
-      Component title, subtitle = TextComponent.empty();
+      Component title, subtitle = null;
       if (event.getWinner() == null) {
         title = TranslatableComponent.of("broadcast.gameOver");
       } else {


### PR DESCRIPTION
At the end of a match, the winner is announced.

The title that pops up on the screen is repurposed as a message sent in chat. `Red wins!`
The same applies to the subtitle "Your team won!" or "Your team lost" also sent in chat (see below).

![image](https://user-images.githubusercontent.com/8608892/95688356-93da7400-0c01-11eb-9e76-8ef43ccbb93a.png)

If the player is on observers the following shows... an empty message.

![image](https://user-images.githubusercontent.com/8608892/95687806-ddc15b00-0bfd-11eb-8540-e54bbbde01c4.png)

As an observer, your team can neither win nor lose so the subtitle is never set. The [not null check](https://github.com/PGMDev/PGM/blob/dev/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java#L96 ) for this always passes now due to the change of subtitle and title being initialised as `Component title, subtitle = TextComponent.empty();` so not `null` to start with.

This was changed [4 months ago](https://github.com/PGMDev/PGM/blame/dev/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java#L65) during a refactor of the text library.




Signed-off-by: Pugzy <pugzy@mail.com>