### PR TITLE
Add Selectable Monument Modes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -245,7 +245,6 @@ public class Core extends TouchableGoal<CoreFactory>
         && block.getData() == this.material.getData();
   }
 
-  @Override
   public String getModeChangeMessage(Material material) {
     return ModeUtils.formatMaterial(material) + " CORE MODE";
   }

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -6,6 +6,7 @@ import static net.kyori.adventure.text.Component.translatable;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -160,8 +161,8 @@ public class Core extends TouchableGoal<CoreFactory>
     this.leaked = true;
   }
 
-  public String getMode() {
-    return this.definition.getMode();
+  public List<String> getModeList() {
+    return this.definition.getModeList();
   }
 
   public boolean hasLeaked() {

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -28,6 +28,7 @@ import tc.oc.pgm.goals.Contribution;
 import tc.oc.pgm.goals.IncrementalGoal;
 import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.TouchableGoal;
+import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.modes.ModeUtils;
 import tc.oc.pgm.regions.CuboidRegion;
 import tc.oc.pgm.regions.FiniteBlockRegion;
@@ -161,7 +162,7 @@ public class Core extends TouchableGoal<CoreFactory>
     this.leaked = true;
   }
 
-  public List<String> getModeList() {
+  public List<Mode> getModeList() {
     return this.definition.getModeList();
   }
 

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -5,12 +5,11 @@ import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import com.google.common.collect.ImmutableSet;
 import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -134,6 +133,10 @@ public class Core extends TouchableGoal<CoreFactory>
     return proximityLocations;
   }
 
+  public ImmutableSet<Mode> getModes() {
+    return this.definition.getModes();
+  }
+
   public MaterialData getMaterial() {
     return this.material;
   }
@@ -163,10 +166,6 @@ public class Core extends TouchableGoal<CoreFactory>
     this.leaked = true;
   }
 
-  public ImmutableSet<Mode> getModes() {
-    return this.definition.getModes();
-  }
-
   public boolean hasLeaked() {
     return this.leaked;
   }
@@ -189,11 +188,6 @@ public class Core extends TouchableGoal<CoreFactory>
   @Override
   public boolean isCompleted(Competitor team) {
     return this.leaked && this.canComplete(team);
-  }
-
-  @Override
-  public boolean isAffectedByModeChanges() {
-    return this.definition.hasModeChanges();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -6,7 +6,6 @@ import static net.kyori.adventure.text.Component.translatable;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -24,11 +23,11 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayerState;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.Contribution;
 import tc.oc.pgm.goals.IncrementalGoal;
 import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.TouchableGoal;
-import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.modes.ModeUtils;
 import tc.oc.pgm.regions.CuboidRegion;
 import tc.oc.pgm.regions.FiniteBlockRegion;
@@ -162,7 +161,7 @@ public class Core extends TouchableGoal<CoreFactory>
     this.leaked = true;
   }
 
-  public List<Mode> getModeList() {
+  public Set<SelfIdentifyingFeatureDefinition> getModeList() {
     return this.definition.getModeList();
   }
 

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableSet;
 import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -23,11 +25,11 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayerState;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.api.region.Region;
-import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.Contribution;
 import tc.oc.pgm.goals.IncrementalGoal;
 import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.TouchableGoal;
+import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.modes.ModeUtils;
 import tc.oc.pgm.regions.CuboidRegion;
 import tc.oc.pgm.regions.FiniteBlockRegion;
@@ -161,8 +163,8 @@ public class Core extends TouchableGoal<CoreFactory>
     this.leaked = true;
   }
 
