### PR TITLE
Reintroduce the player score filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -443,4 +443,9 @@ public abstract class FilterParser {
   public TimeFilter parseTimeFilter(Element el) throws InvalidXMLException {
     return new TimeFilter(XMLUtils.parseDuration(el, null));
   }
+
+  @MethodParser("score")
+  public ScoreFilter parseScoreFilter(Element el) throws InvalidXMLException {
+    return new ScoreFilter(XMLUtils.parseNumericRange(new Node(el), Integer.class));
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/ScoreFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/ScoreFilter.java
@@ -1,0 +1,35 @@
+package tc.oc.pgm.filters;
+
+import com.google.common.collect.Range;
+import tc.oc.pgm.api.filter.query.PartyQuery;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.score.ScoreMatchModule;
+
+/**
+ * Filter which checks if a {@link tc.oc.pgm.api.party.Party}'s score is within a supplied range.
+ *
+ * <p>Will ABSTAIN if the score module is not loaded.
+ */
+public class ScoreFilter extends TypedFilter<PartyQuery> {
+
+  private final Range<Integer> values;
+
+  public ScoreFilter(Range<Integer> values) {
+    this.values = values;
+  }
+
+  @Override
+  public Class<? extends PartyQuery> getQueryType() {
+    return PartyQuery.class;
+  }
+
+  @Override
+  protected QueryResponse queryTyped(PartyQuery query) {
+    ScoreMatchModule module = query.getMatch().getModule(ScoreMatchModule.class);
+    if (module == null) return QueryResponse.ABSTAIN;
+
+    return QueryResponse.fromBoolean(
+        query.getParty() instanceof Competitor
+            && values.contains((int) module.getScore((Competitor) query.getParty())));
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -382,11 +382,17 @@ public final class XMLUtils {
    * <p>[0, 1)
    *
    * <p>for a closed-open range from 0 to 1
+   *
+   * <p>Also supports singleton ranges derived from providing a number with no delimiter
    */
   public static <T extends Number & Comparable<T>> Range<T> parseNumericRange(
       Node node, Class<T> type) throws InvalidXMLException {
     Matcher matcher = RANGE_RE.matcher(node.getValue());
     if (!matcher.matches()) {
+      T value = parseNumber(node, node.getValue(), type, true);
+      if (value != null) {
+        return Range.singleton(value);
+      }
       throw new InvalidXMLException(
           "Invalid " + type.getSimpleName().toLowerCase() + " range '" + node.getValue() + "'",
           node);


### PR DESCRIPTION
Re-introduces the score filter that was added after this version was branched off. 

Also adds single-number range support since that filter supported both and other places probably should too. 