### PR TITLE
Implement end overtime

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/TimeLimitCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/TimeLimitCommand.java
@@ -29,7 +29,8 @@ public final class TimeLimitCommand {
       Duration duration,
       @Nullable VictoryCondition result,
       @Nullable Duration overtime,
-      @Nullable Duration maxOvertime) {
+      @Nullable Duration maxOvertime,
+      @Nullable Duration endOvertime) {
 
     final TimeLimitMatchModule time = match.needModule(TimeLimitMatchModule.class);
 
@@ -40,6 +41,7 @@ public final class TimeLimitCommand {
             duration.isNegative() ? Duration.ZERO : duration,
             overtime,
             maxOvertime,
+            endOvertime,
             result,
             true));
     time.start();

--- a/core/src/main/java/tc/oc/pgm/timelimit/OvertimeCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/OvertimeCountdown.java
@@ -16,7 +16,7 @@ import tc.oc.pgm.util.text.TemporalComponent;
 
 public class OvertimeCountdown extends TimeLimitCountdown {
 
-  private @Nullable Instant maxRefresh;
+  private @Nullable Instant overtimeStart, overtimeEnd;
   private @Nullable Competitor winner;
 
   public OvertimeCountdown(Match match, TimeLimit timeLimit) {
@@ -75,14 +75,15 @@ public class OvertimeCountdown extends TimeLimitCountdown {
 
     match.sendMessage(translatable("broadcast.overtime", NamedTextColor.YELLOW));
     if (timeLimit.getMaxOvertime() != null) {
+      overtimeStart = Instant.now();
+      overtimeEnd = overtimeStart.plus(timeLimit.getMaxOvertime());
+
       match.sendMessage(
           translatable(
               "broadcast.overtime.limit",
               NamedTextColor.YELLOW,
               TemporalComponent.briefNaturalApproximate(timeLimit.getMaxOvertime())
                   .color(NamedTextColor.AQUA)));
-
-      maxRefresh = Instant.now().plus(timeLimit.getMaxOvertime()).minus(timeLimit.getOvertime());
     }
   }
 
@@ -91,10 +92,10 @@ public class OvertimeCountdown extends TimeLimitCountdown {
     Competitor newWinner = timeLimit.currentWinner(match);
 
     if ((newWinner == null || this.winner != newWinner)
-        && (maxRefresh == null || !Instant.now().isAfter(maxRefresh))) {
+        && (overtimeEnd == null || !Instant.now().isAfter(overtimeEnd))) {
       this.winner = newWinner;
       start(); // Force the countdown to be re-scheduled
-      remaining = total;
+      remaining = total = this.total;
     }
     super.onTick(remaining, total);
   }
@@ -104,6 +105,20 @@ public class OvertimeCountdown extends TimeLimitCountdown {
   }
 
   public void start() {
-    this.getMatch().getCountdown().start(this, this.timeLimit.getOvertime());
+    Duration overtime = this.timeLimit.getOvertime();
+    Duration endOvertime = this.timeLimit.getEndOvertime();
+    Duration maxOvertime = this.timeLimit.getMaxOvertime();
+
+    if (overtime != null && endOvertime != null && maxOvertime != null && overtimeStart != null) {
+      long otMillis = overtime.toMillis();
+      long endOtMillis = endOvertime.toMillis();
+      long maxOtMillis = maxOvertime.toMillis();
+      long elapsedMillis = Duration.between(overtimeStart, Instant.now()).toMillis();
+
+      overtime =
+          Duration.ofMillis((otMillis + (endOtMillis - otMillis) * elapsedMillis / maxOtMillis));
+    }
+
+    this.getMatch().getCountdown().start(this, this.total = overtime);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
@@ -17,7 +17,7 @@ import tc.oc.pgm.util.collection.RankedSet;
 
 @FeatureInfo(name = "time-limit")
 public class TimeLimit extends SelfIdentifyingFeatureDefinition implements VictoryCondition {
-  private final Duration duration, overtime, maxOvertime;
+  private final Duration duration, overtime, maxOvertime, endOvertime;
   private final @Nullable VictoryCondition result;
   private final boolean show;
 
@@ -26,12 +26,14 @@ public class TimeLimit extends SelfIdentifyingFeatureDefinition implements Victo
       Duration duration,
       @Nullable Duration overtime,
       @Nullable Duration maxOvertime,
+      @Nullable Duration minOvertime,
       @Nullable VictoryCondition result,
       boolean show) {
     super(id);
     this.duration = checkNotNull(duration);
     this.overtime = overtime;
     this.maxOvertime = maxOvertime;
+    this.endOvertime = minOvertime;
     this.result = result;
     this.show = show;
   }
@@ -46,6 +48,10 @@ public class TimeLimit extends SelfIdentifyingFeatureDefinition implements Victo
 
   public @Nullable Duration getMaxOvertime() {
     return maxOvertime;
+  }
+
+  public @Nullable Duration getEndOvertime() {
+    return endOvertime;
   }
 
   public @Nullable VictoryCondition getResult() {

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
@@ -93,6 +93,7 @@ public class TimeLimitModule implements MapModule<TimeLimitMatchModule> {
           TextParser.parseDuration(el.getTextNormalize()),
           XMLUtils.parseDuration(el.getAttribute("overtime")),
           XMLUtils.parseDuration(el.getAttribute("max-overtime")),
+          XMLUtils.parseDuration(el.getAttribute("end-overtime")),
           parseVictoryCondition(factory, el.getAttribute("result")),
           XMLUtils.parseBoolean(el.getAttribute("show"), true));
     }


### PR DESCRIPTION
Adds the option to add an `end-overtime` that defines how long overtime runs for when you've reached the end, syntax is as follows:
`<timelimit overtime="5m" max-overtime="15m" end-overtime="1m" />`

This defines an overtime, that will, to start with, be a 5m overtime. However, as time goes on, that overtime will keep on shrinking towards the 1m, that will be reached after the 15m (max overtime) have passed.

This allows for lenient overtimes that allow counter-pushes at the start of overtime, but migrate towards a more "sudden-death" approach in overtime as time goes on.

It also supports end overtime being bigger than overtime itself for the oposite effect, although i'm unsure as to how useful that'd be, but you could define overtime=30s and end-overtime=5m and as time goes on overtime just keeps increasing, and once a team gets the lead it starts ticking down from that value.

Useful command to give this a try: `/tl 0s default 1m 15m 5m`