-  public Set<SelfIdentifyingFeatureDefinition> getModeList() {
-    return this.definition.getModeList();
+  public ImmutableSet<Mode> getModes() {
+    return this.definition.getModes();
   }
 
   public boolean hasLeaked() {

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -160,6 +160,10 @@ public class Core extends TouchableGoal<CoreFactory>
     this.leaked = true;
   }
 
+  public String getMode() {
+    return this.definition.getMode();
+  }
+
   public boolean hasLeaked() {
     return this.leaked;
   }

--- a/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
@@ -2,12 +2,14 @@ package tc.oc.pgm.core;
 
 import java.util.Set;
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableSet;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
-import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.ProximityGoalDefinition;
 import tc.oc.pgm.goals.ProximityMetric;
+import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.teams.TeamFactory;
 
 @FeatureInfo(name = "core")
@@ -15,7 +17,7 @@ public class CoreFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final MaterialData material;
   protected final int leakLevel;
-  protected final Set<SelfIdentifyingFeatureDefinition> modeList;
+  protected final ImmutableSet<Mode> modeList;
   protected final boolean modeChanges;
   protected final boolean showProgress;
 
@@ -29,7 +31,7 @@ public class CoreFactory extends ProximityGoalDefinition {
       Region region,
       MaterialData material,
       int leakLevel,
-      @Nullable Set<SelfIdentifyingFeatureDefinition> modeList,
+      @Nullable ImmutableSet<Mode> modeList,
       boolean modeChanges,
       boolean showProgress) {
 
@@ -46,7 +48,7 @@ public class CoreFactory extends ProximityGoalDefinition {
     return this.region;
   }
 
-  public Set<SelfIdentifyingFeatureDefinition> getModeList() {
+  public ImmutableSet<Mode> getModes() {
     return this.modeList;
   }
 

--- a/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
@@ -7,6 +7,7 @@ import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.goals.ProximityGoalDefinition;
 import tc.oc.pgm.goals.ProximityMetric;
+import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.teams.TeamFactory;
 
 @FeatureInfo(name = "core")
@@ -14,7 +15,7 @@ public class CoreFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final MaterialData material;
   protected final int leakLevel;
-  protected final List<String> modeList;
+  protected final List<Mode> modeList;
   protected final boolean modeChanges;
   protected final boolean showProgress;
 
@@ -28,7 +29,7 @@ public class CoreFactory extends ProximityGoalDefinition {
       Region region,
       MaterialData material,
       int leakLevel,
-      @Nullable List<String> modeList,
+      @Nullable List<Mode> modeList,
       boolean modeChanges,
       boolean showProgress) {
 
@@ -45,7 +46,7 @@ public class CoreFactory extends ProximityGoalDefinition {
     return this.region;
   }
 
-  public List<String> getModeList() {
+  public List<Mode> getModeList() {
     return this.modeList;
   }
 

--- a/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
@@ -1,13 +1,13 @@
 package tc.oc.pgm.core;
 
-import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.ProximityGoalDefinition;
 import tc.oc.pgm.goals.ProximityMetric;
-import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.teams.TeamFactory;
 
 @FeatureInfo(name = "core")
@@ -15,7 +15,7 @@ public class CoreFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final MaterialData material;
   protected final int leakLevel;
-  protected final List<Mode> modeList;
+  protected final Set<SelfIdentifyingFeatureDefinition> modeList;
   protected final boolean modeChanges;
   protected final boolean showProgress;
 
@@ -29,7 +29,7 @@ public class CoreFactory extends ProximityGoalDefinition {
       Region region,
       MaterialData material,
       int leakLevel,
-      @Nullable List<Mode> modeList,
+      @Nullable Set<SelfIdentifyingFeatureDefinition> modeList,
       boolean modeChanges,
       boolean showProgress) {
 
@@ -46,7 +46,7 @@ public class CoreFactory extends ProximityGoalDefinition {
     return this.region;
   }
 
-  public List<Mode> getModeList() {
+  public Set<SelfIdentifyingFeatureDefinition> getModeList() {
     return this.modeList;
   }
 

--- a/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
@@ -13,6 +13,7 @@ public class CoreFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final MaterialData material;
   protected final int leakLevel;
+  protected final String mode;
   protected final boolean modeChanges;
   protected final boolean showProgress;
 
@@ -26,6 +27,7 @@ public class CoreFactory extends ProximityGoalDefinition {
       Region region,
       MaterialData material,
       int leakLevel,
+      @Nullable String mode,
       boolean modeChanges,
       boolean showProgress) {
 
@@ -33,12 +35,17 @@ public class CoreFactory extends ProximityGoalDefinition {
     this.region = region;
     this.material = material;
     this.leakLevel = leakLevel;
+    this.mode = mode;
     this.modeChanges = modeChanges;
     this.showProgress = showProgress;
   }
 
   public Region getRegion() {
     return this.region;
+  }
+
+  public String getMode() {
+    return this.mode;
   }
 
   public MaterialData getMaterial() {

--- a/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
@@ -1,9 +1,7 @@
 package tc.oc.pgm.core;
 
-import java.util.Set;
-import javax.annotation.Nullable;
-
 import com.google.common.collect.ImmutableSet;
+import javax.annotation.Nullable;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
@@ -18,7 +16,6 @@ public class CoreFactory extends ProximityGoalDefinition {
   protected final MaterialData material;
   protected final int leakLevel;
   protected final ImmutableSet<Mode> modeList;
-  protected final boolean modeChanges;
   protected final boolean showProgress;
 
   public CoreFactory(
@@ -32,7 +29,6 @@ public class CoreFactory extends ProximityGoalDefinition {
       MaterialData material,
       int leakLevel,
       @Nullable ImmutableSet<Mode> modeList,
-      boolean modeChanges,
       boolean showProgress) {
 
     super(id, name, required, visible, owner, proximityMetric);
@@ -40,7 +36,6 @@ public class CoreFactory extends ProximityGoalDefinition {
     this.material = material;
     this.leakLevel = leakLevel;
     this.modeList = modeList;
-    this.modeChanges = modeChanges;
     this.showProgress = showProgress;
   }
 
@@ -58,10 +53,6 @@ public class CoreFactory extends ProximityGoalDefinition {
 
   public int getLeakLevel() {
     return this.leakLevel;
-  }
-
-  public boolean hasModeChanges() {
-    return this.modeChanges;
   }
 
   public boolean getShowProgress() {

--- a/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreFactory.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.core;
 
+import java.util.List;
 import javax.annotation.Nullable;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.feature.FeatureInfo;
@@ -13,7 +14,7 @@ public class CoreFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final MaterialData material;
   protected final int leakLevel;
-  protected final String mode;
+  protected final List<String> modeList;
   protected final boolean modeChanges;
   protected final boolean showProgress;
 
@@ -27,7 +28,7 @@ public class CoreFactory extends ProximityGoalDefinition {
       Region region,
       MaterialData material,
       int leakLevel,
-      @Nullable String mode,
+      @Nullable List<String> modeList,
       boolean modeChanges,
       boolean showProgress) {
 
@@ -35,7 +36,7 @@ public class CoreFactory extends ProximityGoalDefinition {
     this.region = region;
     this.material = material;
     this.leakLevel = leakLevel;
-    this.mode = mode;
+    this.modeList = modeList;
     this.modeChanges = modeChanges;
     this.showProgress = showProgress;
   }
@@ -44,8 +45,8 @@ public class CoreFactory extends ProximityGoalDefinition {
     return this.region;
   }
 
-  public String getMode() {
-    return this.mode;
+  public List<String> getModeList() {
+    return this.modeList;
   }
 
   public MaterialData getMaterial() {

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -157,7 +157,7 @@ public class CoreMatchModule implements MatchModule, Listener {
       if (core.isAffectedByModeChanges()) {
         if (core.getMode() == null) {
           core.replaceBlocks(event.getMode().getMaterialData());
-        } else if (core.getMode().equals(event.getMode().getStage())) {
+        } else if (core.getMode().equals(event.getMode().getId())) {
           core.replaceBlocks(event.getMode().getMaterialData());
         }
       }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -154,10 +154,8 @@ public class CoreMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Core core : this.cores) {
-      if (core.isAffectedByModeChanges()) {
-        if (core.getModeList() == null || core.getModeList().contains(event.getMode())) {
-          core.replaceBlocks(event.getMode().getMaterialData());
-        }
+      if (core.getModeList() == null || core.getModeList().contains(event.getMode())) {
+        core.replaceBlocks(event.getMode().getMaterialData());
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -157,7 +157,7 @@ public class CoreMatchModule implements MatchModule, Listener {
       if (core.isAffectedByModeChanges()) {
         if (core.getMode() == null) {
           core.replaceBlocks(event.getMode().getMaterialData());
-        } else if (core.getMode() != null && core.getMode().equals(event.getMode().getId())) {
+        } else if (core.getMode() != null && core.getMode().equals(event.getMode().getStage())) {
           core.replaceBlocks(event.getMode().getMaterialData());
         }
       }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -155,9 +155,10 @@ public class CoreMatchModule implements MatchModule, Listener {
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Core core : this.cores) {
       if (core.isAffectedByModeChanges()) {
-        if (core.getMode() == null) {
+        if (core.getModeList() == null || core.getModeList().isEmpty()) {
           core.replaceBlocks(event.getMode().getMaterialData());
-        } else if (core.getMode().equals(event.getMode().getId())) {
+          // if a mode on modeList has one that matches get id
+        } else if (core.getModeList().contains(event.getMode().getId())) {
           core.replaceBlocks(event.getMode().getMaterialData());
         }
       }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -155,10 +155,7 @@ public class CoreMatchModule implements MatchModule, Listener {
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Core core : this.cores) {
       if (core.isAffectedByModeChanges()) {
-        if (core.getModeList() == null || core.getModeList().isEmpty()) {
-          core.replaceBlocks(event.getMode().getMaterialData());
-          // if a mode on modeList has one that matches get id
-        } else if (core.getModeList().contains(event.getMode().getId())) {
+        if (core.getModeList() == null || core.getModeList().contains(event.getMode())) {
           core.replaceBlocks(event.getMode().getMaterialData());
         }
       }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -157,7 +157,7 @@ public class CoreMatchModule implements MatchModule, Listener {
       if (core.isAffectedByModeChanges()) {
         if (core.getMode() == null) {
           core.replaceBlocks(event.getMode().getMaterialData());
-        } else if (core.getMode() != null && core.getMode().equals(event.getMode().getStage())) {
+        } else if (core.getMode().equals(event.getMode().getStage())) {
           core.replaceBlocks(event.getMode().getMaterialData());
         }
       }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -154,7 +154,7 @@ public class CoreMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Core core : this.cores) {
-      if (core.getModeList() == null || core.getModeList().contains(event.getMode())) {
+      if (core.getModes() == null || core.getModes().contains(event.getMode())) {
         core.replaceBlocks(event.getMode().getMaterialData());
       }
     }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -155,7 +155,11 @@ public class CoreMatchModule implements MatchModule, Listener {
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Core core : this.cores) {
       if (core.isAffectedByModeChanges()) {
-        core.replaceBlocks(event.getMode().getMaterialData());
+        if (core.getMode() == null) {
+          core.replaceBlocks(event.getMode().getMaterialData());
+        } else if (core.getMode() != null && core.getMode().equals(event.getMode().getId())) {
+          core.replaceBlocks(event.getMode().getMaterialData());
+        }
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -3,7 +3,6 @@ package tc.oc.pgm.core;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -74,7 +73,8 @@ public class CoreModule implements MapModule {
       return ImmutableList.of(RegionModule.class, TeamModule.class);
     }
 
-    public ImmutableSet<Mode> parseModeSet(Node node, MapFactory context) throws InvalidXMLException {
+    public ImmutableSet<Mode> parseModeSet(Node node, MapFactory context)
+        throws InvalidXMLException {
       ImmutableSet.Builder<Mode> modes = ImmutableSet.builder();
       for (String modeId : node.getValue().split("\\s")) {
         Mode mode = context.getFeatures().get(modeId, Mode.class);
@@ -163,7 +163,6 @@ public class CoreModule implements MapModule {
                 material,
                 leakLevel,
                 modeSet,
-                modeChanges,
                 showProgress);
         context.getFeatures().addFeature(coreEl, factory);
         coreFactories.add(factory);

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -21,6 +21,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.goals.GoalMatchModule;
+import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.regions.BlockBoundedValidation;

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
 import org.bukkit.Material;
 import org.bukkit.material.MaterialData;
@@ -165,8 +164,8 @@ public class CoreModule implements MapModule {
         return null;
       }
     }
-    public ImmutableSet<Mode> parseModeSet(Node node)
-            throws InvalidXMLException {
+
+    public ImmutableSet<Mode> parseModeSet(Node node) throws InvalidXMLException {
       ImmutableSet.Builder<Mode> modes = ImmutableSet.builder();
       for (String modeId : node.getValue().split("\\s")) {
         Mode mode = factory.getFeatures().get(modeId, Mode.class);

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -21,7 +21,6 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.goals.GoalMatchModule;
-import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.regions.BlockBoundedValidation;

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -115,7 +115,7 @@ public class CoreModule implements MapModule {
           serialNumbers.put(owner, serial + 1);
         }
 
-        String mode = coreEl.getAttributeValue("mode");
+        String mode = coreEl.getAttributeValue("modes");
         boolean modeChanges = XMLUtils.parseBoolean(coreEl.getAttribute("mode-changes"), false);
         boolean showProgress = XMLUtils.parseBoolean(coreEl.getAttribute("show-progress"), false);
         boolean visible = XMLUtils.parseBoolean(coreEl.getAttribute("show"), true);

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -23,6 +23,7 @@ import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.goals.GoalMatchModule;
 import tc.oc.pgm.goals.ProximityMetric;
+import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.regions.BlockBoundedValidation;
 import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.regions.RegionParser;
@@ -118,13 +119,14 @@ public class CoreModule implements MapModule {
         }
 
         String modes = coreEl.getAttributeValue("modes");
-        List<String> modeList = new ArrayList<>();
+        List<Mode> modeList = new ArrayList<>();
         if (modes != null) {
-          Node node = Node.fromAttr(coreEl, modes);
-          if (node != null) {
-            for (String mode : Splitter.on(" ").split(node.getValue())) {
-              modeList.add(mode);
-            }
+          for (String mode : Splitter.on(" ").split(modes)) {
+            Iterable bigcontext = context.getFeatures().getAll(Mode.class);
+            System.out.println(bigcontext);
+            Mode mode1 = context.getFeatures().get(mode, Mode.class);
+            modeList.add(mode1);
+            System.out.println(mode1);
           }
         }
 

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -115,6 +115,7 @@ public class CoreModule implements MapModule {
           serialNumbers.put(owner, serial + 1);
         }
 
+        String mode = coreEl.getAttributeValue("mode");
         boolean modeChanges = XMLUtils.parseBoolean(coreEl.getAttribute("mode-changes"), false);
         boolean showProgress = XMLUtils.parseBoolean(coreEl.getAttribute("show-progress"), false);
         boolean visible = XMLUtils.parseBoolean(coreEl.getAttribute("show"), true);
@@ -134,6 +135,7 @@ public class CoreModule implements MapModule {
                 region,
                 material,
                 leakLevel,
+                mode,
                 modeChanges,
                 showProgress);
         context.getFeatures().addFeature(coreEl, factory);

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -1,7 +1,9 @@
 package tc.oc.pgm.core;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -115,7 +117,17 @@ public class CoreModule implements MapModule {
           serialNumbers.put(owner, serial + 1);
         }
 
-        String mode = coreEl.getAttributeValue("modes");
+        String modes = coreEl.getAttributeValue("modes");
+        List<String> modeList = new ArrayList<>();
+        if (modes != null) {
+          Node node = Node.fromAttr(coreEl, modes);
+          if (node != null) {
+            for (String mode : Splitter.on(" ").split(node.getValue())) {
+              modeList.add(mode);
+            }
+          }
+        }
+
         boolean modeChanges = XMLUtils.parseBoolean(coreEl.getAttribute("mode-changes"), false);
         boolean showProgress = XMLUtils.parseBoolean(coreEl.getAttribute("show-progress"), false);
         boolean visible = XMLUtils.parseBoolean(coreEl.getAttribute("show"), true);
@@ -135,7 +147,7 @@ public class CoreModule implements MapModule {
                 region,
                 material,
                 leakLevel,
-                mode,
+                modeList,
                 modeChanges,
                 showProgress);
         context.getFeatures().addFeature(coreEl, factory);

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -5,6 +5,7 @@ import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.time.Instant;
@@ -168,7 +169,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return proximityLocations;
   }
 
-  public Set<Mode> getModes() {
+  public ImmutableSet<Mode> getModes() {
     return this.definition.getModes();
   }
 
@@ -618,7 +619,6 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return this.hasMaterial(block.getState().getData());
   }
 
-  @Override
   public String getModeChangeMessage(Material material) {
     return ModeUtils.formatMaterial(material) + " OBJECTIVE MODE";
   }

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -450,8 +450,8 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return this.definition.hasModeChanges();
   }
 
-  public String getMode() {
-    return this.definition.getMode();
+  public List<String> getModeList() {
+    return this.definition.getModeList();
   }
 
   public double getDestructionRequired() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -450,6 +450,10 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return this.definition.hasModeChanges();
   }
 
+  public String getMode() {
+    return this.definition.getMode();
+  }
+
   public double getDestructionRequired() {
     return this.destructionRequired;
   }

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -36,6 +36,7 @@ import tc.oc.pgm.blockdrops.BlockDrops;
 import tc.oc.pgm.blockdrops.BlockDropsMatchModule;
 import tc.oc.pgm.blockdrops.BlockDropsRuleSet;
 import tc.oc.pgm.events.FeatureChangeEvent;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.IncrementalGoal;
 import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.TouchableGoal;
@@ -450,7 +451,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return this.definition.hasModeChanges();
   }
 
-  public List<String> getModeList() {
+  public Set<SelfIdentifyingFeatureDefinition> getModeList() {
     return this.definition.getModeList();
   }
 

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -36,7 +36,6 @@ import tc.oc.pgm.blockdrops.BlockDrops;
 import tc.oc.pgm.blockdrops.BlockDropsMatchModule;
 import tc.oc.pgm.blockdrops.BlockDropsRuleSet;
 import tc.oc.pgm.events.FeatureChangeEvent;
-import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.IncrementalGoal;
 import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.TouchableGoal;
@@ -167,6 +166,10 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
                   .toLocation(getOwner().getMatch().getWorld()));
     }
     return proximityLocations;
+  }
+
+  public Set<Mode> getModes() {
+    return this.definition.getModes();
   }
 
   void addMaterials(SingleMaterialMatcher pattern) {
@@ -445,15 +448,6 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
 
   public int getBreaks() {
     return this.maxHealth - this.health;
-  }
-
-  @Override
-  public boolean isAffectedByModeChanges() {
-    return this.definition.hasModeChanges();
-  }
-
-  public Set<Mode> getModes() {
-    return this.definition.getModes();
   }
 
   public double getDestructionRequired() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -42,6 +42,7 @@ import tc.oc.pgm.goals.ModeChangeGoal;
 import tc.oc.pgm.goals.TouchableGoal;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
+import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.modes.ModeUtils;
 import tc.oc.pgm.regions.FiniteBlockRegion;
 import tc.oc.pgm.teams.Team;
@@ -451,8 +452,8 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return this.definition.hasModeChanges();
   }
 
-  public Set<SelfIdentifyingFeatureDefinition> getModeList() {
-    return this.definition.getModeList();
+  public Set<Mode> getModes() {
+    return this.definition.getModes();
   }
 
   public double getDestructionRequired() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -55,7 +55,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     return this.materials;
   }
 
-  public Set<Mode> getModes() {
+  public ImmutableSet<Mode> getModes() {
     return this.modeList;
   }
 

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -5,9 +5,9 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
-import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.ProximityGoalDefinition;
 import tc.oc.pgm.goals.ProximityMetric;
+import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.util.material.matcher.SingleMaterialMatcher;
 
@@ -16,7 +16,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final Set<SingleMaterialMatcher> materials;
   protected final double destructionRequired;
-  protected final ImmutableSet<SelfIdentifyingFeatureDefinition> modeList;
+  protected final ImmutableSet<Mode> modeList;
   protected final boolean modeChanges;
   protected final boolean showProgress;
   protected final boolean sparks;
@@ -33,7 +33,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       Region region,
       Set<SingleMaterialMatcher> materials,
       double destructionRequired,
-      @Nullable ImmutableSet<SelfIdentifyingFeatureDefinition> modeList,
+      @Nullable ImmutableSet<Mode> modeList,
       boolean modeChanges,
       boolean showProgress,
       boolean sparks,
@@ -58,7 +58,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     return this.materials;
   }
 
-  public Set<SelfIdentifyingFeatureDefinition> getModeList() {
+  public Set<Mode> getModes() {
     return this.modeList;
   }
 

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -14,6 +14,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final Set<SingleMaterialMatcher> materials;
   protected final double destructionRequired;
+  protected final String mode;
   protected final boolean modeChanges;
   protected final boolean showProgress;
   protected final boolean sparks;
@@ -30,6 +31,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       Region region,
       Set<SingleMaterialMatcher> materials,
       double destructionRequired,
+      String mode,
       boolean modeChanges,
       boolean showProgress,
       boolean sparks,
@@ -38,6 +40,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     this.region = region;
     this.materials = materials;
     this.destructionRequired = destructionRequired;
+    this.mode = mode;
     this.modeChanges = modeChanges;
     this.showProgress = showProgress;
     this.sparks = sparks;
@@ -51,6 +54,10 @@ public class DestroyableFactory extends ProximityGoalDefinition {
 
   public Set<SingleMaterialMatcher> getMaterials() {
     return this.materials;
+  }
+
+  public String getMode() {
+    return this.mode;
   }
 
   public double getDestructionRequired() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.destroyable;
 
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
@@ -14,7 +15,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final Set<SingleMaterialMatcher> materials;
   protected final double destructionRequired;
-  protected final String mode;
+  protected final List<String> modeList;
   protected final boolean modeChanges;
   protected final boolean showProgress;
   protected final boolean sparks;
@@ -31,7 +32,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       Region region,
       Set<SingleMaterialMatcher> materials,
       double destructionRequired,
-      String mode,
+      @Nullable List<String> modeList,
       boolean modeChanges,
       boolean showProgress,
       boolean sparks,
@@ -40,7 +41,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     this.region = region;
     this.materials = materials;
     this.destructionRequired = destructionRequired;
-    this.mode = mode;
+    this.modeList = modeList;
     this.modeChanges = modeChanges;
     this.showProgress = showProgress;
     this.sparks = sparks;
@@ -56,8 +57,8 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     return this.materials;
   }
 
-  public String getMode() {
-    return this.mode;
+  public List<String> getModeList() {
+    return this.modeList;
   }
 
   public double getDestructionRequired() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -17,7 +17,6 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   protected final Set<SingleMaterialMatcher> materials;
   protected final double destructionRequired;
   protected final ImmutableSet<Mode> modeList;
-  protected final boolean modeChanges;
   protected final boolean showProgress;
   protected final boolean sparks;
   protected final boolean repairable;
@@ -34,7 +33,6 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       Set<SingleMaterialMatcher> materials,
       double destructionRequired,
       @Nullable ImmutableSet<Mode> modeList,
-      boolean modeChanges,
       boolean showProgress,
       boolean sparks,
       boolean repairable) {
@@ -43,7 +41,6 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     this.materials = materials;
     this.destructionRequired = destructionRequired;
     this.modeList = modeList;
-    this.modeChanges = modeChanges;
     this.showProgress = showProgress;
     this.sparks = sparks;
     this.repairable = repairable;
@@ -64,10 +61,6 @@ public class DestroyableFactory extends ProximityGoalDefinition {
 
   public double getDestructionRequired() {
     return this.destructionRequired;
-  }
-
-  public boolean hasModeChanges() {
-    return this.modeChanges;
   }
 
   public boolean getShowProgress() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -1,10 +1,11 @@
 package tc.oc.pgm.destroyable;
 
-import java.util.List;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.ProximityGoalDefinition;
 import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.teams.TeamFactory;
@@ -15,7 +16,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   protected final Region region;
   protected final Set<SingleMaterialMatcher> materials;
   protected final double destructionRequired;
-  protected final List<String> modeList;
+  protected final ImmutableSet<SelfIdentifyingFeatureDefinition> modeList;
   protected final boolean modeChanges;
   protected final boolean showProgress;
   protected final boolean sparks;
@@ -32,7 +33,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       Region region,
       Set<SingleMaterialMatcher> materials,
       double destructionRequired,
-      @Nullable List<String> modeList,
+      @Nullable ImmutableSet<SelfIdentifyingFeatureDefinition> modeList,
       boolean modeChanges,
       boolean showProgress,
       boolean sparks,
@@ -57,7 +58,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     return this.materials;
   }
 
-  public List<String> getModeList() {
+  public Set<SelfIdentifyingFeatureDefinition> getModeList() {
     return this.modeList;
   }
 

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -128,10 +128,9 @@ public class DestroyableMatchModule implements MatchModule, Listener {
         double oldCompletion = destroyable.getCompletion();
         if (destroyable.getMode() == null) {
           destroyable.replaceBlocks(event.getMode().getMaterialData());
-        } else if (destroyable.getMode() != null) {
-          if (destroyable.getMode().equals(event.getMode().getId())) {
-            destroyable.replaceBlocks(event.getMode().getMaterialData());
-          }
+        } else if (destroyable.getMode() != null
+            && destroyable.getMode().equals(event.getMode().getStage())) {
+          destroyable.replaceBlocks(event.getMode().getMaterialData());
         }
         if (oldCompletion != destroyable.getCompletion()) {
           // Multi-stage destroyables can have their total completion changed by this

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -124,12 +124,9 @@ public class DestroyableMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Destroyable destroyable : this.destroyables) {
-      if (destroyable.isAffectedByModeChanges()) {
+      if (destroyable.getModes() == null || destroyable.getModes().contains(event.getMode())) {
         double oldCompletion = destroyable.getCompletion();
-        if (destroyable.getModeList() == null
-            || destroyable.getModeList().contains(event.getMode())) {
-          destroyable.replaceBlocks(event.getMode().getMaterialData());
-        }
+        destroyable.replaceBlocks(event.getMode().getMaterialData());
         if (oldCompletion != destroyable.getCompletion()) {
           // Multi-stage destroyables can have their total completion changed by this
           this.match.callEvent(new DestroyableHealthChangeEvent(this.match, destroyable, null));

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -126,9 +126,9 @@ public class DestroyableMatchModule implements MatchModule, Listener {
     for (Destroyable destroyable : this.destroyables) {
       if (destroyable.isAffectedByModeChanges()) {
         double oldCompletion = destroyable.getCompletion();
-        if (destroyable.getMode() == null) {
+        if (destroyable.getModeList() == null || destroyable.getModeList().isEmpty()) {
           destroyable.replaceBlocks(event.getMode().getMaterialData());
-        } else if (destroyable.getMode().equals(event.getMode().getId())) {
+        } else if (destroyable.getModeList().contains(event.getMode().getId())) {
           destroyable.replaceBlocks(event.getMode().getMaterialData());
         }
         if (oldCompletion != destroyable.getCompletion()) {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -126,9 +126,8 @@ public class DestroyableMatchModule implements MatchModule, Listener {
     for (Destroyable destroyable : this.destroyables) {
       if (destroyable.isAffectedByModeChanges()) {
         double oldCompletion = destroyable.getCompletion();
-        if (destroyable.getModeList() == null || destroyable.getModeList().isEmpty()) {
-          destroyable.replaceBlocks(event.getMode().getMaterialData());
-        } else if (destroyable.getModeList().contains(event.getMode().getId())) {
+        if (destroyable.getModeList() == null
+            || destroyable.getModeList().contains(event.getMode())) {
           destroyable.replaceBlocks(event.getMode().getMaterialData());
         }
         if (oldCompletion != destroyable.getCompletion()) {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -128,8 +128,7 @@ public class DestroyableMatchModule implements MatchModule, Listener {
         double oldCompletion = destroyable.getCompletion();
         if (destroyable.getMode() == null) {
           destroyable.replaceBlocks(event.getMode().getMaterialData());
-        } else if (destroyable.getMode() != null
-            && destroyable.getMode().equals(event.getMode().getStage())) {
+        } else if (destroyable.getMode().equals(event.getMode().getStage())) {
           destroyable.replaceBlocks(event.getMode().getMaterialData());
         }
         if (oldCompletion != destroyable.getCompletion()) {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -128,7 +128,7 @@ public class DestroyableMatchModule implements MatchModule, Listener {
         double oldCompletion = destroyable.getCompletion();
         if (destroyable.getMode() == null) {
           destroyable.replaceBlocks(event.getMode().getMaterialData());
-        } else if (destroyable.getMode().equals(event.getMode().getStage())) {
+        } else if (destroyable.getMode().equals(event.getMode().getId())) {
           destroyable.replaceBlocks(event.getMode().getMaterialData());
         }
         if (oldCompletion != destroyable.getCompletion()) {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -126,7 +126,13 @@ public class DestroyableMatchModule implements MatchModule, Listener {
     for (Destroyable destroyable : this.destroyables) {
       if (destroyable.isAffectedByModeChanges()) {
         double oldCompletion = destroyable.getCompletion();
-        destroyable.replaceBlocks(event.getMode().getMaterialData());
+        if (destroyable.getMode() == null) {
+          destroyable.replaceBlocks(event.getMode().getMaterialData());
+        } else if (destroyable.getMode() != null) {
+          if (destroyable.getMode().equals(event.getMode().getId())) {
+            destroyable.replaceBlocks(event.getMode().getMaterialData());
+          }
+        }
         if (oldCompletion != destroyable.getCompletion()) {
           // Multi-stage destroyables can have their total completion changed by this
           this.match.callEvent(new DestroyableHealthChangeEvent(this.match, destroyable, null));

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -3,7 +3,6 @@ package tc.oc.pgm.destroyable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -166,8 +165,8 @@ public class DestroyableModule implements MapModule {
         return null;
       }
     }
-    public ImmutableSet<Mode> parseModeSet(Node node)
-            throws InvalidXMLException {
+
+    public ImmutableSet<Mode> parseModeSet(Node node) throws InvalidXMLException {
       ImmutableSet.Builder<Mode> modes = ImmutableSet.builder();
       for (String modeId : node.getValue().split("\\s")) {
         Mode mode = factory.getFeatures().get(modeId, Mode.class);

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -111,7 +111,7 @@ public class DestroyableModule implements MapModule {
         Set<SingleMaterialMatcher> materials =
             XMLUtils.parseMaterialPatternSet(
                 Node.fromRequiredAttr(destroyableEl, "materials", "material"));
-        String mode = destroyableEl.getAttributeValue("mode");
+        String mode = destroyableEl.getAttributeValue("modes");
         boolean modeChanges =
             XMLUtils.parseBoolean(destroyableEl.getAttribute("mode-changes"), false);
         boolean showProgress =

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -111,6 +111,7 @@ public class DestroyableModule implements MapModule {
         Set<SingleMaterialMatcher> materials =
             XMLUtils.parseMaterialPatternSet(
                 Node.fromRequiredAttr(destroyableEl, "materials", "material"));
+        String mode = destroyableEl.getAttributeValue("mode");
         boolean modeChanges =
             XMLUtils.parseBoolean(destroyableEl.getAttribute("mode-changes"), false);
         boolean showProgress =
@@ -134,6 +135,7 @@ public class DestroyableModule implements MapModule {
                 region,
                 materials,
                 destructionRequired,
+                mode,
                 modeChanges,
                 showProgress,
                 sparks,

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -1,8 +1,10 @@
 package tc.oc.pgm.destroyable;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -111,7 +113,17 @@ public class DestroyableModule implements MapModule {
         Set<SingleMaterialMatcher> materials =
             XMLUtils.parseMaterialPatternSet(
                 Node.fromRequiredAttr(destroyableEl, "materials", "material"));
-        String mode = destroyableEl.getAttributeValue("modes");
+
+        String modes = destroyableEl.getAttributeValue("modes");
+        List<String> modeList = new ArrayList<>();
+        if (modes != null) {
+          Node node = Node.fromAttr(destroyableEl, modes);
+          if (node != null) {
+            for (String mode : Splitter.on(" ").split(node.getValue())) {
+              modeList.add(mode);
+            }
+          }
+        }
         boolean modeChanges =
             XMLUtils.parseBoolean(destroyableEl.getAttribute("mode-changes"), false);
         boolean showProgress =
@@ -135,7 +147,7 @@ public class DestroyableModule implements MapModule {
                 region,
                 materials,
                 destructionRequired,
-                mode,
+                modeList,
                 modeChanges,
                 showProgress,
                 sparks,

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -16,7 +16,6 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.blockdrops.BlockDropsModule;
-import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.goals.GoalMatchModule;
 import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.modes.Mode;
@@ -74,7 +73,8 @@ public class DestroyableModule implements MapModule {
       return ImmutableList.of(TeamModule.class, RegionModule.class);
     }
 
-    public ImmutableSet<Mode> parseModeSet(Node node, MapFactory context) throws InvalidXMLException {
+    public ImmutableSet<Mode> parseModeSet(Node node, MapFactory context)
+        throws InvalidXMLException {
       ImmutableSet.Builder<Mode> modes = ImmutableSet.builder();
       for (String modeId : node.getValue().split("\\s")) {
         Mode mode = context.getFeatures().get(modeId, Mode.class);
@@ -161,7 +161,6 @@ public class DestroyableModule implements MapModule {
                 materials,
                 destructionRequired,
                 modeSet,
-                modeChanges,
                 showProgress,
                 sparks,
                 repairable);

--- a/core/src/main/java/tc/oc/pgm/goals/ModeChangeGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/ModeChangeGoal.java
@@ -1,8 +1,10 @@
 package tc.oc.pgm.goals;
 
+import com.google.common.collect.ImmutableSet;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.material.MaterialData;
+import tc.oc.pgm.modes.Mode;
 
 public interface ModeChangeGoal<T extends GoalDefinition> extends Goal<T> {
 
@@ -10,5 +12,5 @@ public interface ModeChangeGoal<T extends GoalDefinition> extends Goal<T> {
 
   boolean isObjectiveMaterial(Block block);
 
-  String getModeChangeMessage(Material material);
+  ImmutableSet<Mode> getModes();
 }

--- a/core/src/main/java/tc/oc/pgm/goals/ModeChangeGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/ModeChangeGoal.java
@@ -11,6 +11,4 @@ public interface ModeChangeGoal<T extends GoalDefinition> extends Goal<T> {
   boolean isObjectiveMaterial(Block block);
 
   String getModeChangeMessage(Material material);
-
-  boolean isAffectedByModeChanges();
 }

--- a/core/src/main/java/tc/oc/pgm/goals/ModeChangeGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/ModeChangeGoal.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.goals;
 
 import com.google.common.collect.ImmutableSet;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.modes.Mode;

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -7,10 +7,9 @@ import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.material.MaterialData;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 
-public class Mode {
-
-  private final @Nullable String id;
+public class Mode extends SelfIdentifyingFeatureDefinition {
   private final MaterialData material;
   private final Duration after;
   private final @Nullable String name;
@@ -27,7 +26,7 @@ public class Mode {
       final Duration after,
       final @Nullable String name,
       Duration showBefore) {
-    this.id = id;
+    super(id);
     this.material = material;
     this.after = after;
     this.name = name;
@@ -58,9 +57,5 @@ public class Mode {
 
   public @Nullable String getName() {
     return this.name;
-  }
-
-  public @Nullable String getId() {
-    return this.id;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -10,6 +10,7 @@ import org.bukkit.material.MaterialData;
 
 public class Mode {
 
+  private final @Nullable String id;
   private final MaterialData material;
   private final Duration after;
   private final @Nullable String name;
@@ -17,14 +18,16 @@ public class Mode {
   private final Duration showBefore;
 
   public Mode(final MaterialData material, final Duration after, Duration showBefore) {
-    this(material, after, null, showBefore);
+    this(null, material, after, null, showBefore);
   }
 
   public Mode(
+      final @Nullable String id,
       final MaterialData material,
       final Duration after,
       final @Nullable String name,
       Duration showBefore) {
+    this.id = id;
     this.material = material;
     this.after = after;
     this.name = name;
@@ -55,5 +58,9 @@ public class Mode {
 
   public @Nullable String getName() {
     return this.name;
+  }
+
+  public @Nullable String getId() {
+    return this.id;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -10,7 +10,7 @@ import org.bukkit.material.MaterialData;
 
 public class Mode {
 
-  private final @Nullable String id;
+  private final @Nullable String stage;
   private final MaterialData material;
   private final Duration after;
   private final @Nullable String name;
@@ -22,12 +22,12 @@ public class Mode {
   }
 
   public Mode(
-      final @Nullable String id,
+      final @Nullable String stage,
       final MaterialData material,
       final Duration after,
       final @Nullable String name,
       Duration showBefore) {
-    this.id = id;
+    this.stage = stage;
     this.material = material;
     this.after = after;
     this.name = name;
@@ -60,7 +60,7 @@ public class Mode {
     return this.name;
   }
 
-  public @Nullable String getId() {
-    return this.id;
+  public @Nullable String getStage() {
+    return this.stage;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -10,7 +10,7 @@ import org.bukkit.material.MaterialData;
 
 public class Mode {
 
-  private final @Nullable String stage;
+  private final @Nullable String id;
   private final MaterialData material;
   private final Duration after;
   private final @Nullable String name;
@@ -22,12 +22,12 @@ public class Mode {
   }
 
   public Mode(
-      final @Nullable String stage,
+      final @Nullable String id,
       final MaterialData material,
       final Duration after,
       final @Nullable String name,
       Duration showBefore) {
-    this.stage = stage;
+    this.id = id;
     this.material = material;
     this.after = after;
     this.name = name;
@@ -60,7 +60,7 @@ public class Mode {
     return this.name;
   }
 
-  public @Nullable String getStage() {
-    return this.stage;
+  public @Nullable String getId() {
+    return this.id;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -57,6 +57,7 @@ public class ObjectiveModesModule implements MapModule {
       }
 
       for (Element modeEl : XMLUtils.flattenElements(doc.getRootElement(), "modes", "mode")) {
+        String id = modeEl.getAttributeValue("id");
         if (modeEl.getAttributeValue("after") == null) {
           throw new InvalidXMLException("No period has been specified", modeEl);
         }
@@ -85,7 +86,7 @@ public class ObjectiveModesModule implements MapModule {
                 "Already scheduled a mode for " + after.getSeconds() + "s", modeEl);
           }
         }
-        parsedModes.add(new Mode(material, after, name, showBefore));
+        parsedModes.add(new Mode(id, material, after, name, showBefore));
       }
 
       return new ObjectiveModesModule(parsedModes);

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -57,7 +57,7 @@ public class ObjectiveModesModule implements MapModule {
       }
 
       for (Element modeEl : XMLUtils.flattenElements(doc.getRootElement(), "modes", "mode")) {
-        String id = modeEl.getAttributeValue("id");
+        String stage = modeEl.getAttributeValue("stage");
         if (modeEl.getAttributeValue("after") == null) {
           throw new InvalidXMLException("No period has been specified", modeEl);
         }
@@ -86,7 +86,7 @@ public class ObjectiveModesModule implements MapModule {
                 "Already scheduled a mode for " + after.getSeconds() + "s", modeEl);
           }
         }
-        parsedModes.add(new Mode(id, material, after, name, showBefore));
+        parsedModes.add(new Mode(stage, material, after, name, showBefore));
       }
 
       return new ObjectiveModesModule(parsedModes);

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -79,14 +79,15 @@ public class ObjectiveModesModule implements MapModule {
         if (!legacyShowBossBar) {
           showBefore = Duration.ZERO;
         }
-
         for (Mode mode : parsedModes) {
           if (mode.getAfter().equals(after)) {
             throw new InvalidXMLException(
                 "Already scheduled a mode for " + after.getSeconds() + "s", modeEl);
           }
         }
-        parsedModes.add(new Mode(id, material, after, name, showBefore));
+        Mode mode = new Mode(id, material, after, name, showBefore);
+        parsedModes.add(mode);
+        factory.getFeatures().addFeature(modeEl, mode);
       }
 
       return new ObjectiveModesModule(parsedModes);

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -57,7 +57,7 @@ public class ObjectiveModesModule implements MapModule {
       }
 
       for (Element modeEl : XMLUtils.flattenElements(doc.getRootElement(), "modes", "mode")) {
-        String stage = modeEl.getAttributeValue("stage");
+        String id = modeEl.getAttributeValue("id");
         if (modeEl.getAttributeValue("after") == null) {
           throw new InvalidXMLException("No period has been specified", modeEl);
         }
@@ -86,7 +86,7 @@ public class ObjectiveModesModule implements MapModule {
                 "Already scheduled a mode for " + after.getSeconds() + "s", modeEl);
           }
         }
-        parsedModes.add(new Mode(stage, material, after, name, showBefore));
+        parsedModes.add(new Mode(id, material, after, name, showBefore));
       }
 
       return new ObjectiveModesModule(parsedModes);


### PR DESCRIPTION
This pull request adds a `mode` attribute to `<core>` and `<destroyable>`, and an `id` attribute to `<mode>` so that monument modes can now be selectable instead of defaulting to all cores and monuments. To maintain compatability, only modes with no `id` can affect cores and destroyables with no `mode`. Modes have a one to many relationship with the objectives. This means that monuments made of more complex materials can now be changed to different materials using multiple `<destroyable>` modules. Maps that use them as "stages" or extra platforms like Miner Sixty Niner, CannonCube, CannonDuel, and Royal Garden CTW will also greatly benefit from this addition, as more can be added, or the platforms can take on more complex patterns.

```xml
<cores material="obsidian" leak="2">
    <core team="red-team" region="left-core" mode-changes="true" mode="glass-mode"/>
    <core team="blue-team" region="right-core" mode-changes="true" mode="gold-mode"/>
</cores>
<destroyables>
    <destroyable id="red-mon" name="red one" owner="red-team" mode-changes="true" mode="glass-mode" region="mon-red" materials="obsidian"/>
    <destroyable id="blue-mon" name="blue one" owner="blue-team" mode-changes="true" mode="gold-mode" region="mon-blu" materials="obsidian"/>
</destroyables>
<modes>
    <mode id="glass-mode" after="10s" material="glass" name="`eGlass Mode" show-before="5s"/>
    <mode id="gold-mode" after="20s" material="gold block" name="`eGold Mode" show-before="5s"/>
</modes>
```

In this example, the Red Core and Red Monument will turn to glass from obsidian in 10 seconds, Blue Core and Blue Monument will turn to gold blocks from obsidian in 20 seconds. You can download this test map as an example to check it out these changes.
[testworld.zip](https://github.com/PGMDev/PGM/files/5741182/testworld.zip)
 
**EDIT:** This deprecates the `mode-changes` attribute as something that defines the Core and Destroyable instance, it remains in the XML parser for compatibility reasons.
