### PR TITLE
Implement filters on respawns & allow multiple of them

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/RespawnOptions.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/RespawnOptions.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.spawns;
 import java.time.Duration;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.util.TimeUtils;
 
 public class RespawnOptions {
@@ -12,6 +13,7 @@ public class RespawnOptions {
   public final boolean blackout; // Blind dead players
   public final boolean spectate; // Allow dead players to fly around
   public final boolean bedSpawn; // Allow players to respawn from beds
+  public final Filter filter; // Filter if this RespawnOption should be the one used
   public final @Nullable Component message; // Message to show respawning players, after the delay
 
   public RespawnOptions(
@@ -20,6 +22,7 @@ public class RespawnOptions {
       boolean blackout,
       boolean spectate,
       boolean bedSpawn,
+      Filter filter,
       @Nullable Component message) {
     this.delay = delay;
     this.delayTicks = Math.max(TimeUtils.toTicks(delay), 20);
@@ -27,6 +30,7 @@ public class RespawnOptions {
     this.blackout = blackout;
     this.spectate = spectate;
     this.bedSpawn = bedSpawn;
+    this.filter = filter;
     this.message = message;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -22,6 +22,8 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerAttackEntityEvent;
 import org.bukkit.event.player.PlayerInitialSpawnEvent;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
@@ -64,8 +66,12 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
     return match;
   }
 
-  public RespawnOptions getRespawnOptions() {
-    return module.respawnOptions;
+  public RespawnOptions getRespawnOptions(Query query) {
+    return module.respawnOptions.stream()
+        .filter(
+            respawnOption -> respawnOption.filter.query(query).equals(Filter.QueryResponse.ALLOW))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("No respawn option could be used"));
   }
 
   public Spawn getDefaultSpawn() {

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
@@ -4,16 +4,20 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.filters.FilterParser;
+import tc.oc.pgm.filters.StaticFilter;
 import tc.oc.pgm.kits.KitModule;
 import tc.oc.pgm.points.PointParser;
 import tc.oc.pgm.regions.RegionModule;
@@ -24,14 +28,15 @@ import tc.oc.pgm.util.xml.XMLUtils;
 
 public class SpawnModule implements MapModule {
 
+  public static final Duration DEFAULT_RESPAWN_DELAY = Duration.ofMillis(2000);
   public static final Duration MINIMUM_RESPAWN_DELAY = Duration.ofMillis(1500);
   public static final Duration IGNORE_CLICKS_DELAY = Duration.ofMillis(500);
 
   protected final Spawn defaultSpawn;
   protected final List<Spawn> spawns;
-  protected final RespawnOptions respawnOptions;
+  protected final List<RespawnOptions> respawnOptions;
 
-  public SpawnModule(Spawn defaultSpawn, List<Spawn> spawns, RespawnOptions respawnOptions) {
+  public SpawnModule(Spawn defaultSpawn, List<Spawn> spawns, List<RespawnOptions> respawnOptions) {
     assert defaultSpawn != null;
     this.defaultSpawn = defaultSpawn;
     this.spawns = spawns;
@@ -44,6 +49,9 @@ public class SpawnModule implements MapModule {
   }
 
   public static class Factory implements MapModuleFactory<SpawnModule> {
+
+    private FilterParser filterParser;
+
     @Override
     public Collection<Class<? extends MapModule>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class, KitModule.class);
@@ -57,6 +65,7 @@ public class SpawnModule implements MapModule {
     @Override
     public SpawnModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
+      this.filterParser = factory.getFilters();
       SpawnParser parser = new SpawnParser(factory, new PointParser(factory));
       List<Spawn> spawns = Lists.newArrayList();
 
@@ -70,27 +79,56 @@ public class SpawnModule implements MapModule {
 
       return new SpawnModule(parser.getDefaultSpawn(), spawns, parseRespawnOptions(doc));
     }
-  }
 
-  protected static RespawnOptions parseRespawnOptions(Document doc) throws InvalidXMLException {
-    Duration delay = MINIMUM_RESPAWN_DELAY;
-    boolean auto = doc.getRootElement().getChild("autorespawn") != null; // Legacy support
-    boolean blackout = false;
-    boolean spectate = false;
-    boolean bedSpawn = false;
-    Component message = null;
+    private List<RespawnOptions> parseRespawnOptions(Document doc) throws InvalidXMLException {
+      List<RespawnOptions> respawnOptions = Lists.newArrayList();
 
-    for (Element elRespawn : doc.getRootElement().getChildren("respawn")) {
-      delay = XMLUtils.parseDuration(elRespawn.getAttribute("delay"), delay);
-      auto = XMLUtils.parseBoolean(elRespawn.getAttribute("auto"), auto);
-      blackout = XMLUtils.parseBoolean(elRespawn.getAttribute("blackout"), blackout);
-      spectate = XMLUtils.parseBoolean(elRespawn.getAttribute("spectate"), spectate);
-      bedSpawn = XMLUtils.parseBoolean(elRespawn.getAttribute("bed"), bedSpawn);
-      message = XMLUtils.parseFormattedText(elRespawn, "message", message);
+      for (Element elRespawn :
+          XMLUtils.flattenElements(doc.getRootElement(), "respawns", "respawn")) {
+        respawnOptions.add(getRespawnOptions(elRespawn));
+      }
+      // Parse root children respawn elements, Keeps old syntax and gives a default spawn if all
+      // others fail
+      respawnOptions.add(
+          getRespawnOptions(
+              doc.getRootElement().getChildren("respawn"),
+              doc.getRootElement().getChild("autorespawn") != null,
+              true));
 
-      if (TimeUtils.isShorterThan(delay, MINIMUM_RESPAWN_DELAY)) delay = MINIMUM_RESPAWN_DELAY;
+      return respawnOptions;
     }
 
-    return new RespawnOptions(delay, auto, blackout, spectate, bedSpawn, message);
+    private RespawnOptions getRespawnOptions(Element element) throws InvalidXMLException {
+      return getRespawnOptions(Collections.singleton(element), false, false);
+    }
+
+    protected RespawnOptions getRespawnOptions(
+        Collection<Element> elements, boolean autorespawn, boolean topLevel)
+        throws InvalidXMLException {
+      Duration delay = DEFAULT_RESPAWN_DELAY;
+      boolean auto = autorespawn;
+      boolean blackout = false;
+      boolean spectate = false;
+      boolean bedSpawn = false;
+      Filter filter = StaticFilter.ALLOW;
+      Component message = null;
+
+      for (Element elRespawn : elements) {
+        delay = XMLUtils.parseDuration(elRespawn.getAttribute("delay"), delay);
+        auto = XMLUtils.parseBoolean(elRespawn.getAttribute("auto"), auto);
+        blackout = XMLUtils.parseBoolean(elRespawn.getAttribute("blackout"), blackout);
+        spectate = XMLUtils.parseBoolean(elRespawn.getAttribute("spectate"), spectate);
+        bedSpawn = XMLUtils.parseBoolean(elRespawn.getAttribute("bed"), bedSpawn);
+        filter = filterParser.parseFilterProperty(elRespawn, "filter", filter);
+        if (filter != StaticFilter.ALLOW && topLevel)
+          throw new InvalidXMLException("Parent respawn elements can't use filters", elRespawn);
+
+        message = XMLUtils.parseFormattedText(elRespawn, "message", message);
+
+        if (TimeUtils.isShorterThan(delay, MINIMUM_RESPAWN_DELAY)) delay = MINIMUM_RESPAWN_DELAY;
+      }
+
+      return new RespawnOptions(delay, auto, blackout, spectate, bedSpawn, filter, message);
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawns/states/State.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/State.java
@@ -30,7 +30,7 @@ public abstract class State {
     this.smm = smm;
     this.player = player;
     this.bukkit = player.getBukkit();
-    this.options = smm.getRespawnOptions();
+    this.options = smm.getRespawnOptions(player.getQuery());
   }
 
   public boolean isCurrent() {


### PR DESCRIPTION
Allows multiple respawn options defined in xml, this feature works as it did in 1.9+ PGM.

```xml
<respawns>
  <respawn delay="10s" filter="after-10m"/>
</respawns>
<respawn delay="1.5s"/>
```
This example respawns players by default in 1.5 seconds, but after 10 minutes the above respawn matches and players will take 10 seconds to respawn