### PR TITLE
Rework stats and allow showing own stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ ops.json
 help.yml
 server.properties
 sportpaper.yml
+sportpaper.jar
 update
 usercache.json
 whitelist.json

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -87,6 +87,9 @@ public final class PGMConfig implements Config {
   private final boolean showFireworks;
   private final boolean participantsSeeObservers;
   private final boolean verboseStats;
+  private final Integer statsShowAfter;
+  private final boolean statsShowHigh;
+  private final boolean statsShowOwn;
 
   // sidebar.*
   private final Component header;
@@ -161,7 +164,6 @@ public final class PGMConfig implements Config {
     this.matchLimit = parseInteger(config.getString("restart.match-limit", "30"));
 
     this.woolRefill = parseBoolean(config.getString("gameplay.refill-wool", "true"));
-    this.verboseStats = parseBoolean(config.getString("ui.verbose-stats", "false"));
     this.griefScore =
         parseInteger(config.getString("gameplay.grief-score", "-10"), Range.atMost(0));
 
@@ -180,6 +182,10 @@ public final class PGMConfig implements Config {
         parseBoolean(config.getString("ui.participants-see-observers", "true"));
     this.showFireworks = parseBoolean(config.getString("ui.fireworks", "true"));
     this.flagBeams = parseBoolean(config.getString("ui.flag-beams", "false"));
+    this.verboseStats = parseBoolean(config.getString("ui.verbose-stats", "false"));
+    this.statsShowAfter = parseInteger(config.getString("ui.stats.show-after", "120"));
+    this.statsShowHigh = parseBoolean(config.getString("ui.stats.show-high", "true"));
+    this.statsShowOwn = parseBoolean(config.getString("ui.stats.show-own", "true"));
 
     final String header = config.getString("sidebar.header");
     this.header = header == null || header.isEmpty() ? null : parseComponent(header);
@@ -558,10 +564,6 @@ public final class PGMConfig implements Config {
     return participantsSeeObservers;
   }
 
-  public boolean showVerboseStats() {
-    return verboseStats;
-  }
-
   @Override
   public boolean canAnytimeJoin() {
     return anytimeJoin;
@@ -575,6 +577,25 @@ public final class PGMConfig implements Config {
   @Override
   public boolean useLegacyFlagBeams() {
     return flagBeams;
+  }
+
+  public boolean showVerboseStats() {
+    return verboseStats;
+  }
+
+  @Override
+  public int showStatsAfter() {
+    return statsShowAfter;
+  }
+
+  @Override
+  public boolean showHighStats() {
+    return statsShowHigh;
+  }
+
+  @Override
+  public boolean showOwnStats() {
+    return statsShowOwn;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -87,7 +87,7 @@ public final class PGMConfig implements Config {
   private final boolean showFireworks;
   private final boolean participantsSeeObservers;
   private final boolean verboseStats;
-  private final Integer statsShowAfter;
+  private final Duration statsShowAfter;
   private final boolean statsShowBest;
   private final boolean statsShowOwn;
 
@@ -182,10 +182,11 @@ public final class PGMConfig implements Config {
         parseBoolean(config.getString("ui.participants-see-observers", "true"));
     this.showFireworks = parseBoolean(config.getString("ui.fireworks", "true"));
     this.flagBeams = parseBoolean(config.getString("ui.flag-beams", "false"));
-    this.verboseStats = parseBoolean(config.getString("ui.verbose-stats", "false"));
-    this.statsShowAfter = parseInteger(config.getString("ui.stats.show-after", "120"));
-    this.statsShowBest = parseBoolean(config.getString("ui.stats.show-best", "true"));
-    this.statsShowOwn = parseBoolean(config.getString("ui.stats.show-own", "true"));
+
+    this.verboseStats = parseBoolean(config.getString("stats.verbose", "true"));
+    this.statsShowAfter = parseDuration(config.getString("stats.show-after", "6s"));
+    this.statsShowBest = parseBoolean(config.getString("stats.show-best", "true"));
+    this.statsShowOwn = parseBoolean(config.getString("stats.show-own", "true"));
 
     final String header = config.getString("sidebar.header");
     this.header = header == null || header.isEmpty() ? null : parseComponent(header);
@@ -584,7 +585,7 @@ public final class PGMConfig implements Config {
   }
 
   @Override
-  public int showStatsAfter() {
+  public Duration showStatsAfter() {
     return statsShowAfter;
   }
 

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -88,7 +88,7 @@ public final class PGMConfig implements Config {
   private final boolean participantsSeeObservers;
   private final boolean verboseStats;
   private final Integer statsShowAfter;
-  private final boolean statsShowHigh;
+  private final boolean statsShowBest;
   private final boolean statsShowOwn;
 
   // sidebar.*
@@ -184,7 +184,7 @@ public final class PGMConfig implements Config {
     this.flagBeams = parseBoolean(config.getString("ui.flag-beams", "false"));
     this.verboseStats = parseBoolean(config.getString("ui.verbose-stats", "false"));
     this.statsShowAfter = parseInteger(config.getString("ui.stats.show-after", "120"));
-    this.statsShowHigh = parseBoolean(config.getString("ui.stats.show-high", "true"));
+    this.statsShowBest = parseBoolean(config.getString("ui.stats.show-best", "true"));
     this.statsShowOwn = parseBoolean(config.getString("ui.stats.show-own", "true"));
 
     final String header = config.getString("sidebar.header");
@@ -589,8 +589,8 @@ public final class PGMConfig implements Config {
   }
 
   @Override
-  public boolean showHighStats() {
-    return statsShowHigh;
+  public boolean showBestStats() {
+    return statsShowBest;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -229,7 +229,7 @@ public interface Config {
   boolean showVerboseStats();
 
   /** @return How many ticks should wait until showing stats */
-  int showStatsAfter();
+  Duration showStatsAfter();
 
   /** @return If stats on match end should shown high scores */
   boolean showBestStats();

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -222,6 +222,22 @@ public interface Config {
   boolean useLegacyFlagBeams();
 
   /**
+   * Gets whether to show a more verbose representation of the match stats at the end of each match
+   *
+   * @return If verbose stats at the end of the match is enabled
+   */
+  boolean showVerboseStats();
+
+  /** @return How many ticks should wait until showing stats */
+  int showStatsAfter();
+
+  /** @return If stats on match end should shown high scores */
+  boolean showHighStats();
+
+  /** @return If stats on match end should show your own stats */
+  boolean showOwnStats();
+
+  /**
    * Gets a format to override the server's "message of the day."
    *
    * <p>{0} = The existing MoTD.
@@ -241,13 +257,6 @@ public interface Config {
    * @return If wool auto refill is enabled.
    */
   boolean shouldRefillWool();
-
-  /**
-   * Gets whether to show a more verbose representation of the match stats at the end of each match
-   *
-   * @return If verbose stats at the end of the match is enabled
-   */
-  boolean showVerboseStats();
 
   /**
    * Gets at which score players should be no longer allowed to keep playing TDM

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -232,7 +232,7 @@ public interface Config {
   int showStatsAfter();
 
   /** @return If stats on match end should shown high scores */
-  boolean showHighStats();
+  boolean showBestStats();
 
   /** @return If stats on match end should show your own stats */
   boolean showOwnStats();

--- a/core/src/main/java/tc/oc/pgm/api/match/event/MatchStatsEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/match/event/MatchStatsEvent.java
@@ -1,17 +1,16 @@
-package tc.oc.pgm.stats;
+package tc.oc.pgm.api.match.event;
 
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.event.MatchEvent;
 
-public class StatsDisplayEvent extends MatchEvent implements Cancellable {
+public class MatchStatsEvent extends MatchEvent implements Cancellable {
 
   private boolean cancelled = false;
   private boolean showBest;
   private boolean showOwn;
 
-  public StatsDisplayEvent(Match match, boolean showBest, boolean showOwn) {
+  public MatchStatsEvent(Match match, boolean showBest, boolean showOwn) {
     super(match);
     this.showBest = showBest;
     this.showOwn = showOwn;

--- a/core/src/main/java/tc/oc/pgm/stats/StatsDisplayEvent.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsDisplayEvent.java
@@ -1,0 +1,56 @@
+package tc.oc.pgm.stats;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.event.MatchEvent;
+
+public class StatsDisplayEvent extends MatchEvent implements Cancellable {
+
+  private boolean cancelled = false;
+  private boolean showHigh;
+  private boolean showOwn;
+
+  public StatsDisplayEvent(Match match, boolean showHigh, boolean showOwn) {
+    super(match);
+    this.showHigh = showHigh;
+    this.showOwn = showOwn;
+  }
+
+  public boolean isShowHigh() {
+    return showHigh;
+  }
+
+  public void setShowHigh(boolean showHigh) {
+    this.showHigh = showHigh;
+  }
+
+  public boolean isShowOwn() {
+    return showOwn;
+  }
+
+  public void setShowOwn(boolean showOwn) {
+    this.showOwn = showOwn;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return cancelled;
+  }
+
+  @Override
+  public void setCancelled(boolean cancelled) {
+    this.cancelled = cancelled;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/stats/StatsDisplayEvent.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsDisplayEvent.java
@@ -8,21 +8,21 @@ import tc.oc.pgm.api.match.event.MatchEvent;
 public class StatsDisplayEvent extends MatchEvent implements Cancellable {
 
   private boolean cancelled = false;
-  private boolean showHigh;
+  private boolean showBest;
   private boolean showOwn;
 
-  public StatsDisplayEvent(Match match, boolean showHigh, boolean showOwn) {
+  public StatsDisplayEvent(Match match, boolean showBest, boolean showOwn) {
     super(match);
-    this.showHigh = showHigh;
+    this.showBest = showBest;
     this.showOwn = showOwn;
   }
 
-  public boolean isShowHigh() {
-    return showHigh;
+  public boolean isShowBest() {
+    return showBest;
   }
 
-  public void setShowHigh(boolean showHigh) {
-    this.showHigh = showHigh;
+  public void setShowBest(boolean showBest) {
+    this.showBest = showBest;
   }
 
   public boolean isShowOwn() {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -76,6 +76,10 @@ ui:
   participants-see-observers: true # Can participants see observers in the tab list?
   flag-beams: false # Should everyone see floating wool flag beams?
   verbose-stats: false # Enable more thorough stats at the end of each match
+  stats:
+    show-after: 120 # Ticks to wait to show stats
+    shown-high: true # Should the leaderboards show
+    show-own: true   # Should your own stats show
 
 # Overrides the header and footer of the side bar.
 sidebar:

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -75,11 +75,13 @@ ui:
   fireworks: true  # Spawn fireworks after objectives are completed?
   participants-see-observers: true # Can participants see observers in the tab list?
   flag-beams: false # Should everyone see floating wool flag beams?
-  verbose-stats: false # Enable more thorough stats at the end of each match
-  stats:
-    show-after: 120 # Ticks to wait to show stats
-    shown-best: true # Should each best stat for anyone in the match show
-    show-own: true   # Should your own stats show
+
+# Changes how stats are shown.
+stats:
+  verbose: true   # Enable more detailed stats?
+  show-after: 6s  # How long to wait after the match ends to show stats?
+  show-best: true # Should show best players stats?
+  show-own: true  # Should show each players own stats?
 
 # Overrides the header and footer of the side bar.
 sidebar:

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -78,7 +78,7 @@ ui:
   verbose-stats: false # Enable more thorough stats at the end of each match
   stats:
     show-after: 120 # Ticks to wait to show stats
-    shown-high: true # Should the leaderboards show
+    shown-best: true # Should each best stat for anyone in the match show
     show-own: true   # Should your own stats show
 
 # Overrides the header and footer of the side bar.

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -56,6 +56,13 @@ match.stats = Kills: {0}  |  Killstreak: {1}  |  Deaths: {2}  |  K/D: {3}
 # {2} = numbers of kills divided by the number of deaths (kill-death ratio)
 match.stats.concise = Kills: {0}  Deaths: {1}  K/D: {2}
 
+# {0} = number of kills
+# {1} = number of consecutive kills
+# {2} = number of deaths
+# {3} = numbers of kills divided by the number of deaths (kill-death ratio)
+# {4} = an amount of damage
+match.stats.own = Your stats: {0} Kills ({1}), {2} Deaths, {3} K/D, {4} Damage
+
 # {0} = a player name
 # {1} = an amount of kills(number)
 match.stats.kills = Kills: {1} by {0}


### PR DESCRIPTION
Moves the stats displaying to an event, which can be cancelled or thrown by 3rd party plugins to decide when stats show, additionally, PGM has a config for when it automatically should be shown, and the event itself has settings for what to show.

![image](https://user-images.githubusercontent.com/11789291/107857623-b25eaf00-6e2f-11eb-8245-8c63db84c95f.png)
(the pic is in spanish due to local server but it shouldn't be a big issue)