### PR TITLE
Play death sounds for predicted kills

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
@@ -121,6 +121,7 @@ public class Alive extends Participating {
     if (!event.isPredicted()) {
       die(event.getKiller());
     }
+    playDeathSound(event.getKiller());
   }
 
   public void die(@Nullable ParticipantState killer) {
@@ -139,8 +140,6 @@ public class Alive extends Participating {
   }
 
   private void playDeathEffect(@Nullable ParticipantState killer) {
-    playDeathSound(killer);
-
     // negative health boost potions sometimes change max health
     for (PotionEffect effect : bukkit.getActivePotionEffects()) {
       // Keep speed and NV for visual continuity


### PR DESCRIPTION
Super simple fix. Predicted kills don't play the death sound to those still online, this PR fixes that.

Tested and works fine 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>