### PR TITLE
Fix Grenades / ItemTags

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
@@ -145,6 +145,7 @@ public class KitMatchModule implements MatchModule, Listener {
       Grenade grenade = Grenade.get(event.getEntity());
       if (grenade != null) {
         event
+            .getEntity()
             .getWorld()
             .createExplosion(
                 event.getEntity(),

--- a/util/src/main/java/tc/oc/pgm/util/inventory/tag/LegacyItemTag.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/tag/LegacyItemTag.java
@@ -43,6 +43,7 @@ final class LegacyItemTag implements ItemTag<String> {
   @Nullable
   @Override
   public String get(ItemStack item) {
+    if (!item.hasItemMeta()) return null;
     final List<String> lore = item.getItemMeta().getLore();
     if (lore == null || lore.isEmpty()) return null;
 
@@ -52,6 +53,7 @@ final class LegacyItemTag implements ItemTag<String> {
 
   @Override
   public void set(ItemStack item, String value) {
+    if (!item.hasItemMeta()) return;
     ItemMeta itemMeta = item.getItemMeta();
     List<String> lore = itemMeta.getLore();
 
@@ -68,6 +70,7 @@ final class LegacyItemTag implements ItemTag<String> {
 
   @Override
   public void clear(ItemStack item) {
+    if (!item.hasItemMeta()) return;
     ItemMeta itemMeta = item.getItemMeta();
     final List<String> lore = itemMeta.getLore();
     if (lore == null || lore.isEmpty()) return;


### PR DESCRIPTION
The SportPaper method `ItemStack.getLore` calls `hasItemMeta`. This replicates that behavior.

Also fixes a `NoSuchMethodError` in spigot 1.8 for `onGrenadeExplode` in `KitMatchModule`

Resolves #858 
