### PR TITLE
Make ObjectiveModesModule weak dependency to Core/Destroyable modules

### DIFF
--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -72,8 +72,13 @@ public class CoreModule implements MapModule {
     private MapFactory factory;
 
     @Override
+    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+      return ImmutableList.of(ObjectiveModesModule.class);
+    }
+
+    @Override
     public Collection<Class<? extends MapModule>> getSoftDependencies() {
-      return ImmutableList.of(RegionModule.class, TeamModule.class, ObjectiveModesModule.class);
+      return ImmutableList.of(RegionModule.class, TeamModule.class);
     }
 
     @Override

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -70,12 +70,12 @@ public class DestroyableModule implements MapModule {
 
     @Override
     public Collection<Class<? extends MapModule>> getWeakDependencies() {
-      return ImmutableList.of(BlockDropsModule.class);
+      return ImmutableList.of(BlockDropsModule.class, ObjectiveModesModule.class);
     }
 
     @Override
     public Collection<Class<? extends MapModule>> getSoftDependencies() {
-      return ImmutableList.of(TeamModule.class, RegionModule.class, ObjectiveModesModule.class);
+      return ImmutableList.of(TeamModule.class, RegionModule.class);
     }
 
     @Override


### PR DESCRIPTION
The previous pull request made `ObjectiveModesModule.class` a SoftDependency which caused some problems, mostly that the core and destroyable does not respond to anything and nothing appears on the scoreboard.

I have actually tested this PR on maps with cores and monuments, both with and without `modes`. They work and it is tracked properly.