### PR TITLE
Add Effect Filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/EffectFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/EffectFilter.java
@@ -1,22 +1,21 @@
 package tc.oc.pgm.filters;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
 import java.util.Collection;
 import org.bukkit.potion.PotionEffect;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.player.MatchPlayer;
 
-public class HasEffectFilter extends ParticipantFilter {
+public class EffectFilter extends ParticipantFilter {
   protected final PotionEffect base;
-  // min/max duration are stored in ticks
-  protected final long minDuration;
-  protected final long maxDuration;
+  // duration is stored in ticks
+  protected final Range<Long> duration;
   protected final boolean amplifier;
 
-  public HasEffectFilter(PotionEffect base, long minDuration, long maxDuration, boolean amplifier) {
+  public EffectFilter(PotionEffect base, Range<Long> duration, boolean amplifier) {
     this.base = Preconditions.checkNotNull(base);
-    this.minDuration = minDuration;
-    this.maxDuration = maxDuration;
+    this.duration = duration;
     this.amplifier = amplifier;
   }
 
@@ -31,8 +30,7 @@ public class HasEffectFilter extends ParticipantFilter {
 
       if (effect.getType().equals(base.getType())
           && (!amplifier || (effect.getAmplifier() == base.getAmplifier()))
-          && ((minDuration == -1) || (effect.getDuration() >= minDuration))
-          && ((maxDuration == -1) || (effect.getDuration() <= maxDuration))) {
+          && duration.contains((long) effect.getDuration())) {
         return QueryResponse.ALLOW;
       }
     }

--- a/core/src/main/java/tc/oc/pgm/filters/EffectFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/EffectFilter.java
@@ -10,10 +10,10 @@ import tc.oc.pgm.api.player.MatchPlayer;
 public class EffectFilter extends ParticipantFilter {
   protected final PotionEffect base;
   // duration is stored in ticks
-  protected final Range<Long> duration;
+  protected final Range<Integer> duration;
   protected final boolean amplifier;
 
-  public EffectFilter(PotionEffect base, Range<Long> duration, boolean amplifier) {
+  public EffectFilter(PotionEffect base, Range<Integer> duration, boolean amplifier) {
     this.base = Preconditions.checkNotNull(base);
     this.duration = duration;
     this.amplifier = amplifier;
@@ -30,7 +30,7 @@ public class EffectFilter extends ParticipantFilter {
 
       if (effect.getType().equals(base.getType())
           && (!amplifier || (effect.getAmplifier() == base.getAmplifier()))
-          && duration.contains((long) effect.getDuration())) {
+          && duration.contains(effect.getDuration())) {
         return QueryResponse.ALLOW;
       }
     }

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.filters;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -472,15 +473,14 @@ public abstract class FilterParser {
 
   @MethodParser("effect")
   public HasEffectFilter parseHasEffect(Element el) throws InvalidXMLException {
-    Attribute minAttribute = el.getAttribute("min-duration");
-    Attribute maxAttribute = el.getAttribute("max-duration");
-    Attribute amplifierAttribute = el.getAttribute("amplifier");
-    long minDuration =
-        minAttribute != null ? XMLUtils.parseDuration(minAttribute).getSeconds() * 20 : -1;
-    long maxDuration =
-        maxAttribute != null ? XMLUtils.parseDuration(maxAttribute).getSeconds() * 20 : -1;
-    boolean amplifier = (amplifierAttribute != null);
-    return new HasEffectFilter(XMLUtils.parsePotionEffect(el), minDuration, maxDuration, amplifier);
+    Duration minDuration = XMLUtils.parseDuration(Node.fromAttr(el, "min-duration"));
+    Duration maxDuration = XMLUtils.parseDuration(Node.fromAttr(el, "max-duration"));
+    boolean amplifier = Node.fromAttr(el, "amplifier") != null ? true : false;
+    return new HasEffectFilter(
+        XMLUtils.parsePotionEffect(el),
+        minDuration != null ? minDuration.getSeconds() * 20 : -1,
+        maxDuration != null ? maxDuration.getSeconds() * 20 : -1,
+        amplifier);
   }
 
   @MethodParser("structural-load")

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -444,13 +444,17 @@ public abstract class FilterParser {
     return new WearingItemFilter(factory.getKits().parseRequiredItem(el));
   }
 
-  @MethodParser("has-effect")
+  @MethodParser("effect")
   public HasEffectFilter parseHasEffect(Element el) throws InvalidXMLException {
-    Element effect = el.getChild("effect");
-    if (effect == null) {
-      throw new InvalidXMLException("Effect expected", el);
-    }
-    return new HasEffectFilter(XMLUtils.parsePotionEffect(effect));
+    Attribute minAttribute = el.getAttribute("min-duration");
+    Attribute maxAttribute = el.getAttribute("max-duration");
+    Attribute amplifierAttribute = el.getAttribute("amplifier");
+    long minDuration =
+        minAttribute != null ? XMLUtils.parseDuration(minAttribute).getSeconds() * 20 : -1;
+    long maxDuration =
+        maxAttribute != null ? XMLUtils.parseDuration(maxAttribute).getSeconds() * 20 : -1;
+    boolean amplifier = (amplifierAttribute != null);
+    return new HasEffectFilter(XMLUtils.parsePotionEffect(el), minDuration, maxDuration, amplifier);
   }
 
   @MethodParser("structural-load")

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -444,6 +444,15 @@ public abstract class FilterParser {
     return new WearingItemFilter(factory.getKits().parseRequiredItem(el));
   }
 
+  @MethodParser("has-effect")
+  public HasEffectFilter parseHasEffect(Element el) throws InvalidXMLException {
+    Element effect = el.getChild("effect");
+    if (effect == null) {
+      throw new InvalidXMLException("Effect expected", el);
+    }
+    return new HasEffectFilter(XMLUtils.parsePotionEffect(effect));
+  }
+
   @MethodParser("structural-load")
   public StructuralLoadFilter parseStructuralLoad(Element el) throws InvalidXMLException {
     return new StructuralLoadFilter(XMLUtils.parseNumber(el, Integer.class));

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -475,15 +475,17 @@ public abstract class FilterParser {
   public EffectFilter parseEffect(Element el) throws InvalidXMLException {
     Duration minDuration = XMLUtils.parseDuration(Node.fromAttr(el, "min-duration"));
     Duration maxDuration = XMLUtils.parseDuration(Node.fromAttr(el, "max-duration"));
-    Range<Long> duration;
+    Range<Integer> duration;
     if (minDuration == null && maxDuration == null) {
       duration = Range.all();
     } else if (minDuration == null) {
-      duration = Range.atMost(maxDuration.getSeconds() * 20);
+      duration = Range.atMost((int) (maxDuration.getSeconds() * 20));
     } else if (maxDuration == null) {
-      duration = Range.atLeast(minDuration.getSeconds() * 20);
+      duration = Range.atLeast((int) (minDuration.getSeconds() * 20));
     } else {
-      duration = Range.closed(minDuration.getSeconds() * 20, maxDuration.getSeconds() * 20);
+      duration =
+          Range.closed(
+              (int) (minDuration.getSeconds() * 20), (int) (maxDuration.getSeconds() * 20));
     }
     boolean amplifier = Node.fromAttr(el, "amplifier") != null;
     return new EffectFilter(XMLUtils.parsePotionEffect(el), duration, amplifier);

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -472,15 +472,21 @@ public abstract class FilterParser {
   }
 
   @MethodParser("effect")
-  public HasEffectFilter parseHasEffect(Element el) throws InvalidXMLException {
+  public EffectFilter parseEffect(Element el) throws InvalidXMLException {
     Duration minDuration = XMLUtils.parseDuration(Node.fromAttr(el, "min-duration"));
     Duration maxDuration = XMLUtils.parseDuration(Node.fromAttr(el, "max-duration"));
-    boolean amplifier = Node.fromAttr(el, "amplifier") != null ? true : false;
-    return new HasEffectFilter(
-        XMLUtils.parsePotionEffect(el),
-        minDuration != null ? minDuration.getSeconds() * 20 : -1,
-        maxDuration != null ? maxDuration.getSeconds() * 20 : -1,
-        amplifier);
+    Range<Long> duration;
+    if (minDuration == null && maxDuration == null) {
+      duration = Range.all();
+    } else if (minDuration == null) {
+      duration = Range.atMost(maxDuration.getSeconds() * 20);
+    } else if (maxDuration == null) {
+      duration = Range.atLeast(minDuration.getSeconds() * 20);
+    } else {
+      duration = Range.closed(minDuration.getSeconds() * 20, maxDuration.getSeconds() * 20);
+    }
+    boolean amplifier = Node.fromAttr(el, "amplifier") != null;
+    return new EffectFilter(XMLUtils.parsePotionEffect(el), duration, amplifier);
   }
 
   @MethodParser("structural-load")

--- a/core/src/main/java/tc/oc/pgm/filters/HasEffectFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/HasEffectFilter.java
@@ -8,9 +8,16 @@ import tc.oc.pgm.api.player.MatchPlayer;
 
 public class HasEffectFilter extends ParticipantFilter {
   protected final PotionEffect base;
+  // min/max duration are stored in ticks
+  protected final long minDuration;
+  protected final long maxDuration;
+  protected final boolean amplifier;
 
-  public HasEffectFilter(PotionEffect base) {
+  public HasEffectFilter(PotionEffect base, long minDuration, long maxDuration, boolean amplifier) {
     this.base = Preconditions.checkNotNull(base);
+    this.minDuration = minDuration;
+    this.maxDuration = maxDuration;
+    this.amplifier = amplifier;
   }
 
   protected Collection<PotionEffect> getEffects(MatchPlayer player) {
@@ -22,11 +29,10 @@ public class HasEffectFilter extends ParticipantFilter {
     for (PotionEffect effect : getEffects(player)) {
       if (effect == null) continue;
 
-      // Match if the effects are the same type and amplifier, and if the player has at least the
-      // desired duration left.
       if (effect.getType().equals(base.getType())
-          && (effect.getAmplifier() == base.getAmplifier())
-          && (effect.getDuration() >= base.getDuration())) {
+          && (!amplifier || (effect.getAmplifier() == base.getAmplifier()))
+          && ((minDuration == -1) || (effect.getDuration() >= minDuration))
+          && ((maxDuration == -1) || (effect.getDuration() <= maxDuration))) {
         return QueryResponse.ALLOW;
       }
     }

--- a/core/src/main/java/tc/oc/pgm/filters/HasEffectFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/HasEffectFilter.java
@@ -1,0 +1,36 @@
+package tc.oc.pgm.filters;
+
+import com.google.common.base.Preconditions;
+import java.util.Collection;
+import org.bukkit.potion.PotionEffect;
+import tc.oc.pgm.api.filter.query.PlayerQuery;
+import tc.oc.pgm.api.player.MatchPlayer;
+
+public class HasEffectFilter extends ParticipantFilter {
+  protected final PotionEffect base;
+
+  public HasEffectFilter(PotionEffect base) {
+    this.base = Preconditions.checkNotNull(base);
+  }
+
+  protected Collection<PotionEffect> getEffects(MatchPlayer player) {
+    return player.getBukkit().getActivePotionEffects();
+  }
+
+  @Override
+  protected QueryResponse queryPlayer(PlayerQuery query, MatchPlayer player) {
+    for (PotionEffect effect : getEffects(player)) {
+      if (effect == null) continue;
+
+      // Match if the effects are the same type and amplifier, and if the player has at least the
+      // desired duration left.
+      if (effect.getType().equals(base.getType())
+          && (effect.getAmplifier() == base.getAmplifier())
+          && (effect.getDuration() >= base.getDuration())) {
+        return QueryResponse.ALLOW;
+      }
+    }
+
+    return QueryResponse.DENY;
+  }
+}


### PR DESCRIPTION
The new `effect` filter returns `ALLOW` if the player has an effect of the same type as the filter. If a mapmaker wants to be more selective, there are three optional attributes: `min-duration`, `max-duration`, and `amplifier`.

Syntax example:
```xml
<filters>
    <effect id="filter1" min-duration="10s" amplifier="1">saturation</effect>
    <effect id="filter2">saturation</effect>
    <effect id="filter3" max-duration="30s" amplifier="2">night vision</effect>
    <effect id="filter4" amplifier="1">water breathing</effect>
    <effect id="filter5" min-duration="10s" max-duration="20s" amplifier="2">night vision</effect>
</filters>
```