### PR TITLE
Implement filters in blitz

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzConfig.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzConfig.java
@@ -2,13 +2,21 @@ package tc.oc.pgm.blitz;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import tc.oc.pgm.api.filter.Filter;
+
 /** Represents information needed to run the Blitz game type. */
 public class BlitzConfig {
-  public BlitzConfig(int lives, boolean broadcastLives) {
+
+  private final int lives;
+  private final boolean broadcastLives;
+  private final Filter filter;
+
+  public BlitzConfig(int lives, boolean broadcastLives, Filter filter) {
     checkArgument(lives > 0, "lives must be greater than zero");
 
     this.lives = lives;
     this.broadcastLives = broadcastLives;
+    this.filter = filter;
   }
 
   /**
@@ -24,6 +32,7 @@ public class BlitzConfig {
     return this.broadcastLives;
   }
 
-  final int lives;
-  final boolean broadcastLives;
+  public Filter getFilter() {
+    return this.filter;
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -62,6 +62,7 @@ public class BlitzMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
   public void handleDeath(final MatchPlayerDeathEvent event) {
     MatchPlayer victim = event.getVictim();
+    if (config.getFilter().query(victim.getQuery()).isDenied()) return;
     if (victim.getParty() instanceof Competitor) {
       Competitor competitor = (Competitor) victim.getParty();
 
@@ -92,7 +93,7 @@ public class BlitzMatchModule implements MatchModule, Listener {
 
   @EventHandler
   public void handleSpawn(final ParticipantSpawnEvent event) {
-    if (this.config.broadcastLives) {
+    if (this.config.getBroadcastLives()) {
       int lives = this.lifeManager.getLives(event.getPlayer().getId());
       event
           .getPlayer()

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzModule.java
@@ -9,11 +9,14 @@ import java.util.List;
 import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.filters.FilterModule;
+import tc.oc.pgm.filters.StaticFilter;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
@@ -39,23 +42,31 @@ public class BlitzModule implements MapModule {
   }
 
   public static class Factory implements MapModuleFactory<BlitzModule> {
+
+    @Override
+    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+      return ImmutableList.of(FilterModule.class);
+    }
+
     @Override
     public BlitzModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
       List<Element> blitzElements = doc.getRootElement().getChildren("blitz");
-      BlitzConfig config = new BlitzConfig(Integer.MAX_VALUE, false);
+
+      int lives = Integer.MAX_VALUE;
+      boolean broadcastLives = false;
+      Filter filter = null;
 
       for (Element blitzEl : blitzElements) {
-        boolean broadcastLives = XMLUtils.parseBoolean(blitzEl.getChild("broadcastLives"), true);
-        int lives =
+        broadcastLives = XMLUtils.parseBoolean(blitzEl.getChild("broadcastLives"), true);
+        lives =
             XMLUtils.parseNumberInRange(
                 Node.fromChildOrAttr(blitzEl, "lives"), Integer.class, Range.atLeast(1), 1);
-
-        config = new BlitzConfig(lives, broadcastLives);
+        filter = factory.getFilters().parseFilterProperty(blitzEl, "filter", StaticFilter.ALLOW);
       }
 
-      if (config.lives != Integer.MAX_VALUE) {
-        return new BlitzModule(config);
+      if (lives != Integer.MAX_VALUE) {
+        return new BlitzModule(new BlitzConfig(lives, broadcastLives, filter));
       }
 
       return null;


### PR DESCRIPTION
Fixes #365 

Adds a filter attribute or child to blitz, if the filter denies, your life counter does not go down.

Example, you will only lose a life when dying after 30s from match start:
```
<blitz>
  <lives>5</lives>
  <filter>
    <time>30s</time>
  </filter>
</blitz>
```

Adding it as an attribute is also valid (note, the filter will have to be defined elsewhere):
```
<blitz filter="time-30-sec">
  <lives>5</lives>
</blitz>
```