### PR TITLE
Fix rounding issues on tab dynamic columns

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/MatchTabView.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchTabView.java
@@ -242,8 +242,9 @@ public class MatchTabView extends TabView implements Listener {
 
   private int getColumnsForTeam(Team team, Collection<Team> teams) {
     if (teams.size() < getWidth()) {
-      int aimCols = Math.round((float) team.getMaxPlayers() * getWidth() / match.getMaxPlayers());
-      return Math.max(1, Math.min(aimCols, getWidth() - teams.size() + 1));
+      float cols = (float) team.getMaxPlayers() * getWidth() / match.getMaxPlayers();
+      if (cols % 1 == 0.5 && cols > ((float) getWidth() / teams.size())) cols -= 0.5;
+      return Math.max(1, Math.min(Math.round(cols), getWidth() - teams.size() + 1));
     } else {
       return 1;
     }


### PR DESCRIPTION
In the scenario that you had 2 teams with max players `30` and `50`, the division would result in `1.5` columns for the first team, and  `2.5` for the second, once rounding, this gives 2 and 3 columns, resulting in issues.

The fix is to round towards the amount of columns per team disregarding size (columns / teams). The team with 1.5 rounds up to 2, while 2.5 rounds down to 2.