### PR TITLE
Fix player locale being ignored

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/text/TextTranslations.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextTranslations.java
@@ -224,7 +224,7 @@ public final class TextTranslations {
         String format = resource.getString(key);
 
         // Single quotes are a special keyword that need to be escaped in MessageFormat
-        // Templates are not escaped, where as translations are escaped
+        // Templates are not escaped, whereas translations are escaped
         if (locale == SOURCE_LOCALE) format = format.replaceAll("'", "''");
 
         TRANSLATIONS_TABLE.put(key, locale, new MessageFormat(format, locale));

--- a/util/src/main/java/tc/oc/pgm/util/text/UTF8Control.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/UTF8Control.java
@@ -6,6 +6,8 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -48,5 +50,10 @@ final class UTF8Control extends ResourceBundle.Control {
       }
     }
     return bundle;
+  }
+
+  @Override
+  public List<Locale> getCandidateLocales(String name, Locale locale) {
+    return Arrays.asList(Locale.ROOT);
   }
 }


### PR DESCRIPTION
Fixes a bug where player locale was ignored due to the bundle search order. From [the javadocs](https://docs.oracle.com/javase/6/docs/api/java/util/ResourceBundle.html#getBundle%28java.lang.String,%20java.util.Locale,%20java.lang.ClassLoader%29):
> `getBundle` uses the base name, the specified locale, and the default locale (obtained from `Locale.getDefault`) to generate a sequence of candidate bundle names. If the specified locale's language, country, and variant are all empty strings, then the base name is the only candidate bundle name. Otherwise, the following sequence is generated from the attribute values of the specified locale (language1, country1, and variant1) and of the default locale (language2, country2, and variant2):
> 
> - `baseName + "_" + language1 + "_" + country1 + "_" + variant1`
> - `baseName + "_" + language1 + "_" + country1`
> - `baseName + "_" + language1`
> - `baseName + "_" + language2 + "_" + country2 + "_" + variant2`
> - `baseName + "_" + language2 + "_" + country2`
> - `baseName + "_" + language2`
> - `baseName`

Screenshots showing that changing locale updates in-game:

![image](https://user-images.githubusercontent.com/9807038/116720478-25f66e00-a9d4-11eb-8c33-5b580ee74423.png)
![image](https://user-images.githubusercontent.com/9807038/116720497-2abb2200-a9d4-11eb-95f0-5dbf002a305d.png)
