### PR TITLE
Keep picker visible during blitz

### DIFF
--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -174,12 +174,17 @@ public class PickerMatchModule implements MatchModule, Listener {
     return teams;
   }
 
+  /** Get if the player participated in blitz match and was eliminated * */
+  private boolean hasParticipated(MatchPlayer player) {
+    return isBlitz && match.getModule(BlitzMatchModule.class).isPlayerEliminated(player.getId());
+  }
+
   /** Does the player have any use for the picker? */
   private boolean canUse(MatchPlayer player) {
     if (player == null) return false;
 
     // Player is eliminated from Blitz
-    if (isBlitz && match.isRunning()) return false;
+    if (isBlitz && match.isRunning() && hasParticipated(player)) return false;
 
     // Player is not observing or dead
     if (!(player.isObserving() || player.isDead())) return false;


### PR DESCRIPTION
# Keep picker visible during blitz

During blitz the picker is hidden from the player after the match starts. While this makes sense for those who have participated and have been eliminated, it's not user friendly for those who have joined after the match has already begun or did not feel like playing. 

This PR makes it so the picker is only hidden on blitz matches after you have been eliminated. Those who did not join will still be shown the picker, and in doing so able to understand they're not able to join the match :)

## Examples
[Join Example - Still being shown the picker](https://p17.tr3.n0.cdn.getcloudapp.com/items/rRuGrzYY/d15463d6-5377-460f-94f8-3517150e14a8.gif)
[Death Example - Picker hidden from players eliminated](https://p17.tr3.n0.cdn.getcloudapp.com/items/7KuPDWKy/b1dc7f3b-0190-449a-9d01-31d52c3d682c.gif)

Signed-off-by: applenick <applenick@users.noreply.github.com>