### PR TITLE
Switch titles to ticks over milliseconds

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/command/ModerationCommand.java
+++ b/core/src/main/java/tc/oc/pgm/community/command/ModerationCommand.java
@@ -10,6 +10,7 @@ import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.event.HoverEvent.showText;
 import static net.kyori.adventure.title.Title.title;
+import static tc.oc.pgm.util.TimeUtils.fromTicks;
 
 import app.ashcon.intake.Command;
 import app.ashcon.intake.CommandException;
@@ -809,29 +810,24 @@ public class ModerationCommand implements Listener {
     Component subtitle = formatPunishmentReason(reason).color(NamedTextColor.GOLD);
 
     // Legacy support - Displays a chat message instead of title
-    if (target.isLegacy()) {
-      target.sendMessage(
-          TextFormatter.horizontalLineHeading(
-              target.getBukkit(), warningTitle, NamedTextColor.GRAY));
-      target.sendMessage(empty());
-      target.sendMessage(
-          TextFormatter.horizontalLineHeading(
-              target.getBukkit(),
-              subtitle,
-              NamedTextColor.YELLOW,
-              TextDecoration.OBFUSCATED,
-              LegacyFormatUtils.MAX_CHAT_WIDTH));
-      target.sendMessage(empty());
-      target.sendMessage(
-          TextFormatter.horizontalLineHeading(
-              target.getBukkit(), warningTitle, NamedTextColor.GRAY));
+    target.sendMessage(
+        TextFormatter.horizontalLineHeading(target.getBukkit(), warningTitle, NamedTextColor.GRAY));
+    target.sendMessage(empty());
+    target.sendMessage(
+        TextFormatter.horizontalLineHeading(
+            target.getBukkit(),
+            subtitle,
+            NamedTextColor.YELLOW,
+            TextDecoration.OBFUSCATED,
+            LegacyFormatUtils.MAX_CHAT_WIDTH));
+    target.sendMessage(empty());
+    target.sendMessage(
+        TextFormatter.horizontalLineHeading(target.getBukkit(), warningTitle, NamedTextColor.GRAY));
 
-    } else {
+    if (!target.isLegacy()) {
       target.showTitle(
           title(
-              warningTitle,
-              subtitle,
-              Title.Times.of(Duration.ofMillis(5), Duration.ofMillis(200), Duration.ofMillis(10))));
+              warningTitle, subtitle, Title.Times.of(fromTicks(5), fromTicks(200), fromTicks(10))));
     }
     target.playSound(WARN_SOUND);
   }

--- a/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
@@ -5,6 +5,7 @@ import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.title.Title.title;
+import static tc.oc.pgm.util.TimeUtils.fromTicks;
 import static tc.oc.pgm.util.text.TemporalComponent.clock;
 import static tc.oc.pgm.util.text.TemporalComponent.seconds;
 
@@ -97,7 +98,7 @@ public abstract class MatchCountdown extends Countdown {
               title(
                   text(remaining.getSeconds(), NamedTextColor.YELLOW),
                   empty(),
-                  Title.Times.of(Duration.ZERO, Duration.ofMillis(5), Duration.ofMillis(15))));
+                  Title.Times.of(Duration.ZERO, fromTicks(5), fromTicks(15))));
     }
 
     super.onTick(remaining, total);


### PR DESCRIPTION
**Change the use of `ofMillis` to `fromTicks` on two instances where this was not updated**

These titles would previously not display. Noticed this earlier during the match start 3.. 2.. 1.. when nothing appeared it felt odd, turns out its been like this for 3 months 🤷 .

**Send both warn message and title to non-legacy players**

Noticed the warn message also used the old miliseconds method and did not show in chat for non-legacy players. A longer warning message or message that is sent at the same as another title would not be readable to the player so having it in chat for them too seems logical.


Another thing I noticed is the "Go!" now displays for everyone even the observers which previously did not happen (as seen in this [tournament match from 4 months ago](https://youtu.be/2E3SXMAiZVM). Open to ideas on what this could be as I liked that as an observer I wasn't told to go.