### PR TITLE
Track burning kills from being punched into lava

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tracker/info/FallState.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/FallState.java
@@ -29,6 +29,9 @@ public class FallState implements FallInfo {
   // A player's fall is cancelled if they are climbing something for more than this many ticks
   public static final long MAX_CLIMBING_TICKS = 10;
 
+  // How long players burn for after touching lava. This is a vanilla value.
+  public static final long MAX_BURNING_TICKS = 255;
+
   public final MatchPlayer victim;
   public final Location origin;
 
@@ -63,9 +66,9 @@ public class FallState implements FallInfo {
   public boolean isClimbing;
   public long climbingTick;
 
-  // The player's most recent in-lava state and the time it was last set true
+  // The player's most recent in-lava state and the time it was last set true and false
   public boolean isInLava;
-  public long inLavaTick;
+  public long inLavaTick, outLavaTick;
 
   // The number of times the player has touched the ground during since isFalling was set true
   public int groundTouchCount;
@@ -130,7 +133,7 @@ public class FallState implements FallInfo {
    * a ladder for MAX_CLIMBING_TICKS
    */
   public boolean isEndedSafely(Tick now) {
-    return !this.isInLava
+    return (!isInLava && now.tick - outLavaTick > MAX_BURNING_TICKS)
         && ((victim.getBukkit().isOnGround()
                 && (now.tick - onGroundTick > MAX_ON_GROUND_TICKS
                     || groundTouchCount > MAX_GROUND_TOUCHES))

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/FallTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/FallTracker.java
@@ -63,7 +63,8 @@ public class FallTracker implements Listener, DamageResolver {
           break;
 
         case FIRE_TICK:
-          if (fall.isInLava) {
+          if (fall.isInLava
+              || match.getTick().tick - fall.outLavaTick < FallState.MAX_BURNING_TICKS) {
             fall.to = FallInfo.To.LAVA;
           } else {
             return null;
@@ -255,12 +256,11 @@ public class FallTracker implements Listener, DamageResolver {
       }
 
       if (isInLava != fall.isInLava) {
-        if ((fall.isInLava = isInLava)) {
+        if (!(fall.isInLava = isInLava)) {
           fall.inLavaTick = now.tick;
         } else {
-          // Because players continue to "fall" as long as they are in lava, moving out of lava
-          // can immediately finish their fall
-          this.checkFallTimeout(fall);
+          fall.outLavaTick = now.tick;
+          this.scheduleCheckFallTimeout(fall, FallState.MAX_BURNING_TICKS + 1);
         }
       }
     }


### PR DESCRIPTION
Makes it so if you're punched into lava and end up burning to death, you'll be reported as a kill for who knocked you into lava, awarding kill rewards to them