### PR TITLE
Map visibility feature

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Datastore.java
+++ b/core/src/main/java/tc/oc/pgm/api/Datastore.java
@@ -1,7 +1,10 @@
 package tc.oc.pgm.api;
 
+import java.util.List;
 import java.util.UUID;
 import tc.oc.pgm.api.map.MapActivity;
+import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.api.map.MapVisibility;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.Settings;
 import tc.oc.pgm.util.skin.Skin;
@@ -48,6 +51,21 @@ public interface Datastore {
    * @return A {@link MapActivity}.
    */
   MapActivity getMapActivity(String poolName);
+
+  /**
+   * Get the visibility data for a given {@link MapInfo}.
+   *
+   * @param map A {@link MapInfo}
+   * @return A {@link MapVisibility}
+   */
+  MapVisibility getMapVisibility(MapInfo map);
+
+  /**
+   * Get a list of {@link MapVisibility} which are hidden
+   *
+   * @return A list of {@link MapVisibility}
+   */
+  List<MapVisibility> getHiddenMaps();
 
   /** Cleans up any resources or connections. */
   void close();

--- a/core/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/core/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -37,6 +37,7 @@ public interface Permissions {
   String BAN = ROOT + ".ban"; // Access to the /ban command
   String FREEZE = ROOT + ".freeze"; // Access to the /freeze command
   String VANISH = ROOT + ".vanish"; // Access to /vanish command
+  String MAPDEV = ROOT + ".mapdev"; // Access to mapdev related commands (/mapvisibility)
 
   String MAPMAKER = GROUP + ".mapmaker"; // Permission group for mapmakers, defined in config.yml
 

--- a/core/src/main/java/tc/oc/pgm/api/map/MapVisibility.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapVisibility.java
@@ -1,0 +1,26 @@
+package tc.oc.pgm.api.map;
+
+/** Holds information about whether a {@link MapInfo} should be viewable * */
+public interface MapVisibility {
+
+  /**
+   * Get the linked {@link MapInfo}
+   *
+   * @return A {@link MapInfo}
+   */
+  MapInfo getMap();
+
+  /**
+   * Get whether this map is publicly viewable or not
+   *
+   * @return if map should be hidden
+   */
+  boolean isHidden();
+
+  /**
+   * Set if the map should be hidden
+   *
+   * @param hidden Whether map should be hidden or not
+   */
+  void setHidden(boolean hidden);
+}

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -81,6 +81,8 @@ public final class MapCommand {
       search = search.filter(map -> matchesName(map, name));
     }
 
+    search = search.filter(map -> isVisible(map, sender));
+
     Set<MapInfo> maps = search.collect(Collectors.toCollection(TreeSet::new));
     int resultsPerPage = 8;
     int pages = (maps.size() + resultsPerPage - 1) / resultsPerPage;
@@ -145,6 +147,11 @@ public final class MapCommand {
     checkNotNull(map);
     query = checkNotNull(query).toLowerCase();
     return map.getName().toLowerCase().contains(query);
+  }
+
+  private static boolean isVisible(MapInfo map, CommandSender viewer) {
+    return viewer.hasPermission(Permissions.STAFF)
+        || !PGM.get().getDatastore().getMapVisibility(map).isHidden();
   }
 
   @Command(

--- a/core/src/main/java/tc/oc/pgm/command/MapVisibilityCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapVisibilityCommand.java
@@ -1,0 +1,85 @@
+package tc.oc.pgm.command;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
+
+import app.ashcon.intake.Command;
+import app.ashcon.intake.CommandException;
+import app.ashcon.intake.parametric.annotation.Default;
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.api.map.MapVisibility;
+import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.PrettyPaginatedComponentResults;
+import tc.oc.pgm.util.named.MapNameStyle;
+import tc.oc.pgm.util.text.TextFormatter;
+
+public class MapVisibilityCommand {
+
+  @Command(
+      aliases = {"mapvisibility", "mvis"},
+      desc = "Toggle viewing visibility for a map",
+      perms = Permissions.MAPDEV)
+  public void setVisibility(Audience viewer, CommandSender sender, MapInfo map) {
+    MapVisibility visibility = PGM.get().getDatastore().getMapVisibility(map);
+    visibility.setHidden(!visibility.isHidden());
+
+    String key = visibility.isHidden() ? "hidden" : "shown";
+    NamedTextColor color = visibility.isHidden() ? NamedTextColor.RED : NamedTextColor.GREEN;
+
+    viewer.sendMessage(
+        translatable(
+            "map.visibility",
+            NamedTextColor.GRAY,
+            translatable("map.visibility." + key, color),
+            map.getStyledName(MapNameStyle.COLOR)));
+  }
+
+  @Command(
+      aliases = {"hiddenmaps"},
+      desc = "View a list of hidden maps",
+      perms = Permissions.MAPDEV)
+  public void viewHiddenMaps(Audience viewer, CommandSender sender, @Default("1") int page)
+      throws CommandException {
+    List<MapVisibility> hiddenMaps = PGM.get().getDatastore().getHiddenMaps();
+
+    int resultsPerPage = 8;
+    int pages = (hiddenMaps.size() + resultsPerPage - 1) / resultsPerPage;
+
+    Component paginated =
+        TextFormatter.paginate(
+            translatable("map.visibility.title"),
+            page,
+            pages,
+            NamedTextColor.DARK_AQUA,
+            NamedTextColor.AQUA,
+            true);
+
+    Component formattedTitle =
+        TextFormatter.horizontalLineHeading(sender, paginated, NamedTextColor.DARK_AQUA, 250);
+
+    new PrettyPaginatedComponentResults<MapVisibility>(formattedTitle, resultsPerPage) {
+      @Override
+      public Component format(MapVisibility map, int index) {
+        return text()
+            .append(text((index + 1) + ". "))
+            .append(map.getMap().getStyledName(MapNameStyle.COLOR_WITH_AUTHORS))
+            .clickEvent(ClickEvent.runCommand("/map " + map.getMap().getName()))
+            .hoverEvent(
+                HoverEvent.showText(
+                    translatable(
+                        "command.maps.hover",
+                        NamedTextColor.GRAY,
+                        map.getMap().getStyledName(MapNameStyle.COLOR))))
+            .build();
+      }
+    }.display(viewer, hiddenMaps, page);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/graph/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/graph/CommandGraph.java
@@ -37,6 +37,7 @@ import tc.oc.pgm.command.ListCommand;
 import tc.oc.pgm.command.MapCommand;
 import tc.oc.pgm.command.MapOrderCommand;
 import tc.oc.pgm.command.MapPoolCommand;
+import tc.oc.pgm.command.MapVisibilityCommand;
 import tc.oc.pgm.command.MatchCommand;
 import tc.oc.pgm.command.ModeCommand;
 import tc.oc.pgm.command.ProximityCommand;
@@ -75,6 +76,7 @@ public class CommandGraph extends BasicBukkitCommandGraph {
     register(new MapCommand());
     register(new MapOrderCommand());
     register(new MapPoolCommand());
+    register(new MapVisibilityCommand());
     register(new MatchCommand());
     register(new ModeCommand(), "mode", "modes");
     register(new ProximityCommand());

--- a/core/src/main/java/tc/oc/pgm/db/MapVisibilityImpl.java
+++ b/core/src/main/java/tc/oc/pgm/db/MapVisibilityImpl.java
@@ -1,0 +1,36 @@
+package tc.oc.pgm.db;
+
+import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.api.map.MapVisibility;
+
+public class MapVisibilityImpl implements MapVisibility {
+
+  private final MapInfo map;
+  private boolean hidden;
+
+  public MapVisibilityImpl(MapInfo map, boolean hidden) {
+    this.map = map;
+    this.hidden = hidden;
+  }
+
+  @Override
+  public MapInfo getMap() {
+    return map;
+  }
+
+  @Override
+  public boolean isHidden() {
+    return hidden;
+  }
+
+  @Override
+  public void setHidden(boolean hidden) {
+    this.hidden = hidden;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof MapVisibility)) return false;
+    return ((MapVisibility) other).getMap().equals(getMap());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
@@ -20,6 +20,7 @@ import java.util.logging.Logger;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import net.md_5.bungee.api.ChatColor;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapContext;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapLibrary;
@@ -208,6 +209,9 @@ public class MapLibraryImpl implements MapLibrary {
         new MapEntry(source, context.clone(), context),
         (m1, m2) -> m1.info.getVersion().isOlderThan(m2.info.getVersion()) ? m2 : m1);
     failed.remove(source);
+
+    // Pre-fetch the map visibility
+    PGM.get().getDatastore().getMapVisibility(context);
 
     return context;
   }

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -74,6 +74,17 @@ map.cycled = Cycled
 
 map.protectPortal = You may not obstruct this area
 
+# {1} = visibility type (e.g. "hidden")
+# {0} = map name
+map.visibility = Map visibility set to {0} for {1}
+
+map.visibility.hidden = hidden
+
+map.visibility.shown  = shown
+
+map.visibility.title = Hidden Maps
+
+
 # {0} = map pool name (e.g. "Mega")
 pool.change = Map pool has been set to {0} in order to better adjust to the current player count.
 


### PR DESCRIPTION
# Map Visibility Feature

Discussed this with @Electroid yesterday. Basically allows for loaded maps to be hidden from public viewing.

Commands:
`/hiddenmaps` - View a list of hidden maps
`/mapvisibility [map]` - Toggle the `hidden` status of the provided map

At the moment hidden maps are only hidden from being visible via `/maps`, however this will be used more widely for other upcoming changes.

## Preview

https://user-images.githubusercontent.com/3377659/120559450-e5fd1f00-c3b5-11eb-8d57-c7f550cf6d8e.mp4


## Suggestions
Could use some suggestions on whether `/hiddenmaps` should be its own dedicated command, or if it should be implemented as a flag under `/maps` for example `/maps -h`.

Also maybe `/mapvisibility` should be `/setvisibility` or `/togglevisibility`? Unsure

Signed-off-by: applenick <applenick@users.noreply.github.com>