### PR TITLE
Correct arguments in destroyable's base translation keys

### DIFF
--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -126,13 +126,13 @@ destroyable.complete = {1} was destroyed by {0}
 # {2} = team name
 destroyable.touch.owned.player = {2}'s {1} damaged by {0}
 
-# {1} = monument name
-# {2} = team name
-destroyable.touch.owned.you = You damaged {2}'s {1}
+# {0} = monument name
+# {1} = team name
+destroyable.touch.owned.you = You damaged {1}'s {0}
 
-# {1} = monument name
-# {2} = team name
-destroyable.touch.owned = {2}'s {1} has been damaged
+# {0} = monument name
+# {1} = team name
+destroyable.touch.owned = {1}'s {0} has been damaged
 
 # {0} = player name
 # {1} = monument name


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/26081543/108862088-ac569400-75ce-11eb-98ad-fac14e05e447.jpg)

Fixes what's shown on the image above at the base translation keys, all languages will have to change the variables independently at Crowdin.

It is to note that whilst I was reviewing `gamemode.properties` I found some other unused strings which also appear to begin from argument {1} instead of argument {0}, such as [destroyable.touch.you](https://github.com/PGMDev/PGM/blob/ea97cf1d0d443f281ffd7eb18eb18c76b96da79a/util/src/main/i18n/templates/gamemode.properties#L142). I am unsure if this is intended, as I also found that this practice is followed by string key [wool.touch.owned.you](https://github.com/PGMDev/PGM/blob/ea97cf1d0d443f281ffd7eb18eb18c76b96da79a/util/src/main/i18n/templates/gamemode.properties#L176) (currently in use), which works just fine in-game, therefore I decided to limit this pr's scope to fixing the issue at stake, but getting a review on this matter would be appreciated.