### PR TITLE
Ensure control points using "recovery" and "decay" work as intended

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -79,9 +79,9 @@ public abstract class ControlPointParser {
 
     final double decayRate, recoveryRate, ownedDecayRate;
     final Node attrIncremental = Node.fromAttr(elControlPoint, "incremental");
-    final Node attrDecay = Node.fromAttr(elControlPoint, "decay-rate");
-    final Node attrRecovery = Node.fromAttr(elControlPoint, "recovery-rate");
-    final Node attrOwnedDecay = Node.fromAttr(elControlPoint, "owned-decay-rate");
+    final Node attrDecay = Node.fromAttr(elControlPoint, "decay", "decay-rate");
+    final Node attrRecovery = Node.fromAttr(elControlPoint, "recovery", "recovery-rate");
+    final Node attrOwnedDecay = Node.fromAttr(elControlPoint, "owned-decay", "owned-decay-rate");
     if (attrIncremental == null) {
       recoveryRate =
           XMLUtils.parseNumber(attrRecovery, Double.class, koth ? 1D : Double.POSITIVE_INFINITY);


### PR DESCRIPTION
#864 reintroduced decay and recovery rates to control points from 1.9+ PGM, while also introducing the possibility for already captured control points to decay from a captured state. However, ControlPointParser only recognizes and parses `recovery-rate` and `decay-rate`, despite 1.9+ PGM's implementation using `recovery` and `decay`. This PR ensures compatibility with maps previously made for 1.9+ PGM by making sure `recovery` and `decay` are also recognized.

I've also made sure that `owned-decay` can also be used alongside `owned-decay-rate`, to keep wording consistent between all 3 attributes.