### PR TITLE
Make length of death animation configurable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -166,7 +166,7 @@ public final class PGMConfig implements Config {
     this.griefScore =
         parseInteger(config.getString("gameplay.grief-score", "-10"), Range.atMost(0));
     this.deathTicks =
-        parseInteger(config.getString("gameplay.death-tick", "15"), Range.atLeast(0));
+        parseInteger(config.getString("gameplay.death-ticks", "15"), Range.closed(0, 20));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -69,6 +69,7 @@ public final class PGMConfig implements Config {
   // gameplay.*
   private final boolean woolRefill;
   private final int griefScore;
+  private final int deathAnimationLength;
 
   // join.*
   private final long minPlayers;
@@ -164,6 +165,8 @@ public final class PGMConfig implements Config {
     this.verboseStats = parseBoolean(config.getString("ui.verbose-stats", "false"));
     this.griefScore =
         parseInteger(config.getString("gameplay.grief-score", "-10"), Range.atMost(0));
+    this.deathAnimationLength =
+        parseInteger(config.getString("gameplay.death-animation-length", "15"));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));
@@ -516,6 +519,11 @@ public final class PGMConfig implements Config {
   @Override
   public int getGriefScore() {
     return griefScore;
+  }
+
+  @Override
+  public int getDeathAnimationLength() {
+    return deathAnimationLength;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -69,7 +69,7 @@ public final class PGMConfig implements Config {
   // gameplay.*
   private final boolean woolRefill;
   private final int griefScore;
-  private final int deathAnimationLength;
+  private final int deathTicks;
 
   // join.*
   private final long minPlayers;
@@ -165,8 +165,8 @@ public final class PGMConfig implements Config {
     this.verboseStats = parseBoolean(config.getString("ui.verbose-stats", "false"));
     this.griefScore =
         parseInteger(config.getString("gameplay.grief-score", "-10"), Range.atMost(0));
-    this.deathAnimationLength =
-        parseInteger(config.getString("gameplay.death-animation-length", "15"));
+    this.deathTicks =
+        parseInteger(config.getString("gameplay.death-tick", "15"), Range.atLeast(0));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));
@@ -522,8 +522,8 @@ public final class PGMConfig implements Config {
   }
 
   @Override
-  public int getDeathAnimationLength() {
-    return deathAnimationLength;
+  public int getDeathTicks() {
+    return deathTicks;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -254,6 +254,13 @@ public interface Config {
   int getGriefScore();
 
   /**
+   * Gets the length in ticks for how long the death animation is shown
+   *
+   * @return length of death animation
+   */
+  int getDeathAnimationLength();
+
+  /**
    * Gets a group of players, used for prefixes and player sorting.
    *
    * @return A list of groups.

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -258,7 +258,7 @@ public interface Config {
    *
    * @return length of death animation
    */
-  int getDeathAnimationLength();
+  int getDeathTicks();
 
   /**
    * Gets a group of players, used for prefixes and player sorting.

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
@@ -22,7 +22,7 @@ import tc.oc.pgm.util.nms.NMSHacks;
 
 /** Player is waiting to respawn after dying in-game */
 public class Dead extends Spawning {
-  private long CORPSE_ROT_TICKS;
+  private static long CORPSE_ROT_TICKS;
 
   private final long deathTick;
   private boolean kitted, rotted;
@@ -33,7 +33,7 @@ public class Dead extends Spawning {
 
   public Dead(SpawnMatchModule smm, MatchPlayer player, long deathTick) {
     super(smm, player);
-    CORPSE_ROT_TICKS = PGM.get().getConfiguration().getDeathAnimationLength();
+    CORPSE_ROT_TICKS = PGM.get().getConfiguration().getDeathTicks();
     this.deathTick = deathTick;
   }
 

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
@@ -9,6 +9,7 @@ import net.kyori.text.format.TextColor;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.PlayerJoinPartyEvent;
@@ -21,7 +22,7 @@ import tc.oc.pgm.util.nms.NMSHacks;
 
 /** Player is waiting to respawn after dying in-game */
 public class Dead extends Spawning {
-  private static final long CORPSE_ROT_TICKS = 15;
+  private long CORPSE_ROT_TICKS;
 
   private final long deathTick;
   private boolean kitted, rotted;
@@ -32,6 +33,7 @@ public class Dead extends Spawning {
 
   public Dead(SpawnMatchModule smm, MatchPlayer player, long deathTick) {
     super(smm, player);
+    CORPSE_ROT_TICKS = PGM.get().getConfiguration().getDeathAnimationLength();
     this.deathTick = deathTick;
   }
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -65,7 +65,7 @@ join:
 gameplay:
   refill-wool: true # Should wool in wool rooms be automatically refilled?
   grief-score: -10 # Score under which players should be kept out of the match
-  death-tick: 15 # how long should the death animation be shown for?
+  death-ticks: 15 # Number of ticks the death animation should last
 
 # Toggles various user interfaces.
 ui:

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -65,6 +65,7 @@ join:
 gameplay:
   refill-wool: true # Should wool in wool rooms be automatically refilled?
   grief-score: -10 # Score under which players should be kept out of the match
+  death-tick: 15 # how long should the death animation be shown for?
 
 # Toggles various user interfaces.
 ui:


### PR DESCRIPTION
This PR makes a config option for how long the death animation should be shown before the player is vanished. The default value in PGM is 15 ticks. Here is a video showing 7 ticks and 3 ticks respectively: [https://youtu.be/0-oW-7wEpQA](url)

For context, this helps an issue where a dead player's animation blocks sword hits.
Signed-off-by: mrcookie