### PR TITLE
Add team checks when vanishing players

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -31,6 +31,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchManager;
+import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.VanishManager;
 import tc.oc.pgm.api.player.event.MatchPlayerAddEvent;
@@ -158,9 +159,15 @@ public class VanishManagerImpl implements VanishManager, Listener {
   @EventHandler(priority = EventPriority.HIGH)
   public void onJoin(PlayerJoinEvent event) {
     MatchPlayer player = matchManager.getPlayer(event.getPlayer());
-    if (isVanished(player.getId())) { // Player is already vanished
+    if (player == null) return;
+    if (player.getParty() instanceof Competitor) return; // Do not vanish players on a team
+
+    if (isVanished(player.getId())) {
       player.setVanished(true);
-    } else if (player
+      return;
+    }
+
+    if (player
         .getBukkit()
         .hasPermission(Permissions.VANISH)) { // Player is not vanished, but has permission to
 
@@ -198,7 +205,13 @@ public class VanishManagerImpl implements VanishManager, Listener {
 
   @EventHandler
   public void checkMatchPlayer(MatchPlayerAddEvent event) {
-    event.getPlayer().setVanished(isVanished(event.getPlayer().getId()));
+    MatchPlayer player = event.getPlayer();
+    // Player is joining to a team so broadcast join
+    if (event.getInitialParty() instanceof Competitor) {
+      setVanished(player, false, false);
+    }
+
+    player.setVanished(isVanished(player.getId()));
   }
 
   private boolean isVanishSubdomain(String address) {

--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -203,7 +203,7 @@ public class VanishManagerImpl implements VanishManager, Listener {
     }
   }
 
-  @EventHandler
+  @EventHandler(priority = EventPriority.MONITOR)
   public void checkMatchPlayer(MatchPlayerAddEvent event) {
     MatchPlayer player = event.getPlayer();
     // Player is joining to a team so broadcast join


### PR DESCRIPTION
Vanish logic currently assumes all players are in observers and even attempts to force this inside the `setVanished` method.

Plugins such as `Events` can allow for a situation where a player is joining the match assigned to a team, it does this by modifying the initial team of the `MatchPlayerAddEvent` to the team they are assigned to. 

This can also cause a situation where a vanish player is forced on to a team on match cycle or on registering a tournament team.

This maintains the logic that already exists, however, stops processing the `PlayerJoinEvent` logic if the player is on a team.
And unvanishes the player with a join message if the player is set to a team from a vanished state in the `PlayerJoinEvent`.

Signed-off-by: Pugzy <pugzy@mail.com>