### PR TITLE
Add configuration option for verbose stats item slot

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -91,6 +91,7 @@ public final class PGMConfig implements Config {
   private final Duration statsShowAfter;
   private final boolean statsShowBest;
   private final boolean statsShowOwn;
+  private final int verboseItemSlot;
 
   // sidebar.*
   private final Component header;
@@ -189,6 +190,7 @@ public final class PGMConfig implements Config {
     this.statsShowAfter = parseDuration(config.getString("stats.show-after", "6s"));
     this.statsShowBest = parseBoolean(config.getString("stats.show-best", "true"));
     this.statsShowOwn = parseBoolean(config.getString("stats.show-own", "true"));
+    this.verboseItemSlot = parseInteger(config.getString("stats.item-slot", "7"));
 
     final String header = config.getString("sidebar.header");
     this.header = header == null || header.isEmpty() ? null : parseComponent(header);
@@ -604,6 +606,11 @@ public final class PGMConfig implements Config {
   @Override
   public boolean showOwnStats() {
     return statsShowOwn;
+  }
+
+  @Override
+  public int getVerboseItemSlot() {
+    return verboseItemSlot;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -244,6 +244,9 @@ public interface Config {
   /** @return If stats on match end should show your own stats */
   boolean showOwnStats();
 
+  /** @return The slot where the verbose item will be placed */
+  int getVerboseItemSlot();
+
   /**
    * Gets a format to override the server's "message of the day."
    *

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -76,6 +76,7 @@ public class StatsMatchModule implements MatchModule, Listener {
   private final Duration showAfter = PGM.get().getConfiguration().showStatsAfter();
   private final boolean bestStats = PGM.get().getConfiguration().showBestStats();
   private final boolean ownStats = PGM.get().getConfiguration().showOwnStats();
+  private final int verboseItemSlot = PGM.get().getConfiguration().getVerboseItemSlot();
 
   /** Common formats used by stats with decimals */
   public static final DecimalFormat TWO_DECIMALS = new DecimalFormat("#.##");
@@ -343,7 +344,7 @@ public class StatsMatchModule implements MatchModule, Listener {
     }
 
     StatsMainMenu menu = new StatsMainMenu(player, teams, this);
-    player.getInventory().setItem(7, menu.getItem());
+    player.getInventory().setItem(verboseItemSlot, menu.getItem());
 
     if (forceOpen) {
       menu.open();

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -83,6 +83,7 @@ stats:
   show-after: 6s  # How long to wait after the match ends to show stats?
   show-best: true # Should show best players stats?
   show-own: true  # Should show each players own stats?
+  item-slot: 7    # In what slot should we place the verbose stats item?
 
 # Overrides the header and footer of the side bar.
 sidebar:


### PR DESCRIPTION
New config option. Allows the verbose stats item to be placed in a custom slot. 

The item here to be exact 😉 
<img width="560" alt="verbose-stats-item" src="https://user-images.githubusercontent.com/3377659/135586652-135ac662-2723-4b78-aa3f-53d49deafc59.png">


Signed-off-by: applenick <applenick@users.noreply.github.com>