### PR TITLE
Rewrite legacy flag beams

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -602,8 +602,11 @@ public interface NMSHacks {
 
   class FakeArmorStand extends FakeLivingEntity<EntityArmorStand> {
 
-    public FakeArmorStand(World world) {
+    private final ItemStack head;
+
+    public FakeArmorStand(World world, ItemStack head) {
       super(new EntityArmorStand(((CraftWorld) world).getHandle()));
+      this.head = head;
 
       entity.setInvisible(true);
       NBTTagCompound tag = entity.getNBTTag();
@@ -616,6 +619,12 @@ public interface NMSHacks {
       tag.setBoolean("NoGravity", true);
       tag.setBoolean("NoAI", true);
       entity.f(tag);
+    }
+
+    @Override
+    public void spawn(Player viewer, Location location, Vector velocity) {
+      super.spawn(viewer, location, velocity);
+      if (head != null) wear(viewer, 4, head);
     }
   }
 


### PR DESCRIPTION
Rewritten legacy flag beams to cut down on their complexity and improve lag for the client-side, avoiding unnecessary re-spawning of beams every time one is picked up or dropped.

Now there's a 1 to 1 map between flag and beam, and each beam controls N viewing players, this avoids having to create and mantain maps for beams for each player, while simplifying other operations, no more "track flag" or "untrack flag"