### PR TITLE
Reintroduce max health kit

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -140,6 +140,7 @@ public abstract class KitParser {
     kits.add(this.parseGameModeKit(el));
     kits.add(this.parseShieldKit(el));
     kits.add(this.parseTeamSwitchKit(el));
+    kits.add(this.parseMaxHealthKit(el));
     kits.addAll(this.parseRemoveKits(el));
 
     kits.removeAll(Collections.singleton((Kit) null)); // Remove any nulls returned above
@@ -685,5 +686,19 @@ public abstract class KitParser {
           el.getAttributeValue("team") + " is not a valid team name!", el);
     }
     return new TeamSwitchKit(team, showTitle);
+  }
+
+  public MaxHealthKit parseMaxHealthKit(Element parent) throws InvalidXMLException {
+    Element el = XMLUtils.getUniqueChild(parent, "max-health");
+    if (el == null) return null;
+
+    double maxHealth = XMLUtils.parseNumber(el, Double.class);
+
+    if (maxHealth < 1) {
+      throw new InvalidXMLException(
+          maxHealth + " is not a valid max-health value, must be greater than 0", el);
+    }
+
+    return new MaxHealthKit(maxHealth);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/MaxHealthKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/MaxHealthKit.java
@@ -1,0 +1,34 @@
+package tc.oc.pgm.kits;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.api.player.MatchPlayer;
+
+public class MaxHealthKit extends AbstractKit {
+
+  public static final double DEFAULT_MAX_HEALTH = 20.0;
+
+  private final double maxHealth;
+
+  public MaxHealthKit(double maxHealth) {
+    checkArgument(maxHealth > 0, "max health must be greater than zero");
+    this.maxHealth = maxHealth;
+  }
+
+  @Override
+  public void applyPostEvent(MatchPlayer player, boolean force, List<ItemStack> displacedItems) {
+    player.getBukkit().setMaxHealth(maxHealth);
+  }
+
+  @Override
+  public boolean isRemovable() {
+    return true;
+  }
+
+  @Override
+  public void remove(MatchPlayer player) {
+    player.getBukkit().setMaxHealth(DEFAULT_MAX_HEALTH);
+  }
+}


### PR DESCRIPTION
# Reintroduce max health kit

Adds back functionality of the `max-health` kit.

Example XML:
```xml
<kit id="max-health-kit" force="true">
     <!-- Double health, default is 20 -->
     <max-health>40</max-health>
</kit>
```
This is a fairly simple change and should not break anything 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>