### PR TITLE
Use correct key in /mode error message

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -127,6 +127,6 @@ public final class ModeCommand {
   }
 
   private static void throwNoResults() {
-    throw exception("command.noResults");
+    throw exception("command.emptyResult");
   }
 }


### PR DESCRIPTION
This is currently what is shown when using `/mode list`
<img width="325" alt="Screen Shot 2021-05-18 at 1 12 23 PM" src="https://user-images.githubusercontent.com/3377659/118717262-b1486f80-b7da-11eb-92f2-65ea94f231e5.png">

After checking the translation templates, there's no such key! The best alternative I found was `command.emptyResult` 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>