### PR TITLE
Reduce vertical flag pickup allowance from below

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/state/Uncarried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Uncarried.java
@@ -9,6 +9,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -129,9 +130,12 @@ public abstract class Uncarried extends Spawned {
     return true;
   }
 
-  protected boolean inPickupRange(Location playerLoc) {
+  protected boolean inPickupRange(Player player) {
+    Location playerLoc = player.getLocation();
     Location flagLoc = this.getLocation();
-    if (playerLoc.getY() < flagLoc.getY() + 2 && playerLoc.getY() >= flagLoc.getY() - 2) {
+
+    if (playerLoc.getY() < flagLoc.getY() + 2
+        && (playerLoc.getY() >= flagLoc.getY() - (player.isOnGround() ? 1 : 0.7))) {
       double dx = playerLoc.getX() - flagLoc.getX();
       double dz = playerLoc.getZ() - flagLoc.getZ();
 
@@ -159,7 +163,7 @@ public abstract class Uncarried extends Spawned {
     MatchPlayer player = this.flag.getMatch().getPlayer(event.getPlayer());
     if (player == null || !player.canInteract() || player.getBukkit().isDead()) return;
 
-    if (this.inPickupRange(player.getBukkit().getLocation()) && this.canPickup(player)) {
+    if (this.inPickupRange(player.getBukkit()) && this.canPickup(player)) {
       this.pickupFlag(player);
     }
   }


### PR DESCRIPTION
PGM currently allows you to pick up the flag even if you are stood 2 blocks below the base of it.

A couple examples of this issue in action:
https://gyazo.com/cba5a7117eb6630a4110c0c924a23f15 and https://gyazo.com/f4b72fc8a014d03533055abd9b71d8c0

Many maps (competitive) use one-way drops and varied height terrain to make players commit and add choke points. Players can simply stand below these drops and pick flags up in locations you wouldn't expect. PGM is very lenient vertically to the point where it is illogical. This fixes that issue by reducing the height a player can be (feet to base of flag) to 1 whole block when standing and 0.7 blocks when jumping. 

Below is an image showing the change which makes the first two situations impossible but allows for the latter.

![image](https://user-images.githubusercontent.com/8608892/113585131-b6cf6900-9623-11eb-8b9d-83396751b16e.png)

I had originally tried to fix this on a per map basis by defining all the possible locations that have this quirk and then the locations where it would be acceptable to pick the flag up from, this is messy and adds unnecessary complexity to the pick-up filters. Plus there's no way currently to filter the location of the flag in that pickup query (but that's an issue for another day).

I know of no maps that would be negatively affected due to this and I would consider the over-generous calculation prior to be a bug. If a mapmaker has made a map with this strange trait in mind let me know and we can look at making this logic non-default and then apply it with a `flag` or `post` attribute.

Signed-off-by: Pugzy <pugzy@mail.com>