### PR TITLE
Verbose stats fixes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/StatsCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/StatsCommand.java
@@ -9,6 +9,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
+import tc.oc.pgm.ffa.Tribute;
 import tc.oc.pgm.stats.StatsMatchModule;
 import tc.oc.pgm.util.chat.Audience;
 import tc.oc.pgm.util.text.TextException;
@@ -20,7 +21,10 @@ public final class StatsCommand {
       aliases = {"stats"},
       desc = "Show your stats for the match")
   public void stats(Audience audience, CommandSender sender, MatchPlayer player, Match match) {
-    if (match.isFinished() && PGM.get().getConfiguration().showVerboseStats()) {
+    if (match.isFinished()
+        && PGM.get().getConfiguration().showVerboseStats()
+        && !match.getCompetitors().stream()
+            .allMatch(c -> c instanceof Tribute)) { // Should not try to trigger on FFA
       match.needModule(StatsMatchModule.class).displayVerboseStatsAndGiveItem(player);
     } else if (player.getSettings().getValue(SettingKey.STATS).equals(SettingValue.STATS_ON)) {
       audience.sendMessage(

--- a/core/src/main/java/tc/oc/pgm/menu/InventoryMenuUtils.java
+++ b/core/src/main/java/tc/oc/pgm/menu/InventoryMenuUtils.java
@@ -31,11 +31,11 @@ public class InventoryMenuUtils {
 
     final int offset = 18 * page;
 
-    final int size = itemsWithoutSpaces.size() - offset;
+    final int size = itemsWithoutSpaces.size() - offset; // The amount of items left to place
 
     if (size > 13)
       for (int i = 13; i < 18; i++) {
-        itemsWithSpaces.add(size > i ? itemsWithoutSpaces.get(i) : null);
+        itemsWithSpaces.add(size > i ? itemsWithoutSpaces.get(i + offset) : null);
         if (i != 17) itemsWithSpaces.add(null);
       }
     else emptyRow(itemsWithSpaces);
@@ -43,14 +43,14 @@ public class InventoryMenuUtils {
     if (size > 0)
       for (int i = 0; i < 4; i++) {
         itemsWithSpaces.add(null);
-        itemsWithSpaces.add(size > i ? itemsWithoutSpaces.get(i) : null);
+        itemsWithSpaces.add(size > i ? itemsWithoutSpaces.get(i + offset) : null);
         if (i == 3) itemsWithSpaces.add(null);
       }
     else emptyRow(itemsWithSpaces);
 
     if (size > 8)
       for (int i = 8; i < 13; i++) {
-        itemsWithSpaces.add(size > i ? itemsWithoutSpaces.get(i) : null);
+        itemsWithSpaces.add(size > i ? itemsWithoutSpaces.get(i + offset) : null);
         if (i != 12) itemsWithSpaces.add(null);
       }
     else emptyRow(itemsWithSpaces);
@@ -58,7 +58,7 @@ public class InventoryMenuUtils {
     if (size > 4)
       for (int i = 4; i < 8; i++) {
         itemsWithSpaces.add(null);
-        itemsWithSpaces.add(size > i ? itemsWithoutSpaces.get(i) : null);
+        itemsWithSpaces.add(size > i ? itemsWithoutSpaces.get(i + offset) : null);
         if (i == 7) itemsWithSpaces.add(null);
       }
     else emptyRow(itemsWithSpaces);
@@ -73,7 +73,7 @@ public class InventoryMenuUtils {
     itemsWithSpaces.add(null);
     itemsWithSpaces.add(null);
     itemsWithSpaces.add(
-        size > offset && offset != 0
+        itemsWithoutSpaces.size() > offset + 18 // Does the menu need another page?
             ? new PageInventoryMenuItem(inventoryTitle, itemsWithoutSpaces, page, true)
             : null);
     itemsWithSpaces.add(null);

--- a/core/src/main/java/tc/oc/pgm/menu/PageInventoryMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/menu/PageInventoryMenuItem.java
@@ -9,15 +9,18 @@ import org.bukkit.event.inventory.ClickType;
 import tc.oc.pgm.api.player.MatchPlayer;
 
 public class PageInventoryMenuItem implements InventoryMenuItem {
-  private final List<InventoryMenuItem> to;
+  private final List<InventoryMenuItem> inventoryItems;
   private final int toPage;
   private final boolean next;
   private final Component inventoryTitle;
 
   PageInventoryMenuItem(
-      Component inventoryTitle, List<InventoryMenuItem> to, int currentPage, boolean next) {
+      Component inventoryTitle,
+      List<InventoryMenuItem> inventoryItems,
+      int currentPage,
+      boolean next) {
     this.inventoryTitle = inventoryTitle;
-    this.to = to;
+    this.inventoryItems = inventoryItems;
     this.toPage = next ? ++currentPage : --currentPage;
     this.next = next;
   }
@@ -44,6 +47,7 @@ public class PageInventoryMenuItem implements InventoryMenuItem {
 
   @Override
   public void onInventoryClick(InventoryMenu menu, MatchPlayer player, ClickType clickType) {
-    InventoryMenuUtils.prettyMenu(player.getMatch(), inventoryTitle, to, toPage).display(player);
+    InventoryMenuUtils.prettyMenu(player.getMatch(), inventoryTitle, inventoryItems, toPage)
+        .display(player);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
@@ -1,10 +1,11 @@
 package tc.oc.pgm.stats;
 
+import static tc.oc.pgm.stats.StatsMatchModule.numberComponent;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.Future;
 import net.kyori.text.Component;
-import net.kyori.text.TextComponent;
 import net.kyori.text.TranslatableComponent;
 import net.kyori.text.format.TextColor;
 
@@ -101,10 +102,10 @@ class PlayerStats {
     return TranslatableComponent.of(
         "match.stats",
         TextColor.GRAY,
-        TextComponent.of(kills, TextColor.GREEN),
-        TextComponent.of(killstreak, TextColor.GREEN),
-        TextComponent.of(deaths, TextColor.RED),
-        TextComponent.of(getKD(), TextColor.GREEN));
+        numberComponent(kills, TextColor.GREEN),
+        numberComponent(killstreak, TextColor.GREEN),
+        numberComponent(deaths, TextColor.RED),
+        numberComponent(getKD(), TextColor.GREEN));
   }
 
   // Getters, both raw stats and some handy calculations

--- a/core/src/main/java/tc/oc/pgm/stats/PlayerStatsInventoryMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/PlayerStatsInventoryMenuItem.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.stats;
 
+import static tc.oc.pgm.stats.StatsMatchModule.damageComponent;
 import static tc.oc.pgm.stats.StatsMatchModule.numberComponent;
 
 import java.time.Duration;
@@ -63,13 +64,13 @@ public class PlayerStatsInventoryMenuItem implements InventoryMenuItem {
         TranslatableComponent.of(
             "match.stats.damage.dealt",
             RESET,
-            numberComponent(stats.getDamageDone(), TextColor.GREEN),
-            numberComponent(stats.getBowDamage(), TextColor.YELLOW));
+            damageComponent(stats.getDamageDone(), TextColor.GREEN),
+            damageComponent(stats.getBowDamage(), TextColor.YELLOW));
     Component damageReceivedLore =
         TranslatableComponent.of(
             "match.stats.damage.received",
             RESET,
-            numberComponent(stats.getDamageTaken(), TextColor.RED));
+            damageComponent(stats.getDamageTaken(), TextColor.RED));
     Component bowLore =
         TranslatableComponent.of(
             "match.stats.bow",

--- a/core/src/main/java/tc/oc/pgm/stats/TeamStatsInventoryMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/TeamStatsInventoryMenuItem.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.stats;
 
+import static tc.oc.pgm.stats.StatsMatchModule.damageComponent;
 import static tc.oc.pgm.stats.StatsMatchModule.numberComponent;
 
 import java.util.ArrayList;
@@ -89,11 +90,11 @@ public class TeamStatsInventoryMenuItem implements InventoryMenuItem {
         TranslatableComponent.of(
             "match.stats.damage.dealt",
             RESET,
-            numberComponent(damageDone, TextColor.GREEN),
-            numberComponent(bowDamage, TextColor.YELLOW));
+            damageComponent(damageDone, TextColor.GREEN),
+            damageComponent(bowDamage, TextColor.YELLOW));
     Component damageReceivedLore =
         TranslatableComponent.of(
-            "match.stats.damage.received", RESET, numberComponent(damageTaken, TextColor.RED));
+            "match.stats.damage.received", RESET, damageComponent(damageTaken, TextColor.RED));
     Component bowLore =
         TranslatableComponent.of(
             "match.stats.bow",


### PR DESCRIPTION
Changes damage to hearts
<img width="451" alt="Skjermbilde 2020-11-21 kl  14 12 45" src="https://user-images.githubusercontent.com/19822231/99878180-db422000-2c03-11eb-94cd-e1fd84900d34.png">

Also fixes multiple bugs:

- No longer prevents stats being viewed after the match if the match was a FFA
- Now properly adds pages to the team menus
- Now formats K/D properly
- Now includes damage dealt on absorption (thanks @Pugzy)



Signed-off-by: KingSimon <19822231+KingOfSquares@users.noreply.github.com>