### PR TITLE
Add <gamemode> module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -116,6 +116,13 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   Component getGamemode();
 
   /**
+   * Get a {@link Component} that represents this map's custom gamemode title.
+   *
+   * @return A component of the gamemode name if defined or null.
+   */
+  Component getGame();
+
+  /**
    * Get the maximum number of players that can participate on each team.
    *
    * @return Maximum number of players on each team.

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -39,6 +39,7 @@ public class MapInfoImpl implements MapInfo {
   private final Collection<Contributor> authors;
   private final Collection<Contributor> contributors;
   private final Collection<String> rules;
+  private final Component game;
   private final Component gamemode;
   private final int difficulty;
   private final WorldInfo world;
@@ -60,6 +61,7 @@ public class MapInfoImpl implements MapInfo {
       @Nullable Collection<MapTag> tags,
       @Nullable Collection<Integer> players,
       @Nullable WorldInfo world,
+      @Nullable Component game,
       @Nullable Component gamemode) {
     this.name = checkNotNull(name);
     this.id = checkNotNull(MapInfo.normalizeName(id == null ? name : id));
@@ -74,6 +76,7 @@ public class MapInfoImpl implements MapInfo {
     this.tags = tags == null ? new TreeSet<>() : tags;
     this.players = players == null ? new LinkedList<>() : players;
     this.world = world == null ? new WorldInfoImpl() : world;
+    this.game = game;
     this.gamemode = gamemode;
   }
 
@@ -92,6 +95,7 @@ public class MapInfoImpl implements MapInfo {
         info.getTags(),
         info.getMaxPlayers(),
         info.getWorld(),
+        info.getGame(),
         info.getGamemode());
   }
 
@@ -115,7 +119,8 @@ public class MapInfoImpl implements MapInfo {
         null,
         null,
         parseWorld(root),
-        XMLUtils.parseFormattedText(root, "game"));
+        XMLUtils.parseFormattedText(root, "game"),
+        XMLUtils.parseFormattedText(root, "gamemode"));
   }
 
   @Override
@@ -176,6 +181,11 @@ public class MapInfoImpl implements MapInfo {
   @Override
   public Collection<Integer> getMaxPlayers() {
     return players;
+  }
+
+  @Override
+  public Component getGame() {
+    return game;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import fr.mrmicky.fastboard.FastBoard;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,6 +89,37 @@ public class SidebarMatchModule implements MatchModule, Listener {
   public static final int MAX_ROWS = 16; // Max rows on the scoreboard
   public static final int MAX_LENGTH = 30; // Max characters per line allowed
   public static final int MAX_TITLE = 32; // Max characters allowed in title
+  /*
+  ad: Attack & Defend
+  arcade: Arcade
+  blitz: Blitz
+  ctf: Capture the Flag
+  ctw: Capture the Wool
+  dtc: Destroy the Core
+  dtm: Destroy the Monument
+  ffa: Free-for-all
+  koth: King of the Hill
+  mixed: Mixed Gamemodes
+  rage: Rage
+  scorebox: Scorebox
+  tdm: Deathmatch
+   */
+  protected static final List<String> GAMEMODE_IDS =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              "ad",
+              "arcade",
+              "blitz",
+              "ctf",
+              "ctw",
+              "dtc",
+              "dtm",
+              "ffa",
+              "koth",
+              "mixed",
+              "rage",
+              "scorebox",
+              "tdm"));
 
   protected final Map<UUID, FastBoard> sidebars = new HashMap<>();
   protected final Map<Goal, BlinkTask> blinkingGoals = new HashMap<>();
@@ -258,9 +290,20 @@ public class SidebarMatchModule implements MatchModule, Listener {
       return header.colorIfAbsent(NamedTextColor.AQUA);
     }
 
-    final Component game = map.getGamemode();
+    final Component game = map.getGame();
     if (game != null) {
       return game.colorIfAbsent(NamedTextColor.AQUA);
+    }
+
+    final Component gamemode = map.getGamemode();
+    if (gamemode != null) {
+      String gamemodeCompoment = gamemode.toString();
+      for (String listItem : GAMEMODE_IDS) {
+        if (gamemodeCompoment.contains(listItem)) {
+          Component gamemodeName = translatable("gamemode." + listItem + ".name");
+          return gamemodeName.colorIfAbsent(NamedTextColor.AQUA);
+        }
+      }
     }
 
     final List<Component> games = new LinkedList<>();


### PR DESCRIPTION
This re-adds the `<gamemode>` module back to PGM (if it ever was there). It works similar to how it is already described in the [docs](https://pgm.dev/docs/modules/general/main/#gamemode-ids), as I noticed that there is no code in PGM that uses the tags. This uses the translatable objective names so maps that are based around "Attack & Defend" like BoomBox or a "Scorebox" like Zap and Miner Sixty Niner no longer need to use the untranslatable `<game>` tag. `<game>` was known as `gamemode` in the code so this was changed to `game`.

```xml
<!-- Sets Scorebox as game title -->
<gamemode>scorebox</gamemode>
<!-- Sets Attack/Defend as game title -->
<gamemode>ad</gamemode>
```