### PR TITLE
Fix renewables

### DIFF
--- a/core/src/main/java/tc/oc/pgm/renewable/Renewable.java
+++ b/core/src/main/java/tc/oc/pgm/renewable/Renewable.java
@@ -266,6 +266,7 @@ public class Renewable implements Listener, Tickable {
     Location location = pos.toLocation(match.getWorld());
     Block block = location.getBlock();
     BlockState newState = location.getBlock().getState();
+    newState.setType(material.getItemType());
     newState.setData(material);
 
     BlockRenewEvent event = new BlockRenewEvent(block, newState, this);

--- a/util/src/main/java/tc/oc/pgm/util/block/BlockStates.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/BlockStates.java
@@ -37,6 +37,7 @@ public interface BlockStates {
 
   static BlockState create(World world, BlockVector pos, MaterialData materialData) {
     BlockState state = pos.toLocation(world).getBlock().getState();
+    state.setType(materialData.getItemType());
     state.setData(materialData);
     return state;
   }


### PR DESCRIPTION
BlockState throws an illegal argument exception if you call `setData` and the types don't match. So you have to call `setType` before calling setData.

Fixes #854 
