### PR TITLE
Add Colors as Descriptor Patterns

### DIFF
--- a/core/src/main/java/tc/oc/pgm/goals/GoalDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/goals/GoalDefinition.java
@@ -65,11 +65,12 @@ public abstract class GoalDefinition extends SelfIdentifyingFeatureDefinition {
   // See "objective.name.monument" for examples
   private static final Pattern OBJECTIVE_PATTERN =
       Pattern.compile(
-          "Monument|Core|Wool|Flag|Antenna|Base|Ship|Orb|Tower|Inhibitor|Reactor|Engine");
+          "Monument|Core|Wool|Flag|Antenna|Base|Ship|Orb|Tower|Pillar|Inhibitor|Reactor|Engine");
 
   // See "misc.top" for examples
   private static final Pattern DESCRIPTOR_PATTERN =
-      Pattern.compile("Top|Bottom|Front|Back|Rear|Left|Right|Center|Mid|North|South|East|West");
+      Pattern.compile(
+          "Top|Bottom|Front|Back|Rear|Left|Right|Center|Mid|North|South|East|West|White|Orange|Magenta|Yellow|Lime|Pink|Gray|Cyan|Purple|Blue|Brown|Green|Red|Black|Light");
 
   // TODO: Support languages where words are ordered right-to-left
   private static Component translateName(final String name) {

--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -84,6 +84,8 @@ objective.name.inhibitor = Inhibitor
 
 objective.name.tower = Tower
 
+objective.name.pillar = Pillar
+
 objective.name.base = Base
 
 objective.name.ship = Ship

--- a/util/src/main/i18n/templates/misc.properties
+++ b/util/src/main/i18n/templates/misc.properties
@@ -164,6 +164,8 @@ misc.center = Center
 
 misc.mid = Mid
 
+misc.middle = Middle
+
 misc.north = North
 
 misc.south = South
@@ -171,6 +173,41 @@ misc.south = South
 misc.east = East
 
 misc.west = West
+
+misc.white = White
+
+misc.orange = Orange
+
+misc.magenta = Magenta
+
+misc.lightBlue = Light Blue
+
+misc.yellow = Yellow
+
+misc.lime = Lime
+
+misc.pink = Pink
+
+misc.gray = Gray
+
+misc.lightGray = Light Gray
+
+misc.cyan = Cyan
+
+misc.purple = Purple
+
+misc.blue = Blue
+
+misc.brown = Brown
+
+misc.green = Green
+
+misc.red = Red
+
+misc.black = Black
+
+# Pertains to color (e.g. "Light Blue" or "Light Gray")
+misc.light = Light
 
 # {0} = player name
 misc.teleportTo = Teleport to {0}


### PR DESCRIPTION
- Adds "Pillar" as an objective name
- Adds "Middle" (separate from Mid) as a descriptor
- Adds all wool colours as a descriptor pattern so CTW maps are now fully translated

I have made `Light` (in the context of colour) a separate translator key so it fits easily in the function inside GoalDefinition. If other languages have unique words for "Light Blue" and "Light Grey" I suppose that `Light` can be left blank.