### PR TITLE
Fix KitModule dependencies

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitModule.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.kits;
 
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
 import java.util.logging.Logger;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Document;
@@ -11,6 +13,8 @@ import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.itemmeta.ItemModifyModule;
+import tc.oc.pgm.teams.TeamMatchModule;
+import tc.oc.pgm.teams.TeamModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
 public class KitModule implements MapModule {
@@ -20,7 +24,18 @@ public class KitModule implements MapModule {
     return new KitMatchModule(match);
   }
 
+  @Override
+  public Collection<Class<? extends MatchModule>> getWeakDependencies() {
+    return ImmutableList.of(TeamMatchModule.class);
+  }
+
   public static class Factory implements MapModuleFactory<KitModule> {
+
+    @Override
+    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+      return ImmutableList.of(TeamModule.class);
+    }
+
     @Override
     public KitModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {


### PR DESCRIPTION
# Fix KitModule dependencies

This is a small bug fix. When the team switch kit was added in #799, forgot to add weak dependencies 😅 

On occasion maps which utilize the team switch kit will be unable to find the given team:
<img width="1198" alt="Error" src="https://user-images.githubusercontent.com/3377659/113249686-f7219680-9273-11eb-97ed-2f34dd4baa02.png">

By adding a weak dependency of the team modules to kits, we prevent this from happening. Hooray 😄 

Signed-off-by: applenick <applenick@users.noreply.github.com>