### PR TITLE
Revert "Re-introduce filtered respawn options"

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/RespawnOptions.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/RespawnOptions.java
@@ -3,7 +3,6 @@ package tc.oc.pgm.spawns;
 import java.time.Duration;
 import javax.annotation.Nullable;
 import net.kyori.text.Component;
-import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.util.TimeUtils;
 
 public class RespawnOptions {
@@ -14,7 +13,6 @@ public class RespawnOptions {
   public final boolean spectate; // Allow dead players to fly around
   public final boolean bedSpawn; // Allow players to respawn from beds
   public final @Nullable Component message; // Message to show respawning players, after the delay
-  public final Filter usageFilter; // Filter to determine if these options should be used
 
   public RespawnOptions(
       Duration delay,
@@ -22,8 +20,7 @@ public class RespawnOptions {
       boolean blackout,
       boolean spectate,
       boolean bedSpawn,
-      @Nullable Component message,
-      Filter usageFilter) {
+      @Nullable Component message) {
     this.delay = delay;
     this.delayTicks = Math.max(TimeUtils.toTicks(delay), 20);
     this.auto = auto;
@@ -31,6 +28,5 @@ public class RespawnOptions {
     this.spectate = spectate;
     this.bedSpawn = bedSpawn;
     this.message = message;
-    this.usageFilter = usageFilter;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -65,11 +65,8 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
     return match;
   }
 
-  public RespawnOptions getRespawnOptions(MatchPlayer player) {
-    return module.respawnOptions.stream()
-        .filter(o -> o.usageFilter.query(player.getQuery()).isAllowed())
-        .findFirst()
-        .orElseThrow(() -> new IllegalStateException("Out of spawn options to pick from"));
+  public RespawnOptions getRespawnOptions() {
+    return module.respawnOptions;
   }
 
   public Spawn getDefaultSpawn() {

--- a/core/src/main/java/tc/oc/pgm/spawns/states/State.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/State.java
@@ -30,7 +30,7 @@ public abstract class State {
     this.smm = smm;
     this.player = player;
     this.bukkit = player.getBukkit();
-    this.options = smm.getRespawnOptions(player);
+    this.options = smm.getRespawnOptions();
   }
 
   public void enterState() {


### PR DESCRIPTION
It generated a behaviour change and broke maps without a specified respawn.

Until a new PR is made that fixes it, revert it to fix the plugin not even loading


## Background

The old logic was to generate ONE respawn option from ALL respawn elements in the XML in an incremental manner, using default values as fallback.

The new logic generates A: set of respawn options that are filtered, or B: a default spawn with ONE respawn. 

Logic from https://github.com/OvercastNetwork/ProjectAres/blob/master/PGM/src/main/java/tc/oc/pgm/spawns/SpawnModule.java#L106 should be implemented.

See: https://github.com/PGMDev/PGM/pull/713#discussion_r525589313