### PR TITLE
Fix timelimit victory condition being ignored after match end

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -191,10 +191,9 @@ public class MatchImpl implements Match {
           break;
         case FINISHED:
           calculateVictory(); // Winners must be calculated and saved prior to cancel.
-          Set<Competitor> winners = competitors.getRank(0);
           getExecutor(MatchScope.RUNNING).shutdownNow();
           getCountdown().cancelAll();
-          callEvent(new MatchFinishEvent(this, winners));
+          callEvent(new MatchFinishEvent(this, competitors.getRank(0)));
           break;
       }
 

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
@@ -73,8 +73,7 @@ public class TimeLimit extends SelfIdentifyingFeatureDefinition implements Victo
 
   @Override
   public boolean isCompleted(Match match) {
-    TimeLimitCountdown countdown = match.needModule(TimeLimitMatchModule.class).getCountdown();
-    return countdown != null && match.getCountdown().isFinished(countdown);
+    return match.needModule(TimeLimitMatchModule.class).isFinished();
   }
 
   public @Nullable Competitor currentWinner(Match match) {

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitCountdown.java
@@ -100,11 +100,12 @@ public class TimeLimitCountdown extends MatchCountdown {
   @Override
   public void onEnd(Duration total) {
     super.onEnd(total);
+    TimeLimitMatchModule tl = this.getMatch().needModule(TimeLimitMatchModule.class);
     if (mayEnd()) {
+      tl.setFinished(true);
       this.getMatch().calculateVictory();
     } else {
-      TimeLimitMatchModule tl = this.getMatch().getModule(TimeLimitMatchModule.class);
-      if (tl != null) tl.startOvertime();
+      tl.startOvertime();
     }
     this.freeze(Duration.ZERO);
   }

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitMatchModule.java
@@ -12,6 +12,7 @@ public class TimeLimitMatchModule implements MatchModule {
   private @Nullable TimeLimit timeLimit;
   private @Nullable TimeLimitCountdown countdown;
   private @Nullable OvertimeCountdown overtime;
+  private boolean finished; // If Time limit ended this match
 
   public TimeLimitMatchModule(Match match, @Nullable TimeLimit timeLimit) {
     this.match = match;
@@ -26,6 +27,14 @@ public class TimeLimitMatchModule implements MatchModule {
   @Override
   public void enable() {
     this.start();
+  }
+
+  public boolean isFinished() {
+    return finished;
+  }
+
+  public void setFinished(boolean finished) {
+    this.finished = finished;
   }
 
   public @Nullable TimeLimit getTimeLimit() {


### PR DESCRIPTION
Currently the time limit victory condition is not correctly reporting after match finish, since the countdown is cancelled. This changes it so the completion is saved and used.