### PR TITLE
Ensure doDaylightCycle is set to correct value on match start

### DIFF
--- a/core/src/main/java/tc/oc/pgm/gamerules/GameRulesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/gamerules/GameRulesMatchModule.java
@@ -19,21 +19,23 @@ public class GameRulesMatchModule implements MatchModule {
 
   @Override
   public void load() {
-    // saves and sets gamerules from XML
+    // first, set doDaylightCycle according to timelock
+    WorldTimeModule wtm = this.match.getModule(WorldTimeModule.class);
+    this.match
+        .getWorld()
+        .setGameRuleValue(
+            GameRule.DO_DAYLIGHT_CYCLE.getId(), Boolean.toString(!wtm.isTimeLocked()));
+
+    // second, set any gamerules defined in the map's XML
+    // doDaylightCycle set in XML's gamerules module will take precedence over timelock
     for (Map.Entry<String, String> gameRule : this.gameRules.entrySet()) {
-      gameRules.put(gameRule.getKey(), gameRule.getValue());
       this.match.getWorld().setGameRuleValue(gameRule.getKey(), gameRule.getValue());
     }
 
-    // saves gamerules from world (level.dat) as fallback
+    // lastly, retrieve gamerules from the map's level.dat and set them if absent
     for (String gameRule : this.match.getWorld().getGameRules()) {
       gameRules.putIfAbsent(gameRule, this.match.getWorld().getGameRuleValue(gameRule));
     }
-
-    // if timelock is off, save doDayLightCycle as true
-    WorldTimeModule wtm = this.match.getModule(WorldTimeModule.class);
-    gameRules.put(
-        GameRule.DO_DAYLIGHT_CYCLE.getId(), Boolean.toString(wtm != null && !wtm.isTimeLocked()));
   }
 
   public String getGameRule(String gameRule) {

--- a/core/src/main/java/tc/oc/pgm/gamerules/GameRulesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/gamerules/GameRulesMatchModule.java
@@ -32,9 +32,8 @@ public class GameRulesMatchModule implements MatchModule {
 
     // if timelock is off, save doDayLightCycle as true
     WorldTimeModule wtm = this.match.getModule(WorldTimeModule.class);
-    if (wtm != null && !wtm.isTimeLocked()) {
-      gameRules.put(GameRule.DO_DAYLIGHT_CYCLE.getId(), Boolean.toString(true));
-    }
+    gameRules.put(
+        GameRule.DO_DAYLIGHT_CYCLE.getId(), Boolean.toString(wtm != null && !wtm.isTimeLocked()));
   }
 
   public String getGameRule(String gameRule) {

--- a/core/src/main/java/tc/oc/pgm/gamerules/GameRulesModule.java
+++ b/core/src/main/java/tc/oc/pgm/gamerules/GameRulesModule.java
@@ -1,6 +1,8 @@
 package tc.oc.pgm.gamerules;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -11,6 +13,7 @@ import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.modules.WorldTimeModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
 public class GameRulesModule implements MapModule {
@@ -26,6 +29,11 @@ public class GameRulesModule implements MapModule {
   }
 
   public static class Factory implements MapModuleFactory<GameRulesModule> {
+    @Override
+    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+      return ImmutableList.of(WorldTimeModule.class);
+    }
+
     @Override
     public GameRulesModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -278,7 +278,7 @@ public class PGMListener implements Listener {
 
   @EventHandler
   public void lockFireTick(final MatchFinishEvent event) {
-    setGameRule(event, GameRule.DO_DAYLIGHT_CYCLE.getId(), false);
+    setGameRule(event, GameRule.DO_FIRE_TICK.getId(), false);
   }
 
   //


### PR DESCRIPTION
#879 ensures that game rules like `doDaylightCycle` and `doFireTick` are only enabled once a match starts, if the map has them enabled. However, it seems that the definition of `doDaylightCycle` from the `level.dat` files of maps unintentionally takes precedence over the default setting of `<timelock>` to off, when `<timelock>`  and `doDaylightCycle`  are both undefined within a map's XML. This PR ensures that the default `<timelock>` setting of `off` again takes precedence over the map world's setting, while also fixing an overlooked albeit small error that ensures `doFireTick` is disabled once a match ends.