### PR TITLE
Fix friction being applied after velocity updates

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/LegacyFlagBeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/LegacyFlagBeamMatchModule.java
@@ -98,7 +98,7 @@ public class LegacyFlagBeamMatchModule implements MatchModule, Listener {
     MatchPlayer player = match.getPlayer(event.getPlayer());
     if (player == null) return;
 
-    if (event.getWorld() == match.getWorld()) showLater(player);
+    if (event.getPlayer().getWorld() == match.getWorld()) showLater(player);
     else beams().forEach(beam -> beam.hide(player));
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -868,6 +868,7 @@ public interface NMSHacks {
 
   static void updateVelocity(Player player) {
     EntityPlayer handle = ((CraftPlayer) player).getHandle();
+    handle.velocityChanged = false;
     handle.playerConnection.sendPacket(new PacketPlayOutEntityVelocity(handle));
   }
 


### PR DESCRIPTION
This fixes jump pads being less powerful after the spigot 1.8 changes.

The `updateVelocity` method is sending the velocity update packet, but since the velocity is still marked as changed, CraftBukkit applies friction and then sends a new velocity update packet with the reduced velocity.

Also fixes a `NoSuchMethodError` in `LegacyFlagBeamMatchModule` for Spigot