### PR TITLE
Reintroduce map phase XML tag

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -130,6 +130,13 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   WorldInfo getWorld();
 
   /**
+   * Get the {@link Phase} for the map.
+   *
+   * @return The {@link Phase}.
+   */
+  Phase getPhase();
+
+  /**
    * Create an immutable copy of this info.
    *
    * @return A cloned {@link MapInfo}.

--- a/core/src/main/java/tc/oc/pgm/api/map/Phase.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Phase.java
@@ -13,6 +13,11 @@ public enum Phase {
   }
 
   public static Phase of(String query) {
-    return query.startsWith("dev") ? DEVELOPMENT : PRODUCTION;
+    for (Phase phase : Phase.values()) {
+      if (phase.toString().toLowerCase().startsWith(query.toLowerCase())) {
+        return phase;
+      }
+    }
+    return null;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/Phase.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Phase.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.api.map;
 
 import static net.kyori.adventure.text.Component.translatable;
 
+import java.util.Locale;
 import net.kyori.adventure.text.Component;
 
 public enum Phase {
@@ -13,8 +14,9 @@ public enum Phase {
   }
 
   public static Phase of(String query) {
+    query = query.toLowerCase(Locale.ROOT);
     for (Phase phase : Phase.values()) {
-      if (phase.toString().toLowerCase().startsWith(query.toLowerCase())) {
+      if (phase.toString().toLowerCase(Locale.ROOT).startsWith(query)) {
         return phase;
       }
     }

--- a/core/src/main/java/tc/oc/pgm/api/map/Phase.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Phase.java
@@ -1,0 +1,18 @@
+package tc.oc.pgm.api.map;
+
+import static net.kyori.adventure.text.Component.translatable;
+
+import net.kyori.adventure.text.Component;
+
+public enum Phase {
+  PRODUCTION,
+  DEVELOPMENT;
+
+  public Component toComponent() {
+    return translatable("map.phase." + this.name().toLowerCase());
+  }
+
+  public static Phase of(String query) {
+    return query.startsWith("dev") ? DEVELOPMENT : PRODUCTION;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -7,6 +7,7 @@ import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.event.ClickEvent.runCommand;
 import static net.kyori.adventure.text.event.HoverEvent.showText;
+import static tc.oc.pgm.util.text.TextException.invalidFormat;
 
 import app.ashcon.intake.Command;
 import app.ashcon.intake.CommandException;
@@ -58,7 +59,7 @@ public final class MapCommand {
       @Fallback(Type.NULL) @Switch('t') String tags,
       @Fallback(Type.NULL) @Switch('a') String author,
       @Fallback(Type.NULL) @Switch('n') String name,
-      @Fallback(Type.NULL) @Switch('p') String phase)
+      @Fallback(Type.NULL) @Switch('p') String phaseType)
       throws CommandException {
     Stream<MapInfo> search = Sets.newHashSet(library.getMaps()).stream();
     if (tags != null) {
@@ -83,11 +84,10 @@ public final class MapCommand {
       search = search.filter(map -> matchesName(map, name));
     }
 
-    if (phase != null) {
-      search = search.filter(map -> matchesPhase(map, phase));
-    } else {
-      search = search.filter(map -> map.getPhase() == Phase.PRODUCTION);
-    }
+    Phase phase = phaseType == null ? Phase.PRODUCTION : Phase.of(phaseType);
+    if (phase == null) throw invalidFormat(phaseType, Phase.class, null);
+
+    search = search.filter(map -> map.getPhase() == phase);
 
     Set<MapInfo> maps = search.collect(Collectors.toCollection(TreeSet::new));
     int resultsPerPage = 8;

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -34,6 +34,7 @@ import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapLibrary;
 import tc.oc.pgm.api.map.MapTag;
+import tc.oc.pgm.api.map.Phase;
 import tc.oc.pgm.rotation.MapPool;
 import tc.oc.pgm.rotation.MapPoolManager;
 import tc.oc.pgm.util.Audience;
@@ -56,7 +57,8 @@ public final class MapCommand {
       @Default("1") Integer page,
       @Fallback(Type.NULL) @Switch('t') String tags,
       @Fallback(Type.NULL) @Switch('a') String author,
-      @Fallback(Type.NULL) @Switch('n') String name)
+      @Fallback(Type.NULL) @Switch('n') String name,
+      @Fallback(Type.NULL) @Switch('p') String phase)
       throws CommandException {
     Stream<MapInfo> search = Sets.newHashSet(library.getMaps()).stream();
     if (tags != null) {
@@ -79,6 +81,12 @@ public final class MapCommand {
 
     if (name != null) {
       search = search.filter(map -> matchesName(map, name));
+    }
+
+    if (phase != null) {
+      search = search.filter(map -> matchesPhase(map, phase));
+    } else {
+      search = search.filter(map -> map.getPhase() == Phase.PRODUCTION);
     }
 
     Set<MapInfo> maps = search.collect(Collectors.toCollection(TreeSet::new));
@@ -145,6 +153,12 @@ public final class MapCommand {
     checkNotNull(map);
     query = checkNotNull(query).toLowerCase();
     return map.getName().toLowerCase().contains(query);
+  }
+
+  private static boolean matchesPhase(MapInfo map, String query) {
+    checkNotNull(map);
+    query = checkNotNull(query).toLowerCase();
+    return map.getPhase().equals(Phase.of(query));
   }
 
   @Command(
@@ -225,6 +239,12 @@ public final class MapCommand {
           text()
               .append(mapInfoLabel("map.info.proto"))
               .append(text(map.getProto().toString(), NamedTextColor.GOLD))
+              .build());
+
+      audience.sendMessage(
+          text()
+              .append(mapInfoLabel("map.info.phase"))
+              .append(map.getPhase().toComponent().color(NamedTextColor.GOLD))
               .build());
     }
 

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -18,6 +18,7 @@ import org.jdom2.Element;
 import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapTag;
+import tc.oc.pgm.api.map.Phase;
 import tc.oc.pgm.api.map.WorldInfo;
 import tc.oc.pgm.map.contrib.PlayerContributor;
 import tc.oc.pgm.map.contrib.PseudonymContributor;
@@ -33,6 +34,7 @@ public class MapInfoImpl implements MapInfo {
   private final String id;
   private final Version proto;
   private final Version version;
+  private final Phase phase;
   private final String name;
   private final String description;
   private final LocalDate created;
@@ -60,7 +62,8 @@ public class MapInfoImpl implements MapInfo {
       @Nullable Collection<MapTag> tags,
       @Nullable Collection<Integer> players,
       @Nullable WorldInfo world,
-      @Nullable Component gamemode) {
+      @Nullable Component gamemode,
+      Phase phase) {
     this.name = checkNotNull(name);
     this.id = checkNotNull(MapInfo.normalizeName(id == null ? name : id));
     this.proto = checkNotNull(proto);
@@ -75,6 +78,7 @@ public class MapInfoImpl implements MapInfo {
     this.players = players == null ? new LinkedList<>() : players;
     this.world = world == null ? new WorldInfoImpl() : world;
     this.gamemode = gamemode;
+    this.phase = phase;
   }
 
   public MapInfoImpl(MapInfo info) {
@@ -92,7 +96,8 @@ public class MapInfoImpl implements MapInfo {
         info.getTags(),
         info.getMaxPlayers(),
         info.getWorld(),
-        info.getGamemode());
+        info.getGamemode(),
+        info.getPhase());
   }
 
   public MapInfoImpl(Element root) throws InvalidXMLException {
@@ -115,7 +120,9 @@ public class MapInfoImpl implements MapInfo {
         null,
         null,
         parseWorld(root),
-        XMLUtils.parseFormattedText(root, "game"));
+        XMLUtils.parseFormattedText(root, "game"),
+        XMLUtils.parseEnum(
+            Node.fromLastChildOrAttr(root, "phase"), Phase.class, "phase", Phase.PRODUCTION));
   }
 
   @Override
@@ -186,6 +193,11 @@ public class MapInfoImpl implements MapInfo {
   @Override
   public WorldInfo getWorld() {
     return world;
+  }
+
+  @Override
+  public Phase getPhase() {
+    return phase;
   }
 
   @Override

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -40,6 +40,8 @@ map.info.pools = Pools
 
 map.info.objective = Objective
 
+map.info.phase = Phase
+
 # {0} = name of a maptag (e.g "#tnt" or "#controlpoint")
 map.info.mapTag.hover = Click to list all {0} maps
 
@@ -73,6 +75,10 @@ map.cycle = Cycling in {0}
 map.cycled = Cycled
 
 map.protectPortal = You may not obstruct this area
+
+map.phase.production = Production
+
+map.phase.development = Development
 
 # {0} = map pool name (e.g. "Mega")
 pool.change = Map pool has been set to {0} in order to better adjust to the current player count.

--- a/util/src/main/i18n/templates/misc.properties
+++ b/util/src/main/i18n/templates/misc.properties
@@ -225,5 +225,7 @@ type.uuid = uuid
 
 type.localdate = (yyyy-mm-dd) date
 
+type.phase = phase
+
 # {0} = a URL (e.g. "https://oc.tc")
 chat.clickLink = More info at {0}


### PR DESCRIPTION
# Reintroduce map phase XML tag

This PR reintroduces the map phase tag, allowing for map authors to identify whether their map is in a `DEVELOPMENT` or `PRODUCTION` phase. In addition to including the xml tag, the phase will now be displayed under `/map` for those with the debug perm. Also `/maps` can now be filtered by using the `-p [phase]` flag. Maps in the development phase are hidden from `/maps` by default.

### XML Example
```xml
<phase>development</phase> # Identify the map is in a developmental stage
<phase>production</phase> # Identify the map is in a production stage (production is the default value)

```

### /maps and /map Example

Example of `/map` when a map is in the `PRODUCTION` phase
<img width="953" alt="production" src="https://user-images.githubusercontent.com/3377659/122635334-1de3b200-d098-11eb-8728-dfea74a7da7d.png">

Example of using `/map` which now has a `-p [phase]` flag
![maps](https://user-images.githubusercontent.com/3377659/122635343-2936dd80-d098-11eb-87c5-916b94e6e076.gif)


As always, please let me know if there's any suggestions! 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>