### PR TITLE
Add bonus-points module

### DIFF
--- a/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -348,6 +348,12 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
     if (oldCapturingTeam != this.capturingTeam) {
       this.match.callEvent(
           new CapturingTeamChangeEvent(this.match, this, oldCapturingTeam, this.capturingTeam));
+
+      ScoreMatchModule scoreMatchModule = this.getMatch().getModule(ScoreMatchModule.class);
+      // Gives a set number of bonus points to a team when captured.
+      if (this.capturingTeam != null && scoreMatchModule != null) {
+        scoreMatchModule.incrementScore(this.capturingTeam, this.getDefinition().getPointsBonus());
+      }
     }
 
     if (oldControllingTeam != this.controllingTeam) {

--- a/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
+++ b/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
@@ -69,6 +69,9 @@ public class ControlPointDefinition extends GoalDefinition {
   // Rate that the owner's score increases, or 0 if the CP does not affect score
   private final float pointsPerSecond;
 
+  // Set number of points given to owner
+  private final float pointsBonus;
+
   // If this is less than +inf, the effective pointsPerSecond will increase over time
   // at an exponential rate, such that it doubles every time this many seconds elapses.
   private final float pointsGrowth;
@@ -96,6 +99,7 @@ public class ControlPointDefinition extends GoalDefinition {
       boolean neutralState,
       boolean permanent,
       float pointsPerSecond,
+      float pointsBonus,
       float pointsGrowth,
       boolean progress) {
 
@@ -115,6 +119,7 @@ public class ControlPointDefinition extends GoalDefinition {
     this.neutralState = neutralState;
     this.permanent = permanent;
     this.pointsPerSecond = pointsPerSecond;
+    this.pointsBonus = pointsBonus;
     this.pointsGrowth = pointsGrowth;
     this.showProgress = progress;
   }
@@ -217,6 +222,10 @@ public class ControlPointDefinition extends GoalDefinition {
 
   public float getPointsPerSecond() {
     return this.pointsPerSecond;
+  }
+
+  public float getPointsBonus() {
+    return this.pointsBonus;
   }
 
   public float getPointsGrowth() {

--- a/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -75,6 +75,8 @@ public abstract class ControlPointParser {
     boolean permanent = XMLUtils.parseBoolean(elControlPoint.getAttribute("permanent"), false);
     float pointsPerSecond =
         XMLUtils.parseNumber(elControlPoint.getAttribute("points"), Float.class, 1f);
+    float pointsBonus =
+        XMLUtils.parseNumber(elControlPoint.getAttribute("bonus-points"), Float.class, 1f);
     float pointsGrowth =
         XMLUtils.parseNumber(
             elControlPoint.getAttribute("points-growth"), Float.class, Float.POSITIVE_INFINITY);
@@ -110,6 +112,7 @@ public abstract class ControlPointParser {
         neutralState,
         permanent,
         pointsPerSecond,
+        pointsBonus,
         pointsGrowth,
         showProgress);
   }


### PR DESCRIPTION
This adds a `bonus-points` module that can let control points give a set number of points when captured.
```xml
   <!-- Gives exactly 20 points when captured -->
    <control-point name="The Hill" id="pi-cp" capture-time="1s" bonus-points="20" points="0">
        <capture><region id="hill"/></capture>
        <progress><region id="hill"/></progress>
        <captured><region id="hill"/></captured>
    </control-point>

   <!-- Gives exactly 10 points when captured, then awards 1 point per second -->
    <control-point name="The Hill" id="pi-cp" capture-time="1s" bonus-points="10">
        <capture><region id="hill"/></capture>
        <progress><region id="hill"/></progress>
        <captured><region id="hill"/></captured>
    </control-point>
```
Still a work in progress because it gives the team the points the second they start capturing the hill, rather than when capturing but otherwise it still works.