### PR TITLE
Fix playercount formatting in FFA match

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
@@ -95,7 +95,7 @@ public final class MatchCommand {
                   translatable("match.info.players", NamedTextColor.YELLOW)
                       .append(text(": ", NamedTextColor.GRAY))
                       .append(text(match.getParticipants().size(), NamedTextColor.WHITE))
-                      .append(text('/' + ffamm.getMaxPlayers(), NamedTextColor.GRAY)))
+                      .append(text("/" + ffamm.getMaxPlayers(), NamedTextColor.GRAY)))
               .build());
     }
 


### PR DESCRIPTION
Change some single quotes to double quotes. The single quotes mess up the formatting of the player count in a FFA match: 
![afbeelding](https://user-images.githubusercontent.com/1810738/112715948-cb08bd00-8ee3-11eb-82ff-0fb8f85c9350.png)
After: 
![afbeelding](https://user-images.githubusercontent.com/1810738/112715985-fbe8f200-8ee3-11eb-82a5-f74d239bed89.png)

