### PR TITLE
Remove scheduled mode limitation

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -79,12 +79,6 @@ public class ObjectiveModesModule implements MapModule {
         if (!legacyShowBossBar) {
           showBefore = Duration.ZERO;
         }
-        for (Mode mode : parsedModes) {
-          if (mode.getAfter().equals(after)) {
-            throw new InvalidXMLException(
-                "Already scheduled a mode for " + after.getSeconds() + "s", modeEl);
-          }
-        }
         Mode mode = new Mode(id, material, after, name, showBefore);
         parsedModes.add(mode);
         factory.getFeatures().addFeature(modeEl, mode);


### PR DESCRIPTION
After a quick test to see if anything bad would happen if two modes fired off at the same time, nothing happened. This pull request simply removes this restriction from the XML parser. This will help in making selectable monument modes more flexible.
