### PR TITLE
Fix match end stats showing current killstreak instead of max

### DIFF
--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -268,7 +268,7 @@ public class StatsMatchModule implements MatchModule, Listener {
             translatable(
                 "match.stats.own",
                 numberComponent(stats.getKills(), NamedTextColor.GREEN),
-                numberComponent(stats.getKillstreak(), NamedTextColor.GREEN)
+                numberComponent(stats.getMaxKillstreak(), NamedTextColor.GREEN)
                     .hoverEvent(showText(ksHover)),
                 numberComponent(stats.getDeaths(), NamedTextColor.RED),
                 numberComponent(stats.getKD(), NamedTextColor.GREEN),


### PR DESCRIPTION
Currently on match end invidivual stats, it shows your current killstreak instead of your max