### PR TITLE
Fix errors when no mappool exists

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -170,11 +170,12 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
       }
     }
 
-    if (config.getMapPoolFile() == null) {
-      mapOrder = new RandomMapOrder(Lists.newArrayList(mapLibrary.getMaps()));
-    } else {
-      mapOrder = new MapPoolManager(logger, new File(config.getMapPoolFile()), datastore);
+    if (config.getMapPoolFile() != null) {
+      MapPoolManager manager =
+          new MapPoolManager(logger, new File(config.getMapPoolFile()), datastore);
+      if (manager.getActiveMapPool() != null) mapOrder = manager;
     }
+    if (mapOrder == null) mapOrder = new RandomMapOrder(Lists.newArrayList(mapLibrary.getMaps()));
 
     // FIXME: To avoid startup lag, we "prefetch" usernames after map pools are loaded.
     // Change MapPoolManager so it doesn't depend on all maps being loaded.

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -232,7 +232,7 @@ public class MapPoolManager implements MapOrder {
   @Override
   public void setNextMap(MapInfo map) {
     overriderMap = map;
-    activeMapPool.setNextMap(map); // Notify pool a next map has been set
+    if (activeMapPool != null) activeMapPool.setNextMap(map); // Notify pool a next map has been set
   }
 
   @Override


### PR DESCRIPTION
Currently if you have a mappool file defined (which is a PGM default) but the mappools file doesn't exist or has no valid maps, you are using a mappool manager without an active pool, making /sn or /cycle 5 map throws a NPE. 

This prevents the NPE as well as making is so if there's no active pool it loads a random map order, which should be the normal fallback behaviour for servers that don't require normal pools