### PR TITLE
Bump Adventure to 4.9.1

### DIFF
--- a/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
+++ b/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
@@ -13,7 +13,7 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.scoreboard.NameTagVisibility;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -157,7 +157,7 @@ public class Tribute implements Competitor {
   }
 
   @Override
-  public net.kyori.adventure.audience.@NonNull Audience audience() {
+  public net.kyori.adventure.audience.@NotNull Audience audience() {
     return player != null ? this.player : Audience.empty();
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/modifier/relation/AttackerQueryModifier.java
+++ b/core/src/main/java/tc/oc/pgm/filters/modifier/relation/AttackerQueryModifier.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.filters.modifier.relation;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.DamageQuery;
 import tc.oc.pgm.api.filter.query.Query;

--- a/core/src/main/java/tc/oc/pgm/filters/modifier/relation/SameTeamQueryModifier.java
+++ b/core/src/main/java/tc/oc/pgm/filters/modifier/relation/SameTeamQueryModifier.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.filters.modifier.relation;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.PartyQuery;
 import tc.oc.pgm.api.filter.query.PlayerQuery;

--- a/core/src/main/java/tc/oc/pgm/filters/modifier/relation/VictimQueryModifier.java
+++ b/core/src/main/java/tc/oc/pgm/filters/modifier/relation/VictimQueryModifier.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.filters.modifier.relation;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.DamageQuery;
 import tc.oc.pgm.api.filter.query.Query;

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -29,7 +29,7 @@ import org.bukkit.event.EventException;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.RegisteredListener;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.Modules;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.feature.Feature;
@@ -308,7 +308,7 @@ public class MatchImpl implements Match {
   }
 
   @Override
-  public @NonNull Audience audience() {
+  public @NotNull Audience audience() {
     final Collection<Audience> audiences = new ArrayList<>(getPlayers());
     audiences.add(Audience.console());
     return Audience.get(audiences);

--- a/pom.xml
+++ b/pom.xml
@@ -107,13 +107,13 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.8.1</version>
+            <version>4.9.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-plain</artifactId>
-            <version>4.8.1</version>
+            <version>4.9.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/util/src/main/java/tc/oc/pgm/util/text/TextTranslations.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextTranslations.java
@@ -33,7 +33,7 @@ import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.translation.Translator;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /** A singleton for accessing {@link MessageFormat} and {@link Component} translations. */
 @SuppressWarnings("UnstableApiUsage")
@@ -107,13 +107,13 @@ public final class TextTranslations {
         .addSource(
             new Translator() {
               @Override
-              public @NonNull Key name() {
+              public @NotNull Key name() {
                 return NAMESPACE;
               }
 
               @Override
               public @Nullable MessageFormat translate(
-                  final @NonNull String key, final @NonNull Locale locale) {
+                  final @NotNull String key, final @NotNull Locale locale) {
                 return TextTranslations.getNearestKey(locale, key);
               }
             });


### PR DESCRIPTION
As was noted in the PGM discord, Adventure 4.9.1 is released and PGM should be bumped to that. Adventure 4.9.1 seems to use JetBrains' annotations instead of Checker Framework so I switched to that where required when encountering build errors.