### PR TITLE
Always catch bad team names early

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
@@ -43,7 +43,7 @@ public class ControlPointDefinition extends GoalDefinition {
   private final float timeMultiplier;
 
   // The team that owns the point when the match starts, null for no owner (neutral state) or ffa
-  private final TeamFactory initialOwner;
+  @Nullable private final TeamFactory initialOwner;
 
   // Conditions required for a team to capture:
   public enum CaptureCondition {
@@ -90,7 +90,7 @@ public class ControlPointDefinition extends GoalDefinition {
       BlockVector capturableDisplayBeacon,
       Duration timeToCapture,
       float timeMultiplier,
-      TeamFactory initialOwner,
+      @Nullable TeamFactory initialOwner,
       CaptureCondition captureCondition,
       boolean incrementalCapture,
       boolean neutralState,
@@ -191,6 +191,7 @@ public class ControlPointDefinition extends GoalDefinition {
     return this.timeMultiplier;
   }
 
+  @Nullable
   public TeamFactory getInitialOwner() {
     return this.initialOwner;
   }

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -86,7 +86,7 @@ public class CoreModule implements MapModule {
 
         // TODO: rename to owner on the next breaking revision
         TeamFactory owner =
-            Teams.getTeam(XMLUtils.getRequiredAttribute(coreEl, "team").getValue(), context);
+            Teams.getTeam(new Node(XMLUtils.getRequiredAttribute(coreEl, "team")), context);
         Region region;
         RegionParser parser = context.getRegions();
         if (context.getProto().isOlderThan(MapProtos.MODULE_SUBELEMENT_VERSION)) {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -25,6 +25,7 @@ import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.teams.TeamModule;
+import tc.oc.pgm.teams.Teams;
 import tc.oc.pgm.util.material.matcher.SingleMaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
@@ -86,7 +87,7 @@ public class DestroyableModule implements MapModule {
               ImmutableSet.of("destroyables"),
               ImmutableSet.of("destroyable"))) {
         TeamFactory owner =
-            teamModule.parseTeam(XMLUtils.getRequiredAttribute(destroyableEl, "owner"), context);
+            Teams.getTeam(new Node(XMLUtils.getRequiredAttribute(destroyableEl, "owner")), context);
         String name = XMLUtils.getRequiredAttribute(destroyableEl, "name").getValue();
 
         double destructionRequired = 1.0;

--- a/core/src/main/java/tc/oc/pgm/teams/TeamModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamModule.java
@@ -105,13 +105,7 @@ public class TeamModule implements MapModule<TeamMatchModule> {
     if (attr == null) {
       return null;
     }
-    String name = attr.getValue();
-    TeamFactory team = Teams.getTeam(name, factory);
-
-    if (team == null) {
-      throw new InvalidXMLException("unknown team '" + name + "'", attr);
-    }
-    return team;
+    return Teams.getTeam(new Node(attr), factory);
   }
 
   private static TeamFactory parseTeamDefinition(Element el, MapFactory factory)

--- a/core/src/main/java/tc/oc/pgm/teams/Teams.java
+++ b/core/src/main/java/tc/oc/pgm/teams/Teams.java
@@ -17,10 +17,6 @@ public class Teams {
 
   private Teams() {}
 
-  /**
-   * Lookup a team by name or ID. Prior to {@link MapProtos#FILTER_FEATURES}, teams are looked up by
-   * name.
-   */
   public static TeamFactory getTeam(String team, MapFactory factory) {
     TeamFactory teamFactory = factory.getFeatures().get(team, TeamFactory.class);
     if (factory.getProto().isOlderThan(FILTER_FEATURES)) {
@@ -34,18 +30,28 @@ public class Teams {
     return teamFactory;
   }
 
+  /**
+   * Lookup a team by name or ID. Prior to {@link MapProtos#FILTER_FEATURES}, teams are looked up by
+   * name.
+   */
+  public static TeamFactory getTeam(Node node, MapFactory factory) throws InvalidXMLException {
+    TeamFactory teamFactory = getTeam(node.getValueNormalize(), factory);
+
+    if (teamFactory == null) {
+      throw new InvalidXMLException("unknown team '" + node.getValue() + "'", node);
+    }
+
+    return teamFactory;
+  }
+
   public static TeamFactory getTeam(String team, Match match) {
     return match.needModule(TeamMatchModule.class).bestFuzzyMatch(team).getInfo();
   }
 
   public static FeatureReference<TeamFactory> getTeamRef(Node node, MapFactory factory)
       throws InvalidXMLException {
-    String id = node.getValueNormalize();
     if (factory.getProto().isOlderThan(FILTER_FEATURES)) {
-      TeamFactory definition = getTeam(id, factory);
-      if (definition == null) {
-        throw new InvalidXMLException("Unknown team '" + id + "'", node);
-      }
+      TeamFactory definition = getTeam(node, factory);
       return new ImmediateFeatureReference<>(definition);
     } else {
       return factory.getFeatures().createReference(node, TeamFactory.class);

--- a/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
+++ b/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
@@ -26,7 +26,9 @@ import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.teams.TeamModule;
+import tc.oc.pgm.teams.Teams;
 import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class WoolModule implements MapModule {
@@ -84,7 +86,7 @@ public class WoolModule implements MapModule {
         String id = woolEl.getAttributeValue("id");
         boolean craftable = Boolean.parseBoolean(woolEl.getAttributeValue("craftable", "true"));
         TeamFactory team =
-            teamModule.parseTeam(XMLUtils.getRequiredAttribute(woolEl, "team"), factory);
+            Teams.getTeam(new Node(XMLUtils.getRequiredAttribute(woolEl, "team")), factory);
         DyeColor color = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(woolEl, "color"));
         Region placement;
         if (factory.getProto().isOlderThan(MapProtos.MODULE_SUBELEMENT_VERSION)) {


### PR DESCRIPTION
Some parsers would throw NPEs for missing teams instead of reporting that they were invalid. 