### PR TITLE
Tweak tab updating rate limit values

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
@@ -40,7 +40,7 @@ import tc.oc.pgm.util.tablist.TabManager;
 public class MatchTabManager extends TabManager implements Listener {
 
   // Min and max delay to trigger an update after tablist is invalidated
-  private static final int MIN_DELAY = 100, MAX_DELAY = 1000, TIME_RATIO = 20;
+  private static final int MIN_DELAY = 100, MAX_DELAY = 2000, TIME_RATIO = 40;
 
   private final Map<Team, TeamTabEntry> teamEntries;
   private final Map<Match, MapTabEntry> mapEntries;


### PR DESCRIPTION
Allow the tablist to render itself as slow as once every 2 seconds, and make the most time it can take be half a tick every second.

Tablist still managed to take a significant part of CPU time after cycle before match start with high amount of players on ffa, this should make those cases get delay increased easier, and to a higher max