### PR TITLE
Add comment to map-pools.yml

### DIFF
--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -23,7 +23,9 @@ pools:
     dynamic: true
     players: 1
 
-    # A list of map names in this pool. Names are case-sensitive.
+    # A list of map names in this pool.
+    # Uses map name given in map.xml, do not use folder name
+    # Names are case-sensitive.
     maps:
       - Airship Battle
       - Harb

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -24,7 +24,7 @@ pools:
     players: 1
 
     # A list of map names in this pool.
-    # Uses map name given in map.xml, do not use folder name
+    # Uses map name given in map.xml, do not use folder name.
     # Names are case-sensitive.
     maps:
       - Airship Battle


### PR DESCRIPTION
This adds a quick comment to the default `map-pools.yml` to explain to new users that the configuration file uses the map name given in `map.xml` and **not the name of the map folder.**