### PR TITLE
Re-add WorldTimeModule null check to prevent NPE in GameRulesMatchModule

### DIFF
--- a/core/src/main/java/tc/oc/pgm/gamerules/GameRulesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/gamerules/GameRulesMatchModule.java
@@ -24,7 +24,8 @@ public class GameRulesMatchModule implements MatchModule {
     this.match
         .getWorld()
         .setGameRuleValue(
-            GameRule.DO_DAYLIGHT_CYCLE.getId(), Boolean.toString(!wtm.isTimeLocked()));
+            GameRule.DO_DAYLIGHT_CYCLE.getId(),
+            Boolean.toString(wtm != null && !wtm.isTimeLocked()));
 
     // second, set any gamerules defined in the map's XML
     // doDaylightCycle set in XML's gamerules module will take precedence over timelock


### PR DESCRIPTION
I had originally thought that setting WorldTimeModule as a soft dependency for GameRulesModule would prevent a situation like this. However, some maps in certain circumstances (such as Tetrad, as noticed today on OCC) can potentially throw an NPE when they are attempted to be cycled to.