### PR TITLE
Defer validations for translated regions to their base

### DIFF
--- a/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
@@ -44,6 +44,8 @@ public class FeatureRegionParser extends RegionParser {
       throws InvalidXMLException {
     if (region instanceof XMLRegionReference) {
       factory.getFeatures().validate((XMLRegionReference) region, validation);
+    } else if (region instanceof TransformedRegion) {
+      factory.getFeatures().validate(((XMLRegionReference) ((TransformedRegion) region).region), validation);
     } else {
       super.validate(region, validation, node);
     }

--- a/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
@@ -44,8 +44,11 @@ public class FeatureRegionParser extends RegionParser {
       throws InvalidXMLException {
     if (region instanceof XMLRegionReference) {
       factory.getFeatures().validate((XMLRegionReference) region, validation);
-    } else if (region instanceof TransformedRegion && ((TransformedRegion) region).region instanceof XMLRegionReference) {
-      factory.getFeatures().validate(((XMLRegionReference) ((TransformedRegion) region).region), validation);
+    } else if (region instanceof TransformedRegion
+        && ((TransformedRegion) region).region instanceof XMLRegionReference) {
+      factory
+          .getFeatures()
+          .validate(((XMLRegionReference) ((TransformedRegion) region).region), validation);
     } else {
       super.validate(region, validation, node);
     }

--- a/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
@@ -48,7 +48,7 @@ public class FeatureRegionParser extends RegionParser {
         && ((TransformedRegion) region).region instanceof XMLRegionReference) {
       factory
           .getFeatures()
-          .validate(((XMLRegionReference) ((TransformedRegion) region).region), validation);
+          .validate((XMLRegionReference) ((TransformedRegion) region).region, validation);
     } else {
       super.validate(region, validation, node);
     }

--- a/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
@@ -44,7 +44,7 @@ public class FeatureRegionParser extends RegionParser {
       throws InvalidXMLException {
     if (region instanceof XMLRegionReference) {
       factory.getFeatures().validate((XMLRegionReference) region, validation);
-    } else if (region instanceof TransformedRegion) {
+    } else if (region instanceof TransformedRegion && ((TransformedRegion) region).region instanceof XMLRegionReference) {
       factory.getFeatures().validate(((XMLRegionReference) ((TransformedRegion) region).region), validation);
     } else {
       super.validate(region, validation, node);


### PR DESCRIPTION
Fixes a super rare bug involving region reference parsing

Basically, if you run validations during parsing on a translated region that has a reference as the region being translated, validations will fail with an ISS. This occurs because the logic that queues validations for references until after feature resolution doesn't take into account references inside of other region types. Since the check doesn't see the type being validated as a reference (since the reference is wrapped), normal validations are executed on an un-resolved reference. 

Example failing case:
```xml
        <progress-display-region>  <translate offset="10,0,0"><region id="progress"/></translate></progress-display-region>
```