### PR TITLE
Round longest player shot stat not ceil

### DIFF
--- a/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
@@ -88,7 +88,7 @@ public class PlayerStats {
 
   protected void setLongestBowKill(double distance) {
     if (distance > longestBowKill) {
-      longestBowKill = (int) Math.ceil(distance);
+      longestBowKill = (int) Math.round(distance);
     }
   }
 


### PR DESCRIPTION
Fixes off by one discrepancy found in https://github.com/PGMDev/PGM/issues/892.

The death message builder is using `Math.round` whereas the PlayerStats class uses `Math.ceil` so numbers lower than .5 would be rounded down in one output but up in the other. This makes it consistent fixing this issue.

Signed-off-by: Pugzy <pugzy@mail.com>