### PR TITLE
Add "team-color" attribute to Armor Kits

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
@@ -40,12 +40,13 @@ public class ArmorKit extends AbstractKit {
     for (Map.Entry<ArmorType, ArmorItem> entry : this.armor.entrySet()) {
       int slot = entry.getKey().ordinal();
       if (force || wearing[slot] == null || wearing[slot].getType() == Material.AIR) {
-        if (entry.getValue().teamColor) {
-          LeatherArmorMeta meta = (LeatherArmorMeta) entry.getValue().stack.getItemMeta();
-          meta.setColor(player.getParty().getFullColor());
-          entry.getValue().stack.setItemMeta(meta);
-        }
         wearing[slot] = entry.getValue().stack.clone();
+
+        if (entry.getValue().teamColor) {
+          LeatherArmorMeta meta = (LeatherArmorMeta) wearing[slot].getItemMeta();
+          meta.setColor(player.getParty().getFullColor());
+          wearing[slot].setItemMeta(meta);
+        }
 
         KitMatchModule kitMatchModule = player.getMatch().getModule(KitMatchModule.class);
         if (kitMatchModule != null) {

--- a/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
@@ -4,12 +4,14 @@ import java.util.List;
 import java.util.Map;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
 import tc.oc.pgm.api.player.MatchPlayer;
 
 public class ArmorKit extends AbstractKit {
   public static class ArmorItem {
     public final ItemStack stack;
     public final boolean locked;
+    public boolean teamColor = false;
 
     public ArmorItem(ItemStack stack, boolean locked) {
       this.stack = stack;
@@ -37,6 +39,11 @@ public class ArmorKit extends AbstractKit {
     for (Map.Entry<ArmorType, ArmorItem> entry : this.armor.entrySet()) {
       int slot = entry.getKey().ordinal();
       if (force || wearing[slot] == null || wearing[slot].getType() == Material.AIR) {
+        if (entry.getValue().teamColor) {
+          LeatherArmorMeta meta = (LeatherArmorMeta) entry.getValue().stack.getItemMeta();
+          meta.setColor(player.getParty().getFullColor());
+          entry.getValue().stack.setItemMeta(meta);
+        }
         wearing[slot] = entry.getValue().stack.clone();
 
         KitMatchModule kitMatchModule = player.getMatch().getModule(KitMatchModule.class);

--- a/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
@@ -11,11 +11,12 @@ public class ArmorKit extends AbstractKit {
   public static class ArmorItem {
     public final ItemStack stack;
     public final boolean locked;
-    public boolean teamColor = false;
+    public final boolean teamColor;
 
-    public ArmorItem(ItemStack stack, boolean locked) {
+    public ArmorItem(ItemStack stack, boolean locked, boolean teamColor) {
       this.stack = stack;
       this.locked = locked;
+      this.teamColor = teamColor;
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -203,7 +203,14 @@ public abstract class KitParser {
     }
     ItemStack stack = parseItem(el, true);
     boolean locked = XMLUtils.parseBoolean(el.getAttribute("locked"), false);
-    return new ArmorKit.ArmorItem(stack, locked);
+    ArmorKit.ArmorItem armorItem = new ArmorKit.ArmorItem(stack, locked);
+    if (stack.getType() == Material.LEATHER_HELMET
+        || stack.getType() == Material.LEATHER_CHESTPLATE
+        || stack.getType() == Material.LEATHER_LEGGINGS
+        || stack.getType() == Material.LEATHER_BOOTS) {
+      armorItem.teamColor = XMLUtils.parseBoolean(el.getAttribute("team-color"), false);
+    }
+    return armorItem;
   }
 
   public ArmorKit parseArmorKit(Element el) throws InvalidXMLException {

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -459,17 +459,14 @@ public abstract class KitParser {
     }
 
     if (meta instanceof LeatherArmorMeta) {
-      org.jdom2.Attribute teamColor = el.getAttribute("team-color");
-      if (teamColor == null) {
-        LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
-        org.jdom2.Attribute attrColor = el.getAttribute("color");
-        if (attrColor != null) {
-          String raw = attrColor.getValue();
-          if (!raw.matches("[a-fA-F0-9]{6}")) {
-            throw new InvalidXMLException("Invalid color format", attrColor);
-          }
-          armorMeta.setColor(Color.fromRGB(Integer.parseInt(attrColor.getValue(), 16)));
+      LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
+      org.jdom2.Attribute attrColor = el.getAttribute("color");
+      if (attrColor != null) {
+        String raw = attrColor.getValue();
+        if (!raw.matches("[a-fA-F0-9]{6}")) {
+          throw new InvalidXMLException("Invalid color format", attrColor);
         }
+        armorMeta.setColor(Color.fromRGB(Integer.parseInt(attrColor.getValue(), 16)));
       }
     }
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -203,11 +203,8 @@ public abstract class KitParser {
     }
     ItemStack stack = parseItem(el, true);
     boolean locked = XMLUtils.parseBoolean(el.getAttribute("locked"), false);
-    ArmorKit.ArmorItem armorItem = new ArmorKit.ArmorItem(stack, locked);
-    if (stack.getItemMeta() instanceof LeatherArmorMeta) {
-      armorItem.teamColor = XMLUtils.parseBoolean(el.getAttribute("team-color"), false);
-    }
-    return armorItem;
+    boolean teamColor = XMLUtils.parseBoolean(el.getAttribute("team-color"), false);
+    return new ArmorKit.ArmorItem(stack, locked, teamColor);
   }
 
   public ArmorKit parseArmorKit(Element el) throws InvalidXMLException {

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -203,7 +203,10 @@ public abstract class KitParser {
     }
     ItemStack stack = parseItem(el, true);
     boolean locked = XMLUtils.parseBoolean(el.getAttribute("locked"), false);
-    boolean teamColor = XMLUtils.parseBoolean(el.getAttribute("team-color"), false);
+
+    boolean teamColor =
+        stack.getItemMeta() instanceof LeatherArmorMeta
+            && XMLUtils.parseBoolean(el.getAttribute("team-color"), false);
     return new ArmorKit.ArmorItem(stack, locked, teamColor);
   }
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -204,10 +204,7 @@ public abstract class KitParser {
     ItemStack stack = parseItem(el, true);
     boolean locked = XMLUtils.parseBoolean(el.getAttribute("locked"), false);
     ArmorKit.ArmorItem armorItem = new ArmorKit.ArmorItem(stack, locked);
-    if (stack.getType() == Material.LEATHER_HELMET
-        || stack.getType() == Material.LEATHER_CHESTPLATE
-        || stack.getType() == Material.LEATHER_LEGGINGS
-        || stack.getType() == Material.LEATHER_BOOTS) {
+    if (stack.getItemMeta() instanceof LeatherArmorMeta) {
       armorItem.teamColor = XMLUtils.parseBoolean(el.getAttribute("team-color"), false);
     }
     return armorItem;
@@ -462,14 +459,17 @@ public abstract class KitParser {
     }
 
     if (meta instanceof LeatherArmorMeta) {
-      LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
-      org.jdom2.Attribute attrColor = el.getAttribute("color");
-      if (attrColor != null) {
-        String raw = attrColor.getValue();
-        if (!raw.matches("[a-fA-F0-9]{6}")) {
-          throw new InvalidXMLException("Invalid color format", attrColor);
+      org.jdom2.Attribute teamColor = el.getAttribute("team-color");
+      if (teamColor == null) {
+        LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
+        org.jdom2.Attribute attrColor = el.getAttribute("color");
+        if (attrColor != null) {
+          String raw = attrColor.getValue();
+          if (!raw.matches("[a-fA-F0-9]{6}")) {
+            throw new InvalidXMLException("Invalid color format", attrColor);
+          }
+          armorMeta.setColor(Color.fromRGB(Integer.parseInt(attrColor.getValue(), 16)));
         }
-        armorMeta.setColor(Color.fromRGB(Integer.parseInt(attrColor.getValue(), 16)));
       }
     }
 


### PR DESCRIPTION
When ever I create maps, most of the time I have to create a separate kit for the teams while trying to find the correct color that corresponds to their color.

Like so:
```xml
<helmet color="cd00cd" unbreakable="true" material="leather helmet"/>
```

So, I added an attribute that automatically uses the team's color so that I can just use the default kit and it will automatically use the team's color when applied.

Like so:
```xml
<helmet team-color="true" unbreakable="true" material="leather helmet"/>
```

I made it so "team-color" overrides the "color" attribute since it is applied during the match and not beforehand.