### PR TITLE
Fix several bossbar issues

### DIFF
--- a/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
@@ -8,6 +8,7 @@ import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.title.Title.title;
 
 import java.time.Duration;
+import javax.annotation.Nullable;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -34,7 +35,7 @@ public abstract class MatchCountdown extends Countdown {
   }
 
   public MatchCountdown(Match match) {
-    this(match, BossBar.Color.PURPLE);
+    this(match, BossBar.Color.BLUE);
   }
 
   public Match getMatch() {
@@ -122,6 +123,8 @@ public abstract class MatchCountdown extends Countdown {
     if (showBossBar()) {
       bossBar.progress(bossBarProgress(remaining, total));
       bossBar.name(formatText());
+      BossBar.Color color = barColor();
+      if (color != null) bossBar.color(color);
 
       match.showBossBar(bossBar);
     } else {
@@ -140,6 +143,11 @@ public abstract class MatchCountdown extends Countdown {
     } else {
       return NamedTextColor.DARK_RED;
     }
+  }
+
+  @Nullable
+  protected BossBar.Color barColor() {
+    return null;
   }
 
   protected Component secondsRemaining(TextColor color) {

--- a/core/src/main/java/tc/oc/pgm/restart/RestartCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/restart/RestartCountdown.java
@@ -14,7 +14,7 @@ import tc.oc.pgm.util.TimeUtils;
 public class RestartCountdown extends MatchCountdown {
 
   public RestartCountdown(Match match) {
-    super(match, BossBar.Color.RED);
+    super(match, BossBar.Color.BLUE);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/timelimit/OvertimeCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/OvertimeCountdown.java
@@ -6,6 +6,7 @@ import static net.kyori.adventure.text.Component.translatable;
 import java.time.Duration;
 import java.time.Instant;
 import javax.annotation.Nullable;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
@@ -48,6 +49,11 @@ public class OvertimeCountdown extends TimeLimitCountdown {
             NamedTextColor.YELLOW,
             text(colonTime(), urgencyColor()).decoration(TextDecoration.BOLD, false))
         .decoration(TextDecoration.BOLD, true);
+  }
+
+  @Nullable
+  protected BossBar.Color barColor() {
+    return BossBar.Color.YELLOW;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
@@ -26,7 +26,7 @@ public class TimeLimitCountdown extends MatchCountdown {
   protected final TimeLimit timeLimit;
 
   public TimeLimitCountdown(Match match, TimeLimit timeLimit) {
-    super(match, BossBar.Color.BLUE);
+    super(match);
     this.timeLimit = timeLimit;
   }
 
@@ -73,6 +73,18 @@ public class TimeLimitCountdown extends MatchCountdown {
         // Play the portal crescendo sound up to the last moment
         this.getMatch().playSound(CRESCENDO_SOUND);
       }
+    }
+  }
+
+  @Nullable
+  protected BossBar.Color barColor() {
+    long seconds = remaining.getSeconds();
+    if (seconds > 60) {
+      return BossBar.Color.GREEN;
+    } else if (seconds > 30) {
+      return BossBar.Color.YELLOW;
+    } else {
+      return BossBar.Color.RED;
     }
   }
 


### PR DESCRIPTION
Fixes: 
 - On server start, joining a match sends you an unready bar, but it is not updated and is left as just a blank bar
 - If you cycle, then join, it would leave behind the match start bossbar
 - Overtime bossbar is now yellow, and other bossbars now use old PGM bossbar colors