### PR TITLE
Fix ItemTag meta not being set

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/inventory/tag/LegacyItemTag.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/tag/LegacyItemTag.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -53,8 +54,11 @@ final class LegacyItemTag implements ItemTag<String> {
 
   @Override
   public void set(ItemStack item, String value) {
-    if (!item.hasItemMeta()) return;
     ItemMeta itemMeta = item.getItemMeta();
+    if (!item.hasItemMeta()) {
+      // Create missing item meta if none is found
+      itemMeta = Bukkit.getItemFactory().getItemMeta(item.getType());
+    }
     List<String> lore = itemMeta.getLore();
 
     // If the item has no lore, ensure there is at least 1 line.


### PR DESCRIPTION
# Fix ItemTag meta not being set

Due to the fix merged in #859, ItemTag meta is never applied if no existing meta is found.

Primary issue this has caused, players are unable to open the voting book 😢 

This PR resolves that issue 🎉 (and has been tested to ensure it actually works)  

Signed-off-by: applenick <applenick@users.noreply.github.com>