### PR TITLE
Fix previews for non-player inventory holders

### DIFF
--- a/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
@@ -310,6 +310,9 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
           this.previewPlayerInventory(
               Bukkit.getServer().getPlayerExact(pl), tracker.getPlayerInventory());
         }
+      } else {
+        InventoryHolder holder = tracker.getWatched().getHolder();
+        this.previewInventory(Bukkit.getServer().getPlayerExact(pl), holder.getInventory());
       }
     }
   }


### PR DESCRIPTION
When observers right click the players of a match, they are shown a preview of the their current inventory, and this preview is kept updated so that if the inventory changes, the preview will also reflect these changes. This behaviour was not being applied, however, to other inventory holders such as chests, hoppers, or anything that was not a player, and observers would have to re-right click the container to update the contents of their preview.

This commit makes non-player inventory holders's previews update lively, just like when previewing a player's inventory.