### PR TITLE
Make player death animation hitbox tiny

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -69,7 +69,6 @@ public final class PGMConfig implements Config {
   // gameplay.*
   private final boolean woolRefill;
   private final int griefScore;
-  private final int deathTicks;
 
   // join.*
   private final long minPlayers;
@@ -165,8 +164,6 @@ public final class PGMConfig implements Config {
     this.verboseStats = parseBoolean(config.getString("ui.verbose-stats", "false"));
     this.griefScore =
         parseInteger(config.getString("gameplay.grief-score", "-10"), Range.atMost(0));
-    this.deathTicks =
-        parseInteger(config.getString("gameplay.death-ticks", "15"), Range.closed(0, 20));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));
@@ -519,11 +516,6 @@ public final class PGMConfig implements Config {
   @Override
   public int getGriefScore() {
     return griefScore;
-  }
-
-  @Override
-  public int getDeathTicks() {
-    return deathTicks;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -254,13 +254,6 @@ public interface Config {
   int getGriefScore();
 
   /**
-   * Gets the length in ticks for how long the death animation is shown
-   *
-   * @return length of death animation
-   */
-  int getDeathTicks();
-
-  /**
    * Gets a group of players, used for prefixes and player sorting.
    *
    * @return A list of groups.

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
@@ -24,7 +24,7 @@ import tc.oc.pgm.util.xml.XMLUtils;
 
 public class SpawnModule implements MapModule {
 
-  public static final Duration MINIMUM_RESPAWN_DELAY = Duration.ofSeconds(2);
+  public static final Duration MINIMUM_RESPAWN_DELAY = Duration.ofMillis(1500);
   public static final Duration IGNORE_CLICKS_DELAY = Duration.ofMillis(500);
 
   protected final Spawn defaultSpawn;

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
@@ -11,7 +11,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -25,7 +24,7 @@ import tc.oc.pgm.util.nms.NMSHacks;
 
 /** Player is waiting to respawn after dying in-game */
 public class Dead extends Spawning {
-  private static final long CORPSE_ROT_TICKS = PGM.get().getConfiguration().getDeathTicks();
+  private static final long CORPSE_ROT_TICKS = 20;
 
   private static final PotionEffect CONFUSION =
       new PotionEffect(PotionEffectType.CONFUSION, 100, 0, true, false);

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -65,7 +65,6 @@ join:
 gameplay:
   refill-wool: true # Should wool in wool rooms be automatically refilled?
   grief-score: -10 # Score under which players should be kept out of the match
-  death-ticks: 15 # Number of ticks the death animation should last
 
 # Toggles various user interfaces.
 ui:

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -475,7 +475,7 @@ public interface NMSHacks {
 
   static void playDeathAnimation(Player player) {
     EntityPlayer handle = ((CraftPlayer) player).getHandle();
-    PacketPlayOutEntityMetadata packet =
+    PacketPlayOutEntityMetadata metadata =
         new PacketPlayOutEntityMetadata(handle.getId(), handle.getDataWatcher(), false);
 
     // Add/replace health to zero
@@ -483,25 +483,32 @@ public interface NMSHacks {
     DataWatcher.WatchableObject zeroHealth =
         new DataWatcher.WatchableObject(3, 6, 0f); // type 3 (float), index 6 (health)
 
-    if (packet.b != null) {
-      for (int i = 0; i < packet.b.size(); i++) {
-        DataWatcher.WatchableObject wo = packet.b.get(i);
+    if (metadata.b != null) {
+      for (int i = 0; i < metadata.b.size(); i++) {
+        DataWatcher.WatchableObject wo = metadata.b.get(i);
         if (wo.a() == 6) {
-          packet.b.set(i, zeroHealth);
+          metadata.b.set(i, zeroHealth);
           replaced = true;
         }
       }
     }
 
     if (!replaced) {
-      if (packet.b == null) {
-        packet.b = Collections.singletonList(zeroHealth);
-      } else {
-        packet.b.add(zeroHealth);
-      }
+      if (metadata.b != null) metadata.b.add(zeroHealth);
+      else metadata.b = Collections.singletonList(zeroHealth);
     }
 
-    sendPacketToViewers(player, packet);
+    Location location = player.getLocation();
+    PacketPlayOutBed useBed =
+        new PacketPlayOutBed(
+            ((CraftPlayer) player).getHandle(),
+            new BlockPosition(location.getX(), location.getY(), location.getZ()));
+
+    Packet<?> teleport = teleportEntityPacket(player.getEntityId(), location);
+
+    sendPacketToViewers(player, metadata);
+    sendPacketToViewers(player, useBed);
+    sendPacketToViewers(player, teleport);
   }
 
   static org.bukkit.enchantments.Enchantment getEnchantment(String key) {


### PR DESCRIPTION
A few changes to death animations: 
 - Increased death ticks from 15 to 20, matching vanilla and getting the particle at the end of the animation
 - Removed option to configure length of death animation
 - Minimum respawn time in xml is now 1,5s (down from 2s), can't make it one second or animation wouldn't have time to finish
 - Fake the corpse entering a bed in order to make clients see them as a tiny hitbox