### PR TITLE
Fallback map order fix

### DIFF
--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import tc.oc.pgm.api.Datastore;
@@ -95,24 +96,29 @@ public class MapPoolManager implements MapOrder {
   private void loadMapPools() {
     this.mapPools.clear(); // For reloads
 
-    mapPoolFileConfig.getConfigurationSection("pools").getKeys(false).stream()
-        .map(key -> MapPool.of(this, mapPoolFileConfig, key))
-        .filter(MapPool::isEnabled)
-        .forEach(pool -> mapPools.put(pool, database.getMapActivity(pool.getName())));
+    ConfigurationSection pools = mapPoolFileConfig.getConfigurationSection("pools");
+    if (pools != null && pools.getKeys(false) != null && !pools.getKeys(false).isEmpty()) {
+      pools.getKeys(false).stream()
+          .map(key -> MapPool.of(this, mapPoolFileConfig, key))
+          .filter(MapPool::isEnabled)
+          .forEach(pool -> mapPools.put(pool, database.getMapActivity(pool.getName())));
 
-    activeMapPool =
-        mapPools.entrySet().stream()
-            .filter(e -> e.getValue().isActive())
-            .findFirst()
-            .map(Map.Entry::getKey)
-            .orElse(null);
+      activeMapPool =
+          mapPools.entrySet().stream()
+              .filter(e -> e.getValue().isActive())
+              .findFirst()
+              .map(Map.Entry::getKey)
+              .orElse(null);
+    }
 
     if (activeMapPool == null) {
       logger.log(Level.WARNING, "No active map pool was found, defaulting to first dynamic pool.");
       activeMapPool =
           mapPools.keySet().stream().sorted().filter(MapPool::isDynamic).findFirst().orElse(null);
       if (activeMapPool == null) {
-        logger.log(Level.SEVERE, "Failed to find any dynamic map pool!");
+        logger.log(
+            Level.SEVERE,
+            "Failed to find any dynamic map pool! Will use fallback map order (shuffled)");
       }
     } else {
       logger.log(Level.INFO, "Resuming last active map pool (" + activeMapPool.getName() + ")");
@@ -158,7 +164,9 @@ public class MapPoolManager implements MapOrder {
 
     if (mapPool == activeMapPool) return;
 
-    activeMapPool.unloadPool(match);
+    if (activeMapPool != null) {
+      activeMapPool.unloadPool(match);
+    }
 
     // Set new active pool
     activeMapPool = mapPool;
@@ -204,6 +212,12 @@ public class MapPoolManager implements MapOrder {
     return options;
   }
 
+  public MapOrder getFallback() {
+    if (fallback == null)
+      fallback = new RandomMapOrder(Lists.newArrayList(PGM.get().getMapLibrary().getMaps()));
+    return fallback;
+  }
+
   @Override
   public MapInfo popNextMap() {
     if (overriderMap != null) {
@@ -213,10 +227,7 @@ public class MapPoolManager implements MapOrder {
     }
 
     if (activeMapPool == null) {
-      if (fallback == null)
-        fallback = new RandomMapOrder(Lists.newArrayList(PGM.get().getMapLibrary().getMaps()));
-
-      return fallback.popNextMap();
+      return getFallback().popNextMap();
     }
 
     return activeMapPool.popNextMap();
@@ -226,13 +237,20 @@ public class MapPoolManager implements MapOrder {
   public MapInfo getNextMap() {
     if (overriderMap != null) return overriderMap;
     if (activeMapPool != null) return activeMapPool.getNextMap();
+    if (activeMapPool == null) return getFallback().getNextMap();
     return null;
   }
 
   @Override
   public void setNextMap(MapInfo map) {
     overriderMap = map;
-    if (activeMapPool != null) activeMapPool.setNextMap(map); // Notify pool a next map has been set
+
+    // Notify pool/fallback a next map has been set
+    if (activeMapPool != null) {
+      activeMapPool.setNextMap(map);
+    } else {
+      getFallback().setNextMap(map);
+    }
   }
 
   @Override
@@ -255,6 +273,11 @@ public class MapPoolManager implements MapOrder {
   public void matchEnded(Match match) {
     if (hasMatchCountLimit()) {
       matchCount++;
+    }
+
+    if (activeMapPool == null) {
+      getFallback().matchEnded(match);
+      return;
     }
 
     if (activeMapPool.isDynamic() || shouldRevert(match)) {


### PR DESCRIPTION
# Fallback map order fix

Was curious about when the random map order gets enabled.

After doing some investigating, it seems that originally the idea was if no `map-pools.yml` was found, then PGM should resort to using the fallback map order.

Due to the way configurations are loaded, if no `map-pools.yml` is provided the one located in the resources directory is read instead. So it's not currently possible to delete the `map-pools.yml` as a default one will be used, similar to starting a PGM server for the first time and receiving the default maps.

An alternative method would be to set the existing `map-pools.yml` contents as follows:
```yml
pools: []
```
With no defined pools, ideally PGM should recognize this and fallback to the random map order. Though due to some unsafe calls to the `activeMapPool`, this results in several NPEs and PGM not being able to enable. 

This PR resolves that issue by ensuring the calls are safe and the fallback does in fact work 🙂 

Let me know if there's any suggestions or feedback 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>