### PR TITLE
Ensure repeating kill streak filters have a clamped range

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -299,6 +299,11 @@ public abstract class FilterParser {
       }
     }
 
+    if (!range.hasUpperBound() && repeat) {
+      throw new InvalidXMLException(
+          "kill-streak filters with repeat=\"true\" must define a max or count", el);
+    }
+
     return new KillStreakFilter(range, repeat);
   }
 


### PR DESCRIPTION
Open ranges cause the calculation math to fail. Also, original PGM would not let you provide open ranges so should probably carry over that behavior.