### PR TITLE
Ensure max-health kit is always reset

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/MaxHealthKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/MaxHealthKit.java
@@ -8,7 +8,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 
 public class MaxHealthKit extends AbstractKit {
 
-  public static final double DEFAULT_MAX_HEALTH = 20.0;
+  public static final double BUKKIT_DEFAULT = 20.0;
 
   private final double maxHealth;
 
@@ -29,6 +29,6 @@ public class MaxHealthKit extends AbstractKit {
 
   @Override
   public void remove(MatchPlayer player) {
-    player.getBukkit().setMaxHealth(DEFAULT_MAX_HEALTH);
+    player.getBukkit().setMaxHealth(BUKKIT_DEFAULT);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -43,6 +43,7 @@ import tc.oc.pgm.api.setting.Settings;
 import tc.oc.pgm.api.time.Tick;
 import tc.oc.pgm.events.PlayerResetEvent;
 import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.kits.MaxHealthKit;
 import tc.oc.pgm.kits.WalkSpeedKit;
 import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.ClassLogger;
@@ -259,6 +260,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     bukkit.setFallDistance(0);
     bukkit.setFireTicks(0);
     bukkit.setFoodLevel(20); // full
+    bukkit.setMaxHealth(MaxHealthKit.BUKKIT_DEFAULT);
     bukkit.setHealth(bukkit.getMaxHealth());
     bukkit.setLevel(0);
     bukkit.setExp(0); // clear xp


### PR DESCRIPTION
# Ensure max-health kit is always reset

This resolves #885, which was introduced due to the reintroduction of the max-health kit in #868.

Solution was simply calling `Player#setMaxHealth` with the default Bukkit value from `MatchPlayer#reset`. Also updated the variable name in `MaxHealthKit` to keep a consistent pattern with `WalkSpeedKit`.

Tested and works as intended 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>