### PR TITLE
Allow dead players to use picker helmet

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
@@ -46,6 +46,7 @@ import tc.oc.pgm.api.player.MatchPlayerState;
 import tc.oc.pgm.api.player.event.ObserverInteractEvent;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerBlockTransformEvent;
+import tc.oc.pgm.util.MatchPlayers;
 import tc.oc.pgm.util.event.PlayerBlockEvent;
 
 /**
@@ -106,7 +107,7 @@ public class EventFilterMatchModule implements MatchModule, Listener {
 
     return cancel(
         event,
-        match.getParticipant(entity) == null,
+        !MatchPlayers.canInteract(match.getParticipant(entity)),
         entity.getWorld(),
         match.getPlayer(entity),
         null);

--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -349,7 +349,7 @@ public class PickerMatchModule implements MatchModule, Listener {
     this.picking.remove(match.getPlayer((Player) event.getPlayer()));
   }
 
-  @EventHandler(priority = EventPriority.HIGHEST)
+  @EventHandler
   public void rightClickIcon(final ObserverInteractEvent event) {
     final boolean right = event.getClickType() == ClickType.RIGHT;
     final boolean left = event.getClickType() == ClickType.LEFT;

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -21,7 +21,6 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerAttackEntityEvent;
 import org.bukkit.event.player.PlayerInitialSpawnEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -34,11 +33,11 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.event.CompetitorRemoveEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
+import tc.oc.pgm.api.player.event.ObserverInteractEvent;
 import tc.oc.pgm.api.time.Tick;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerJoinPartyEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
-import tc.oc.pgm.modules.EventFilterMatchModule;
 import tc.oc.pgm.spawns.states.Joining;
 import tc.oc.pgm.spawns.states.Observing;
 import tc.oc.pgm.spawns.states.State;
@@ -211,13 +210,10 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
     }
   }
 
-  /**
-   * This handler must run after {@link EventFilterMatchModule#onInteract(PlayerInteractEvent)} and
-   * before the event handler in WorldEdit for compass clicking.
-   */
-  @EventHandler(priority = EventPriority.LOW)
-  public void onInteract(final PlayerInteractEvent event) {
-    MatchPlayer player = match.getPlayer(event.getPlayer());
+  // Listen on HIGH so the picker can handle this first
+  @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+  public void onObserverInteract(final ObserverInteractEvent event) {
+    MatchPlayer player = event.getPlayer();
     if (player != null) {
       State state = states.get(player);
       if (state != null) state.onEvent(event);

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
@@ -10,11 +10,10 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
 import org.bukkit.Location;
-import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerAttackEntityEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.player.event.ObserverInteractEvent;
 import tc.oc.pgm.spawns.Spawn;
 import tc.oc.pgm.spawns.SpawnMatchModule;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
@@ -43,13 +42,9 @@ public abstract class Spawning extends Participating {
   }
 
   @Override
-  public void onEvent(PlayerInteractEvent event) {
+  public void onEvent(ObserverInteractEvent event) {
     super.onEvent(event);
-    event.setCancelled(true);
-    if (event.getAction() == Action.LEFT_CLICK_AIR
-        || event.getAction() == Action.LEFT_CLICK_BLOCK) {
-      requestSpawn();
-    }
+    requestSpawn();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawns/states/State.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/State.java
@@ -7,11 +7,11 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerAttackEntityEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.api.match.event.MatchStartEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
+import tc.oc.pgm.api.player.event.ObserverInteractEvent;
 import tc.oc.pgm.events.PlayerJoinPartyEvent;
 import tc.oc.pgm.spawns.RespawnOptions;
 import tc.oc.pgm.spawns.SpawnMatchModule;
@@ -81,7 +81,7 @@ public abstract class State {
 
   public void onEvent(final InventoryClickEvent event) {}
 
-  public void onEvent(final PlayerInteractEvent event) {}
+  public void onEvent(final ObserverInteractEvent event) {}
 
   public void onEvent(final PlayerAttackEntityEvent event) {}
 


### PR DESCRIPTION
Currently, you can not open the team picker helmet you are given when you die as the interact event is cancelled.
This picker lets you change teams, join observers and change classes (when classes exist).

![image](https://user-images.githubusercontent.com/8608892/102713474-69bbc700-42c0-11eb-8f1c-41ab8a78f1b4.png)

Looking into this it seems like OCN PGM had a slightly modified Observer event system which resolves this.
Rejigging the event priorities and listening for the ObserverInteractEvent on dead players allows the event to be caught and used.

This also fixes an issue in the `EventFilterMatchModule` where the check for cancelling an event was incorrect.

There is a strange when the `picker` setting is set to `off` as the picker will not popup which means the death helmet will not work but I think the current picker settings need a review before a solution is made.