### PR TITLE
Fix cycle bossbar not going after cycle

### DIFF
--- a/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
@@ -41,6 +41,10 @@ public abstract class MatchCountdown extends Countdown {
     return this.match;
   }
 
+  public BossBar getBossBar() {
+    return this.bossBar;
+  }
+
   protected abstract Component formatText();
 
   protected boolean showChat() {

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.cycle;
 
 import java.time.Duration;
 import javax.annotation.Nullable;
+import net.kyori.adventure.bossbar.BossBar;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -12,6 +13,7 @@ import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.events.PlayerLeaveMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.restart.RestartManager;
 
@@ -20,6 +22,7 @@ public class CycleMatchModule implements MatchModule, Listener {
 
   private final MapOrder mapOrder;
   private final Match match;
+  private BossBar bossbar;
 
   public CycleMatchModule(Match match) {
     this.match = match;
@@ -35,7 +38,9 @@ public class CycleMatchModule implements MatchModule, Listener {
     // In case the cycle config is set to -1 used to disable autocycle
     if (duration.isNegative()) duration = Duration.ofSeconds(30);
     match.finish();
-    match.getCountdown().start(new CycleCountdown(match), duration);
+    CycleCountdown countdown = new CycleCountdown(match);
+    match.getCountdown().start(countdown, duration);
+    this.bossbar = countdown.getBossBar();
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
@@ -60,5 +65,10 @@ public class CycleMatchModule implements MatchModule, Listener {
         startCountdown(duration);
       }
     }
+  }
+
+  @EventHandler
+  public void onLeave(PlayerLeaveMatchEvent event) {
+    if (bossbar != null) event.getPlayer().hideBossBar(bossbar);
   }
 }


### PR DESCRIPTION
Since players may leave the match before cycle actually gets to 0 (due to async player moving from match to match) it can happen that you are no longer part of the audience by the time the bossbar is removed.

To fix this, when a player leaves the match the cycle bossbar is removed. Ideally it'd be nice if adventure had a `getBossbars` method for audiences or a `hideAllBossbars` that we could invoke when a player leaves the match, to avoid having code scattered arround removing different bossbars when a player leaves (like the unready bar, and now the cycle bar)