### PR TITLE
Fix freeze title duration NPE

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/community/modules/FreezeMatchModule.java
@@ -10,7 +10,7 @@ import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.event.ClickEvent.runCommand;
 import static net.kyori.adventure.text.event.HoverEvent.showText;
 import static net.kyori.adventure.title.Title.title;
-import static tc.oc.pgm.util.TimeUtils.INFINITE_DURATION;
+import static tc.oc.pgm.util.TimeUtils.MAX_TICK;
 import static tc.oc.pgm.util.TimeUtils.fromTicks;
 
 import com.google.common.cache.Cache;
@@ -358,7 +358,7 @@ public class FreezeMatchModule implements MatchModule, Listener {
         freezee.sendWarning(title);
       } else {
         freezee.showTitle(
-            title(empty(), title, Title.Times.of(fromTicks(5), INFINITE_DURATION, fromTicks(5))));
+            title(empty(), title, Title.Times.of(fromTicks(5), fromTicks(MAX_TICK), fromTicks(5))));
       }
       freezee.playSound(FREEZE_SOUND);
 


### PR DESCRIPTION
# Freeze NPE

Just a super quick PR, resolves an NPE thrown when sending a freeze title to player.
Switched it to use `MAX_TICK` instead of `INFINITE_DURATION`

However, just a note, freeze will be removed from PGM once the community branch is merged 😉 

Signed-off-by: applenick <applenick@users.noreply.github.com>