### PR TITLE
Resolve issues related to FFA timelimit & /match command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
@@ -127,7 +127,7 @@ public class ScoreMatchModule implements MatchModule, Listener {
             .append(TextComponent.of(": ", TextColor.DARK_AQUA))
             .append(TextFormatter.list(scoreMessages, TextColor.GRAY))
             .build();
-    if (matchPlayer != null && ffamm != null) {
+    if (matchPlayer != null && matchPlayer.getCompetitor() != null && ffamm != null) {
       returnMessage =
           returnMessage.append(
               TextComponent.builder()
@@ -138,7 +138,8 @@ public class ScoreMatchModule implements MatchModule, Listener {
                   .color(TextFormatter.convert(matchPlayer.getCompetitor().getColor()))
                   .append(
                       TextComponent.of(
-                          (int) scores.get(matchPlayer).doubleValue(), TextColor.WHITE))
+                          (int) scores.get(matchPlayer.getCompetitor()).doubleValue(),
+                          TextColor.WHITE))
                   .build());
     }
     return returnMessage;

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
@@ -16,7 +16,6 @@ import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.VictoryCondition;
 import tc.oc.pgm.result.VictoryConditions;
-import tc.oc.pgm.teams.TeamModule;
 import tc.oc.pgm.util.text.TextException;
 import tc.oc.pgm.util.text.TextParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -42,11 +41,6 @@ public class TimeLimitModule implements MapModule<TimeLimitMatchModule> {
   }
 
   public static class Factory implements MapModuleFactory<TimeLimitModule> {
-    @Nullable
-    @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
-      return ImmutableList.of(TeamModule.class);
-    }
 
     @Override
     public TimeLimitModule parse(MapFactory factory, Logger logger, Document doc)


### PR DESCRIPTION
# Resolve issues related to FFA timelimit & /match command

Recently from the merging of PR #619 & #676, two issues were introduced that impact FFA matches. 

The first minor issue was a NPE being thrown when doing `/match` as an observer. Cause was due to the method which renders the new score format messages calling getCompetitor() on Observers, which results in a null. So fixed that by just adding a null check. 

Second and the more pressing issue, is the absence of time limits both from the map itself & the `/timelimit` command, during FFA matches. I deduced this was from @KingOfSquares fix which saw the `TeamModule` added as a soft dependency for the `TimeLimitModule`. However a FFA match does not contain the TeamModule so that’s most likely why it failed to load. 

@KingOfSquares I simply reverted your change of adding the soft dependency, and that resolved the issue of missing time limits. I am unsure if that un-fixes the issue you were originally trying to solve. But hopefully you can look further into that.

Anyway, I tested the changes here and they do fix the issues mentioned above and should be all good 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>