### PR TITLE
Time Adjust 

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -108,6 +108,8 @@ import tc.oc.pgm.start.StartMatchModule;
 import tc.oc.pgm.stats.StatsMatchModule;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.teams.TeamModule;
+import tc.oc.pgm.timeadjust.TimeAdjustMatchModule;
+import tc.oc.pgm.timeadjust.TimeAdjustModule;
 import tc.oc.pgm.timelimit.TimeLimitMatchModule;
 import tc.oc.pgm.timelimit.TimeLimitModule;
 import tc.oc.pgm.tnt.TNTMatchModule;
@@ -244,6 +246,7 @@ public interface Modules {
     register(
         WorldBorderModule.class, WorldBorderMatchModule.class, new WorldBorderModule.Factory());
     register(SpawnerModule.class, SpawnerMatchModule.class, new SpawnerModule.Factory());
+    register(TimeAdjustModule.class, TimeAdjustMatchModule.class, new TimeAdjustModule.Factory());
 
     // MapModules that are also MatchModules
     register(WorldTimeModule.class, WorldTimeModule.class, new WorldTimeModule.Factory());

--- a/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjust.java
+++ b/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjust.java
@@ -1,0 +1,67 @@
+package tc.oc.pgm.timeadjust;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.time.Duration;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.timelimit.TimeLimit;
+import tc.oc.pgm.timelimit.TimeLimitMatchModule;
+
+public class TimeAdjust {
+
+  private Duration time;
+  private boolean broadcast;
+
+  public TimeAdjust(Duration time, boolean broadcast) {
+    this.time = checkNotNull(time);
+    this.broadcast = broadcast;
+  }
+
+  public Duration getTime() {
+    return time;
+  }
+
+  public boolean isBroadcast() {
+    return broadcast;
+  }
+
+  private boolean isTimeSafe(Duration current) {
+    return !current.plus(time).isNegative();
+  }
+
+  public boolean adjustTime(Match match) {
+    TimeLimitMatchModule timeLimit = match.needModule(TimeLimitMatchModule.class);
+    if (timeLimit.getFinalRemaining() != null) {
+      // If we are able to add/subtract time to the match, do so.
+      // In the case of the time being subtracted to a negative, trigger match end.
+      if (isTimeSafe(timeLimit.getFinalRemaining())) {
+        TimeLimit adjusted = getNewTime(timeLimit.getFinalRemaining(), timeLimit.getTimeLimit());
+        timeLimit.cancel();
+        timeLimit.setTimeLimit(adjusted);
+        timeLimit.start();
+        return isBroadcast();
+      } else {
+        timeLimit.setFinished(true);
+        match.calculateVictory();
+      }
+    }
+    return false;
+  }
+
+  private TimeLimit getNewTime(Duration finalTime, TimeLimit oldLimit) {
+    Duration adjustedTime = finalTime.plus(time);
+    return new TimeLimit(
+        oldLimit.getId(),
+        adjustedTime,
+        oldLimit.getOvertime(),
+        oldLimit.getMaxOvertime(),
+        oldLimit.getEndOvertime(),
+        oldLimit.getResult(),
+        oldLimit.getShow());
+  }
+
+  @Override
+  public String toString() {
+    return String.format("{TimeAdjust: time=%s broadcast=%s}", time.toString(), broadcast);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustMatchModule.java
@@ -35,13 +35,9 @@ public class TimeAdjustMatchModule implements MatchModule, Listener {
     Map<Goal, TimeAdjust> adjusts = Maps.newHashMap();
     adjustmentDefs.forEach(
         (def, time) -> {
-          // def.getGoal(match);  <-- Not Working
-          Goal goal = match.getFeatureContext().get(def.getId(), Goal.class);
+          Goal goal = def.getGoal(match);
           if (goal != null) {
             adjusts.put(goal, time);
-          } else {
-            // TODO: DEBUG: Remove this
-            match.getLogger().info(def.getId() + " could not find a loaded goal!!!");
           }
         });
     this.adjustments = adjusts;
@@ -50,7 +46,7 @@ public class TimeAdjustMatchModule implements MatchModule, Listener {
   @EventHandler
   public void onGoalComplete(GoalCompleteEvent event) {
     TimeAdjust time = adjustments.get(event.getGoal());
-    if (time != null && time.adjustTime(match)) {
+    if (time != null && time.adjustTime(match) && match.isRunning()) {
       match.sendMessage(createBroadcast(time));
     }
   }

--- a/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustMatchModule.java
@@ -56,7 +56,7 @@ public class TimeAdjustMatchModule implements MatchModule, Listener {
     String key = "misc." + (decrease ? "decrease" : "increase");
     NamedTextColor color = decrease ? NamedTextColor.RED : NamedTextColor.GREEN;
     return translatable(
-        "match.timeLimit.increase",
+        "match.timeLimit.adjust",
         NamedTextColor.YELLOW,
         translatable(key, color),
         duration(adjust.getTime(), color));

--- a/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustMatchModule.java
@@ -1,0 +1,68 @@
+package tc.oc.pgm.timeadjust;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.util.text.TemporalComponent.duration;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.goals.Goal;
+import tc.oc.pgm.goals.GoalDefinition;
+import tc.oc.pgm.goals.events.GoalCompleteEvent;
+
+@ListenerScope(MatchScope.RUNNING)
+public class TimeAdjustMatchModule implements MatchModule, Listener {
+
+  private final Match match;
+  private final Map<GoalDefinition, TimeAdjust> adjustmentDefs;
+  private Map<Goal, TimeAdjust> adjustments;
+
+  public TimeAdjustMatchModule(Match match, Map<GoalDefinition, TimeAdjust> adjustments) {
+    this.match = match;
+    this.adjustmentDefs = checkNotNull(adjustments);
+  }
+
+  @Override
+  public void load() {
+    Map<Goal, TimeAdjust> adjusts = Maps.newHashMap();
+    adjustmentDefs.forEach(
+        (def, time) -> {
+          // def.getGoal(match);  <-- Not Working
+          Goal goal = match.getFeatureContext().get(def.getId(), Goal.class);
+          if (goal != null) {
+            adjusts.put(goal, time);
+          } else {
+            // TODO: DEBUG: Remove this
+            match.getLogger().info(def.getId() + " could not find a loaded goal!!!");
+          }
+        });
+    this.adjustments = adjusts;
+  }
+
+  @EventHandler
+  public void onGoalComplete(GoalCompleteEvent event) {
+    TimeAdjust time = adjustments.get(event.getGoal());
+    if (time != null && time.adjustTime(match)) {
+      match.sendMessage(createBroadcast(time));
+    }
+  }
+
+  private Component createBroadcast(TimeAdjust adjust) {
+    boolean decrease = adjust.getTime().isNegative();
+    String key = "misc." + (decrease ? "decrease" : "increase");
+    NamedTextColor color = decrease ? NamedTextColor.RED : NamedTextColor.GREEN;
+    return translatable(
+        "match.timeLimit.increase",
+        NamedTextColor.YELLOW,
+        translatable(key, color),
+        duration(adjust.getTime(), color));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustModule.java
+++ b/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustModule.java
@@ -1,0 +1,82 @@
+package tc.oc.pgm.timeadjust;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import tc.oc.pgm.api.feature.FeatureDefinition;
+import tc.oc.pgm.api.map.MapModule;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.map.factory.MapModuleFactory;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.core.CoreModule;
+import tc.oc.pgm.destroyable.DestroyableModule;
+import tc.oc.pgm.goals.GoalDefinition;
+import tc.oc.pgm.goals.GoalMatchModule;
+import tc.oc.pgm.timelimit.TimeLimitMatchModule;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.XMLUtils;
+import tc.oc.pgm.wool.WoolModule;
+
+public class TimeAdjustModule implements MapModule {
+
+  private final Map<GoalDefinition, TimeAdjust> timeAdjusts;
+
+  public TimeAdjustModule(Map<GoalDefinition, TimeAdjust> timeAdjusts) {
+    this.timeAdjusts = timeAdjusts;
+  }
+
+  @Override
+  public TimeAdjustMatchModule createMatchModule(Match match) throws ModuleLoadException {
+    return new TimeAdjustMatchModule(match, timeAdjusts);
+  }
+
+  @Override
+  public Collection<Class> getHardDependencies() {
+    return ImmutableList.of(GoalMatchModule.class, TimeLimitMatchModule.class);
+  }
+
+  public static class Factory implements MapModuleFactory<TimeAdjustModule> {
+
+    @Override
+    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+      return ImmutableList.of(DestroyableModule.class, WoolModule.class, CoreModule.class);
+    }
+
+    @Override
+    public TimeAdjustModule parse(MapFactory factory, Logger logger, Document doc)
+        throws InvalidXMLException {
+      Map<GoalDefinition, TimeAdjust> adjustments = Maps.newHashMap();
+
+      for (Element adjustEl :
+          XMLUtils.flattenElements(doc.getRootElement(), "time-adjust", "adjust")) {
+
+        String goalId = adjustEl.getAttributeValue("id");
+
+        FeatureDefinition goal = factory.getFeatures().get(goalId);
+        if (goal == null) {
+          throw new InvalidXMLException(
+              "No objective with the id (" + goalId + ") was found!", adjustEl);
+        }
+
+        if (!(goal instanceof GoalDefinition)) {
+          throw new InvalidXMLException(goalId + " is not a valid objective id", adjustEl);
+        }
+        TimeAdjust adjust = parseTimeAdjust(factory, adjustEl);
+        adjustments.put((GoalDefinition) goal, adjust);
+      }
+      return new TimeAdjustModule(adjustments);
+    }
+
+    private static TimeAdjust parseTimeAdjust(MapFactory factory, Element el)
+        throws InvalidXMLException {
+      return new TimeAdjust(
+          XMLUtils.parseDuration(el.getAttribute("time")),
+          XMLUtils.parseBoolean(el.getAttribute("broadcast"), true));
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustModule.java
+++ b/core/src/main/java/tc/oc/pgm/timeadjust/TimeAdjustModule.java
@@ -12,17 +12,20 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.core.CoreMatchModule;
 import tc.oc.pgm.core.CoreModule;
+import tc.oc.pgm.destroyable.DestroyableMatchModule;
 import tc.oc.pgm.destroyable.DestroyableModule;
 import tc.oc.pgm.goals.GoalDefinition;
 import tc.oc.pgm.goals.GoalMatchModule;
-import tc.oc.pgm.timelimit.TimeLimitMatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
+import tc.oc.pgm.wool.WoolMatchModule;
 import tc.oc.pgm.wool.WoolModule;
 
-public class TimeAdjustModule implements MapModule {
+public class TimeAdjustModule implements MapModule<TimeAdjustMatchModule> {
 
   private final Map<GoalDefinition, TimeAdjust> timeAdjusts;
 
@@ -36,8 +39,14 @@ public class TimeAdjustModule implements MapModule {
   }
 
   @Override
-  public Collection<Class> getHardDependencies() {
-    return ImmutableList.of(GoalMatchModule.class, TimeLimitMatchModule.class);
+  public Collection<Class<? extends MatchModule>> getSoftDependencies() {
+    return ImmutableList.of(GoalMatchModule.class);
+  }
+
+  @Override
+  public Collection<Class<? extends MatchModule>> getWeakDependencies() {
+    return ImmutableList.of(
+        DestroyableMatchModule.class, WoolMatchModule.class, CoreMatchModule.class);
   }
 
   public static class Factory implements MapModuleFactory<TimeAdjustModule> {

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -152,6 +152,9 @@ match.timeLimit.result = {1} after {0}
 # {1} = some criteria to win the match
 match.timeLimit.commandOutput = The time limit is {0} with the result {1}
 
+# {0} = increase or decreased
+match.timeLimit.increase = The time limit has been {0} by {1}
+
 broadcast.go = Go!
 
 broadcast.matchStart = The match has started!

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -153,7 +153,8 @@ match.timeLimit.result = {1} after {0}
 match.timeLimit.commandOutput = The time limit is {0} with the result {1}
 
 # {0} = increase or decreased
-match.timeLimit.increase = The time limit has been {0} by {1}
+# {1} = duration
+match.timeLimit.adjust = The time limit has been {0} by {1}
 
 broadcast.go = Go!
 

--- a/util/src/main/i18n/templates/misc.properties
+++ b/util/src/main/i18n/templates/misc.properties
@@ -197,6 +197,10 @@ misc.serverFull = Server is full, consider upgrading to premium to be able to jo
 
 misc.serverRestart = Server restarting!
 
+misc.increase = increased
+
+misc.decrease = decreased
+
 type.int = whole number
 
 type.float = decimal number


### PR DESCRIPTION
# Time Adjust

New feature suggested by dragonstomper64 👏 

Basically allows for objectives to extend the time limit of a match once completed (core leaked, wool placed, destroyable destroyed) 

## XML 
```xml
<time-adjust>

<!-- When red core is leaked, add 10 mins -->
<adjust id="red-core" time="10m"/> 

<!-- When blue wool is placed, subtract 5 mins -->
<adjust id="blue-wool" time="-5m"/> 

<!-- When green monument is destroyed, add 10 mins and don't broadcast -->
<adjust id="green-monument" time="10m" broadcast="false"/> 

</time-adjust>
```

## Examples

### Wool
https://youtu.be/6zOz3aXkQa0

### Core
https://youtu.be/eDyttJGii40

### Destroyables
https://youtu.be/xYo0gNiur24

## Screenshots
Example of broadcast when time is increased
<img width="880" alt="increase" src="https://user-images.githubusercontent.com/3377659/112777100-275c0180-8ff6-11eb-9f12-b6cf55f509f7.png">

Example of broadcast when time is decreased
<img width="887" alt="decrease" src="https://user-images.githubusercontent.com/3377659/112777101-27f49800-8ff6-11eb-8dc8-995d0be8f755.png">



## ToDo

Objectives:
- [x] Cores
- [x] Wools
- [x] Destroyables
- [ ] Flags
- [ ] Control Points
- [ ] Score box?

## Feedback
Any feedback on how to improve this would be appreciated 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>