### PR TITLE
Add query modifier for checking acting player info

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -19,6 +19,7 @@ import tc.oc.pgm.api.player.PlayerRelation;
 import tc.oc.pgm.classes.ClassModule;
 import tc.oc.pgm.classes.PlayerClass;
 import tc.oc.pgm.features.XMLFeatureReference;
+import tc.oc.pgm.filters.modifier.PlayerBlockQueryModifier;
 import tc.oc.pgm.filters.modifier.location.LocalLocationQueryModifier;
 import tc.oc.pgm.filters.modifier.location.LocationQueryModifier;
 import tc.oc.pgm.filters.modifier.location.WorldLocationQueryModifier;
@@ -492,5 +493,10 @@ public abstract class FilterParser {
     } else {
       return new WorldLocationQueryModifier(parseChild(el), vector, relative);
     }
+  }
+
+  @MethodParser("player")
+  public PlayerBlockQueryModifier parsePlayerFilter(Element el) throws InvalidXMLException {
+    return new PlayerBlockQueryModifier(parseChild(el));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/modifier/PlayerBlockQueryModifier.java
+++ b/core/src/main/java/tc/oc/pgm/filters/modifier/PlayerBlockQueryModifier.java
@@ -1,0 +1,27 @@
+package tc.oc.pgm.filters.modifier;
+
+import javax.annotation.Nullable;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.query.PlayerQuery;
+import tc.oc.pgm.api.filter.query.Query;
+
+public class PlayerBlockQueryModifier extends QueryModifier<PlayerQuery> {
+
+  public PlayerBlockQueryModifier(Filter filter) {
+    super(filter);
+  }
+
+  @Nullable
+  @Override
+  protected Query modifyQuery(PlayerQuery query) {
+    // Abstain when no player can be found, eg: they disconnected
+    if (query.getPlayer() == null) return null;
+
+    return query.getPlayer().getQuery();
+  }
+
+  @Override
+  public Class<? extends PlayerQuery> getQueryType() {
+    return PlayerQuery.class;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/filters/modifier/QueryModifier.java
+++ b/core/src/main/java/tc/oc/pgm/filters/modifier/QueryModifier.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.filters.modifier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import javax.annotation.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.filters.TypedFilter;
@@ -9,6 +10,9 @@ import tc.oc.pgm.filters.TypedFilter;
 /**
  * Takes a query and modifies it before passing it onto its child filter. Might transform query type
  * so {@link #getQueryType()} on this modifier can be different from its child filter
+ *
+ * <p>If the modified query returns {@code null} this modifier will abstain without querying the
+ * child filter.
  *
  * @param <Q> is the type of query this filter can modify before passing it on to its child filter
  */
@@ -21,11 +25,14 @@ public abstract class QueryModifier<Q extends Query> extends TypedFilter<Q> {
   }
 
   /** Returns a modified {@link Query} */
+  @Nullable
   protected abstract Query modifyQuery(Q query);
 
   public abstract Class<? extends Q> getQueryType();
 
   protected QueryResponse queryTyped(Q query) {
-    return filter.query(modifyQuery(query));
+    Query modifiedQuery = modifyQuery(query);
+
+    return modifiedQuery == null ? QueryResponse.ABSTAIN : filter.query(modifiedQuery);
   }
 }


### PR DESCRIPTION
Let's say you wanted to prevent a player from opening chests unless they're in a specific region (the wool room maybe).

The current way of filtering location on a `block-break` or `use` event target the location of the physical block (which is always in the wool room). In this instance, I want to query the location of the actor (player) rather than the block in question.

For this, I have created a `PlayerBlockQueryModifier` which sets focus on the player in the event vs the block. This also slightly modifies the newly created base `QueryModifier` class allowing for unmodified queries to abstain by returning null. In this case, the player within the `PlayerQuery` can be null (when offline) so a fallback was required.

See the example below where the player can only use items within the yellow wool room if they too are in that region.

```xml
<!--- filter with region -->
<player id="player-in-yellow-wool">
    <rectangle id="yellow-wool-room" min="534.5,-354" max="544,-339"/>
</player>

<!--- application -->
<apply use="player-in-yellow-wool" region="yellow-wool-room" message="You can not interact with this from here."/>
```

Open to suggestions if this can be completed an alternative way (existing XML or improved implementation). 
Discussed with Pablo and Simon in Discord so ty for help.

