### PR TITLE
Apply colors to TextFormatter with size of 1

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextFormatter.java
@@ -45,7 +45,7 @@ public final class TextFormatter {
       case 0:
         return empty();
       case 1:
-        return textList.get(0);
+        return textList.get(0).colorIfAbsent(color);
       case 2:
         return translatable("misc.list.pair", color, textList);
       default:


### PR DESCRIPTION
Discovered by @calcastor, where the colour on the gamemode title does not apply to maps using a single `<gamemode>` tag. 

![image](https://user-images.githubusercontent.com/7586568/126885889-278e99b1-9dd4-491b-8102-dcdef8fabe3f.png)

This function is used in a handful of places and I've tested some of them.