### PR TITLE
Fix several issues on player states

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -169,8 +169,8 @@ public interface MatchPlayer extends Audience, Named, Tickable, InventoryHolder 
    */
   boolean canSee(MatchPlayer other);
 
-  /** Reset the {@link MatchPlayer} when changing between {@link org.bukkit.GameMode}s. */
-  void resetGamemode();
+  /** Reset the {@link MatchPlayer} ability to interact with the world . */
+  void resetInteraction();
 
   /** Reset the {@link #getInventory()} of the {@link MatchPlayer}. */
   void resetInventory();

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -218,7 +218,6 @@ public class MatchImpl implements Match {
         end.set(System.currentTimeMillis());
       }
 
-      getPlayers().forEach(MatchPlayer::resetGamemode);
       return true;
     }
     return false;

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.spawns.states;
 import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Set;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -34,6 +35,8 @@ public class Observing extends State {
       Sets.newHashSet(
           Material.WATER_LILY, Material.BUCKET, Material.LAVA_BUCKET, Material.WATER_BUCKET);
 
+  private static final double VOID_HEIGHT = -64;
+
   private final boolean reset;
   private final boolean teleport;
   private PermissionAttachment permissionAttachment;
@@ -57,11 +60,13 @@ public class Observing extends State {
 
     if (reset) player.reset();
     player.setDead(false);
-    player.resetGamemode();
+    player.resetInteraction();
+    bukkit.setGameMode(GameMode.CREATIVE);
+    bukkit.setAllowFlight(true);
 
     Spawn spawn = smm.getDefaultSpawn();
 
-    if (teleport) {
+    if (teleport || player.getBukkit().getLocation().getY() <= VOID_HEIGHT) {
       Location location = spawn.getSpawn(player);
       if (location != null) {
         PlayerRespawnEvent event = new PlayerRespawnEvent(player.getBukkit(), location, false);
@@ -89,7 +94,7 @@ public class Observing extends State {
 
     player.getBukkit().updateInventory();
     player.setVisible(true);
-    player.resetGamemode();
+    player.resetVisibility();
 
     // The player is not standing on anything, turn their flying on
     if (bukkit.getAllowFlight()) {

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
@@ -29,7 +29,8 @@ public abstract class Spawning extends Participating {
     super.enterState();
 
     player.setDead(true);
-    player.resetGamemode();
+    player.resetInteraction();
+    player.resetVisibility();
   }
 
   public void requestSpawn() {

--- a/core/src/main/java/tc/oc/pgm/spawns/states/State.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/State.java
@@ -33,6 +33,10 @@ public abstract class State {
     this.options = smm.getRespawnOptions();
   }
 
+  public boolean isCurrent() {
+    return entered && !exited;
+  }
+
   public void enterState() {
     if (exited) {
       throw new IllegalStateException("Tried to enter already exited state " + this);

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -314,6 +314,44 @@ public interface NMSHacks {
         metadata.dataWatcher);
   }
 
+  static void spawnEntity(Player player, int type, int entityId, Location location) {
+    sendPacket(player, spawnEntityPacket(type, entityId, location));
+  }
+
+  static Packet spawnEntityPacket(int type, int entityId, Location location) {
+    return new PacketPlayOutSpawnEntity(
+        entityId,
+        location.getX(),
+        location.getY(),
+        location.getZ(),
+        0,
+        0,
+        0,
+        (int) location.getPitch(),
+        (int) location.getYaw(),
+        type,
+        0);
+  }
+
+  static void spawnFreezeEntity(Player player, int entityId, boolean legacy) {
+    if (legacy) {
+      Location location = player.getLocation().add(0, 0.286, 0);
+      if (location.getY() < -64) {
+        location.setY(-64);
+        player.teleport(location);
+      }
+
+      NMSHacks.spawnEntity(player, 66, entityId, location);
+    } else {
+      Location loc = player.getLocation().subtract(0, 1.1, 0);
+
+      NMSHacks.EntityMetadata metadata = NMSHacks.createEntityMetadata();
+      NMSHacks.setEntityMetadata(metadata, false, false, false, false, true, (short) 0);
+      NMSHacks.setArmorStandFlags(metadata, false, false, false, false);
+      NMSHacks.spawnLivingEntity(player, EntityType.ARMOR_STAND, entityId, loc, metadata);
+    }
+  }
+
   static void entityAttach(Player player, int entityID, int vehicleID, boolean leash) {
     sendPacket(player, new PacketPlayOutAttachEntity(entityID, vehicleID, leash));
   }


### PR DESCRIPTION
Fixed a few issues relating to player states arround the playerbase, notably:
 - Fixed players switching gamemode multiple times on the same tick
 - Fixed bugged players on death animation being left on blitz
 - Fixed legacy (1.7) players glitching thru the world or falling when frozen, see #488 
 - Reverted mitigation of legacy players using adventure mode to prevent flying bug, the root issue is [fixed upstream](https://github.com/ViaVersion/ViaRewind/pull/231)