### PR TITLE
Fix several issues with flag beams

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -162,7 +162,7 @@ public interface Modules {
     // register(ProjectileTrailMatchModule.class, ProjectileTrailMatchModule::new);
 
     // Modules that help older player versions
-    register(LegacyFlagBeamMatchModule.class, LegacyFlagBeamMatchModule::new);
+    register(LegacyFlagBeamMatchModule.class, new LegacyFlagBeamMatchModule.Factory());
 
     // Community MatchModules
     register(FreezeMatchModule.class, FreezeMatchModule::new);

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -61,6 +61,7 @@ import tc.oc.pgm.spawns.events.ParticipantDespawnEvent;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.inventory.ItemBuilder;
 import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextFormatter;
@@ -91,6 +92,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
   private final Location bannerLocation;
   private final BannerMeta bannerMeta;
   private final ItemStack bannerItem;
+  private final ItemStack legacyBannerItem;
   private final AngleProvider bannerYawProvider;
   private final @Nullable Team owner;
   private final Set<Team> capturers;
@@ -164,10 +166,19 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     }
 
     this.bannerLocation = Materials.getLocationWithYaw(banner);
-    this.bannerMeta = Materials.getItemMeta(banner);
     this.bannerYawProvider = new StaticAngleProvider(this.bannerLocation.getYaw());
+
+    this.bannerMeta = Materials.getItemMeta(banner);
+    this.bannerMeta.setDisplayName(getColoredName());
     this.bannerItem = new ItemStack(Material.BANNER);
     this.bannerItem.setItemMeta(this.getBannerMeta());
+
+    this.legacyBannerItem =
+        new ItemBuilder()
+            .material(Material.WOOL)
+            .color(getDyeColor())
+            .name(getColoredName())
+            .build();
   }
 
   private static Banner toBanner(Block block) {
@@ -210,6 +221,10 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
 
   public ItemStack getBannerItem() {
     return bannerItem;
+  }
+
+  public ItemStack getLegacyBannerItem() {
+    return legacyBannerItem;
   }
 
   public BaseState getState() {

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -9,6 +9,7 @@ import static tc.oc.pgm.util.TimeUtils.fromTicks;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -23,6 +24,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.party.Competitor;
@@ -47,6 +49,7 @@ import tc.oc.pgm.spawns.events.ParticipantDespawnEvent;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 /** State of a flag when a player has picked it up and is wearing the banner on their head. */
 public class Carried extends Spawned implements Missing {
@@ -127,6 +130,12 @@ public class Carried extends Spawned implements Missing {
             .lockArmorSlot(this.carrier, ArmorType.HELMET, false);
 
     this.carrier.getBukkit().getInventory().setHelmet(this.flag.getBannerItem().clone());
+    PGM.get()
+        .getExecutor()
+        .schedule(
+            () -> NMSHacks.sendLegacyWearing(carrier.getBukkit(), 4, flag.getLegacyBannerItem()),
+            50L,
+            TimeUnit.MILLISECONDS);
 
     SidebarMatchModule smm = this.flag.getMatch().getModule(SidebarMatchModule.class);
     if (smm != null) smm.blinkGoal(this.flag, 2, null);


### PR DESCRIPTION
Prevents legacy flag beams loading if there are no flags, additionally, it includes a number of bugfixes and improvements to flags like showing the head item as wool for legacy players and moving the up a few blocks so the hitboxes don't block hits from above

Closes #811

![image](https://user-images.githubusercontent.com/11789291/113368199-6c699600-935e-11eb-93ef-fa7308c2dcfb.png)
