### PR TITLE
Replace core and destroyable translatables with objective, fix hardcoded translatable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.core;
 
+import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.api.map.MapProtos.MODES_IMPLEMENTATION_VERSION;
 
@@ -26,6 +27,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.ParticipantBlockTransformEvent;
+import tc.oc.pgm.goals.GoalDefinition;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
 import tc.oc.pgm.modes.ObjectiveModeChangeEvent;
@@ -93,7 +95,7 @@ public class CoreMatchModule implements MatchModule, Listener {
             Competitor team = player.getParty();
 
             if (team == core.getOwner()) {
-              event.setCancelled(translatable("core.damageOwn"));
+              event.setCancelled(translatable("objective.damageOwn", text(core.getName())));
             } else if (event.getOldState().getData().equals(core.getMaterial())) {
               this.match.callEvent(new CoreBlockBreakEvent(core, player, event.getOldState()));
               core.touch(player);
@@ -134,7 +136,7 @@ public class CoreMatchModule implements MatchModule, Listener {
           && core.getCasingRegion().contains(center)
           && player.getParty() == core.getOwner()) {
         event.setCancelled(true);
-        player.sendWarning(translatable("core.damageOwn"));
+        player.sendWarning(translatable("objective.damageOwn", core.getDefinition().getComponentName()));
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.core;
 
-import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.api.map.MapProtos.MODES_IMPLEMENTATION_VERSION;
 
@@ -27,7 +26,6 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.ParticipantBlockTransformEvent;
-import tc.oc.pgm.goals.GoalDefinition;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
 import tc.oc.pgm.modes.ObjectiveModeChangeEvent;
@@ -95,7 +93,7 @@ public class CoreMatchModule implements MatchModule, Listener {
             Competitor team = player.getParty();
 
             if (team == core.getOwner()) {
-              event.setCancelled(translatable("objective.damageOwn", text(core.getName())));
+              event.setCancelled(translatable("objective.damageOwn", core.getComponentName()));
             } else if (event.getOldState().getData().equals(core.getMaterial())) {
               this.match.callEvent(new CoreBlockBreakEvent(core, player, event.getOldState()));
               core.touch(player);
@@ -136,7 +134,7 @@ public class CoreMatchModule implements MatchModule, Listener {
           && core.getCasingRegion().contains(center)
           && player.getParty() == core.getOwner()) {
         event.setCancelled(true);
-        player.sendWarning(translatable("objective.damageOwn", core.getDefinition().getComponentName()));
+        player.sendWarning(translatable("objective.damageOwn", core.getComponentName()));
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -420,14 +420,14 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     if (deltaHealth < 0) {
       // Damage
       if (player != null && player.getParty() == this.getOwner()) {
-        return "destroyable.damageOwn";
+        return "objective.damageOwn";
       }
     } else if (deltaHealth > 0) {
       // Repair
       if (player != null && player.getParty() != this.getOwner()) {
-        return "destroyable.repairOther";
+        return "objective.repairOther";
       } else if (!this.definition.isRepairable()) {
-        return "destroyable.repairDisabled";
+        return "objective.repairDisabled";
       }
     }
 

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -1,9 +1,7 @@
 package tc.oc.pgm.destroyable;
 
-import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 
-import java.awt.*;
 import java.util.Collection;
 import org.bukkit.block.Block;
 import org.bukkit.entity.minecart.ExplosiveMinecart;

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.destroyable;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 
+import java.awt.*;
 import java.util.Collection;
 import org.bukkit.block.Block;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
@@ -75,7 +76,7 @@ public class DestroyableMatchModule implements MatchModule, Listener {
               event.getNewState(),
               ParticipantBlockTransformEvent.getPlayerState(event));
       if (reasonKey != null) {
-        event.setCancelled(translatable(reasonKey));
+        event.setCancelled(translatable(reasonKey, destroyable.getComponentName()));
         return;
       }
     }
@@ -115,8 +116,7 @@ public class DestroyableMatchModule implements MatchModule, Listener {
           && destroyable.hasMaterial(material)) {
 
         event.setCancelled(true);
-        // TODO: translate this
-        player.sendWarning(text("You may not damage your own objective."));
+        player.sendWarning(translatable("objective.damageOwn", destroyable.getComponentName()));
       }
     }
   }

--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -114,15 +114,6 @@ objective.credit.unknown = unknown forces
 # {0} = objective name
 objective.credit.future = You will receive credit when {0} is completed
 
-# TODO: Replace with objective.damageOwn, etc.
-destroyable.damageOwn = You may not damage your own objective.
-
-destroyable.repairOther = You may not repair an enemy objective.
-
-destroyable.repairDisabled = This objective may not be repaired.
-
-core.damageOwn = You may not damage your own core.
-
 # {0} = objective name (e.g. "Left Core")
 objective.damageOwn = You may not damage your own {0}
 


### PR DESCRIPTION
- Translates a hardcoded damageOwn error with proper translation key
- Completes another TODO that replaces `destroyable.damageOwn`, `destroyable.repairOther`, `destroyable.repairDisabled` and `core.damageOwn` with `objective` equivalent.

Nice to start off hacktoberfest lol