### PR TITLE
Fix observers interacting with block drops

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
@@ -229,7 +229,7 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onBlockPunch(PlayerPunchBlockEvent event) {
     final MatchPlayer player = match.getPlayer(event.getPlayer());
-    if (player == null) return;
+    if (player == null || !player.canInteract()) return;
 
     RayBlockIntersection hit = event.getRay();
 
@@ -249,7 +249,7 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onBlockTrample(PlayerTrampleBlockEvent event) {
     final MatchPlayer player = match.getPlayer(event.getPlayer());
-    if (player == null) return;
+    if (player == null || !player.canInteract()) return;
 
     BlockDrops drops =
         getRuleSet().getDrops(event, event.getBlock().getState(), player.getParticipantState());

--- a/util/src/main/java/tc/oc/pgm/util/listener/PlayerBlockListener.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/PlayerBlockListener.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.util.listener;
 
 import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.Event;
@@ -21,7 +20,6 @@ public class PlayerBlockListener implements Listener {
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerAnimation(final PlayerAnimationEvent event) {
     if (event.getAnimationType() != PlayerAnimationType.ARM_SWING) return;
-    if (event.getPlayer().getGameMode() != GameMode.ADVENTURE) return;
 
     // Client cannot punch blocks in adventure mode, so we detect it ourselves.
     RayBlockIntersection hit = event.getPlayer().getTargetedBlock(true, false);
@@ -33,8 +31,6 @@ public class PlayerBlockListener implements Listener {
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerCoarseMove(final PlayerCoarseMoveEvent event) {
     if (!event.getPlayer().isOnGround()) return;
-    if (!(event.getPlayer().getGameMode() == GameMode.SURVIVAL
-        || event.getPlayer().getGameMode() == GameMode.ADVENTURE)) return;
 
     Block block = event.getBlockTo().getBlock();
     if (!block.getType().isSolid()) {


### PR DESCRIPTION
Fixes #728 and allows any gamemode to punch and trample block drops as long as they can interact with the match (inside a team, playing, alive...)