### PR TITLE
Make completion sounds for control points half as loud

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -1,9 +1,13 @@
 package tc.oc.pgm.controlpoint;
 
+import static net.kyori.adventure.key.Key.key;
+import static net.kyori.adventure.sound.Sound.sound;
+
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import net.kyori.adventure.sound.Sound;
 import org.bukkit.ChatColor;
 import org.bukkit.event.HandlerList;
 import org.bukkit.util.Vector;
@@ -34,6 +38,11 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
 
   public static final String SYMBOL_CP_INCOMPLETE = "\u29be"; // ⦾
   public static final String SYMBOL_CP_COMPLETE = "\u29bf"; // ⦿
+
+  protected static final Sound GOOD_SOUND =
+      sound(key("portal.travel"), Sound.Source.MASTER, 0.35f, 2f);
+  protected static final Sound BAD_SOUND =
+      sound(key("mob.blaze.death"), Sound.Source.MASTER, 0.4f, 0.8f);
 
   protected final ControlPointPlayerTracker playerTracker;
   protected final ControlPointBlockDisplay blockDisplay;
@@ -146,6 +155,11 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
   /** Progress towards "capturing" the ControlPoint for the current capturingTeam */
   public Duration getCapturingTime() {
     return this.capturingTime;
+  }
+
+  @Override
+  public Sound getCompletionSound(boolean isGood) {
+    return isGood ? GOOD_SOUND : BAD_SOUND;
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/goals/Goal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/Goal.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.goals;
 
 import javax.annotation.Nullable;
+import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -61,6 +62,8 @@ public interface Goal<T extends GoalDefinition> extends Feature<T> {
   Color getColor();
 
   DyeColor getDyeColor();
+
+  Sound getCompletionSound(boolean positive);
 
   ChatColor renderSidebarStatusColor(@Nullable Competitor competitor, Party viewer);
 

--- a/core/src/main/java/tc/oc/pgm/goals/GoalMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/goals/GoalMatchModule.java
@@ -1,8 +1,5 @@
 package tc.oc.pgm.goals;
 
-import static net.kyori.adventure.key.Key.key;
-import static net.kyori.adventure.sound.Sound.sound;
-
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -50,11 +47,6 @@ public class GoalMatchModule implements MatchModule, Listener {
       return new GoalMatchModule(match);
     }
   }
-
-  protected static final Sound GOOD_SOUND =
-      sound(key("portal.travel"), Sound.Source.MASTER, 0.7f, 2f);
-  protected static final Sound BAD_SOUND =
-      sound(key("mob.blaze.death"), Sound.Source.MASTER, 0.8f, 0.8f);
 
   protected final Match match;
   protected final List<Goal> goals = new ArrayList<>();
@@ -167,16 +159,18 @@ public class GoalMatchModule implements MatchModule, Listener {
     // Don't play the objective sound if the match is over, because the win/lose sound will play
     // instead
     if (!match.calculateVictory() && event.getGoal().isVisible()) {
+      Sound goodSound = event.getGoal().getCompletionSound(true);
+      Sound badSound = event.getGoal().getCompletionSound(false);
+
       for (MatchPlayer player : event.getMatch().getPlayers()) {
+        if (!player.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ALL))
+          continue;
+
         if (player.getParty() instanceof Competitor
             && event.isGood() != (event.getCompetitor() == player.getParty())) {
-          if (player.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ALL)) {
-            player.playSound(BAD_SOUND);
-          }
+          if (badSound != null) player.playSound(badSound);
         } else {
-          if (player.getSettings().getValue(SettingKey.SOUNDS).equals(SettingValue.SOUNDS_ALL)) {
-            player.playSound(GOOD_SOUND);
-          }
+          if (goodSound != null) player.playSound(goodSound);
         }
       }
     }

--- a/core/src/main/java/tc/oc/pgm/goals/SimpleGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/SimpleGoal.java
@@ -1,7 +1,11 @@
 package tc.oc.pgm.goals;
 
+import static net.kyori.adventure.key.Key.key;
+import static net.kyori.adventure.sound.Sound.sound;
+
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -21,6 +25,11 @@ public abstract class SimpleGoal<T extends GoalDefinition> implements Goal<T> {
 
   public static final String SYMBOL_INCOMPLETE = "\u2715"; // ✕
   public static final String SYMBOL_COMPLETE = "\u2714"; // ✔
+
+  protected static final Sound GOOD_SOUND =
+      sound(key("portal.travel"), Sound.Source.MASTER, 0.7f, 2f);
+  protected static final Sound BAD_SOUND =
+      sound(key("mob.blaze.death"), Sound.Source.MASTER, 0.8f, 0.8f);
 
   protected final Logger logger;
   protected final T definition;
@@ -70,6 +79,11 @@ public abstract class SimpleGoal<T extends GoalDefinition> implements Goal<T> {
   @Override
   public DyeColor getDyeColor() {
     return DyeColor.WHITE;
+  }
+
+  @Override
+  public Sound getCompletionSound(boolean isGood) {
+    return isGood ? GOOD_SOUND : BAD_SOUND;
   }
 
   @Override


### PR DESCRIPTION
Usually in Koth maps the sounds are extremely spammy and very lound, it's deafening. This makes all those sounds half as loud as well as opening the door to other objectives having their own sounds