### PR TITLE
Amend event priority in ItemTransferListener

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
@@ -471,7 +471,7 @@ public class ItemTransferListener implements Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
   public void collectToCursor(InventoryClickEvent event) {
     // If this hasn't been cancelled yet, cancel it so our implementation can take over
     if (event.getAction() == InventoryAction.COLLECT_TO_CURSOR) {
@@ -484,9 +484,7 @@ public class ItemTransferListener implements Listener {
   public void onPlayerInventoryClick(InventoryClickEvent event) {
     // Control-double-click on a stack, all similar stacks are moved to the cursor, up to the max
     // stack size
-    // We cancel all of these and redo them ourselves. We have to do it from a InventoryClickedEvent
-    // because
-    // we can't make the necessary changes from inside a InventoryClickEvent.
+    // We cancel all of these and redo them ourselves.
     if (this.collectToCursor) {
       this.collectToCursor = false;
 

--- a/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
@@ -93,6 +93,7 @@ public class ItemTransferListener implements Listener {
     // Ignored actions
     switch (event.getAction()) {
       case CLONE_STACK: // Out of scope
+      case COLLECT_TO_CURSOR: // Handled by InventoryClickedEvent
       case NOTHING:
       case UNKNOWN:
         return;
@@ -483,7 +484,9 @@ public class ItemTransferListener implements Listener {
   public void onPlayerInventoryClick(InventoryClickEvent event) {
     // Control-double-click on a stack, all similar stacks are moved to the cursor, up to the max
     // stack size
-    // We cancel all of these and redo them ourselves.
+    // We cancel all of these and redo them ourselves. We have to do it from a InventoryClickedEvent
+    // because
+    // we can't make the necessary changes from inside a InventoryClickEvent.
     if (this.collectToCursor) {
       this.collectToCursor = false;
 

--- a/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
@@ -93,7 +93,7 @@ public class ItemTransferListener implements Listener {
     // Ignored actions
     switch (event.getAction()) {
       case CLONE_STACK: // Out of scope
-      case COLLECT_TO_CURSOR: // Handled by InventoryClickedEvent
+      case COLLECT_TO_CURSOR: // Handled in onPlayerInventoryClick
       case NOTHING:
       case UNKNOWN:
         return;
@@ -471,7 +471,7 @@ public class ItemTransferListener implements Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void collectToCursor(InventoryClickEvent event) {
     // If this hasn't been cancelled yet, cancel it so our implementation can take over
     if (event.getAction() == InventoryAction.COLLECT_TO_CURSOR) {
@@ -480,7 +480,7 @@ public class ItemTransferListener implements Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.HIGHEST)
+  @EventHandler(priority = EventPriority.MONITOR)
   public void onPlayerInventoryClick(InventoryClickEvent event) {
     // Control-double-click on a stack, all similar stacks are moved to the cursor, up to the max
     // stack size


### PR DESCRIPTION
In further testing following #921 being merged I found that this had not actually been the root cause of the problem and caused some unexpected behaviour when sorting from chests into inventory with double clicking to collect stacks. This re-adds `COLLECT_TO_CURSOR` to the ignored actions for onPlayerClickInventory, and increases the priority of onPlayerInventoryClick's InventoryClickEvent to `MONITOR`. With this change, double clicking to stack all of a single item from a chest or within a player's own inventory works as would be expected in vanilla Minecraft.