### PR TITLE
Allow gamemode to be case insensitive

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -28,7 +28,7 @@ public enum Gamemode {
 
   public static Gamemode byId(String gamemodeId) {
     for (Gamemode gamemode : Gamemode.values()) {
-      if (gamemode.getId().equals(gamemodeId)) {
+      if (gamemode.getId().equalsIgnoreCase(gamemodeId)) {
         return gamemode;
       }
     }


### PR DESCRIPTION
Quick fix following #873 

If a game mode is defined using a different case such as `CTW` instead of `ctw` or `Arcade` instead of `arcade` the map will not load. This PR fixes that by ignoring the case when checking gamemode id.

Tested and works 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>