### PR TITLE
Update verbose stat implementation

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/StatsCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/StatsCommand.java
@@ -4,6 +4,7 @@ import app.ashcon.intake.Command;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
 import org.bukkit.command.CommandSender;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
@@ -19,7 +20,9 @@ public final class StatsCommand {
       aliases = {"stats"},
       desc = "Show your stats for the match")
   public void stats(Audience audience, CommandSender sender, MatchPlayer player, Match match) {
-    if (player.getSettings().getValue(SettingKey.STATS).equals(SettingValue.STATS_ON)) {
+    if (match.isFinished() && PGM.get().getConfiguration().showVerboseStats()) {
+      match.needModule(StatsMatchModule.class).displayVerboseStatsAndGiveItem(player);
+    } else if (player.getSettings().getValue(SettingKey.STATS).equals(SettingValue.STATS_ON)) {
       audience.sendMessage(
           TextFormatter.horizontalLineHeading(
               sender,

--- a/core/src/main/java/tc/oc/pgm/stats/PlayerStatsInventoryMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/PlayerStatsInventoryMenuItem.java
@@ -25,7 +25,7 @@ import tc.oc.pgm.util.text.TextTranslations;
 public class PlayerStatsInventoryMenuItem implements InventoryMenuItem {
 
   private final MatchPlayer player;
-  private final TextColor RESET = TextColor.WHITE;
+  private final TextColor RESET = TextColor.GRAY;
 
   PlayerStatsInventoryMenuItem(MatchPlayer player) {
     this.player = player;
@@ -45,43 +45,45 @@ public class PlayerStatsInventoryMenuItem implements InventoryMenuItem {
   public List<String> getLore(MatchPlayer player) {
     List<String> lore = new ArrayList<>();
     StatsMatchModule smm = player.getMatch().needModule(StatsMatchModule.class);
-    PlayerStats stats = smm.getPlayerStat(player.getId());
+    PlayerStats stats = smm.getPlayerStat(this.player.getId());
 
-    Component killLore =
+    Component statLore =
         TranslatableComponent.of(
-            "match.stats.kills.concise", RESET, numberComponent(stats.getKills(), TextColor.GREEN));
-    Component deathLore =
-        TranslatableComponent.of(
-            "match.stats.deaths.concise", RESET, numberComponent(stats.getDeaths(), TextColor.RED));
-    Component kdLore =
-        TranslatableComponent.of(
-            "match.stats.kd.concise", RESET, numberComponent(stats.getKD(), TextColor.GREEN));
+            "match.stats.concise",
+            RESET,
+            numberComponent(stats.getKills(), TextColor.GREEN),
+            numberComponent(stats.getDeaths(), TextColor.RED),
+            numberComponent(stats.getKD(), TextColor.GREEN));
     Component killstreakLore =
         TranslatableComponent.of(
             "match.stats.killstreak.concise",
             RESET,
             numberComponent(stats.getMaxKillstreak(), TextColor.GREEN));
-    Component damageLore =
+    Component damageDealtLore =
         TranslatableComponent.of(
-            "match.stats.damage.concise",
+            "match.stats.damage.dealt",
             RESET,
             numberComponent(stats.getDamageDone(), TextColor.GREEN),
-            numberComponent(stats.getBowDamage(), TextColor.YELLOW),
+            numberComponent(stats.getBowDamage(), TextColor.YELLOW));
+    Component damageReceivedLore =
+        TranslatableComponent.of(
+            "match.stats.damage.received",
+            RESET,
             numberComponent(stats.getDamageTaken(), TextColor.RED));
     Component bowLore =
         TranslatableComponent.of(
-            "match.stats.bow.concise",
+            "match.stats.bow",
             RESET,
+            numberComponent(stats.getShotsHit(), TextColor.YELLOW),
             numberComponent(stats.getShotsTaken(), TextColor.YELLOW),
             numberComponent(stats.getArrowAccuracy(), TextColor.YELLOW));
 
     Player bukkit = player.getBukkit();
 
-    lore.add(TextTranslations.translateLegacy(killLore, bukkit));
-    lore.add(TextTranslations.translateLegacy(deathLore, bukkit));
-    lore.add(TextTranslations.translateLegacy(kdLore, bukkit));
+    lore.add(TextTranslations.translateLegacy(statLore, bukkit));
     lore.add(TextTranslations.translateLegacy(killstreakLore, bukkit));
-    lore.add(TextTranslations.translateLegacy(damageLore, bukkit));
+    lore.add(TextTranslations.translateLegacy(damageDealtLore, bukkit));
+    lore.add(TextTranslations.translateLegacy(damageReceivedLore, bukkit));
     lore.add(TextTranslations.translateLegacy(bowLore, bukkit));
 
     if (!optionalStat(

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -14,7 +14,6 @@ import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
-import net.kyori.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Arrow;
@@ -269,12 +268,21 @@ public class StatsMatchModule implements MatchModule, Listener {
     if ((action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)) {
       ItemStack item = event.getPlayer().getItemInHand();
 
-      if (item.getType() == Material.RED_SANDSTONE) {
+      if (item.getType() == Material.PAPER) {
         MatchPlayer player = match.getPlayer(event.getPlayer());
         if (player == null) return;
-        endOfMatchMenu.display(player);
+        displayVerboseStatsAndGiveItem(player);
       }
     }
+  }
+
+  public void displayVerboseStatsAndGiveItem(MatchPlayer player) {
+    if (endOfMatchMenu == null)
+      return; // If allPlayerStats.isEmpty() == null the menu never gets defined
+    player
+        .getInventory()
+        .setItem(7, new VerboseStatsInventoryMenuItem(endOfMatchMenu).createItem(player));
+    endOfMatchMenu.display(player);
   }
 
   private Map.Entry<UUID, Integer> sortStats(Map<UUID, Integer> map) {
@@ -294,8 +302,8 @@ public class StatsMatchModule implements MatchModule, Listener {
   }
 
   /**
-   * Wraps a {@link Number} in a {@link Component} that is bolded and colored with the given {@link
-   * TextColor}. Rounds the number to a maximum of 2 decimals
+   * Wraps a {@link Number} in a {@link Component} that is colored with the given {@link TextColor}.
+   * Rounds the number to a maximum of 2 decimals
    *
    * <p>If the number is NaN "-" is wrapped instead
    *
@@ -303,7 +311,7 @@ public class StatsMatchModule implements MatchModule, Listener {
    *
    * @param stat The number you want wrapped
    * @param color The color you want the number to be
-   * @return A bolded and colored component wrapping the given number or "-" if NaN
+   * @return a colored component wrapping the given number or "-" if NaN
    */
   public static Component numberComponent(Number stat, TextColor color) {
     double doubleStat = stat.doubleValue();
@@ -325,7 +333,7 @@ public class StatsMatchModule implements MatchModule, Listener {
       if (decimals.chars().sum() == 1 || tenThousand) returnValue = ONE_DECIMAL.format(doubleStat);
       else returnValue = TWO_DECIMALS.format(doubleStat);
     }
-    return TextComponent.of(returnValue + (tenThousand ? "k" : ""), color, TextDecoration.BOLD);
+    return TextComponent.of(returnValue + (tenThousand ? "k" : ""), color);
   }
 
   @EventHandler

--- a/core/src/main/java/tc/oc/pgm/stats/TeamStatsInventoryMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/TeamStatsInventoryMenuItem.java
@@ -28,7 +28,7 @@ public class TeamStatsInventoryMenuItem implements InventoryMenuItem {
   private final Competitor team;
   private final InventoryMenu teamSubGUI;
 
-  private final TextColor RESET = TextColor.WHITE;
+  private final TextColor RESET = TextColor.GRAY;
 
   TeamStatsInventoryMenuItem(Match match, Competitor team) {
     this.team = team;
@@ -77,35 +77,36 @@ public class TeamStatsInventoryMenuItem implements InventoryMenuItem {
     double teamKD = teamDeaths == 0 ? teamKills : teamKills / (double) teamDeaths;
     double teamBowAcc = shotsTaken == 0 ? Double.NaN : shotsHit / (shotsTaken / (double) 100);
 
-    Component killLore =
+    Component statLore =
         TranslatableComponent.of(
-            "match.stats.kills.concise", RESET, numberComponent(teamKills, TextColor.GREEN));
-    Component deathLore =
+            "match.stats.concise",
+            RESET,
+            numberComponent(teamKills, TextColor.GREEN),
+            numberComponent(teamDeaths, TextColor.RED),
+            numberComponent(teamKD, TextColor.GREEN));
+
+    Component damageDealtLore =
         TranslatableComponent.of(
-            "match.stats.deaths.concise", RESET, numberComponent(teamDeaths, TextColor.RED));
-    Component kdLore =
-        TranslatableComponent.of(
-            "match.stats.kd.concise", RESET, numberComponent(teamKD, TextColor.GREEN));
-    Component damageLore =
-        TranslatableComponent.of(
-            "match.stats.damage.concise",
+            "match.stats.damage.dealt",
             RESET,
             numberComponent(damageDone, TextColor.GREEN),
-            numberComponent(bowDamage, TextColor.YELLOW),
-            numberComponent(damageTaken, TextColor.RED));
+            numberComponent(bowDamage, TextColor.YELLOW));
+    Component damageReceivedLore =
+        TranslatableComponent.of(
+            "match.stats.damage.received", RESET, numberComponent(damageTaken, TextColor.RED));
     Component bowLore =
         TranslatableComponent.of(
-            "match.stats.bow.concise",
+            "match.stats.bow",
             RESET,
+            numberComponent(shotsHit, TextColor.YELLOW),
             numberComponent(shotsTaken, TextColor.YELLOW),
             numberComponent(teamBowAcc, TextColor.YELLOW));
 
     Player bukkit = player.getBukkit();
 
-    lore.add(TextTranslations.translateLegacy(killLore, bukkit));
-    lore.add(TextTranslations.translateLegacy(deathLore, bukkit));
-    lore.add(TextTranslations.translateLegacy(kdLore, bukkit));
-    lore.add(TextTranslations.translateLegacy(damageLore, bukkit));
+    lore.add(TextTranslations.translateLegacy(statLore, bukkit));
+    lore.add(TextTranslations.translateLegacy(damageDealtLore, bukkit));
+    lore.add(TextTranslations.translateLegacy(damageReceivedLore, bukkit));
     lore.add(TextTranslations.translateLegacy(bowLore, bukkit));
 
     return lore;

--- a/core/src/main/java/tc/oc/pgm/stats/VerboseStatsInventoryMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/VerboseStatsInventoryMenuItem.java
@@ -41,7 +41,7 @@ public class VerboseStatsInventoryMenuItem implements InventoryMenuItem {
 
   @Override
   public Material getMaterial(MatchPlayer player) {
-    return Material.RED_SANDSTONE;
+    return Material.PAPER;
   }
 
   @Override

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -51,12 +51,14 @@ match.class.notFound = No class matched query.
 # {3} = numbers of kills divided by the number of deaths (kill-death ratio)
 match.stats = Kills: {0}  |  Killstreak: {1}  |  Deaths: {2}  |  K/D: {3}
 
+# {0} = number of kills
+# {1} = number of deaths
+# {2} = numbers of kills divided by the number of deaths (kill-death ratio)
+match.stats.concise = Kills: {0}  Deaths: {1}  K/D: {2}
+
 # {0} = a player name
 # {1} = an amount of kills(number)
 match.stats.kills = Kills: {1} by {0}
-
-# {0} = an amount of kills(number)
-match.stats.kills.concise = Kills: {0}
 
 # {0} = a player name
 # {1} = a killstreak(number)
@@ -69,12 +71,6 @@ match.stats.killstreak.concise = Best Killstreak: {0}
 # {1} = an amount of deaths(number)
 match.stats.deaths = Deaths: {1} by {0}
 
-# {0} = an amount of deaths(number)
-match.stats.deaths.concise = Deaths: {0}
-
-# {0} = numbers of kills divided by the number of deaths (kill-death ratio)
-match.stats.kd.concise = K/D: {0}
-
 # {0} = a player name
 # {1} = an amount of blocks
 match.stats.bowshot = Longest Shot: {1} blocks by {0}
@@ -83,20 +79,24 @@ match.stats.bowshot = Longest Shot: {1} blocks by {0}
 # {1} = an amount of damage
 match.stats.damage = Damage: {1} by {0}
 
-# {0} = the number of damage done
-# {1} = the number of damage done with a bow
-# {2} = the number of damage taken
-match.stats.damage.concise = Damage Dealt (Bow) / Received: {0} ({1}) / {2}
+# {0} = an amount of damage
+# {1} = an amount of damage
+match.stats.damage.dealt = Damage Dealt (Bow): {0} ({1})
 
-# {0} = the number of bow shots taken
-# {1} = the number representing someones accuracy(e.g 35%)
-match.stats.bow.concise = Bow Shots / Accuracy: {0} / {1}%
+# {0} = an amount of damage
+match.stats.damage.received = Damage Received: {0}
+
+# {0} = number of arrows hit
+# {1} = number of arrows shot
+# {2} = accuracy represented as a percentage
+match.stats.bow = Bow Hits: {0} / {1} ({2})
+
 
 # {0} = the number of flags captured
 match.stats.flagsCaptured.concise = Flags Captured: {0}
 
 # {0} = a number representing the duration of the capture
-match.stats.flaghold.concise = Longest Flag Capture: {0}
+match.stats.flaghold.concise = Longest Flag Hold: {0}
 
 # {0} the amount of monument pieces broken(number)
 match.stats.broken.concise = Monument Blocks Broken: {0}


### PR DESCRIPTION
- Fixes a bug where a player could only see their own stats on all player heads in the menu.
- Changes the layout of the stats hover for teams and players, also changes some wording
- If verbose stats is enabled and the match is over /stats now work as an item retriever + menu opener
- Changes the verbose stat item material into paper
- Stat hovers in the menu now are gray without bolded numbers to be more consistent with the rest of PGM

Hope I didn't forget anything!

Picture if the new stat hover layout
https://cdn.discordapp.com/attachments/346410063335915521/778752823101620224/Skjermbilde_2020-11-18_kl._23.45.37.png

Signed-off-by: KingSimon <19822231+KingOfSquares@users.noreply.github.com>