### PR TITLE
Fix Timelock Evaluation

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -271,7 +271,13 @@ public class PGMListener implements Listener {
   @EventHandler
   public void unlockTime(final MatchStartEvent event) {
     boolean unlockTime = false;
-    if (!event.getMatch().getModule(WorldTimeModule.class).isTimeLocked()) {
+    boolean isTimeLocked = event.getMatch().getModule(WorldTimeModule.class).isTimeLocked();
+    boolean isDaylightCycle =
+        Boolean.parseBoolean(event.getMatch().getWorld().getGameRuleValue(DO_DAYLIGHT_CYCLE));
+    // isTimeLocked() will be false if no timelock module is found
+    // if timelock is false and daylightcycle is true, set unlockTime to true
+    // if timelock is false and daylightcycle is false, set to true
+    if ((!isTimeLocked && isDaylightCycle) || !isTimeLocked && !isDaylightCycle) {
       unlockTime = true;
     }
 

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -76,8 +76,6 @@ public class PGMListener implements Listener {
   // Single-write, multi-read lock used to create the first match
   private final ReentrantReadWriteLock lock;
 
-  private boolean isDaylightCycle = false;
-
   public PGMListener(Plugin parent, MatchManager mm, VanishManager vm) {
     this.parent = parent;
     this.mm = mm;
@@ -267,18 +265,13 @@ public class PGMListener implements Listener {
   //
   @EventHandler
   public void lockTime(final MatchLoadEvent event) {
-    isDaylightCycle =
-        Boolean.parseBoolean(event.getMatch().getWorld().getGameRuleValue(DO_DAYLIGHT_CYCLE));
     event.getMatch().getWorld().setGameRuleValue(DO_DAYLIGHT_CYCLE, Boolean.toString(false));
   }
 
   @EventHandler
   public void unlockTime(final MatchStartEvent event) {
-    Boolean isTimeLocked = event.getMatch().getModule(WorldTimeModule.class).isTimeLocked();
-    // isTimeLocked() will be null if no timelock module is found
-    // if there is no timelock module and daylight cycle is enabled, unlock time
-    // if there is timelock module and its off, unlock time
-    boolean unlockTime = isTimeLocked == null ? isDaylightCycle : !isTimeLocked;
+    // if there is a timelock module and it is off, unlock time
+    boolean unlockTime = !event.getMatch().getModule(WorldTimeModule.class).isTimeLocked();
 
     GameRulesMatchModule gameRulesModule = event.getMatch().getModule(GameRulesMatchModule.class);
     if (gameRulesModule != null && gameRulesModule.getGameRules().containsKey(DO_DAYLIGHT_CYCLE)) {

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -272,12 +272,13 @@ public class PGMListener implements Listener {
   public void unlockTime(final MatchStartEvent event) {
     boolean unlockTime = false;
     boolean isTimeLocked = event.getMatch().getModule(WorldTimeModule.class).isTimeLocked();
+    boolean isLockAbsent = event.getMatch().getModule(WorldTimeModule.class).isLockAbsent();
     boolean isDaylightCycle =
         Boolean.parseBoolean(event.getMatch().getWorld().getGameRuleValue(DO_DAYLIGHT_CYCLE));
     // isTimeLocked() will be false if no timelock module is found
-    // if timelock is false and daylightcycle is true, set unlockTime to true
-    // if timelock is false and daylightcycle is false, set to true
-    if ((!isTimeLocked && isDaylightCycle) || !isTimeLocked && !isDaylightCycle) {
+    // if there is no timelock module and daylight cycle is enabled, unlock time
+    // if there is timelock module and its off, unlock time
+    if ((isLockAbsent && isDaylightCycle) || (!isLockAbsent && !isTimeLocked)) {
       unlockTime = true;
     }
 

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -271,14 +271,13 @@ public class PGMListener implements Listener {
   @EventHandler
   public void unlockTime(final MatchStartEvent event) {
     boolean unlockTime = false;
-    boolean isTimeLocked = event.getMatch().getModule(WorldTimeModule.class).isTimeLocked();
-    boolean isLockAbsent = event.getMatch().getModule(WorldTimeModule.class).isLockAbsent();
+    Boolean isTimeLocked = event.getMatch().getModule(WorldTimeModule.class).isTimeLocked();
     boolean isDaylightCycle =
         Boolean.parseBoolean(event.getMatch().getWorld().getGameRuleValue(DO_DAYLIGHT_CYCLE));
-    // isTimeLocked() will be false if no timelock module is found
+    // isTimeLocked() will be null if no timelock module is found
     // if there is no timelock module and daylight cycle is enabled, unlock time
     // if there is timelock module and its off, unlock time
-    if ((isLockAbsent && isDaylightCycle) || (!isLockAbsent && !isTimeLocked)) {
+    if (((isTimeLocked == null) && isDaylightCycle) || (isTimeLocked != null && !isTimeLocked)) {
       unlockTime = true;
     }
 

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -76,6 +76,8 @@ public class PGMListener implements Listener {
   // Single-write, multi-read lock used to create the first match
   private final ReentrantReadWriteLock lock;
 
+  private boolean isDaylightCycle = false;
+
   public PGMListener(Plugin parent, MatchManager mm, VanishManager vm) {
     this.parent = parent;
     this.mm = mm;
@@ -265,21 +267,18 @@ public class PGMListener implements Listener {
   //
   @EventHandler
   public void lockTime(final MatchLoadEvent event) {
+    isDaylightCycle =
+        Boolean.parseBoolean(event.getMatch().getWorld().getGameRuleValue(DO_DAYLIGHT_CYCLE));
     event.getMatch().getWorld().setGameRuleValue(DO_DAYLIGHT_CYCLE, Boolean.toString(false));
   }
 
   @EventHandler
   public void unlockTime(final MatchStartEvent event) {
-    boolean unlockTime = false;
     Boolean isTimeLocked = event.getMatch().getModule(WorldTimeModule.class).isTimeLocked();
-    boolean isDaylightCycle =
-        Boolean.parseBoolean(event.getMatch().getWorld().getGameRuleValue(DO_DAYLIGHT_CYCLE));
     // isTimeLocked() will be null if no timelock module is found
     // if there is no timelock module and daylight cycle is enabled, unlock time
     // if there is timelock module and its off, unlock time
-    if (((isTimeLocked == null) && isDaylightCycle) || (isTimeLocked != null && !isTimeLocked)) {
-      unlockTime = true;
-    }
+    boolean unlockTime = isTimeLocked == null ? isDaylightCycle : !isTimeLocked;
 
     GameRulesMatchModule gameRulesModule = event.getMatch().getModule(GameRulesMatchModule.class);
     if (gameRulesModule != null && gameRulesModule.getGameRules().containsKey(DO_DAYLIGHT_CYCLE)) {

--- a/core/src/main/java/tc/oc/pgm/modules/WorldTimeModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/WorldTimeModule.java
@@ -13,17 +13,17 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class WorldTimeModule implements MapModule, MatchModule {
-  private final Boolean lock;
+  private final boolean lock;
   private final Long time;
   private final boolean random;
 
-  public WorldTimeModule(Boolean lock, Long time, boolean random) {
+  public WorldTimeModule(boolean lock, Long time, boolean random) {
     this.lock = lock;
     this.time = time;
     this.random = random;
   }
 
-  public Boolean isTimeLocked() {
+  public boolean isTimeLocked() {
     return this.lock;
   }
 
@@ -39,7 +39,7 @@ public class WorldTimeModule implements MapModule, MatchModule {
     @Override
     public WorldTimeModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
-      Boolean lock = null;
+      boolean lock = true;
       Element worldEl = doc.getRootElement().getChild("world");
       // legacy
       Element timelockEl = doc.getRootElement().getChild("timelock");

--- a/core/src/main/java/tc/oc/pgm/modules/WorldTimeModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/WorldTimeModule.java
@@ -14,17 +14,23 @@ import tc.oc.pgm.util.xml.XMLUtils;
 
 public class WorldTimeModule implements MapModule, MatchModule {
   private final boolean lock;
+  private final boolean lockAbsent;
   private final Long time;
   private final boolean random;
 
-  public WorldTimeModule(boolean lock, Long time, boolean random) {
+  public WorldTimeModule(boolean lock, boolean lockAbsent, Long time, boolean random) {
     this.lock = lock;
+    this.lockAbsent = lockAbsent;
     this.time = time;
     this.random = random;
   }
 
   public boolean isTimeLocked() {
     return this.lock;
+  }
+
+  public boolean isLockAbsent() {
+    return this.lockAbsent;
   }
 
   public Long getTime() {
@@ -40,11 +46,13 @@ public class WorldTimeModule implements MapModule, MatchModule {
     public WorldTimeModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
       boolean lock = false;
+      boolean lockAbsent = true;
       Element worldEl = doc.getRootElement().getChild("world");
       // legacy
       Element timelockEl = doc.getRootElement().getChild("timelock");
       if (timelockEl != null) {
         lock = parseTimeLock(timelockEl);
+        lockAbsent = false;
       }
 
       Long time = null;
@@ -54,6 +62,7 @@ public class WorldTimeModule implements MapModule, MatchModule {
           timelockEl = worldEl.getChild("timelock");
           if (timelockEl != null) {
             lock = parseTimeLock(timelockEl);
+            lockAbsent = false;
           }
         }
         Element timeSetEl = worldEl.getChild("timeset");
@@ -65,7 +74,7 @@ public class WorldTimeModule implements MapModule, MatchModule {
           random = true;
         }
       }
-      return new WorldTimeModule(lock, time, random);
+      return new WorldTimeModule(lock, lockAbsent, time, random);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/WorldTimeModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/WorldTimeModule.java
@@ -13,24 +13,18 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class WorldTimeModule implements MapModule, MatchModule {
-  private final boolean lock;
-  private final boolean lockAbsent;
+  private final Boolean lock;
   private final Long time;
   private final boolean random;
 
-  public WorldTimeModule(boolean lock, boolean lockAbsent, Long time, boolean random) {
+  public WorldTimeModule(Boolean lock, Long time, boolean random) {
     this.lock = lock;
-    this.lockAbsent = lockAbsent;
     this.time = time;
     this.random = random;
   }
 
-  public boolean isTimeLocked() {
+  public Boolean isTimeLocked() {
     return this.lock;
-  }
-
-  public boolean isLockAbsent() {
-    return this.lockAbsent;
   }
 
   public Long getTime() {
@@ -45,14 +39,12 @@ public class WorldTimeModule implements MapModule, MatchModule {
     @Override
     public WorldTimeModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
-      boolean lock = false;
-      boolean lockAbsent = true;
+      Boolean lock = null;
       Element worldEl = doc.getRootElement().getChild("world");
       // legacy
       Element timelockEl = doc.getRootElement().getChild("timelock");
       if (timelockEl != null) {
         lock = parseTimeLock(timelockEl);
-        lockAbsent = false;
       }
 
       Long time = null;
@@ -62,7 +54,6 @@ public class WorldTimeModule implements MapModule, MatchModule {
           timelockEl = worldEl.getChild("timelock");
           if (timelockEl != null) {
             lock = parseTimeLock(timelockEl);
-            lockAbsent = false;
           }
         }
         Element timeSetEl = worldEl.getChild("timeset");
@@ -74,7 +65,7 @@ public class WorldTimeModule implements MapModule, MatchModule {
           random = true;
         }
       }
-      return new WorldTimeModule(lock, lockAbsent, time, random);
+      return new WorldTimeModule(lock, time, random);
     }
   }
 


### PR DESCRIPTION
This fixes maps that intentionally use the DoDayLightCycle gamerule to stop time and do not use `<timelock>` like ~BlockBlock,~ ~BlocksCTW~, BoomBox, etc, and maps that intentionally have timelock turned off but DoDayLightCycle set to false, such as Sunrise Over Paradise and ~Moonlight Summit, both of~ which are to have sunrise and sunset. 

WorldTimeModule will pass a false if it does not find a `<timelock>` module. Bit confusing dealing with two booleans that deal with the same thing innit, so now there's a third boolean `isLockAbsent` to record if `<timelock>` even exists in the XML.