### PR TITLE
./mode is shorthand for ./mode list, likewise ./vote is shorthand for ./vote list

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -14,6 +14,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.commons.lang.WordUtils;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.command.graph.DefaultCommand;
 import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.modes.ModeChangeCountdown;
 import tc.oc.pgm.modes.ModesPaginatedResult;
@@ -69,6 +70,7 @@ public final class ModeCommand {
       aliases = {"list", "page"},
       desc = "List all objectivs modes",
       usage = "[page]")
+  @DefaultCommand
   public void list(Audience audience, Match match, @Default("1") int page) throws CommandException {
     showList(page, audience, getModes(match));
   }

--- a/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/VotingCommand.java
@@ -21,6 +21,7 @@ import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.command.graph.DefaultCommand;
 import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.rotation.MapPoolManager;
 import tc.oc.pgm.rotation.VotingPool;
@@ -142,6 +143,7 @@ public class VotingCommand {
   @Command(
       aliases = {"list", "ls"},
       desc = "View a list of maps that have been selected for the next vote")
+  @DefaultCommand
   public void listMaps(CommandSender sender, Audience viewer, MapOrder mapOrder)
       throws CommandException {
     VotingPool vote = getVotingPool(sender, mapOrder);

--- a/core/src/main/java/tc/oc/pgm/command/graph/DefaultCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/DefaultCommand.java
@@ -1,0 +1,11 @@
+package tc.oc.pgm.command.graph;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** When present, this command will be ran when its parent node is ran without any arguments. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DefaultCommand {}

--- a/core/src/main/java/tc/oc/pgm/command/graph/DefaultCommandDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/DefaultCommandDispatcher.java
@@ -1,0 +1,83 @@
+package tc.oc.pgm.command.graph;
+
+import app.ashcon.intake.CommandException;
+import app.ashcon.intake.CommandMapping;
+import app.ashcon.intake.InvalidUsageException;
+import app.ashcon.intake.InvocationCommandException;
+import app.ashcon.intake.argument.CommandContext;
+import app.ashcon.intake.argument.Namespace;
+import app.ashcon.intake.dispatcher.SimpleDispatcher;
+import app.ashcon.intake.parametric.ProvisionException;
+import app.ashcon.intake.util.auth.AuthorizationException;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class DefaultCommandDispatcher extends SimpleDispatcher {
+
+  protected final String defaultCommand;
+
+  public DefaultCommandDispatcher(String defaultCommand) {
+    this.defaultCommand = defaultCommand;
+  }
+
+  @Override
+  public boolean call(String arguments, Namespace namespace, List<String> parentCommands)
+      throws CommandException, InvocationCommandException, AuthorizationException {
+    if (!testPermission(namespace)) {
+      throw new AuthorizationException();
+    }
+
+    String[] split = CommandContext.split(arguments);
+    Set<String> aliases = getPrimaryAliases();
+
+    if (aliases.isEmpty()) {
+      throw new ProvisionException("There are no sub-commands for " + parentCommands);
+    } else if (arguments.length() == 0) {
+      CommandMapping defaultMapping = get(defaultCommand);
+      List<String> defaultSubParents =
+          ImmutableList.<String>builder().addAll(parentCommands).add(defaultCommand).build();
+      if (defaultMapping != null) {
+        try {
+          defaultMapping.getCallable().call("", namespace, defaultSubParents);
+        } catch (AuthorizationException e) {
+          throw e;
+        } catch (CommandException e) {
+          throw e;
+        } catch (InvocationCommandException e) {
+          throw e;
+        } catch (Throwable t) {
+          throw new InvocationCommandException(t);
+        }
+
+        return true;
+      }
+    } else if (split.length > 0) {
+      String subCommand = split[0];
+      String subArguments = Joiner.on(" ").join(Arrays.copyOfRange(split, 1, split.length));
+      List<String> subParents =
+          ImmutableList.<String>builder().addAll(parentCommands).add(subCommand).build();
+      CommandMapping mapping = get(subCommand);
+
+      if (mapping != null) {
+        try {
+          mapping.getCallable().call(subArguments, namespace, subParents);
+        } catch (AuthorizationException e) {
+          throw e;
+        } catch (CommandException e) {
+          throw e;
+        } catch (InvocationCommandException e) {
+          throw e;
+        } catch (Throwable t) {
+          throw new InvocationCommandException(t);
+        }
+
+        return true;
+      }
+    }
+
+    throw new InvalidUsageException(null, this, parentCommands, true);
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9807038/106669564-c5f25600-65a3-11eb-8c34-06e2b45a224d.png)

`/mode` and `/modes` without any arguments will run `/mode list`. Running a child command that doesn't exist will send the parent command help (as seen with `/mode a`).