### PR TITLE
Add queued restart countdown time config option

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -61,6 +61,7 @@ public final class PGMConfig implements Config {
   private final Duration startTime;
   private final Duration huddleTime;
   private final Duration cycleTime;
+  private final Duration restartTime;
 
   // restart.*
   private final Duration uptimeLimit;
@@ -159,6 +160,7 @@ public final class PGMConfig implements Config {
     this.startTime = parseDuration(config.getString("countdown.start", "30s"));
     this.huddleTime = parseDuration(config.getString("countdown.huddle", "0s"));
     this.cycleTime = parseDuration(config.getString("countdown.cycle", "30s"));
+    this.restartTime = parseDuration(config.getString("countdown.restart", "30s"));
 
     this.uptimeLimit = parseDuration(config.getString("restart.uptime", "1d"));
     this.matchLimit = parseInteger(config.getString("restart.match-limit", "30"));
@@ -473,6 +475,11 @@ public final class PGMConfig implements Config {
   @Override
   public Duration getCycleTime() {
     return cycleTime;
+  }
+
+  @Override
+  public Duration getRestartTime() {
+    return restartTime;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -82,6 +82,13 @@ public interface Config {
   Duration getCycleTime();
 
   /**
+   * Gets a duration to wait before restarting the server.
+   *
+   * @return A duration.
+   */
+  Duration getRestartTime();
+
+  /**
    * Gets a duration to wait before the server should restart.
    *
    * @return A duration, disabled if non-positive.

--- a/core/src/main/java/tc/oc/pgm/command/RestartCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/RestartCommand.java
@@ -3,9 +3,9 @@ package tc.oc.pgm.command;
 import static net.kyori.adventure.text.Component.translatable;
 
 import app.ashcon.intake.Command;
-import app.ashcon.intake.parametric.annotation.Default;
 import app.ashcon.intake.parametric.annotation.Switch;
 import java.time.Duration;
+import javax.annotation.Nullable;
 import net.kyori.adventure.text.format.NamedTextColor;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
@@ -21,10 +21,7 @@ public final class RestartCommand {
       flags = "f",
       perms = Permissions.STOP)
   public void restart(
-      Audience audience,
-      Match match,
-      @Default("30s") Duration duration,
-      @Switch('f') boolean force) {
+      Audience audience, Match match, @Nullable Duration duration, @Switch('f') boolean force) {
     RestartManager.queueRestart("Restart requested via /queuerestart command", duration);
 
     if (force && match.isRunning()) {

--- a/core/src/main/java/tc/oc/pgm/restart/RestartListener.java
+++ b/core/src/main/java/tc/oc/pgm/restart/RestartListener.java
@@ -61,7 +61,7 @@ public class RestartListener implements Listener {
           Duration countdownTime =
               RestartManager.getCountdown() != null
                   ? RestartManager.getCountdown()
-                  : Duration.ofSeconds(30);
+                  : PGM.get().getConfiguration().getRestartTime();
           this.logger.info("Starting restart countdown from " + countdownTime);
           ctx.start(new RestartCountdown(match), countdownTime);
         }

--- a/core/src/main/java/tc/oc/pgm/restart/RestartManager.java
+++ b/core/src/main/java/tc/oc/pgm/restart/RestartManager.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
+import tc.oc.pgm.api.PGM;
 
 public class RestartManager {
 
@@ -16,19 +17,15 @@ public class RestartManager {
 
   /** Queues a restart to be initiated at next available opportunity. */
   public static boolean queueRestart(String reason) {
-    if (!isQueued()) {
-      RestartManager.queuedAt = Instant.now();
-      RestartManager.reason = reason;
-      return true;
-    }
-    return false;
+    return queueRestart(reason, null);
   }
 
-  public static boolean queueRestart(String reason, Duration countdown) {
+  public static boolean queueRestart(String reason, @Nullable Duration countdown) {
     if (!isQueued()) {
       RestartManager.queuedAt = Instant.now();
       RestartManager.reason = reason;
-      RestartManager.countdown = countdown;
+      RestartManager.countdown =
+          (countdown != null) ? countdown : PGM.get().getConfiguration().getRestartTime();
       return true;
     }
     return false;

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -44,6 +44,7 @@ countdown:
   start: "30s"    # After a match cycles or /start
   cycle: "30s"    # After a match ends or /cycle
   huddle: -1      # Before a match starts (only recommended for "ranked" matches)
+  restart: "30s"  # After a restart countdown is queued or /qr
 
 # Sets thresholds for when to restart the server.
 #


### PR DESCRIPTION
This allows you to configure the amount of time a restart countdown will take.
Within ranked we wish to restart the servers quicker than the typical 30 seconds but this option is not currently configurable.

This config option already exists for start, cycle, and huddle countdowns. This extends it to restart countdowns too.

```
countdown:
  start: "30s"    # After a match cycles or /start
  cycle: "30s"    # After a match ends or /cycle
  huddle: -1      # Before a match starts (only recommended for "ranked" matches)
  restart: "30s"  # After a restart countdown is queued or /qr
```

This value will be used as the default for the `queuerestart` command (unless a time is specified) and for automated restarts.

Happy for suggestions on the config hint and `Config` interface docblock to avoid confusion with the `getMatchLimit` value.

Signed-off-by: Pugzy <pugzy@mail.com>