### PR TITLE
Wait for module unload to clear sidebar list

### DIFF
--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -153,6 +153,10 @@ public class SidebarMatchModule implements MatchModule, Listener {
     for (BlinkTask task : ImmutableSet.copyOf(this.blinkingGoals.values())) {
       task.stop();
     }
+  }
+
+  @Override
+  public void unload() {
     this.sidebars.clear();
   }
 
@@ -169,7 +173,7 @@ public class SidebarMatchModule implements MatchModule, Listener {
 
   @EventHandler
   public void removePlayer(PlayerLeaveMatchEvent event) {
-    sidebars.remove(event.getPlayer().getId());
+    sidebars.remove(event.getPlayer().getId()).delete();
     renderSidebarDebounce();
   }
 


### PR DESCRIPTION
Fixes https://github.com/PGMDev/PGM/issues/757 where scoreboards are not updated to reflect the final state of the match on end.

The recent refactor of sidebars added `this.sidebars.clear();` at the end of the `SidebarMatchModule` modules `disable` method. 

The match module's disable method is called on match end this clears all stored scoreboards meaning when the debounced render method is called the scoreboards are null and do not get updated. I have modded the clear logic to unload and also added `.delete` to the unused scoreboard when a player switches team. 

Signed-off-by: Pugzy <pugzy@mail.com>