### PR TITLE
Fix tablist player death color

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/types/PlayerComponent.java
@@ -72,7 +72,7 @@ public interface PlayerComponent {
     TextComponent.Builder name = TextComponent.builder(player != null ? player.getName() : defName);
 
     if (!isOffline && style.has(NameStyle.Flag.DEATH) && isDead(player)) {
-      name.color(TextColor.GRAY);
+      name.color(TextColor.DARK_GRAY);
     } else if (style.has(NameStyle.Flag.COLOR)) {
       name.color(isOffline ? OFFLINE_COLOR : provider.getColor(uuid));
     }


### PR DESCRIPTION
# Fix tablist player death color

Simple fix, resolves #692 

~~I’m waiting on @Pablete1234’s response in the original issue to see vanished names require a fix as well. Otherwise should be good to go.~~

Ready to merge 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>