### PR TITLE
Fix control point visual-material attribute name closes #723

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -50,7 +50,7 @@ public abstract class ControlPointParser {
     Filter playerFilter = filterParser.parseFilterProperty(elControlPoint, "player-filter");
 
     Filter visualMaterials;
-    List<Filter> filters = filterParser.parseFiltersProperty(elControlPoint, "visual-world");
+    List<Filter> filters = filterParser.parseFiltersProperty(elControlPoint, "visual-materials");
     if (filters.isEmpty()) {
       visualMaterials = VISUAL_MATERIALS;
     } else {


### PR DESCRIPTION
As discussed in #723 this attribute is references as `visual-material` in all documentation `docs.oc.tc` and `pgm.dev`.

I have checked the entire OCC and OCN maps repository (plus others) and found only one instance of `visual-world` used by Bolt who I assume source dived to debug an issue where the original `visual-material` did not exist finding this alternate name.

For the above reasons and the low usage of the feature (3 instances the whole of OCN), I believe it is safe to drop support for the assumed typo error made during the open-source process. 

Signed-off-by: Pugzy <pugzy@mail.com>