### PR TITLE
Try to load the TeamModule before the TimeLimitModule

### DIFF
--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
@@ -16,6 +16,7 @@ import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.VictoryCondition;
 import tc.oc.pgm.result.VictoryConditions;
+import tc.oc.pgm.teams.TeamModule;
 import tc.oc.pgm.util.text.TextException;
 import tc.oc.pgm.util.text.TextParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -41,6 +42,12 @@ public class TimeLimitModule implements MapModule<TimeLimitMatchModule> {
   }
 
   public static class Factory implements MapModuleFactory<TimeLimitModule> {
+
+    @Nullable
+    @Override
+    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+      return ImmutableList.of(TeamModule.class);
+    }
 
     @Override
     public TimeLimitModule parse(MapFactory factory, Logger logger, Document doc)


### PR DESCRIPTION
- This is necessary to make sure that teams can be a victory conditions when timelimit runs out.

Last time I did a soft dependency that was bad, now it is weak, which should not break anything!

Signed-off-by: KingSimon <19822231+KingOfSquares@users.noreply.github.com>