### PR TITLE
Add owner-points module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -355,8 +355,8 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
           new ControllerChangeEvent(this.match, this, oldControllingTeam, this.controllingTeam));
 
       ScoreMatchModule scoreMatchModule = this.getMatch().getModule(ScoreMatchModule.class);
-      // Gives a set number of owner points to a team when captured.
-      if (this.controllingTeam != null && scoreMatchModule != null) {
+      // Gives a set number of owner points to a team when captured, lost when an enemy captures
+      if (scoreMatchModule != null) {
         if (oldControllingTeam != null) {
           scoreMatchModule.incrementScore(
               oldControllingTeam, getDefinition().getPointsOwner() * -1);

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -348,17 +348,23 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
     if (oldCapturingTeam != this.capturingTeam) {
       this.match.callEvent(
           new CapturingTeamChangeEvent(this.match, this, oldCapturingTeam, this.capturingTeam));
-      ScoreMatchModule scoreMatchModule = this.getMatch().getModule(ScoreMatchModule.class);
-      // Gives a set number of Owner points to a team when captured.
-      if (this.capturingTeam != null && scoreMatchModule != null) {
-        scoreMatchModule.incrementScore(this.capturingTeam, this.getDefinition().getPointsOwner());
-      }
     }
 
     if (oldControllingTeam != this.controllingTeam) {
       this.match.callEvent(
           new ControllerChangeEvent(this.match, this, oldControllingTeam, this.controllingTeam));
 
+      ScoreMatchModule scoreMatchModule = this.getMatch().getModule(ScoreMatchModule.class);
+      // Gives a set number of owner points to a team when captured.
+      if (this.controllingTeam != null && scoreMatchModule != null) {
+        if (oldControllingTeam != null) {
+          scoreMatchModule.incrementScore(
+              oldControllingTeam, getDefinition().getPointsOwner() * -1);
+        }
+        if (this.controllingTeam != null) {
+          scoreMatchModule.incrementScore(this.controllingTeam, getDefinition().getPointsOwner());
+        }
+      }
       if (this.controllingTeam == null) {
         this.match.callEvent(new GoalCompleteEvent(this.match, this, oldControllingTeam, false));
       } else {

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -349,9 +349,9 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
       this.match.callEvent(
           new CapturingTeamChangeEvent(this.match, this, oldCapturingTeam, this.capturingTeam));
       ScoreMatchModule scoreMatchModule = this.getMatch().getModule(ScoreMatchModule.class);
-      // Gives a set number of bonus points to a team when captured.
+      // Gives a set number of Owner points to a team when captured.
       if (this.capturingTeam != null && scoreMatchModule != null) {
-        scoreMatchModule.incrementScore(this.capturingTeam, this.getDefinition().getPointsBonus());
+        scoreMatchModule.incrementScore(this.capturingTeam, this.getDefinition().getPointsOwner());
       }
     }
 

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -348,6 +348,11 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
     if (oldCapturingTeam != this.capturingTeam) {
       this.match.callEvent(
           new CapturingTeamChangeEvent(this.match, this, oldCapturingTeam, this.capturingTeam));
+      ScoreMatchModule scoreMatchModule = this.getMatch().getModule(ScoreMatchModule.class);
+      // Gives a set number of bonus points to a team when captured.
+      if (this.capturingTeam != null && scoreMatchModule != null) {
+        scoreMatchModule.incrementScore(this.capturingTeam, this.getDefinition().getPointsBonus());
+      }
     }
 
     if (oldControllingTeam != this.controllingTeam) {

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
@@ -70,7 +70,7 @@ public class ControlPointDefinition extends GoalDefinition {
   private final float pointsPerSecond;
 
   // Set number of points given to owner
-  private final float pointsBonus;
+  private final float pointsOwner;
 
   // If this is less than +inf, the effective pointsPerSecond will increase over time
   // at an exponential rate, such that it doubles every time this many seconds elapses.
@@ -99,7 +99,7 @@ public class ControlPointDefinition extends GoalDefinition {
       boolean neutralState,
       boolean permanent,
       float pointsPerSecond,
-      float pointsBonus,
+      float pointsOwner,
       float pointsGrowth,
       boolean progress) {
 
@@ -119,7 +119,7 @@ public class ControlPointDefinition extends GoalDefinition {
     this.neutralState = neutralState;
     this.permanent = permanent;
     this.pointsPerSecond = pointsPerSecond;
-    this.pointsBonus = pointsBonus;
+    this.pointsOwner = pointsOwner;
     this.pointsGrowth = pointsGrowth;
     this.showProgress = progress;
   }
@@ -225,8 +225,8 @@ public class ControlPointDefinition extends GoalDefinition {
     return this.pointsPerSecond;
   }
 
-  public float getPointsBonus() {
-    return this.pointsBonus;
+  public float getPointsOwner() {
+    return this.pointsOwner;
   }
 
   public float getPointsGrowth() {

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
@@ -69,6 +69,9 @@ public class ControlPointDefinition extends GoalDefinition {
   // Rate that the owner's score increases, or 0 if the CP does not affect score
   private final float pointsPerSecond;
 
+  // Set number of points given to owner
+  private final float pointsBonus;
+
   // If this is less than +inf, the effective pointsPerSecond will increase over time
   // at an exponential rate, such that it doubles every time this many seconds elapses.
   private final float pointsGrowth;
@@ -96,6 +99,7 @@ public class ControlPointDefinition extends GoalDefinition {
       boolean neutralState,
       boolean permanent,
       float pointsPerSecond,
+      float pointsBonus,
       float pointsGrowth,
       boolean progress) {
 
@@ -115,6 +119,7 @@ public class ControlPointDefinition extends GoalDefinition {
     this.neutralState = neutralState;
     this.permanent = permanent;
     this.pointsPerSecond = pointsPerSecond;
+    this.pointsBonus = pointsBonus;
     this.pointsGrowth = pointsGrowth;
     this.showProgress = progress;
   }
@@ -218,6 +223,10 @@ public class ControlPointDefinition extends GoalDefinition {
 
   public float getPointsPerSecond() {
     return this.pointsPerSecond;
+  }
+
+  public float getPointsBonus() {
+    return this.pointsBonus;
   }
 
   public float getPointsGrowth() {

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -87,6 +87,8 @@ public abstract class ControlPointParser {
     boolean permanent = XMLUtils.parseBoolean(elControlPoint.getAttribute("permanent"), false);
     float pointsPerSecond =
         XMLUtils.parseNumber(elControlPoint.getAttribute("points"), Float.class, 1f);
+    float pointsBonus =
+        XMLUtils.parseNumber(elControlPoint.getAttribute("bonus-points"), Float.class, 1f);
     float pointsGrowth =
         XMLUtils.parseNumber(
             elControlPoint.getAttribute("points-growth"), Float.class, Float.POSITIVE_INFINITY);
@@ -122,6 +124,7 @@ public abstract class ControlPointParser {
         neutralState,
         permanent,
         pointsPerSecond,
+        pointsBonus,
         pointsGrowth,
         showProgress);
   }

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -87,8 +87,8 @@ public abstract class ControlPointParser {
     boolean permanent = XMLUtils.parseBoolean(elControlPoint.getAttribute("permanent"), false);
     float pointsPerSecond =
         XMLUtils.parseNumber(elControlPoint.getAttribute("points"), Float.class, 1f);
-    float pointsBonus =
-        XMLUtils.parseNumber(elControlPoint.getAttribute("bonus-points"), Float.class, 1f);
+    float pointsOwner =
+        XMLUtils.parseNumber(elControlPoint.getAttribute("owner-points"), Float.class, 0f);
     float pointsGrowth =
         XMLUtils.parseNumber(
             elControlPoint.getAttribute("points-growth"), Float.class, Float.POSITIVE_INFINITY);
@@ -124,7 +124,7 @@ public abstract class ControlPointParser {
         neutralState,
         permanent,
         pointsPerSecond,
-        pointsBonus,
+        pointsOwner,
         pointsGrowth,
         showProgress);
   }


### PR DESCRIPTION
This adds a `owner-points` module that can let control points give a set number of points when captured.
```xml
    <!-- Gives exactly 20 points when captured, removes 20 points when control point lost -->
    <control-point name="The Hill" id="hill" capture-time="1s" owner-points="20" points="0">
        <capture><region id="hill"/></capture>
        <progress><region id="hill"/></progress>
        <captured><region id="hill"/></captured>
    </control-point>

    <!-- Holds 10 points when captured, then awards 1 point per second -->
    <control-point name="The Hill" id="second-hill" capture-time="1s" owner-points="10">
        <capture><region id="hill-2"/></capture>
        <progress><region id="hill-2"/></progress>
        <captured><region id="hill-2"/></captured>
    </control-point>

    <!-- Holds 40 points when captured, then awards 3 points per second -->
    <control-point name="The Hill" id="third-hill" capture-time="1s" owner-points="40" points="3">
        <capture><region id="hill-3"/></capture>
        <progress><region id="hill-3"/></progress>
        <captured><region id="hill-3"/></captured>
    </control-point>
```
Still a work in progress because it gives the team the points the moment they start capturing the hill, rather than when capturing but otherwise it still works, just needs another case added into it but what I've tried so far didn't work. I'll check the code @Pablete1234 was talking about later. Fixes #716