### PR TITLE
Add Temporal Component for duration in seconds

### DIFF
--- a/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
@@ -6,7 +6,7 @@ import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.title.Title.title;
 import static tc.oc.pgm.util.text.TemporalComponent.clock;
-import static tc.oc.pgm.util.text.TemporalComponent.duration;
+import static tc.oc.pgm.util.text.TemporalComponent.seconds;
 
 import java.time.Duration;
 import javax.annotation.Nullable;
@@ -152,7 +152,7 @@ public abstract class MatchCountdown extends Countdown {
   }
 
   protected Component secondsRemaining(TextColor color) {
-    return duration(remaining, color).build();
+    return seconds(remaining.getSeconds(), color).build();
   }
 
   protected TextComponent.Builder colonTime() {

--- a/util/src/main/java/tc/oc/pgm/util/text/TemporalComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TemporalComponent.java
@@ -155,6 +155,20 @@ public final class TemporalComponent {
     return clock(duration.getSeconds());
   }
 
+  /**
+   * Creates a {@link Component} that represents a duration in seconds.
+   *
+   * @param seconds a number of seconds
+   * @param color a unit color
+   * @return a component builder
+   */
+  public static TranslatableComponent.Builder seconds(
+      final long seconds, final @Nullable TextColor color) {
+    return translatable()
+        .key((seconds == 1) ? "misc.second" : "misc.seconds")
+        .args(color == null ? text(seconds) : text(seconds, color));
+  }
+
   // TODO: Change these signature after the Community refactor
 
   @Deprecated


### PR DESCRIPTION
This PR adds a new Temporal Component that will always display the provided value in seconds.

As fancy as the new duration components are, using them in the boss bar countdowns cause the player to lose information and can mislead them with inaccurate values.

The table below shows the current format where seconds are dropped by rounding down meaning that `61` seconds to `119` seconds will all display as 1 minute remaining. I don't think this new formatting is particularly useful for this specific purpose and reduces the accuracy of info the player is given.

Starting a timer for 2 minutes displays `1 minute` remaining for 59 of the seconds when there is still actually another minute remaining.

| Duration | Display |
|-|-|
| /start 61 | Match starting in 1 minute |
| /start 119 | Match starting in 1 minute |

Most countdowns are under 1 minute, start countdowns are typically sub `30` seconds and monument mode changes (which also use the boss bar countdown) default to `60` seconds in XML. In cases where it's longer than 60 seconds, I think the accuracy of knowing how many seconds are remaining far outweighs the mental conversion someone may have to do to translate seconds to minutes.

One location where I have noticed this becomes an issue is the `Events` plugin which uses a longer initial start timer of `300` seconds which gets reduced when players ready up. Until the 60 second mark, the boss bar is ambiguous and pretty useless as it can be so wildly out.

![image](https://user-images.githubusercontent.com/8608892/108727101-17955d00-7520-11eb-99ca-b6a2da3209e7.png)

I did attempt to mock up both minutes and seconds (bottom example) but this was messy and created a rather long boss bar title (where would you stop? hours? weeks? years?). The component changes that introduced this issue was a direct commit to `dev` and did not go through the PR process so may have gone unnoticed.



Signed-off-by: Pugzy <pugzy@mail.com>