### PR TITLE
Custom pool cycle times

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapOrder.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapOrder.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.api.map;
 
+import java.time.Duration;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 
 /**
@@ -33,6 +35,15 @@ public interface MapOrder {
 
   /** Removes any map that was set manually, returning the server to what was previously chosen. */
   void resetNextMap();
+
+  /**
+   * Returns the duration used for cycles in {@link CycleMatchModule}.
+   *
+   * @return The cycle duration
+   */
+  default Duration getCycleTime() {
+    return PGM.get().getConfiguration().getCycleTime();
+  }
 
   /**
    * Notify the {@link MapOrder} that a match just ended, to allow it to run actions before cycle

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -16,6 +16,7 @@ import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerLeaveMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.restart.RestartManager;
+import tc.oc.pgm.rotation.MapPoolManager;
 
 @ListenerScope(MatchScope.LOADED)
 public class CycleMatchModule implements MatchModule, Listener {
@@ -60,7 +61,8 @@ public class CycleMatchModule implements MatchModule, Listener {
     mapOrder.matchEnded(match);
 
     if (!RestartManager.isQueued()) {
-      Duration duration = PGM.get().getConfiguration().getCycleTime();
+      Duration duration = getCycleTime(mapOrder);
+
       if (!duration.isNegative()) {
         startCountdown(duration);
       }
@@ -70,5 +72,24 @@ public class CycleMatchModule implements MatchModule, Listener {
   @EventHandler
   public void onLeave(PlayerLeaveMatchEvent event) {
     if (bossbar != null) event.getPlayer().hideBossBar(bossbar);
+  }
+
+  private Duration getCycleTime(MapOrder order) {
+    Duration cycleTime = null;
+
+    // Check if pool has custom cycle time
+    if (order instanceof MapPoolManager) {
+      MapPoolManager manager = (MapPoolManager) order;
+      if (manager != null && manager.getActiveMapPool() != null) {
+        cycleTime = manager.getActiveMapPool().getCycleTime();
+      }
+    }
+
+    // Default to the main cycle time when not found
+    if (cycleTime == null || cycleTime.isNegative()) {
+      cycleTime = PGM.get().getConfiguration().getCycleTime();
+    }
+
+    return cycleTime;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -16,7 +16,6 @@ import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerLeaveMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.restart.RestartManager;
-import tc.oc.pgm.rotation.MapPoolManager;
 
 @ListenerScope(MatchScope.LOADED)
 public class CycleMatchModule implements MatchModule, Listener {
@@ -61,7 +60,7 @@ public class CycleMatchModule implements MatchModule, Listener {
     mapOrder.matchEnded(match);
 
     if (!RestartManager.isQueued()) {
-      Duration duration = getCycleTime(mapOrder);
+      Duration duration = mapOrder.getCycleTime();
 
       if (!duration.isNegative()) {
         startCountdown(duration);
@@ -72,24 +71,5 @@ public class CycleMatchModule implements MatchModule, Listener {
   @EventHandler
   public void onLeave(PlayerLeaveMatchEvent event) {
     if (bossbar != null) event.getPlayer().hideBossBar(bossbar);
-  }
-
-  private Duration getCycleTime(MapOrder order) {
-    Duration cycleTime = null;
-
-    // Check if pool has custom cycle time
-    if (order instanceof MapPoolManager) {
-      MapPoolManager manager = (MapPoolManager) order;
-      if (manager != null && manager.getActiveMapPool() != null) {
-        cycleTime = manager.getActiveMapPool().getCycleTime();
-      }
-    }
-
-    // Default to the main cycle time when not found
-    if (cycleTime == null || cycleTime.isNegative()) {
-      cycleTime = PGM.get().getConfiguration().getCycleTime();
-    }
-
-    return cycleTime;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
@@ -84,10 +84,6 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
     return dynamic;
   }
 
-  public Duration getCycleTime() {
-    return cycleTime;
-  }
-
   public List<MapInfo> getMaps() {
     return maps;
   }
@@ -98,6 +94,11 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
 
   protected MapInfo getRandom() {
     return maps.get((int) (Math.random() * maps.size()));
+  }
+
+  @Override
+  public Duration getCycleTime() {
+    return cycleTime;
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPool.java
@@ -1,5 +1,8 @@
 package tc.oc.pgm.rotation;
 
+import static tc.oc.pgm.util.text.TextParser.parseDuration;
+
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -22,6 +25,7 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
   protected final boolean enabled;
   protected final List<MapInfo> maps;
   protected final int players;
+  protected final Duration cycleTime;
 
   protected final boolean dynamic;
 
@@ -48,6 +52,7 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
     this.enabled = section.getBoolean("enabled");
     this.players = section.getInt("players");
     this.dynamic = section.getBoolean("dynamic", true);
+    this.cycleTime = parseDuration(section.getString("cycle-time", "-1s"));
 
     MapLibrary library = PGM.get().getMapLibrary();
     List<MapInfo> mapList =
@@ -77,6 +82,10 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
 
   public boolean isDynamic() {
     return dynamic;
+  }
+
+  public Duration getCycleTime() {
+    return cycleTime;
   }
 
   public List<MapInfo> getMaps() {

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -264,6 +264,14 @@ public class MapPoolManager implements MapOrder {
     activeMapPool.matchEnded(match);
   }
 
+  @Override
+  public Duration getCycleTime() {
+    if (activeMapPool != null && !activeMapPool.getCycleTime().isNegative()) {
+      return activeMapPool.getCycleTime();
+    }
+    return PGM.get().getConfiguration().getCycleTime();
+  }
+
   private boolean shouldRevert(Match match) {
     return match.getPlayers().stream()
             .noneMatch(mp -> mp.getBukkit().hasPermission(Permissions.STAFF))

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -266,8 +266,9 @@ public class MapPoolManager implements MapOrder {
 
   @Override
   public Duration getCycleTime() {
-    if (activeMapPool != null && !activeMapPool.getCycleTime().isNegative()) {
-      return activeMapPool.getCycleTime();
+    Duration cycleTime;
+    if (activeMapPool != null && !(cycleTime = activeMapPool.getCycleTime()).isNegative()) {
+      return cycleTime;
     }
     return PGM.get().getConfiguration().getCycleTime();
   }

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -22,6 +22,9 @@ pools:
     # on the server reaches the "players" threshold.
     dynamic: true
     players: 1
+    
+    # How long should should a map cycle last?
+    cycle-time: "15s"
 
     # A list of map names in this pool.
     # Uses map name given in map.xml, do not use folder name.

--- a/pom.xml
+++ b/pom.xml
@@ -103,13 +103,13 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-plain</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Custom pool cycle times

This PR allows for map pools to have custom cycle times defined in the `map-pools.yml` 


## Example `map-pools.yml`
```yml
pools:
  tnt:
    type: ordered
    cycle-time: 15s   # The match would cycle after 15 seconds instead of 30 in this example
    players: 1
    maps:
    - cos(tnt)
    ...
```

Also I included a commit which bumps [adventure](https://github.com/KyoriPowered/adventure) to `4.8.1` which resolves an error when trying to build. Not sure if it was fine to combine the two, but it saved some time. Let me know if you want a separate PR for that.

The changes to map pools have been tested and work as intended 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>