### PR TITLE
Reintroduce team switch kit

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -28,6 +28,7 @@ import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
 import tc.oc.pgm.events.PlayerParticipationStartEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
+import tc.oc.pgm.teams.TeamMatchModule;
 
 public class BlitzMatchModule implements MatchModule, Listener {
 
@@ -84,13 +85,17 @@ public class BlitzMatchModule implements MatchModule, Listener {
   public void handleLeave(final PlayerPartyChangeEvent event) {
     int lives = this.lifeManager.getLives(event.getPlayer().getId());
     if (event.getOldParty() instanceof Competitor && lives > 0) {
+      if (event.getNewParty() != null && event.getNewParty() instanceof Competitor)
+        return; // Team switch
       this.handleElimination(event.getPlayer(), (Competitor) event.getOldParty());
     }
   }
 
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void handleJoin(final PlayerParticipationStartEvent event) {
-    if (event.getMatch().isRunning()) {
+    MatchPlayer player = event.getPlayer();
+    TeamMatchModule tmm = player.getMatch().getModule(TeamMatchModule.class);
+    if (match.isRunning() && (tmm != null && !tmm.isForced(player))) {
       event.cancel(
           translatable(
               "blitz.joinDenied", translatable("gamemode.blitz.name", NamedTextColor.AQUA)));

--- a/core/src/main/java/tc/oc/pgm/command/TeamCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/TeamCommand.java
@@ -35,6 +35,7 @@ public final class TeamCommand {
     final MatchPlayer joiner = match.getPlayer(player);
     if (joiner == null) throw exception("command.playerNotFound");
 
+    teams.setForced(joiner, true);
     final Party oldParty = joiner.getParty();
     if (team == null) {
       teams.forceJoin(joiner, null);

--- a/core/src/main/java/tc/oc/pgm/kits/DelayedKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/DelayedKit.java
@@ -1,0 +1,29 @@
+package tc.oc.pgm.kits;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.api.player.MatchPlayer;
+
+public abstract class DelayedKit extends AbstractKit {
+
+  public abstract void applyDelayed(MatchPlayer player, boolean force);
+
+  @Override
+  public void applyPostEvent(MatchPlayer player, boolean force, List<ItemStack> displacedItems) {
+    Party party = player.getParty();
+    player
+        .getMatch()
+        .getExecutor(MatchScope.RUNNING)
+        .schedule(
+            () -> {
+              if (player.isAlive() && player.getParty().equals(party)) {
+                applyDelayed(player, force);
+              }
+            },
+            50,
+            TimeUnit.MILLISECONDS);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -678,11 +678,12 @@ public abstract class KitParser {
     Element el = XMLUtils.getUniqueChild(parent, "team-switch");
     if (el == null) return null;
 
+    boolean showTitle = XMLUtils.parseBoolean(el.getAttribute("title"), true);
     TeamFactory team = Teams.getTeam(el.getAttributeValue("team"), factory);
     if (team == null) {
       throw new InvalidXMLException(
           el.getAttributeValue("team") + " is not a valid team name!", el);
     }
-    return new TeamSwitchKit(team);
+    return new TeamSwitchKit(team, showTitle);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -46,6 +46,8 @@ import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.projectile.ProjectileDefinition;
 import tc.oc.pgm.shield.ShieldKit;
 import tc.oc.pgm.shield.ShieldParameters;
+import tc.oc.pgm.teams.TeamFactory;
+import tc.oc.pgm.teams.Teams;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -137,6 +139,7 @@ public abstract class KitParser {
     kits.add(this.parseFlyKit(el));
     kits.add(this.parseGameModeKit(el));
     kits.add(this.parseShieldKit(el));
+    kits.add(this.parseTeamSwitchKit(el));
     kits.addAll(this.parseRemoveKits(el));
 
     kits.removeAll(Collections.singleton((Kit) null)); // Remove any nulls returned above
@@ -669,5 +672,17 @@ public abstract class KitParser {
     Duration rechargeDelay =
         XMLUtils.parseDuration(el.getAttribute("delay"), ShieldParameters.DEFAULT_DELAY);
     return new ShieldKit(new ShieldParameters(health, rechargeDelay));
+  }
+
+  public TeamSwitchKit parseTeamSwitchKit(Element parent) throws InvalidXMLException {
+    Element el = XMLUtils.getUniqueChild(parent, "team-switch");
+    if (el == null) return null;
+
+    TeamFactory team = Teams.getTeam(el.getAttributeValue("team"), factory);
+    if (team == null) {
+      throw new InvalidXMLException(
+          el.getAttributeValue("team") + " is not a valid team name!", el);
+    }
+    return new TeamSwitchKit(team);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -678,7 +678,7 @@ public abstract class KitParser {
     Element el = XMLUtils.getUniqueChild(parent, "team-switch");
     if (el == null) return null;
 
-    boolean showTitle = XMLUtils.parseBoolean(el.getAttribute("title"), true);
+    boolean showTitle = XMLUtils.parseBoolean(el.getAttribute("show-title"), true);
     TeamFactory team = Teams.getTeam(el.getAttributeValue("team"), factory);
     if (team == null) {
       throw new InvalidXMLException(

--- a/core/src/main/java/tc/oc/pgm/kits/TeamSwitchKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/TeamSwitchKit.java
@@ -1,0 +1,23 @@
+package tc.oc.pgm.kits;
+
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.teams.TeamFactory;
+import tc.oc.pgm.teams.TeamMatchModule;
+
+public class TeamSwitchKit extends DelayedKit {
+
+  private final TeamFactory team;
+
+  public TeamSwitchKit(TeamFactory team) {
+    this.team = team;
+  }
+
+  @Override
+  public void applyDelayed(MatchPlayer player, boolean force) {
+    TeamMatchModule tmm = player.getMatch().getModule(TeamMatchModule.class);
+    if (tmm != null) {
+      tmm.setForced(player, true);
+      tmm.forceJoin(player, tmm.getTeam(team));
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/kits/TeamSwitchKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/TeamSwitchKit.java
@@ -7,17 +7,17 @@ import tc.oc.pgm.teams.TeamMatchModule;
 public class TeamSwitchKit extends DelayedKit {
 
   private final TeamFactory team;
+  private final boolean showTitle;
 
-  public TeamSwitchKit(TeamFactory team) {
+  public TeamSwitchKit(TeamFactory team, boolean showTitle) {
     this.team = team;
+    this.showTitle = showTitle;
   }
 
   @Override
   public void applyDelayed(MatchPlayer player, boolean force) {
-    TeamMatchModule tmm = player.getMatch().getModule(TeamMatchModule.class);
-    if (tmm != null) {
-      tmm.setForced(player, true);
-      tmm.forceJoin(player, tmm.getTeam(team));
-    }
+    TeamMatchModule tmm = player.getMatch().needModule(TeamMatchModule.class);
+    tmm.setTeamSwitchKit(player, showTitle, true);
+    tmm.forceJoin(player, tmm.getTeam(team));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -4,8 +4,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static net.kyori.adventure.key.Key.key;
 import static net.kyori.adventure.sound.Sound.sound;
+import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.title.Title.title;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,6 +21,8 @@ import javax.annotation.Nullable;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.title.Title.Times;
+import net.kyori.adventure.util.Ticks;
 import org.apache.commons.lang.math.Fraction;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -109,6 +113,9 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
 
   // Players who were forced into the match
   private final Set<MatchPlayer> forced = new HashSet<>();
+
+  // Players who are being switched between teams see TeamSwitchKit
+  private final Map<MatchPlayer, Boolean> teamSwitchKit = new HashMap<>();
 
   // Minimum at any time of the number of additional players needed to start the match
   private int minPlayersNeeded = Integer.MAX_VALUE;
@@ -241,6 +248,23 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
 
   public boolean isForced(MatchPlayer player) {
     return forced.contains(player);
+  }
+
+  public void setTeamSwitchKit(MatchPlayer player, boolean showTitle, boolean add) {
+    setForced(player, add);
+    if (add) {
+      teamSwitchKit.put(player, showTitle);
+    } else {
+      teamSwitchKit.remove(player);
+    }
+  }
+
+  public boolean hasTeamSwitchKit(MatchPlayer player) {
+    return teamSwitchKit.containsKey(player);
+  }
+
+  public boolean showTeamSwitchTitle(MatchPlayer player) {
+    return teamSwitchKit.getOrDefault(player, false);
   }
 
   public boolean canSwitchTeams(MatchPlayer joining) {
@@ -588,9 +612,28 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPartyChange(PlayerPartyChangeEvent event) {
+    MatchPlayer player = event.getPlayer();
+
     if (event.getNewParty() instanceof Team
         || (event.getNewParty() instanceof ObserverParty && event.getOldParty() != null)) {
-      event.getPlayer().sendMessage(translatable("join.ok.team", event.getNewParty().getName()));
+      Component joinMsg = translatable("join.ok.team", event.getNewParty().getName());
+      boolean title = false;
+
+      // Players with team switch kit, check for title value and remove from map
+      if (hasTeamSwitchKit(player)) {
+        title = showTeamSwitchTitle(player);
+        setTeamSwitchKit(player, false, false);
+      }
+
+      if (title) {
+        player.showTitle(
+            title(
+                space(),
+                joinMsg,
+                Times.of(Ticks.duration(5), Ticks.duration(20), Ticks.duration(5))));
+      } else {
+        player.sendMessage(joinMsg);
+      }
     }
 
     if (event.getNewParty() instanceof ObserverParty) {

--- a/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -625,7 +625,7 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
         setTeamSwitchKit(player, false, false);
       }
 
-      if (title) {
+      if (title && !player.isLegacy()) {
         player.showTitle(
             title(
                 space(),

--- a/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -107,6 +107,9 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
   // Players who autojoined their current team
   private final Set<MatchPlayer> autoJoins = new HashSet<>();
 
+  // Players who were forced into the match
+  private final Set<MatchPlayer> forced = new HashSet<>();
+
   // Minimum at any time of the number of additional players needed to start the match
   private int minPlayersNeeded = Integer.MAX_VALUE;
 
@@ -226,6 +229,18 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
 
   protected boolean isAutoJoin(MatchPlayer player) {
     return autoJoins.contains(player);
+  }
+
+  public void setForced(MatchPlayer player, boolean force) {
+    if (force) {
+      forced.add(player);
+    } else {
+      forced.remove(player);
+    }
+  }
+
+  public boolean isForced(MatchPlayer player) {
+    return forced.contains(player);
   }
 
   public boolean canSwitchTeams(MatchPlayer joining) {
@@ -576,6 +591,10 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
     if (event.getNewParty() instanceof Team
         || (event.getNewParty() instanceof ObserverParty && event.getOldParty() != null)) {
       event.getPlayer().sendMessage(translatable("join.ok.team", event.getNewParty().getName()));
+    }
+
+    if (event.getNewParty() instanceof ObserverParty) {
+      setForced(event.getPlayer(), false);
     }
     updateReadiness();
   }


### PR DESCRIPTION
# Reintroduce Team Switch Kit

Quick PR to reimplement the team switch kit back into PGM. Also funny enough this fixes #732 

Thanks to @CrazyisCreeps for helping me test 😄 

A little background, this kit is primarily used for the Infection gamemode. But also could have some nifty applications when applied to new maps 😁  

## Example XML:
```xml
 <kit id="switch-to-apple-team" force="true">
     <team-switch team="apples" title="true"/>
 </kit>
```

## Video
Updated

https://user-images.githubusercontent.com/3377659/107834175-5ff79280-6d4a-11eb-8a8a-489bf0d86a22.mp4

Original Video

https://user-images.githubusercontent.com/3377659/107683199-25143280-6c56-11eb-8d2d-bd1c71e4fe2f.mp4


Signed-off-by: applenick <applenick@users.noreply.github.com>