### PR TITLE
Make victory conditions respect completion rules

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/match/Match.java
+++ b/core/src/main/java/tc/oc/pgm/api/match/Match.java
@@ -329,6 +329,13 @@ public interface Match extends MatchPlayerResolver, Audience, ModuleContext<Matc
   Collection<Competitor> getCompetitors();
 
   /**
+   * Get all the {@link Competitor}s in the {@link Match} ordered by closest to winning.
+   *
+   * @return All the {@link Competitor}s in closeness to winning order.
+   */
+  Collection<Competitor> getSortedCompetitors();
+
+  /**
    * Get all the currently winning {@link Competitor}s in the {@link Match}.
    *
    * @return All the winning {@link Competitor}s.

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -389,7 +389,7 @@ public class SidebarMatchModule implements MatchModule, Listener {
 
       // Scores/Blitz
       if (hasScores || isBlitz) {
-        for (Competitor competitor : match.getCompetitors()) {
+        for (Competitor competitor : match.getSortedCompetitors()) {
           String text;
           if (hasScores) {
             text = renderScore(competitor);
@@ -418,7 +418,7 @@ public class SidebarMatchModule implements MatchModule, Listener {
       }
 
       // Team-specific goals
-      List<Competitor> sortedCompetitors = new ArrayList<>(match.getCompetitors());
+      List<Competitor> sortedCompetitors = new ArrayList<>(match.getSortedCompetitors());
       sortedCompetitors.retainAll(competitorsWithGoals);
 
       if (party instanceof Competitor) {

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -304,7 +304,7 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   public void giveVerboseStatsItem(MatchPlayer player, boolean forceOpen) {
     // Find out if verbose stats is relevant for this match
-    final Collection<Competitor> competitors = match.getCompetitors();
+    final Collection<Competitor> competitors = match.getSortedCompetitors();
     boolean showAllVerboseStats =
         verboseStats && competitors.stream().allMatch(c -> c instanceof Team);
     if (!showAllVerboseStats) return;


### PR DESCRIPTION
Fixes #770 

It is needed to split competitors and ranked competitors, because some completion rules use that same list, causing a stack overflow.

Competitors is now an unsorted set of all the competitors in the match, while `winners` is a ranked set of them. Victory conditions are sorted so completed conditions take precedence over non-completed conditions.

This should now respect the regression tests in 1.12+ PGM: <https://github.com/OvercastNetwork/ProjectAres/blob/master/PGM/src/main/java/tc/oc/pgm/victory/VictoryMatchModule.java#L26>
- In a goals + blitz match, a team that completes all their goals should win, even if they have fewer players than other teams.
- In a goals + blitz match, a team that runs out of players should lose, even if they have more goals completed.
- When a time limit elapses with a default result, it should end the match, but not affect the final ranking of competitors.
- When a time limit elapses with a tie result, no team should win, even if some teams are leading according to other conditions.