### PR TITLE
Cleanup map pool manager & fix blitz obs count

### DIFF
--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.rotation;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
@@ -40,6 +41,7 @@ public class MapPoolManager implements MapOrder {
 
   private Map<MapPool, MapActivity> mapPools = Maps.newHashMap();
   private MapPool activeMapPool;
+  private MapOrder fallback; // Fallback map order in case no pool exists
 
   /* If a time limit is added via /setpool <name> -t [time], then after this duration the map pool will revert automatically */
   private Duration poolTimeLimit = null;
@@ -90,65 +92,47 @@ public class MapPoolManager implements MapOrder {
     loadMapPools();
   }
 
-  private int loadMapPools() {
-    List<MapPool> pools =
-        mapPoolFileConfig.getConfigurationSection("pools").getKeys(false).stream()
-            .map(key -> MapPool.of(this, mapPoolFileConfig, key))
-            .filter(MapPool::isEnabled)
-            .collect(Collectors.toList());
-
-    List<MapActivity> activity =
-        pools.stream()
-            .map(MapPool::getName)
-            .map(database::getMapActivity)
-            .collect(Collectors.toList());
-
+  private void loadMapPools() {
     this.mapPools.clear(); // For reloads
 
-    pools.forEach(
-        pool ->
-            mapPools.put(
-                pool,
-                activity.stream()
-                    .filter(a -> a.getPoolName().equalsIgnoreCase(pool.getName()))
-                    .findAny()
-                    .orElse(null)));
+    mapPoolFileConfig.getConfigurationSection("pools").getKeys(false).stream()
+        .map(key -> MapPool.of(this, mapPoolFileConfig, key))
+        .filter(MapPool::isEnabled)
+        .forEach(pool -> mapPools.put(pool, database.getMapActivity(pool.getName())));
 
-    Optional<MapActivity> lastActive =
-        mapPools.values().stream().filter(ma -> ma.isActive()).findFirst();
-    if (lastActive.isPresent()) {
-      activeMapPool = getMapPoolByName(lastActive.get().getPoolName());
-    }
+    activeMapPool =
+        mapPools.entrySet().stream()
+            .filter(e -> e.getValue().isActive())
+            .findFirst()
+            .map(Map.Entry::getKey)
+            .orElse(null);
 
     if (activeMapPool == null) {
       logger.log(Level.WARNING, "No active map pool was found, defaulting to first dynamic pool.");
       activeMapPool =
-          mapPools.keySet().stream().sorted().filter(mp -> mp.isDynamic()).findFirst().orElse(null);
+          mapPools.keySet().stream().sorted().filter(MapPool::isDynamic).findFirst().orElse(null);
       if (activeMapPool == null) {
         logger.log(Level.SEVERE, "Failed to find any dynamic map pool!");
       }
     } else {
       logger.log(Level.INFO, "Resuming last active map pool (" + activeMapPool.getName() + ")");
     }
-
-    return pools.size();
   }
 
   public void saveMapPools() {
-    mapPools.entrySet().stream()
-        .forEach(
-            e -> {
-              String nextMap = null;
-              if (e.getKey() instanceof Rotation) {
-                nextMap = e.getKey().getNextMap().getName();
-              }
+    mapPools.forEach(
+        (key, value) -> {
+          String nextMap = null;
+          if (key instanceof Rotation) {
+            nextMap = key.getNextMap().getName();
+          }
 
-              boolean active =
-                  getActiveMapPool() != null
-                      && getActiveMapPool().getName().equalsIgnoreCase(e.getKey().getName())
-                      && e.getKey().isDynamic();
-              e.getValue().update(nextMap, active);
-            });
+          boolean active =
+              getActiveMapPool() != null
+                  && getActiveMapPool().getName().equalsIgnoreCase(key.getName())
+                  && key.isDynamic();
+          value.update(nextMap, active);
+        });
   }
 
   public MapPool getActiveMapPool() {
@@ -229,7 +213,10 @@ public class MapPoolManager implements MapOrder {
     }
 
     if (activeMapPool == null) {
-      getActiveMapPool();
+      if (fallback == null)
+        fallback = new RandomMapOrder(Lists.newArrayList(PGM.get().getMapLibrary().getMaps()));
+
+      return fallback.popNextMap();
     }
 
     return activeMapPool.popNextMap();
@@ -256,13 +243,10 @@ public class MapPoolManager implements MapOrder {
   }
 
   public Optional<MapPool> getAppropriateDynamicPool(Match match) {
-    int obs =
-        match.getModule(BlitzMatchModule.class) != null
-            ? (int) (match.getObservers().size() * 0.85)
-            : (int) (match.getObservers().size() * 0.5);
-    int activePlayers = match.getPlayers().size() - obs;
+    double obsBias = match.getModule(BlitzMatchModule.class) != null ? 0.5 : 0.85;
+    double activePlayers = match.getParticipants().size() + match.getObservers().size() * obsBias;
     return mapPools.keySet().stream()
-        .filter(pool -> pool.isDynamic())
+        .filter(MapPool::isDynamic)
         .filter(pool -> activePlayers >= pool.getPlayers())
         .max(MapPool::compareTo);
   }
@@ -281,10 +265,8 @@ public class MapPoolManager implements MapOrder {
   }
 
   private boolean shouldRevert(Match match) {
-    return !match.getPlayers().stream()
-            .filter(mp -> mp.getBukkit().hasPermission(Permissions.STAFF))
-            .findAny()
-            .isPresent()
+    return match.getPlayers().stream()
+            .noneMatch(mp -> mp.getBukkit().hasPermission(Permissions.STAFF))
         || !activeMapPool.isDynamic()
             && poolTimeLimit != null
             && TimeUtils.isLongerThan(Duration.between(poolStartTime, Instant.now()), poolTimeLimit)


### PR DESCRIPTION
Fixed a few issues with pools, most notably, when a blitz match ends since most players are in obs it would switch to the smallest pool.

Also prevented a crash on startup due to dynamic pools file being set with no pools that are dynamic (now it will use a fallback pgm map order that just picks maps sequentially)