### PR TITLE
New post filters

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -417,6 +417,12 @@ public abstract class FilterParser {
         this.factory.getFeatures().createReference(new Node(el), FlagDefinition.class));
   }
 
+  @MethodParser("previous-post")
+  public PreviousPostFilter parsePreviousPost(Element el) throws InvalidXMLException {
+    return new PreviousPostFilter(
+        this.factory.getFeatures().createReference(new Node(el), Post.class));
+  }
+
   @MethodParser("cause")
   public CauseFilter parseCause(Element el) throws InvalidXMLException {
     return new CauseFilter(XMLUtils.parseEnum(el, CauseFilter.Cause.class, "cause filter"));

--- a/core/src/main/java/tc/oc/pgm/filters/PreviousPostFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/PreviousPostFilter.java
@@ -1,0 +1,27 @@
+package tc.oc.pgm.filters;
+
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.filters.query.FlagQuery;
+import tc.oc.pgm.flag.Flag;
+import tc.oc.pgm.flag.Post;
+
+public class PreviousPostFilter extends TypedFilter<FlagQuery> {
+  private final FeatureReference<? extends Post> postReference;
+
+  public PreviousPostFilter(FeatureReference<? extends Post> post) {
+    this.postReference = post;
+  }
+
+  @Override
+  public Class<? extends FlagQuery> getQueryType() {
+    return FlagQuery.class;
+  }
+
+  @Override
+  protected QueryResponse queryTyped(FlagQuery query) {
+    final Post post = this.postReference.get();
+    final Flag flag = query.getFlag();
+    if (post == null) return QueryResponse.ABSTAIN;
+    return QueryResponse.fromBoolean(flag.getPreviousPost().equals(post));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/filters/query/FlagQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/FlagQuery.java
@@ -1,0 +1,26 @@
+package tc.oc.pgm.filters.query;
+
+import tc.oc.pgm.flag.Flag;
+
+public class FlagQuery extends GoalQuery {
+  private final Flag flag;
+
+  public FlagQuery(Flag flag) {
+    super(flag);
+    this.flag = flag;
+  }
+
+  public Flag getFlag() {
+    return flag;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof FlagQuery)) return false;
+    if (!super.equals(o)) return false;
+    FlagQuery query = (FlagQuery) o;
+    if (!flag.equals(query.flag)) return false;
+    return true;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -290,7 +290,6 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
       if (definition.isSequential()) {
         // Start posts collection at sequential count
         Collections.rotate(possiblePosts, -sequentialPostCounter);
-        sequentialPostCounter++;
       } else {
         Collections.shuffle(possiblePosts);
       }
@@ -303,7 +302,11 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
 
   private Post getNextPost(Collection<Post> posts) {
     return posts.stream()
-        .filter(post -> post.getRespawnFilter().query(query).isAllowed())
+        .filter(
+            post -> {
+              sequentialPostCounter++;
+              return post.getRespawnFilter().query(query).isAllowed();
+            })
         .findFirst()
         .orElse(definition.getDefaultPost());
   }

--- a/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
@@ -61,7 +61,8 @@ public class FlagParser {
     boolean permanent = XMLUtils.parseBoolean(el.getAttribute("permanent"), false);
     double pointsPerSecond = XMLUtils.parseNumber(el.getAttribute("points-rate"), Double.class, 0D);
     Filter pickupFilter = filterParser.parseFilterProperty(el, "pickup-filter", StaticFilter.ALLOW);
-
+    Filter respawnFilter =
+        filterParser.parseFilterProperty(el, "respawn-filter", StaticFilter.ALLOW);
     Duration recoverTime =
         XMLUtils.parseDuration(
             Node.fromAttr(el, "recover-time", "return-time"), Post.DEFAULT_RETURN_TIME);
@@ -95,7 +96,8 @@ public class FlagParser {
             sequential,
             permanent,
             pointsPerSecond,
-            pickupFilter);
+            pickupFilter,
+            respawnFilter);
     posts.add(post);
     factory.getFeatures().addFeature(el, post);
 

--- a/core/src/main/java/tc/oc/pgm/flag/Post.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Post.java
@@ -38,6 +38,7 @@ public class Post extends SelfIdentifyingFeatureDefinition {
   private final boolean permanent; // Flag enters Completed state when at this post
   private final double pointsPerSecond; // Points awarded while any flag is at this post
   private final Filter pickupFilter; // Filter players who can pickup a flag at this post
+  private final Filter respawnFilter; // Filter if a flag can respawn to this post
   private final @Nullable String
       postName; // The name of the post to be shown in chat when the flag is respawning
 
@@ -54,7 +55,8 @@ public class Post extends SelfIdentifyingFeatureDefinition {
       boolean sequential,
       boolean permanent,
       double pointsPerSecond,
-      Filter pickupFilter) {
+      Filter pickupFilter,
+      Filter respawnFilter) {
 
     super(id);
     checkArgument(respawnTime == null || respawnSpeed == null);
@@ -69,6 +71,7 @@ public class Post extends SelfIdentifyingFeatureDefinition {
     this.permanent = permanent;
     this.pointsPerSecond = pointsPerSecond;
     this.pickupFilter = pickupFilter;
+    this.respawnFilter = respawnFilter;
     this.postName = name;
   }
 
@@ -116,6 +119,10 @@ public class Post extends SelfIdentifyingFeatureDefinition {
 
   public Filter getPickupFilter() {
     return this.pickupFilter;
+  }
+
+  public Filter getRespawnFilter() {
+    return this.respawnFilter;
   }
 
   public Location getReturnPoint(Flag flag, AngleProvider yawProvider) {


### PR DESCRIPTION
This adds the `respawn-filter` attribute to posts, which determine if a flag can respawn to a given post or not. It also adds the filter `previous-post` ex `<previous-post>post_id</previous-post>` which returns true if the post_id matches the post_id of the given flag's previous respawn post. 

I also added a `FlagQuery` class. 

Example:
In KOTF, to prevent flags from respawning to the same post twice in a row, an XML could look like this:

<img width="285" alt="filter" src="https://user-images.githubusercontent.com/28692086/103155018-8bee9280-4761-11eb-880a-80c269f9e8c2.PNG">

<img width="574" alt="post" src="https://user-images.githubusercontent.com/28692086/103155020-91e47380-4761-11eb-83b7-27c4b7e6d21c.PNG">

Each post would need its own filter. 

If there are no valid posts for a flag to respawn to, it will respawn to its default post. 

Closes https://github.com/PGMDev/PGM/issues/543