### PR TITLE
Fix various issues with player stats

### DIFF
--- a/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
@@ -10,7 +10,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
 /** A wrapper for stat info belonging to a {@link tc.oc.pgm.api.player.MatchPlayer} */
-class PlayerStats {
+public class PlayerStats {
   // K/D
   private int kills;
   private int deaths;

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -95,13 +95,19 @@ public class StatsMatchModule implements MatchModule, Listener {
     ParticipantState damager =
         match.needModule(TrackerMatchModule.class).getOwner(event.getDamager());
     ParticipantState damaged = match.getParticipantState(event.getEntity());
-    if ((damaged != null && damager != null) && damaged.getId() == damager.getId()) return;
+
+    // Prevent tracking damage to entities or self
+    if (damaged == null || (damager != null && damaged.getId() == damager.getId())) return;
+
     boolean bow = event.getDamager() instanceof Arrow;
     // Absorbed damage gets removed so we add it back
+    double absorptionHearts = -event.getDamage(EntityDamageEvent.DamageModifier.ABSORPTION);
     double realFinalDamage =
-        event.getFinalDamage() - event.getDamage(EntityDamageEvent.DamageModifier.ABSORPTION);
+        Math.min(event.getFinalDamage(), ((Player) event.getEntity()).getHealth())
+            + absorptionHearts;
+
     if (damager != null) getPlayerStat(damager).onDamage(realFinalDamage, bow);
-    if (damaged != null) getPlayerStat(damaged).onDamaged(realFinalDamage);
+    getPlayerStat(damaged).onDamaged(realFinalDamage);
   }
 
   @EventHandler


### PR DESCRIPTION
This PR fixes a couple of issues with stats.

- Prevent damage to entities counting as damage given. 
  (natural mobs and spawnable entities like armor stands could be farmed to boost stats)
- Prevent damage values over the players' current health + absorption (https://github.com/PGMDev/PGM/issues/817).
  (would make rage kills produce massive damage values)
- Make `PlayerStats` public so values can be accessed outside PGM.

The whole damage system could be updated one day to use the PGM trackers but that's a different kettle of fish.

Signed-off-by: Pugzy <pugzy@mail.com>