### PR TITLE
Add clear-effects option to ClearItemsKit

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/ClearItemsKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ClearItemsKit.java
@@ -2,14 +2,19 @@ package tc.oc.pgm.kits;
 
 import java.util.List;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import tc.oc.pgm.api.player.MatchPlayer;
 
 /** Clears the player's inventory, including anything they may be holding on the cursor */
 public class ClearItemsKit extends AbstractKit {
+  private final boolean items;
   private final boolean armor;
+  private final boolean effects;
 
-  public ClearItemsKit(boolean armor) {
+  public ClearItemsKit(boolean items, boolean armor, boolean effects) {
+    this.items = items;
     this.armor = armor;
+    this.effects = effects;
   }
 
   @Override
@@ -17,7 +22,14 @@ public class ClearItemsKit extends AbstractKit {
     if (this.armor) {
       player.getBukkit().getInventory().setArmorContents(new ItemStack[4]);
     }
-    player.getBukkit().getInventory().clear();
-    player.getBukkit().getOpenInventory().setCursor(null);
+    if (this.effects) {
+      for (PotionEffect potion : player.getBukkit().getActivePotionEffects()) {
+        player.getBukkit().removePotionEffect(potion.getType());
+      }
+    }
+    if (this.items) {
+      player.getBukkit().getInventory().clear();
+      player.getBukkit().getOpenInventory().setCursor(null);
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/ClearItemsKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ClearItemsKit.java
@@ -5,7 +5,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import tc.oc.pgm.api.player.MatchPlayer;
 
-/** Clears the player's inventory, including anything they may be holding on the cursor */
+/**
+ * Clears the player's inventory and status effects, including anything they may be holding on the
+ * cursor
+ */
 public class ClearItemsKit extends AbstractKit {
   private final boolean items;
   private final boolean armor;

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -168,8 +168,8 @@ public abstract class KitParser {
   }
 
   public ClearItemsKit parseClearItemsKit(Element el) throws InvalidXMLException {
-    Element applyClear = el.getChild("clearinventory");
-    if (applyClear != null) {
+    Element applyClear = el.getChild("clear");
+    if (applyClear != null && applyClear.hasAttributes()) {
       boolean items = XMLUtils.parseBoolean(applyClear.getAttribute("items"), false);
       boolean armor = XMLUtils.parseBoolean(applyClear.getAttribute("armor"), false);
       boolean effects = XMLUtils.parseBoolean(applyClear.getAttribute("effects"), false);
@@ -178,7 +178,6 @@ public abstract class KitParser {
       // legacy
       if ("".equals(el.getChildText("clear"))) return new ClearItemsKit(true, true, false);
       if ("".equals(el.getChildText("clear-items"))) return new ClearItemsKit(true, false, false);
-      if ("".equals(el.getChildText("clear-effects"))) return new ClearItemsKit(false, false, true);
     }
     return null;
   }

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -168,8 +168,18 @@ public abstract class KitParser {
   }
 
   public ClearItemsKit parseClearItemsKit(Element el) throws InvalidXMLException {
-    if ("".equals(el.getChildText("clear"))) return new ClearItemsKit(true);
-    if ("".equals(el.getChildText("clear-items"))) return new ClearItemsKit(false);
+    Element applyClear = el.getChild("clearinventory");
+    if (applyClear != null) {
+      boolean items = XMLUtils.parseBoolean(applyClear.getAttribute("items"), false);
+      boolean armor = XMLUtils.parseBoolean(applyClear.getAttribute("armor"), false);
+      boolean effects = XMLUtils.parseBoolean(applyClear.getAttribute("effects"), false);
+      return new ClearItemsKit(items, armor, effects);
+    } else {
+      // legacy
+      if ("".equals(el.getChildText("clear"))) return new ClearItemsKit(true, true, false);
+      if ("".equals(el.getChildText("clear-items"))) return new ClearItemsKit(true, false, false);
+      if ("".equals(el.getChildText("clear-effects"))) return new ClearItemsKit(false, false, true);
+    }
     return null;
   }
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -169,14 +169,13 @@ public abstract class KitParser {
 
   public ClearItemsKit parseClearItemsKit(Element el) throws InvalidXMLException {
     Element applyClear = el.getChild("clear");
-    if (applyClear != null && applyClear.hasAttributes()) {
-      boolean items = XMLUtils.parseBoolean(applyClear.getAttribute("items"), false);
-      boolean armor = XMLUtils.parseBoolean(applyClear.getAttribute("armor"), false);
+    if (applyClear != null) {
+      boolean items = XMLUtils.parseBoolean(applyClear.getAttribute("items"), true);
+      boolean armor = XMLUtils.parseBoolean(applyClear.getAttribute("armor"), true);
       boolean effects = XMLUtils.parseBoolean(applyClear.getAttribute("effects"), false);
       return new ClearItemsKit(items, armor, effects);
     } else {
       // legacy
-      if ("".equals(el.getChildText("clear"))) return new ClearItemsKit(true, true, false);
       if ("".equals(el.getChildText("clear-items"))) return new ClearItemsKit(true, false, false);
     }
     return null;


### PR DESCRIPTION
This PR adds a method to clear potions and other status effects from a player using a kit. This works just like the `<clear/>` and `<clear-items>` tags. This also adds a new method of parsing the ClearItemsKit which allows more finer configuration. Because of this, it is now possible to clear/keep only the armor slots.

```xml
<kit id="clear-effects" force="true">
      <clearinventory items="false" armor="false" effects="true"/>
</kit>
<!-- legacy -->
<kit id="clear-effects" force="true">
      <clear-effects/>
</kit>
```