### PR TITLE
Add repeat-posts tag to flags

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
@@ -50,6 +50,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
   private boolean
       showRespawnOnPickup; // When a flag is picked up, if true, it will display where it will
   // respawn. Will be set to false if a net defines a different respawn post.
+  private final boolean repeatPosts;
 
   public FlagDefinition(
       @Nullable String id,
@@ -75,7 +76,8 @@ public class FlagDefinition extends ProximityGoalDefinition {
       @Nullable ProximityMetric flagProximityMetric,
       @Nullable ProximityMetric netProximityMetric,
       boolean sequential,
-      boolean showRespawnOnPickup) {
+      boolean showRespawnOnPickup,
+      boolean repeatPosts) {
 
     // We can't use the owner field in OwnedGoal because our owner
     // is a reference that can't be resolved until after parsing.
@@ -106,6 +108,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
     this.showBeam = showBeam;
     this.sequential = sequential;
     this.showRespawnOnPickup = showRespawnOnPickup;
+    this.repeatPosts = repeatPosts;
   }
 
   public @Nullable DyeColor getColor() {
@@ -195,6 +198,10 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
   public boolean willShowRespawnOnPickup() {
     return showRespawnOnPickup;
+  }
+
+  public boolean willRepeatPosts() {
+    return repeatPosts;
   }
 
   public void setShowRespawnOnPickup(boolean value) {

--- a/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
@@ -222,6 +222,7 @@ public class FlagParser {
     Component carryMessage = XMLUtils.parseFormattedText(el, "carry-message");
     boolean showRespawnOnPickup =
         XMLUtils.parseBoolean(el.getAttribute("show-respawn-on-pickup"), true);
+    boolean repeatPosts = XMLUtils.parseBoolean(el.getAttribute("repeat-posts"), true);
     boolean dropOnWater = XMLUtils.parseBoolean(el.getAttribute("drop-on-water"), true);
     boolean showBeam = XMLUtils.parseBoolean(el.getAttribute("beam"), true);
     ProximityMetric flagProximityMetric =
@@ -273,7 +274,8 @@ public class FlagParser {
             flagProximityMetric,
             netProximityMetric,
             sequential,
-            showRespawnOnPickup);
+            showRespawnOnPickup,
+            repeatPosts);
     flags.add(flag);
     factory.getFeatures().addFeature(el, flag);
 


### PR DESCRIPTION
This option would allow map makers to prevent a flag from respawning to the same post two times in a row. 
For example, with `repeat-posts="false"`, a flag will not respawn to the same post twice in a row. To preserve previous behavior, this option defaults to true.

This will help reduce the RNG impact on kotf maps. 

Signed-off-by: mrcookie