### PR TITLE
Add <gamemode> module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -1,0 +1,44 @@
+package tc.oc.pgm.api.map;
+
+public enum Gamemode {
+  ATTACK_DEFEND("ad", "Attack/Defend"),
+  ARCADE("arcade", "Arcade"),
+  BLITZ("blitz", "Blitz"),
+  BLITZ_RAGE("br", "Blitz: Rage"),
+  CAPTURE_THE_FLAG("ctf", "Capture the Flag"),
+  CONTROL_THE_POINT("cp", "Control the Point"),
+  CAPTURE_THE_WOOL("ctw", "Capture the Wool"),
+  DESTROY_THE_CORE("dtc", "Destroy the Core"),
+  DESTROY_THE_MONUMENT("dtm", "Destroy the Monument"),
+  FREE_FOR_ALL("ffa", "Free For All"),
+  FLAG_FOOTBALL("ffb", "Flag Football"),
+  KING_OF_THE_HILL("koth", "King of the Hill"),
+  KING_OF_THE_FLAG("kotf", "King of the Flag"),
+  MIXED("mixed", "Mixed"),
+  RAGE("rage", "Rage"),
+  RACE_FOR_WOOL("rfw", "Race for Wool"),
+  SCOREBOX("scorebox", "Scorebox"),
+  DEATHMATCH("tdm", "Deathmatch");
+
+  private final String id;
+  private final String name;
+  private final MapTag mapTag;
+
+  Gamemode(String id, String name) {
+    this.id = id;
+    this.name = name;
+    this.mapTag = new MapTag(id, name, true, false);
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public MapTag getMapTag() {
+    return mapTag;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -1,44 +1,32 @@
 package tc.oc.pgm.api.map;
 
 public enum Gamemode {
-  ATTACK_DEFEND("ad", "Attack/Defend"),
-  ARCADE("arcade", "Arcade"),
-  BLITZ("blitz", "Blitz"),
-  BLITZ_RAGE("br", "Blitz: Rage"),
-  CAPTURE_THE_FLAG("ctf", "Capture the Flag"),
-  CONTROL_THE_POINT("cp", "Control the Point"),
-  CAPTURE_THE_WOOL("ctw", "Capture the Wool"),
-  DESTROY_THE_CORE("dtc", "Destroy the Core"),
-  DESTROY_THE_MONUMENT("dtm", "Destroy the Monument"),
-  FREE_FOR_ALL("ffa", "Free For All"),
-  FLAG_FOOTBALL("ffb", "Flag Football"),
-  KING_OF_THE_HILL("koth", "King of the Hill"),
-  KING_OF_THE_FLAG("kotf", "King of the Flag"),
-  MIXED("mixed", "Mixed"),
-  RAGE("rage", "Rage"),
-  RACE_FOR_WOOL("rfw", "Race for Wool"),
-  SCOREBOX("scorebox", "Scorebox"),
-  DEATHMATCH("tdm", "Deathmatch");
+  ATTACK_DEFEND("ad"),
+  ARCADE("arcade"),
+  BLITZ("blitz"),
+  BLITZ_RAGE("br"),
+  CAPTURE_THE_FLAG("ctf"),
+  CONTROL_THE_POINT("cp"),
+  CAPTURE_THE_WOOL("ctw"),
+  DESTROY_THE_CORE("dtc"),
+  DESTROY_THE_MONUMENT("dtm"),
+  FREE_FOR_ALL("ffa"),
+  FLAG_FOOTBALL("ffb"),
+  KING_OF_THE_HILL("koth"),
+  KING_OF_THE_FLAG("kotf"),
+  MIXED("mixed"),
+  RAGE("rage"),
+  RACE_FOR_WOOL("rfw"),
+  SCOREBOX("scorebox"),
+  DEATHMATCH("tdm");
 
   private final String id;
-  private final String name;
-  private final MapTag mapTag;
 
-  Gamemode(String id, String name) {
+  Gamemode(String id) {
     this.id = id;
-    this.name = name;
-    this.mapTag = new MapTag(id, name, true, false);
   }
 
   public String getId() {
     return id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public MapTag getMapTag() {
-    return mapTag;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -26,6 +26,16 @@ public enum Gamemode {
     this.id = id;
   }
 
+  public static Gamemode byId(String gamemodeId) {
+    Gamemode gm = null;
+    for (Gamemode gamemode : Gamemode.values()) {
+      if (gamemode.getId().equals(gamemodeId)) {
+        gm = gamemode;
+      }
+    }
+    return gm;
+  }
+
   public String getId() {
     return id;
   }

--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -27,13 +27,12 @@ public enum Gamemode {
   }
 
   public static Gamemode byId(String gamemodeId) {
-    Gamemode gm = null;
     for (Gamemode gamemode : Gamemode.values()) {
       if (gamemode.getId().equals(gamemodeId)) {
-        gm = gamemode;
+        return gamemode;
       }
     }
-    return gm;
+    return null;
   }
 
   public String getId() {

--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -109,6 +109,13 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   Collection<MapTag> getTags();
 
   /**
+   * Get a {@link Component} that represents this map's custom game title.
+   *
+   * @return A component of the gamemode name if defined or null.
+   */
+  Component getGame();
+
+  /**
    * Get a {@link Component} that represents this map's gamemode name.
    *
    * @return A component of the gamemode name if defined or null.

--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -111,7 +111,7 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   /**
    * Get a {@link Component} that represents this map's custom game title.
    *
-   * @return The list of defined gamemodes, empty list if none are defined.
+   * @return Returns the defined gamemode title, empty if not defined.
    */
   Component getGamemode();
 

--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -118,7 +118,7 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   /**
    * Get a {@link Collection<Gamemode>} that represents this map's gamemodes.
    *
-   * @return A component of gamemodes if defined or null.
+   * @return A Collection of gamemodes if defined or null.
    */
   Collection<Gamemode> getGamemodes();
 

--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -116,11 +116,11 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   Component getGame();
 
   /**
-   * Get a {@link Component} that represents this map's gamemode name.
+   * Get a {@link String} that represents this map's gamemode name.
    *
    * @return A component of the gamemode name if defined or null.
    */
-  Component getGamemode();
+  String getGamemode();
 
   /**
    * Get the maximum number of players that can participate on each team.

--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -113,14 +113,14 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
    *
    * @return A component of the gamemode name if defined or null.
    */
-  Component getGame();
+  Component getGamemode();
 
   /**
-   * Get a {@link String} that represents this map's gamemode name.
+   * Get a {@link Collection<Gamemode>} that represents this map's gamemodes.
    *
-   * @return A component of the gamemode name if defined or null.
+   * @return A component of gamemodes if defined or null.
    */
-  String getGamemode();
+  Collection<Gamemode> getGamemodes();
 
   /**
    * Get the maximum number of players that can participate on each team.

--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -111,7 +111,7 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   /**
    * Get a {@link Component} that represents this map's custom game title.
    *
-   * @return A component of the gamemode name if defined or null.
+   * @return The list of defined gamemodes, empty list if none are defined.
    */
   Component getGamemode();
 

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -39,6 +39,7 @@ public class MapInfoImpl implements MapInfo {
   private final Collection<Contributor> authors;
   private final Collection<Contributor> contributors;
   private final Collection<String> rules;
+  private final Component game;
   private final Component gamemode;
   private final int difficulty;
   private final WorldInfo world;
@@ -60,6 +61,7 @@ public class MapInfoImpl implements MapInfo {
       @Nullable Collection<MapTag> tags,
       @Nullable Collection<Integer> players,
       @Nullable WorldInfo world,
+      @Nullable Component game,
       @Nullable Component gamemode) {
     this.name = checkNotNull(name);
     this.id = checkNotNull(MapInfo.normalizeName(id == null ? name : id));
@@ -74,6 +76,7 @@ public class MapInfoImpl implements MapInfo {
     this.tags = tags == null ? new TreeSet<>() : tags;
     this.players = players == null ? new LinkedList<>() : players;
     this.world = world == null ? new WorldInfoImpl() : world;
+    this.game = game;
     this.gamemode = gamemode;
   }
 
@@ -92,6 +95,7 @@ public class MapInfoImpl implements MapInfo {
         info.getTags(),
         info.getMaxPlayers(),
         info.getWorld(),
+        info.getGame(),
         info.getGamemode());
   }
 
@@ -115,7 +119,8 @@ public class MapInfoImpl implements MapInfo {
         null,
         null,
         parseWorld(root),
-        XMLUtils.parseFormattedText(root, "game"));
+        XMLUtils.parseFormattedText(root, "game"),
+        XMLUtils.parseFormattedText(root, "gamemode"));
   }
 
   @Override
@@ -176,6 +181,11 @@ public class MapInfoImpl implements MapInfo {
   @Override
   public Collection<Integer> getMaxPlayers() {
     return players;
+  }
+
+  @Override
+  public Component getGame() {
+    return game;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -65,7 +65,7 @@ public class MapInfoImpl implements MapInfo {
       @Nullable Collection<Integer> players,
       @Nullable WorldInfo world,
       @Nullable Component gamemode,
-      @Nullable Collection<Gamemode> gamemodes) {
+      @Nullable Collection<Gamemode> gamemodes,
       Phase phase) {
     this.name = checkNotNull(name);
     this.id = checkNotNull(MapInfo.normalizeName(id == null ? name : id));
@@ -101,7 +101,7 @@ public class MapInfoImpl implements MapInfo {
         info.getMaxPlayers(),
         info.getWorld(),
         info.getGamemode(),
-        info.getGamemodes());
+        info.getGamemodes(),
         info.getPhase());
   }
 
@@ -126,7 +126,7 @@ public class MapInfoImpl implements MapInfo {
         null,
         parseWorld(root),
         XMLUtils.parseFormattedText(root, "game"),
-        parseGamemodes(root));
+        parseGamemodes(root),
         XMLUtils.parseEnum(
             Node.fromLastChildOrAttr(root, "phase"), Phase.class, "phase", Phase.PRODUCTION));
   }

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -257,10 +257,11 @@ public class MapInfoImpl implements MapInfo {
   private static List<Gamemode> parseGamemodes(Element root) throws InvalidXMLException {
     List<Gamemode> gamemodes = new ArrayList<>();
     for (Element gamemodeEl : root.getChildren("gamemode")) {
-      for (Gamemode gamemode : Gamemode.values()) {
-        if (gamemode.getId().equals(gamemodeEl.getText())) {
-          gamemodes.add(gamemode);
-        }
+      Gamemode gm = Gamemode.byId(gamemodeEl.getText());
+      if (gm == null) {
+        throw new InvalidXMLException("Unknown gamemode", gamemodeEl);
+      } else {
+        gamemodes.add(gm);
       }
     }
     return gamemodes;

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -270,11 +270,8 @@ public class MapInfoImpl implements MapInfo {
     List<Gamemode> gamemodes = new ArrayList<>();
     for (Element gamemodeEl : root.getChildren("gamemode")) {
       Gamemode gm = Gamemode.byId(gamemodeEl.getText());
-      if (gm == null) {
-        throw new InvalidXMLException("Unknown gamemode", gamemodeEl);
-      } else {
-        gamemodes.add(gm);
-      }
+      if (gm == null) throw new InvalidXMLException("Unknown gamemode", gamemodeEl);
+      gamemodes.add(gm);
     }
     return gamemodes;
   }

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -273,35 +273,7 @@ public class SidebarMatchModule implements MatchModule, Listener {
           gamemodes.stream()
               .map(gm -> translatable("gamemode." + gm.getId() + suffix))
               .collect(Collectors.toList());
-      Component gamemodeTitle = null;
-
-      switch (gamemodes.size()) {
-        case 1:
-          gamemodeTitle = gmComponents.get(0).colorIfAbsent(NamedTextColor.AQUA);
-          break;
-        case 2:
-          gamemodeTitle =
-              Component.translatable("misc.list.pair", gmComponents.get(0), gmComponents.get(1))
-                  .colorIfAbsent(NamedTextColor.AQUA);
-          break;
-        case 3:
-          gamemodeTitle =
-              Component.translatable("misc.list.start", gmComponents.get(0), gmComponents.get(1))
-                  .append(
-                      Component.translatable(
-                          "misc.list.end", TextColor.fromHexString(""), gmComponents.get(2)))
-                  .colorIfAbsent(NamedTextColor.AQUA);
-          break;
-        case 4:
-          gamemodeTitle =
-              Component.translatable("misc.list.start", gmComponents.get(0), gmComponents.get(1))
-                  .append(
-                      Component.translatable(
-                          "misc.list.end", gmComponents.get(2), gmComponents.get(3)))
-                  .colorIfAbsent(NamedTextColor.AQUA);
-          break;
-      }
-      return gamemodeTitle;
+      return TextFormatter.list(gmComponents, NamedTextColor.AQUA);
     }
 
     final List<Component> games = new LinkedList<>();

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.map.Gamemode;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.match.Match;
@@ -258,15 +260,29 @@ public class SidebarMatchModule implements MatchModule, Listener {
       return header.colorIfAbsent(NamedTextColor.AQUA);
     }
 
-    final Component game = map.getGame();
-    if (game != null) {
-      return game.colorIfAbsent(NamedTextColor.AQUA);
+    final Component gamemode = map.getGamemode();
+    if (gamemode != null) {
+      return gamemode.colorIfAbsent(NamedTextColor.AQUA);
     }
 
-    final String gamemode = map.getGamemode();
-    if (gamemode != null) {
-      Component gamemodeName = translatable("gamemode." + gamemode + ".name");
-      return gamemodeName.colorIfAbsent(NamedTextColor.AQUA);
+    final Collection<Gamemode> gamemodes = map.getGamemodes();
+    if (!gamemodes.isEmpty()) {
+      Iterator<Gamemode> gamemodeIterator = gamemodes.iterator();
+      String firstgamemodeId = gamemodeIterator.next().getId();
+      if (gamemodeIterator.hasNext()) {
+        String secondgamemodeId = gamemodeIterator.next().getId();
+        Component firstComponent =
+            Component.translatable("gamemode." + firstgamemodeId + ".acronym");
+        Component secondComponent =
+            Component.translatable("gamemode." + secondgamemodeId + ".acronym");
+        return firstComponent
+            .append(Component.text(" & "))
+            .append(secondComponent)
+            .colorIfAbsent(NamedTextColor.AQUA);
+      } else {
+        return Component.translatable("gamemode." + firstgamemodeId + ".name")
+            .colorIfAbsent(NamedTextColor.AQUA);
+      }
     }
 
     final List<Component> games = new LinkedList<>();

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -93,14 +93,19 @@ public class SidebarMatchModule implements MatchModule, Listener {
   ad: Attack & Defend
   arcade: Arcade
   blitz: Blitz
+  br: Blitz: Rage
   ctf: Capture the Flag
+  cp: Control the Point
   ctw: Capture the Wool
   dtc: Destroy the Core
   dtm: Destroy the Monument
   ffa: Free-for-all
+  ffb: Flag Football
+  kotf: King of the Flag
   koth: King of the Hill
   mixed: Mixed Gamemodes
   rage: Rage
+  rfw: Race for Wool
   scorebox: Scorebox
   tdm: Deathmatch
    */
@@ -110,14 +115,19 @@ public class SidebarMatchModule implements MatchModule, Listener {
               "ad",
               "arcade",
               "blitz",
+              "br",
               "ctf",
+              "cp",
               "ctw",
               "dtc",
               "dtm",
               "ffa",
+              "ffb",
+              "kotf",
               "koth",
               "mixed",
               "rage",
+              "rfw",
               "scorebox",
               "tdm"));
 

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.scoreboard;
 
+import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 
 import com.google.common.collect.ImmutableList;
@@ -11,7 +12,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -267,22 +267,48 @@ public class SidebarMatchModule implements MatchModule, Listener {
 
     final Collection<Gamemode> gamemodes = map.getGamemodes();
     if (!gamemodes.isEmpty()) {
-      Iterator<Gamemode> gamemodeIterator = gamemodes.iterator();
-      String firstgamemodeId = gamemodeIterator.next().getId();
-      if (gamemodeIterator.hasNext()) {
-        String secondgamemodeId = gamemodeIterator.next().getId();
-        Component firstComponent =
-            Component.translatable("gamemode." + firstgamemodeId + ".acronym");
-        Component secondComponent =
-            Component.translatable("gamemode." + secondgamemodeId + ".acronym");
-        return firstComponent
-            .append(Component.text(" & "))
-            .append(secondComponent)
-            .colorIfAbsent(NamedTextColor.AQUA);
-      } else {
-        return Component.translatable("gamemode." + firstgamemodeId + ".name")
-            .colorIfAbsent(NamedTextColor.AQUA);
+      Component gamemodeTitle = null;
+      List<Component> gamemodeComponents = new ArrayList<>();
+      for (Gamemode value : gamemodes) {
+        Component gmComponent;
+        // Make this smarter using MAX_LENGTH
+        if (gamemodes.size() <= 1) {
+          gmComponent = Component.translatable("gamemode." + value.getId() + ".name");
+        } else {
+          gmComponent = Component.translatable("gamemode." + value.getId() + ".acronym");
+        }
+        gamemodeComponents.add(gmComponent);
       }
+      switch (gamemodes.size()) {
+        case 1:
+          gamemodeTitle = gamemodeComponents.get(0).colorIfAbsent(NamedTextColor.AQUA);
+          break;
+        case 2:
+          gamemodeTitle =
+              Component.translatable(
+                      "misc.list.pair", gamemodeComponents.get(0), gamemodeComponents.get(1))
+                  .colorIfAbsent(NamedTextColor.AQUA);
+          break;
+        case 3:
+          gamemodeTitle =
+              Component.translatable(
+                      "misc.list.start", gamemodeComponents.get(0), gamemodeComponents.get(1))
+                  .append(
+                      Component.translatable(
+                          "misc.list.end", TextColor.fromHexString(""), gamemodeComponents.get(2)))
+                  .colorIfAbsent(NamedTextColor.AQUA);
+          break;
+        case 4:
+          gamemodeTitle =
+              Component.translatable(
+                      "misc.list.start", gamemodeComponents.get(0), gamemodeComponents.get(1))
+                  .append(
+                      Component.translatable(
+                          "misc.list.end", gamemodeComponents.get(2), gamemodeComponents.get(3)))
+                  .colorIfAbsent(NamedTextColor.AQUA);
+          break;
+      }
+      return gamemodeTitle;
     }
 
     final List<Component> games = new LinkedList<>();

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -267,44 +268,36 @@ public class SidebarMatchModule implements MatchModule, Listener {
 
     final Collection<Gamemode> gamemodes = map.getGamemodes();
     if (!gamemodes.isEmpty()) {
+      String suffix = gamemodes.size() <= 1 ? ".name" : ".acronym";
+      List<Component> gmComponents =
+          gamemodes.stream()
+              .map(gm -> translatable("gamemode." + gm.getId() + suffix))
+              .collect(Collectors.toList());
       Component gamemodeTitle = null;
-      List<Component> gamemodeComponents = new ArrayList<>();
-      for (Gamemode value : gamemodes) {
-        Component gmComponent;
-        // Make this smarter using MAX_LENGTH
-        if (gamemodes.size() <= 1) {
-          gmComponent = Component.translatable("gamemode." + value.getId() + ".name");
-        } else {
-          gmComponent = Component.translatable("gamemode." + value.getId() + ".acronym");
-        }
-        gamemodeComponents.add(gmComponent);
-      }
+
       switch (gamemodes.size()) {
         case 1:
-          gamemodeTitle = gamemodeComponents.get(0).colorIfAbsent(NamedTextColor.AQUA);
+          gamemodeTitle = gmComponents.get(0).colorIfAbsent(NamedTextColor.AQUA);
           break;
         case 2:
           gamemodeTitle =
-              Component.translatable(
-                      "misc.list.pair", gamemodeComponents.get(0), gamemodeComponents.get(1))
+              Component.translatable("misc.list.pair", gmComponents.get(0), gmComponents.get(1))
                   .colorIfAbsent(NamedTextColor.AQUA);
           break;
         case 3:
           gamemodeTitle =
-              Component.translatable(
-                      "misc.list.start", gamemodeComponents.get(0), gamemodeComponents.get(1))
+              Component.translatable("misc.list.start", gmComponents.get(0), gmComponents.get(1))
                   .append(
                       Component.translatable(
-                          "misc.list.end", TextColor.fromHexString(""), gamemodeComponents.get(2)))
+                          "misc.list.end", TextColor.fromHexString(""), gmComponents.get(2)))
                   .colorIfAbsent(NamedTextColor.AQUA);
           break;
         case 4:
           gamemodeTitle =
-              Component.translatable(
-                      "misc.list.start", gamemodeComponents.get(0), gamemodeComponents.get(1))
+              Component.translatable("misc.list.start", gmComponents.get(0), gmComponents.get(1))
                   .append(
                       Component.translatable(
-                          "misc.list.end", gamemodeComponents.get(2), gamemodeComponents.get(3)))
+                          "misc.list.end", gmComponents.get(2), gmComponents.get(3)))
                   .colorIfAbsent(NamedTextColor.AQUA);
           break;
       }

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -105,21 +105,21 @@ public class SidebarMatchModule implements MatchModule, Listener {
   tdm: Deathmatch
    */
   protected static final List<String> GAMEMODE_IDS =
-          Collections.unmodifiableList(
-                  Arrays.asList(
-                          "ad",
-                          "arcade",
-                          "blitz",
-                          "ctf",
-                          "ctw",
-                          "dtc",
-                          "dtm",
-                          "ffa",
-                          "koth",
-                          "mixed",
-                          "rage",
-                          "scorebox",
-                          "tdm"));
+      Collections.unmodifiableList(
+          Arrays.asList(
+              "ad",
+              "arcade",
+              "blitz",
+              "ctf",
+              "ctw",
+              "dtc",
+              "dtm",
+              "ffa",
+              "koth",
+              "mixed",
+              "rage",
+              "scorebox",
+              "tdm"));
 
   protected final Map<UUID, FastBoard> sidebars = new HashMap<>();
   protected final Map<Goal, BlinkTask> blinkingGoals = new HashMap<>();

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import fr.mrmicky.fastboard.FastBoard;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,6 +89,37 @@ public class SidebarMatchModule implements MatchModule, Listener {
   public static final int MAX_ROWS = 16; // Max rows on the scoreboard
   public static final int MAX_LENGTH = 30; // Max characters per line allowed
   public static final int MAX_TITLE = 32; // Max characters allowed in title
+  /*
+  ad: Attack & Defend
+  arcade: Arcade
+  blitz: Blitz
+  ctf: Capture the Flag
+  ctw: Capture the Wool
+  dtc: Destroy the Core
+  dtm: Destroy the Monument
+  ffa: Free-for-all
+  koth: King of the Hill
+  mixed: Mixed Gamemodes
+  rage: Rage
+  scorebox: Scorebox
+  tdm: Deathmatch
+   */
+  protected static final List<String> GAMEMODE_IDS =
+          Collections.unmodifiableList(
+                  Arrays.asList(
+                          "ad",
+                          "arcade",
+                          "blitz",
+                          "ctf",
+                          "ctw",
+                          "dtc",
+                          "dtm",
+                          "ffa",
+                          "koth",
+                          "mixed",
+                          "rage",
+                          "scorebox",
+                          "tdm"));
 
   protected final Map<UUID, FastBoard> sidebars = new HashMap<>();
   protected final Map<Goal, BlinkTask> blinkingGoals = new HashMap<>();
@@ -258,9 +290,20 @@ public class SidebarMatchModule implements MatchModule, Listener {
       return header.colorIfAbsent(NamedTextColor.AQUA);
     }
 
-    final Component game = map.getGamemode();
+    final Component game = map.getGame();
     if (game != null) {
       return game.colorIfAbsent(NamedTextColor.AQUA);
+    }
+
+    final Component gamemode = map.getGamemode();
+    if (gamemode != null) {
+      String gamemodeCompoment = gamemode.toString();
+      for (String listItem : GAMEMODE_IDS) {
+        if (gamemodeCompoment.contains(listItem)) {
+          Component gamemodeName = translatable("gamemode." + listItem + ".name");
+          return gamemodeName.colorIfAbsent(NamedTextColor.AQUA);
+        }
+      }
     }
 
     final List<Component> games = new LinkedList<>();

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableSet;
 import fr.mrmicky.fastboard.FastBoard;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -89,47 +88,6 @@ public class SidebarMatchModule implements MatchModule, Listener {
   public static final int MAX_ROWS = 16; // Max rows on the scoreboard
   public static final int MAX_LENGTH = 30; // Max characters per line allowed
   public static final int MAX_TITLE = 32; // Max characters allowed in title
-  /*
-  ad: Attack & Defend
-  arcade: Arcade
-  blitz: Blitz
-  br: Blitz: Rage
-  ctf: Capture the Flag
-  cp: Control the Point
-  ctw: Capture the Wool
-  dtc: Destroy the Core
-  dtm: Destroy the Monument
-  ffa: Free-for-all
-  ffb: Flag Football
-  kotf: King of the Flag
-  koth: King of the Hill
-  mixed: Mixed Gamemodes
-  rage: Rage
-  rfw: Race for Wool
-  scorebox: Scorebox
-  tdm: Deathmatch
-   */
-  protected static final List<String> GAMEMODE_IDS =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              "ad",
-              "arcade",
-              "blitz",
-              "br",
-              "ctf",
-              "cp",
-              "ctw",
-              "dtc",
-              "dtm",
-              "ffa",
-              "ffb",
-              "kotf",
-              "koth",
-              "mixed",
-              "rage",
-              "rfw",
-              "scorebox",
-              "tdm"));
 
   protected final Map<UUID, FastBoard> sidebars = new HashMap<>();
   protected final Map<Goal, BlinkTask> blinkingGoals = new HashMap<>();
@@ -305,15 +263,10 @@ public class SidebarMatchModule implements MatchModule, Listener {
       return game.colorIfAbsent(NamedTextColor.AQUA);
     }
 
-    final Component gamemode = map.getGamemode();
+    final String gamemode = map.getGamemode();
     if (gamemode != null) {
-      String gamemodeCompoment = gamemode.toString();
-      for (String listItem : GAMEMODE_IDS) {
-        if (gamemodeCompoment.contains(listItem)) {
-          Component gamemodeName = translatable("gamemode." + listItem + ".name");
-          return gamemodeName.colorIfAbsent(NamedTextColor.AQUA);
-        }
-      }
+      Component gamemodeName = translatable("gamemode." + gamemode + ".name");
+      return gamemodeName.colorIfAbsent(NamedTextColor.AQUA);
     }
 
     final List<Component> games = new LinkedList<>();

--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -8,6 +8,10 @@ gamemode.ctw.name = Capture the Wool
 
 gamemode.ctf.name = Capture the Flag
 
+gamemode.ffb.name = Flag Football
+
+gamemode.kotf.name = King of the Flag
+
 gamemode.tdm.name = Deathmatch
 
 gamemode.ad.name = Attack/Defend
@@ -19,6 +23,10 @@ gamemode.koth.name = King of the Hill
 gamemode.blitz.name = Blitz
 
 gamemode.rage.name = Rage
+
+gamemode.br.name = Blitz: Rage
+
+gamemode.rfw.name = Race for Wool
 
 gamemode.scorebox.name = Scorebox
 
@@ -36,17 +44,25 @@ gamemode.ctw.acronym = CTW
 
 gamemode.ctf.acronym = CTF
 
+gamemode.ffb.acronym = FFB
+
+gamemode.kotf.acronym = KotF
+
 gamemode.tdm.acronym = TDM
 
 gamemode.ad.acronym = A/D
 
 gamemode.cp.acronym = CP
 
-gamemode.koth.acronym = KoTH
+gamemode.koth.acronym = KotH
 
 gamemode.blitz.acronym = Blitz
 
 gamemode.rage.acronym = Rage
+
+gamemode.br.acronym = Blitz: Rage
+
+gamemode.rfw.acronym = RFW
 
 gamemode.scorebox.acronym = Scorebox
 


### PR DESCRIPTION
This re-adds the `<gamemode>` module back to PGM (if it ever was there). It works similar to how it is already described in the [docs](https://pgm.dev/docs/modules/general/main/#gamemode-ids), as I noticed that there is no code in PGM that uses the tags. You can't do that weird adding thing it talks about. This uses the translatable objective names so maps that are based around "Attack & Defend" like BoomBox or a "Scorebox" like Zap and Miner Sixty Niner, or maps with monument mode trickery no longer need to use the untranslatable `<game>` tag. `<game>` was known as `gamemode` in the code so this was changed to `game`. No new translatable components were added.

```xml
<!-- Sets Scorebox as game title -->
<gamemode>scorebox</gamemode>
<!-- Sets Attack/Defend as game title -->
<gamemode>ad</gamemode>
```