### PR TITLE
Re-introduce player count filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.filters;
 
-import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import java.lang.reflect.Method;
@@ -466,8 +465,7 @@ public abstract class FilterParser {
   @MethodParser("offset")
   public LocationQueryModifier parseOffsetFilter(Element el) throws InvalidXMLException {
     String value = el.getAttributeValue("vector");
-    if (value == null)
-      throw new InvalidXMLException("No vector provided", el);
+    if (value == null) throw new InvalidXMLException("No vector provided", el);
     // Check vector format
     Vector vector = XMLUtils.parseVector(new Node(el), value.replaceAll("[\\^~]", ""));
 
@@ -489,8 +487,7 @@ public abstract class FilterParser {
       relative[i] = coord.startsWith("~");
     }
 
-    if (local == null)
-      throw new InvalidXMLException("No coordinates provided", el);
+    if (local == null) throw new InvalidXMLException("No coordinates provided", el);
 
     if (local) {
       return new LocalLocationQueryModifier(parseChild(el), vector);
@@ -518,8 +515,10 @@ public abstract class FilterParser {
 
     Range<Integer> range = XMLUtils.parseNumericRange(el, Integer.class);
 
-    if (range.hasLowerBound() && range.lowerEndpoint() <= 0) throw new InvalidXMLException("Lower limit must be at least 0", el);
-    if (range.hasUpperBound() && range.upperEndpoint() < 0) throw new InvalidXMLException("Upper limit must be greater than 0", el);
+    if (range.hasLowerBound() && range.lowerEndpoint() <= 0)
+      throw new InvalidXMLException("Lower limit must be at least 0", el);
+    if (range.hasUpperBound() && range.upperEndpoint() < 0)
+      throw new InvalidXMLException("Upper limit must be greater than 0", el);
 
     // Shrink the range to be at least 0 - the maximum possible number of players that can be online
     // For example (assuming the max player count is 20):

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -14,7 +15,6 @@ import org.bukkit.util.Vector;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.player.PlayerRelation;
 import tc.oc.pgm.classes.ClassModule;
@@ -504,21 +504,15 @@ public abstract class FilterParser {
     // TODO: Legacy syntax, maybe bump proto to deprecate
     boolean participants = XMLUtils.parseBoolean(el.getAttribute("participants"), true);
     boolean observers = XMLUtils.parseBoolean(el.getAttribute("observers"), false);
-    countFilter =
-        new TypedFilter<PlayerQuery>() {
-
-          @Override
-          public Class<? extends PlayerQuery> getQueryType() {
-            return PlayerQuery.class;
-          }
-
-          @Override
-          protected QueryResponse queryTyped(PlayerQuery query) {
-            return QueryResponse.fromBoolean(
-                ((observers && query.getPlayer().isObserving()))
-                    || (participants && query.getPlayer().isParticipating()));
-          }
-        };
+    if (participants && observers) {
+      countFilter =
+          new AnyFilter(
+              Arrays.asList(ParticipatingFilter.PARTICIPATING, ParticipatingFilter.OBSERVING));
+    } else if (participants) {
+      countFilter = ParticipatingFilter.PARTICIPATING;
+    } else if (observers) {
+      countFilter = ParticipatingFilter.OBSERVING;
+    }
 
     return new PlayerCountFilter(XMLUtils.parseNumericRange(el, Integer.class), countFilter);
   }

--- a/core/src/main/java/tc/oc/pgm/filters/PlayerCountFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/PlayerCountFilter.java
@@ -1,0 +1,31 @@
+package tc.oc.pgm.filters;
+
+import com.google.common.collect.Range;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.query.MatchQuery;
+import tc.oc.pgm.api.player.MatchPlayer;
+
+/** Check if the number of players in a certain context is within a defined range. */
+public class PlayerCountFilter extends TypedFilter<MatchQuery> {
+  private final Range<Integer> range;
+  private final Filter countFilter;
+
+  public PlayerCountFilter(Range<Integer> range, Filter countFilter) {
+    this.range = range;
+    this.countFilter = countFilter;
+  }
+
+  @Override
+  public Class<? extends MatchQuery> getQueryType() {
+    return MatchQuery.class;
+  }
+
+  @Override
+  public QueryResponse queryTyped(MatchQuery query) {
+    int count = 0;
+    for (MatchPlayer player : query.getMatch().getPlayers()) {
+      if (this.countFilter.query(player.getQuery()) == QueryResponse.ALLOW) count++;
+    }
+    return QueryResponse.fromBoolean(range.contains(count));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/filters/PlayerCountFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/PlayerCountFilter.java
@@ -37,11 +37,10 @@ public class PlayerCountFilter extends TypedFilter<MatchQuery> {
       if (this.countFilter.query(player.getQuery()) == QueryResponse.ALLOW) {
         count++;
         // Too high, give up
-        if (hasUpperBound && range.upperEndpoint() < count) return QueryResponse.DENY;
+        if (hasUpperBound && range.upperEndpoint() < count) break;
 
         // In the range - even if every other player passes the filter we won't go out of bounds
-        if (hasUpperBound && range.contains(count) && count + total <= range.upperEndpoint())
-          return QueryResponse.ALLOW;
+        if (hasUpperBound && range.contains(count) && count + total <= range.upperEndpoint()) break;
       }
     }
     return QueryResponse.fromBoolean(range.contains(count));


### PR DESCRIPTION
Re-adds the `<players>` filter with some more configurability than the legacy syntax. 

The filter now supports a child filter to determine which players should be counter. Legacy options get converted to the new filter. 