### PR TITLE
Avoid faulty initialization of wool proximity

### DIFF
--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
@@ -19,7 +19,6 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.goals.Goal;
-import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.goals.TouchableGoal;
 import tc.oc.pgm.kits.ApplyItemKitEvent;
 import tc.oc.pgm.kits.ApplyKitEvent;
@@ -108,19 +107,6 @@ public class MonumentWool extends TouchableGoal<MonumentWoolFactory>
       ParticipantState participant = this.getMatch().getParticipantState(player);
       if (participant != null && this.canComplete(participant.getParty())) {
         touch(participant);
-
-        // Initialize monument proximity
-        ProximityMetric metric = getProximityMetric(participant.getParty());
-        if (metric != null) {
-          switch (metric.type) {
-            case CLOSEST_BLOCK:
-              updateProximity(participant, this.woolLocation);
-              break;
-            case CLOSEST_PLAYER:
-              updateProximity(participant, player.getLocation());
-              break;
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
Currently grabbing one wool from the chest will NOT update the proximity, and grabbing a second one will, because you must have a wool in your inventory to be able to update that proximity.

This is simply error-prone, as maps where you can't place down safeties shouldn't have a proximity set at all (it should stay at infinity), but currently if you grab one wool, or grab 2 wools, it will have different results. 

I've removed all initialization because simply put, they will update when you actually take the action that updates it. If proximity is closest-player, it will update when you move, and if it's closest-block, it will update when you place one.