### PR TITLE
Add decay-time, recovery-time, and owned-decay-time

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -49,11 +49,6 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
 
   protected final Vector centerPoint;
 
-  // time values to increment by for decay, recovery, and owned-decay
-  protected final float decayIncrement;
-  protected final float recoveryIncrement;
-  protected final float ownedDecayIncrement;
-
   // This is set false after the first state change if definition.permanent == true
   protected boolean capturable = true;
 
@@ -85,24 +80,6 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
     this.playerTracker = new ControlPointPlayerTracker(match, this.getCaptureRegion());
 
     this.blockDisplay = new ControlPointBlockDisplay(match, this);
-
-    this.decayIncrement =
-        definition.getDecayTime().equals(Duration.ZERO)
-            ? 0
-            : (float) definition.getTimeToCapture().toMillis()
-                / (float) definition.getDecayTime().toMillis();
-
-    this.recoveryIncrement =
-        definition.getRecoveryTime().equals(Duration.ZERO)
-            ? 0
-            : (float) definition.getTimeToCapture().toMillis()
-                / (float) definition.getRecoveryTime().toMillis();
-
-    this.ownedDecayIncrement =
-        definition.getOwnedDecayTime().equals(Duration.ZERO)
-            ? 0
-            : (float) definition.getTimeToCapture().toMillis()
-                / (float) definition.getOwnedDecayTime().toMillis();
   }
 
   public void registerEvents() {
@@ -426,9 +403,6 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
    *
    * <p>If there is no neutral state, then the point is always either being captured by a specific
    * team, or not being captured at all.
-   *
-   * <p>If incremental capturing is disabled, then capturingTimeMillis is reset to zero whenever it
-   * stops increasing.
    */
   private void dominate(Competitor dominantTeam, Duration dominantTime) {
     if (!this.capturable || !TimeUtils.isLongerThan(dominantTime, Duration.ZERO)) {
@@ -439,38 +413,29 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
     if (this.controllingTeam != null && definition.hasNeutralState()) {
       // Point is owned and must go through the neutral state before another team can capture it
       if (dominantTeam == this.controllingTeam) {
-        this.regressCapture(dominantTeam, dominantTime);
+        // owner is recovering the point
+        recover(dominantTeam, dominantTime);
       } else if (dominantTeam != null) {
-        this.progressUncapture(dominantTeam, dominantTime);
-      } else if (!definition.isIncrementalCapture()) {
-        // No team is dominant and point is not incremental, so reset the time
-        this.capturingTime = Duration.ZERO;
-      } else if (TimeUtils.isLongerThan(definition.getOwnedDecayTime(), Duration.ZERO)) {
-        // Decay a team's capture
-        this.progressUncapture(
-            null, Duration.ofMillis((long) (ownedDecayIncrement * dominantTime.toMillis())));
-      } else if (TimeUtils.isLongerThan(definition.getRecoveryTime(), Duration.ZERO)
-          && TimeUtils.isLongerThan(this.capturingTime, Duration.ZERO)) {
-        // recover a team's capture -- mutually exclusive with owned decay
-        this.regressCapture(
-            this.controllingTeam,
-            Duration.ofMillis((long) (recoveryIncrement * dominantTime.toMillis())));
+        // non-owner is uncapturing the point
+        uncapture(dominantTeam, dominantTime);
+      } else if (definition.getOwnedDecayRate() > 0.0) {
+        // nobody on point so decay to neutral state
+        ownedDecay(dominantTime);
+      } else {
+        // nobody on point, so "decay" to fully captured
+        decay(dominantTime);
       }
     } else if (this.capturingTeam != null) {
       // Point is being captured by a specific team
       if (dominantTeam == this.capturingTeam) {
-        this.progressCapture(dominantTeam, dominantTime);
+        // capturing team is making progress
+        capture(dominantTime);
       } else if (dominantTeam != null) {
-        this.regressCapture(dominantTeam, dominantTime);
-      } else if (!definition.isIncrementalCapture()) {
-        // No team is dominant and point is not incremental, so reset time and clear capturing team
-        this.capturingTime = Duration.ZERO;
-        this.capturingTeam = null;
-      } else if (TimeUtils.isLongerThan(definition.getDecayTime(), Duration.ZERO)
-          && TimeUtils.isLongerThan(this.capturingTime, Duration.ZERO)) {
-        // No team is dominating, point is incremental, and there is a defined decay time
-        this.regressCapture(
-            null, Duration.ofMillis((long) (decayIncrement * dominantTime.toMillis())));
+        // non-capturing team is dominate, so regress capturing team's progress
+        recover(dominantTeam, dominantTime);
+      } else {
+        // No team is dominating so decay
+        decay(dominantTime);
       }
     } else if (dominantTeam != null
         && dominantTeam != this.controllingTeam
@@ -482,24 +447,30 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
     }
   }
 
-  /** Progress toward the neutral state */
-  private void progressUncapture(Competitor dominantTeam, Duration dominantTime) {
-    this.capturingTime = this.capturingTime.plus(dominantTime);
-
-    if (!TimeUtils.isShorterThan(this.capturingTime, this.definition.getTimeToCapture())) {
-      // If uncapture is complete, recurse with the dominant team's remaining time
-      dominantTime = this.capturingTime.minus(this.definition.getTimeToCapture());
+  private @Nullable Duration addCaptureTime(final Duration duration) {
+    this.capturingTime = this.capturingTime.plus(duration);
+    if (!TimeUtils.isLongerThan(definition.getTimeToCapture(), this.capturingTime)) {
+      final Duration remainder = this.capturingTime.minus(definition.getTimeToCapture());
       this.capturingTime = Duration.ZERO;
-      this.controllingTeam = null;
-      this.dominate(dominantTeam, dominantTime);
+      return remainder;
     }
+    return null;
   }
 
-  /** Progress toward a new controller */
-  private void progressCapture(Competitor dominantTeam, Duration dominantTime) {
-    this.capturingTime = this.capturingTime.plus(dominantTime);
-    if (!TimeUtils.isShorterThan(this.capturingTime, this.definition.getTimeToCapture())) {
-      this.capturingTime = Duration.ZERO;
+  private @Nullable Duration subtractCaptureTime(final Duration duration) {
+    if (TimeUtils.isLongerThan(this.capturingTime, duration)) {
+      this.capturingTime = this.capturingTime.minus(duration);
+      return null;
+    } else {
+      final Duration remainder = duration.minus(this.capturingTime);
+      this.capturingTime = duration.ZERO;
+      return remainder;
+    }
+  }
+  // Progress to a new owner
+  private void capture(Duration dominantTime) {
+    dominantTime = addCaptureTime(dominantTime);
+    if (dominantTime != null) { // Point is captured
       this.controllingTeam = this.capturingTeam;
       this.capturingTeam = null;
       if (this.getDefinition().isPermanent()) {
@@ -508,31 +479,48 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
       }
     }
   }
-
-  /** Regress toward the current state */
-  private void regressCapture(Competitor dominantTeam, Duration dominantTime) {
-    boolean crossZero = false;
-    if (definition.isIncrementalCapture()) {
-      // For incremental points, decrease the capture time
-      if (TimeUtils.isLongerThan(this.capturingTime, dominantTime)) {
-        this.capturingTime = this.capturingTime.minus(dominantTime);
-      } else {
-        dominantTime = dominantTime.minus(this.capturingTime);
-        this.capturingTime = Duration.ZERO;
-        crossZero = true;
-      }
-    } else {
-      // For non-incremental points, reset capture time to zero
-      this.capturingTime = Duration.ZERO;
-      crossZero = true;
+  // Progress towards the neutral state
+  private void uncapture(Competitor dominantTeam, Duration dominantTime) {
+    dominantTime = addCaptureTime(dominantTime);
+    if (dominantTime != null) {
+      this.controllingTeam = null;
+      this.dominate(dominantTeam, dominantTime);
     }
-
-    if (crossZero) {
+  }
+  // Point being pulled back to current state (There is a lead on the point)
+  private void recover(Competitor dominantTeam, Duration dominantTime) {
+    dominantTime =
+        subtractCaptureTime(
+            Duration.ofMillis((long) (definition.getRecoveryRate() * dominantTime.toMillis())));
+    if (dominantTeam != null) {
       this.capturingTeam = null;
       if (dominantTeam != this.controllingTeam) {
         // If the dominant team is not the controller, recurse with the remaining time
-        this.dominate(dominantTeam, dominantTime);
+        this.dominate(
+            dominantTeam,
+            Duration.ofMillis(
+                (long) ((1.0 / definition.getRecoveryRate()) * dominantTime.toMillis())));
       }
+    }
+  }
+  // Point is being decayed back to its current state (No lead on point)
+  private void decay(Duration dominantTime) {
+    dominantTime =
+        subtractCaptureTime(
+            Duration.ofMillis((long) (definition.getDecayRate() * dominantTime.toMillis())));
+    if (dominantTime != null) {
+      this.capturingTeam = null;
+    }
+  }
+
+  // Point is being decayed back to neutral (No lead on point)
+  private void ownedDecay(Duration dominantTime) {
+    dominantTime =
+        addCaptureTime(
+            Duration.ofMillis((long) (definition.getOwnedDecayRate() * dominantTime.toMillis())));
+    if (dominantTime != null) {
+      this.controllingTeam = null;
+      this.capturingTeam = null;
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -418,7 +418,7 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
       } else if (dominantTeam != null) {
         // non-owner is uncapturing the point
         uncapture(dominantTeam, dominantTime);
-      } else if (definition.getOwnedDecayRate() > 0.0) {
+      } else if (definition.getOwnedDecayRate() > 0) {
         // nobody on point so decay to neutral state
         ownedDecay(dominantTime);
       } else {

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
@@ -39,13 +39,13 @@ public class ControlPointDefinition extends GoalDefinition {
   private final Duration timeToCapture;
 
   // Time it takes for a point to decay while unowned. (Time is accurate when near 100% capture)
-  private final Duration decayTime;
+  private final double decayRate;
 
   // Time it takes for a point to recover to captured state. (Accurate when almost uncaptured)
-  private final Duration recoveryTime;
+  private final double recoveryRate;
 
   // Time it takes for a point to transition to neutral state.
-  private final Duration ownedDecayTime;
+  private final double ownedDecayRate;
 
   // Capture time multiplier for increasing or decreasing capture time based on the number of
   // players on the point
@@ -62,10 +62,6 @@ public class ControlPointDefinition extends GoalDefinition {
   }
 
   private final CaptureCondition captureCondition;
-
-  // true: progress is retained if capturing is interrupted
-  // false: progress resets to zero if capturing is interrupted
-  private final boolean incrementalCapture;
 
   // true: point must transition through unowned state to change owners
   // false: point transitions directly from one owner to the next
@@ -101,13 +97,12 @@ public class ControlPointDefinition extends GoalDefinition {
       Filter visualMaterials,
       BlockVector capturableDisplayBeacon,
       Duration timeToCapture,
-      Duration decayTime,
-      Duration recoveryTime,
-      Duration ownedDecayTime,
+      double decayRate,
+      double recoveryRate,
+      double ownedDecayRate,
       float timeMultiplier,
       @Nullable TeamFactory initialOwner,
       CaptureCondition captureCondition,
-      boolean incrementalCapture,
       boolean neutralState,
       boolean permanent,
       float pointsPerSecond,
@@ -124,13 +119,12 @@ public class ControlPointDefinition extends GoalDefinition {
     this.visualMaterials = visualMaterials;
     this.capturableDisplayBeacon = capturableDisplayBeacon;
     this.timeToCapture = timeToCapture;
-    this.decayTime = decayTime;
-    this.recoveryTime = recoveryTime;
-    this.ownedDecayTime = ownedDecayTime;
+    this.decayRate = decayRate;
+    this.recoveryRate = recoveryRate;
+    this.ownedDecayRate = ownedDecayRate;
     this.timeMultiplier = timeMultiplier;
     this.initialOwner = initialOwner;
     this.captureCondition = captureCondition;
-    this.incrementalCapture = incrementalCapture;
     this.neutralState = neutralState;
     this.permanent = permanent;
     this.pointsPerSecond = pointsPerSecond;
@@ -147,20 +141,18 @@ public class ControlPointDefinition extends GoalDefinition {
         + this.getId()
         + " timeToCapture="
         + this.getTimeToCapture()
-        + " decayTime="
-        + this.getDecayTime()
-        + " recoveryTime="
-        + this.getRecoveryTime()
-        + " ownedDecayTime="
-        + this.getOwnedDecayTime()
+        + " decayRate="
+        + this.getDecayRate()
+        + " recoveryRate="
+        + this.getRecoveryRate()
+        + " ownedDecayRate="
+        + this.getOwnedDecayRate()
         + " timeMultiplier="
         + this.getTimeMultiplier()
         + " initialOwner="
         + this.getInitialOwner()
         + " captureCondition="
         + this.getCaptureCondition()
-        + " incrementalCapture="
-        + this.isIncrementalCapture()
         + " neutralState="
         + this.hasNeutralState()
         + " permanent="
@@ -213,16 +205,16 @@ public class ControlPointDefinition extends GoalDefinition {
     return this.timeToCapture;
   }
 
-  public Duration getDecayTime() {
-    return this.decayTime;
+  public double getDecayRate() {
+    return this.decayRate;
   }
 
-  public Duration getRecoveryTime() {
-    return this.recoveryTime;
+  public double getRecoveryRate() {
+    return this.recoveryRate;
   }
 
-  public Duration getOwnedDecayTime() {
-    return this.ownedDecayTime;
+  public double getOwnedDecayRate() {
+    return this.ownedDecayRate;
   }
 
   public float getTimeMultiplier() {
@@ -236,10 +228,6 @@ public class ControlPointDefinition extends GoalDefinition {
 
   public CaptureCondition getCaptureCondition() {
     return this.captureCondition;
-  }
-
-  public boolean isIncrementalCapture() {
-    return this.incrementalCapture;
   }
 
   public boolean hasNeutralState() {

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
@@ -38,6 +38,15 @@ public class ControlPointDefinition extends GoalDefinition {
   // Base time for the point to transition between states
   private final Duration timeToCapture;
 
+  // Time it takes for a point to decay while unowned. (Time is accurate when near 100% capture)
+  private final Duration decayTime;
+
+  // Time it takes for a point to recover to captured state. (Accurate when almost uncaptured)
+  private final Duration recoveryTime;
+
+  // Time it takes for a point to transition to neutral state.
+  private final Duration ownedDecayTime;
+
   // Capture time multiplier for increasing or decreasing capture time based on the number of
   // players on the point
   private final float timeMultiplier;
@@ -92,6 +101,9 @@ public class ControlPointDefinition extends GoalDefinition {
       Filter visualMaterials,
       BlockVector capturableDisplayBeacon,
       Duration timeToCapture,
+      Duration decayTime,
+      Duration recoveryTime,
+      Duration ownedDecayTime,
       float timeMultiplier,
       @Nullable TeamFactory initialOwner,
       CaptureCondition captureCondition,
@@ -112,6 +124,9 @@ public class ControlPointDefinition extends GoalDefinition {
     this.visualMaterials = visualMaterials;
     this.capturableDisplayBeacon = capturableDisplayBeacon;
     this.timeToCapture = timeToCapture;
+    this.decayTime = decayTime;
+    this.recoveryTime = recoveryTime;
+    this.ownedDecayTime = ownedDecayTime;
     this.timeMultiplier = timeMultiplier;
     this.initialOwner = initialOwner;
     this.captureCondition = captureCondition;
@@ -132,6 +147,12 @@ public class ControlPointDefinition extends GoalDefinition {
         + this.getId()
         + " timeToCapture="
         + this.getTimeToCapture()
+        + " decayTime="
+        + this.getDecayTime()
+        + " recoveryTime="
+        + this.getRecoveryTime()
+        + " ownedDecayTime="
+        + this.getOwnedDecayTime()
         + " timeMultiplier="
         + this.getTimeMultiplier()
         + " initialOwner="
@@ -190,6 +211,18 @@ public class ControlPointDefinition extends GoalDefinition {
 
   public Duration getTimeToCapture() {
     return this.timeToCapture;
+  }
+
+  public Duration getDecayTime() {
+    return this.decayTime;
+  }
+
+  public Duration getRecoveryTime() {
+    return this.recoveryTime;
+  }
+
+  public Duration getOwnedDecayTime() {
+    return this.ownedDecayTime;
   }
 
   public float getTimeMultiplier() {

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -77,6 +77,13 @@ public abstract class ControlPointParser {
     Duration timeToCapture =
         XMLUtils.parseDuration(elControlPoint.getAttribute("capture-time"), Duration.ofSeconds(30));
 
+    Duration decayTime =
+        XMLUtils.parseDuration(elControlPoint.getAttribute("decay-time"), Duration.ZERO);
+    Duration recoveryTime =
+        XMLUtils.parseDuration(elControlPoint.getAttribute("recovery-time"), Duration.ZERO);
+    Duration ownedDecayTime =
+        XMLUtils.parseDuration(elControlPoint.getAttribute("owned-decay-time"), Duration.ZERO);
+
     float timeMultiplier =
         XMLUtils.parseNumber(
             elControlPoint.getAttribute("time-multiplier"), Float.class, koth ? 0.1f : 0f);
@@ -117,6 +124,9 @@ public abstract class ControlPointParser {
         visualMaterials,
         capturableDisplayBeacon == null ? null : capturableDisplayBeacon.toBlockVector(),
         timeToCapture,
+        decayTime,
+        recoveryTime,
+        ownedDecayTime,
         timeMultiplier,
         initialOwner,
         captureCondition,

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -89,19 +89,15 @@ public abstract class ControlPointParser {
           XMLUtils.parseNumber(attrDecay, Double.class, koth ? 0.0 : Double.POSITIVE_INFINITY);
       ownedDecayRate = XMLUtils.parseNumber(attrOwnedDecay, Double.class, 0.0);
     } else {
-      if (attrDecay != null)
-        throw new InvalidXMLException("Cannot combine this attribute with incremental", attrDecay);
-      if (attrRecovery != null)
+      if (attrDecay != null || attrRecovery != null || attrOwnedDecay != null)
         throw new InvalidXMLException(
-            "Cannot combine this attribute with incremental", attrRecovery);
-      if (attrOwnedDecay != null)
-        throw new InvalidXMLException(
-            "Cannot combine this attribute with incremental", attrOwnedDecay);
+            "Cannot combine this attribute with incremental",
+            attrDecay != null ? attrDecay : attrRecovery != null ? attrRecovery : attrOwnedDecay);
 
       final boolean incremental = XMLUtils.parseBoolean(attrIncremental, koth);
       recoveryRate = incremental ? 1.0 : Double.POSITIVE_INFINITY;
-      ownedDecayRate = 0.0;
       decayRate = incremental ? 0.0 : Double.POSITIVE_INFINITY;
+      ownedDecayRate = 0.0;
     }
 
     float timeMultiplier =
@@ -109,6 +105,10 @@ public abstract class ControlPointParser {
             elControlPoint.getAttribute("time-multiplier"), Float.class, koth ? 0.1f : 0f);
     boolean neutralState =
         XMLUtils.parseBoolean(elControlPoint.getAttribute("neutral-state"), koth);
+
+    if (neutralState == false && ownedDecayRate > 0) {
+      throw new InvalidXMLException("This attribute requires a neutral state.", attrOwnedDecay);
+    }
     boolean permanent = XMLUtils.parseBoolean(elControlPoint.getAttribute("permanent"), false);
     float pointsPerSecond =
         XMLUtils.parseNumber(elControlPoint.getAttribute("points"), Float.class, 1f);


### PR DESCRIPTION
Addresses https://github.com/PGMDev/PGM/issues/803

Edit: below is outdated, check comment for up-to-date description
I added decay-time, recovery-time, and owned-decay-time attributes to control points. All of these attributes are in units of time. So, for example, if `recover-time="5s"`, assuming a captured point that is 50% uncaptured, it will take 2.5 seconds to recover to fully captured. 99% uncaptured will take ~5s.

Another thing to note is that if an equal number of defenders and attackers(non-dominating team) are standing on the point, the point will decay/recover/owned-decay. 

Signed-off-by: mrcookie