### PR TITLE
Add debug message when map XML reloaded

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
@@ -180,6 +180,7 @@ public class MapLibraryImpl implements MapLibrary {
             throw new RuntimeException(e);
           }
 
+          logger.info(ChatColor.GREEN + "XML changes detected, reloading");
           return loadMapSafe(entry.source, entry.info.getId());
         });
   }


### PR DESCRIPTION
Adds debug message as described in issue https://github.com/PGMDev/PGM/issues/894

![image](https://user-images.githubusercontent.com/8608892/124384971-a898f380-dccb-11eb-999e-0ee31e76b23f.png)

I think this is the right place for it and the way to do it. I can see the logged message 🤷 don't have anyone to test it with :(
De-opped myself and I don't see the message. I can `Bukkit.broadcast` to `Permissions.DEBUG` if the logging stuff isn't correct.

Signed-off-by: Pugzy <pugzy@mail.com>