### PR TITLE
Add Filters to Monument Modes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -14,7 +14,6 @@ import java.util.List;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.apache.commons.lang.WordUtils;
-import org.bouncycastle.math.raw.Mod;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.countdowns.CountdownContext;
@@ -22,7 +21,6 @@ import tc.oc.pgm.modes.ModeChangeCountdown;
 import tc.oc.pgm.modes.ModesPaginatedResult;
 import tc.oc.pgm.modes.ObjectiveModesMatchModule;
 import tc.oc.pgm.util.Audience;
-import tc.oc.pgm.util.text.TextException;
 
 // TODO: make the output nicer
 public final class ModeCommand {
@@ -42,7 +40,9 @@ public final class ModeCommand {
         throwNoResults();
       } else {
         TextComponent.Builder builder =
-            text().append(translatable("command.nextMode", NamedTextColor.DARK_PURPLE).append(space()));
+            text()
+                .append(
+                    translatable("command.nextMode", NamedTextColor.DARK_PURPLE).append(space()));
 
         ModeChangeCountdown next = countdowns.get(0);
         Duration timeLeft = modes.getCountdown().getTimeLeft(next);
@@ -122,10 +122,11 @@ public final class ModeCommand {
   }
 
   @Command(
-          aliases = {"start"},
-          desc = "Starts an objective mode",
-          perms = Permissions.GAMEPLAY)
-  public void start(Audience audience, Match match, int modeNumber, Duration duration) throws CommandException {
+      aliases = {"start"},
+      desc = "Starts an objective mode",
+      perms = Permissions.GAMEPLAY)
+  public void start(Audience audience, Match match, int modeNumber, Duration duration)
+      throws CommandException {
     ObjectiveModesMatchModule modes = getModes(match);
 
     if (!match.isRunning()) {
@@ -150,7 +151,9 @@ public final class ModeCommand {
     countdowns.start(selectedMode, duration);
 
     TextComponent.Builder builder =
-            text().append(translatable("command.selectedModePushed", NamedTextColor.GOLD).append(space()));
+        text()
+            .append(
+                translatable("command.selectedModePushed", NamedTextColor.GOLD).append(space()));
     builder.append(clock(Math.abs(duration.getSeconds())).color(NamedTextColor.AQUA));
     audience.sendMessage(builder);
   }
@@ -175,6 +178,7 @@ public final class ModeCommand {
   private static void throwMatchNotStarted() {
     throw exception("command.matchNotStarted");
   }
+
   private static void throwInvalidNumber(String invalidNumber) {
     throw exception("command.invalidNumber", text(invalidNumber));
   }

--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -69,7 +69,7 @@ public final class ModeCommand {
 
   @Command(
       aliases = {"list", "page"},
-      desc = "List all objectivs modes",
+      desc = "List all objective modes",
       usage = "[page]")
   public void list(Audience audience, Match match, @Default("1") int page) throws CommandException {
     showList(page, audience, getModes(match));

--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -110,12 +110,13 @@ public final class ModeCommand {
     TextComponent.Builder builder =
         text().append(translatable("command.modesPushed", NamedTextColor.GOLD).append(space()));
     if (duration.isNegative()) {
-      builder.append(translatable("command.backwards", NamedTextColor.GOLD).append(space()));
+      builder.append(translatable("command.modesPushedBack", NamedTextColor.GOLD).append(space()));
     } else {
-      builder.append(translatable("command.forwards", NamedTextColor.GOLD).append(space()));
+      builder.append(
+          translatable("command.modesPushedForwards", NamedTextColor.GOLD).append(space()));
     }
 
-    builder.append(translatable("command.by", NamedTextColor.GOLD).append(space()));
+    builder.append(translatable("command.modesPushedBy", NamedTextColor.GOLD).append(space()));
     builder.append(clock(Math.abs(duration.getSeconds())).color(NamedTextColor.AQUA));
 
     audience.sendMessage(builder);

--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -80,7 +80,7 @@ public final class ModeCommand {
 
   @Command(
       aliases = {"push"},
-      desc = "Reschedule all unconditional objective modes",
+      desc = "Reschedule all objective modes with active countdowns",
       perms = Permissions.GAMEPLAY)
   public void push(Audience audience, Match match, Duration duration) {
     ObjectiveModesMatchModule modes = getModes(match);
@@ -150,10 +150,19 @@ public final class ModeCommand {
     countdowns.cancel(selectedMode);
     countdowns.start(selectedMode, duration);
 
+    String modeName;
+    if (selectedMode.getMode().getName() != null) {
+      modeName = selectedMode.getMode().getName();
+    } else {
+      modeName = selectedMode.getMode().getPreformattedMaterialName();
+    }
+
     TextComponent.Builder builder =
         text()
             .append(
-                translatable("command.selectedModePushed", NamedTextColor.GOLD).append(space()));
+                translatable("command.selectedModePushed", text(modeName))
+                    .color(NamedTextColor.GOLD)
+                    .append(space()));
     builder.append(clock(Math.abs(duration.getSeconds())).color(NamedTextColor.AQUA));
     audience.sendMessage(builder);
   }

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -17,8 +17,7 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
   private final MaterialData material;
   private final Duration after;
   private final Filter filter;
-  private final @Nullable
-  String name;
+  private final @Nullable String name;
   private final Component componentName;
   private final Duration showBefore;
   private boolean modeComplete = false;
@@ -28,32 +27,36 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
   }
 
   public Mode(
-          final @Nullable String id,
-          final MaterialData material,
-          final Duration after,
-          final Filter filter,
-          final @Nullable String name,
-          Duration showBefore
-  ) {
+      final @Nullable String id,
+      final MaterialData material,
+      final Duration after,
+      final Filter filter,
+      final @Nullable String name,
+      Duration showBefore) {
     super(id);
     this.material = material;
     this.after = after;
     this.filter = filter;
     this.name = name;
     this.componentName =
-            text(name != null ? name : getPreformattedMaterialName(), NamedTextColor.RED);
+        text(name != null ? name : getPreformattedMaterialName(), NamedTextColor.RED);
     this.showBefore = showBefore;
   }
 
-  public void load(FilterMatchModule fmm, ModeChangeCountdown countdown, CountdownContext countdownContext, Match match) {
+  public void load(
+      FilterMatchModule fmm,
+      ModeChangeCountdown countdown,
+      CountdownContext countdownContext,
+      Match match) {
     // if filter returns ALLOW at any time in the match, start countdown for mode change
-    fmm.onRise(filter, FilterListener -> {
-      if (match.isRunning() && !modeComplete) {
-        countdownContext.start(countdown, countdown.getMode().getAfter());
-        modeComplete = true;
-      }
-    }
-    );
+    fmm.onRise(
+        filter,
+        FilterListener -> {
+          if (match.isRunning() && !modeComplete) {
+            countdownContext.start(countdown, countdown.getMode().getAfter());
+            modeComplete = true;
+          }
+        });
   }
 
   public MaterialData getMaterialData() {
@@ -84,8 +87,7 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
     return this.modeComplete;
   }
 
-  public @Nullable
-  String getName() {
+  public @Nullable String getName() {
     return this.name;
   }
 

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -13,7 +13,7 @@ import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 public class Mode extends SelfIdentifyingFeatureDefinition {
   private final MaterialData material;
   private final Duration after;
-  private final Filter filter;
+  private final @Nullable Filter filter;
   private final @Nullable String name;
   private final Component componentName;
   private final Duration showBefore;
@@ -26,7 +26,7 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
       final @Nullable String id,
       final MaterialData material,
       final Duration after,
-      final Filter filter,
+      final @Nullable Filter filter,
       final @Nullable String name,
       Duration showBefore) {
     super(id);
@@ -59,7 +59,7 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
     return this.showBefore;
   }
 
-  public Filter getFilter() {
+  public @Nullable Filter getFilter() {
     return this.filter;
   }
 

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -8,6 +8,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.filters.dynamic.FilterMatchModule;
@@ -42,11 +43,15 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
   }
 
   public void load(
-      FilterMatchModule fmm, ModeChangeCountdown countdown, CountdownContext countdownContext) {
+          FilterMatchModule fmm, ModeChangeCountdown countdown, CountdownContext countdownContext) {
     // if filter returns ALLOW at any time in the match, start countdown for mode change
     fmm.onRise(
         filter,
-        listener -> countdownContext.start(countdown, countdown.getMode().getAfter()));
+        listener -> {
+          if (!countdownContext.isRunning(countdown)) {
+            countdownContext.start(countdown, countdown.getMode().getAfter());
+          }
+        });
   }
 
   public MaterialData getMaterialData() {

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -8,9 +8,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
-import tc.oc.pgm.filters.dynamic.FilterMatchModule;
 
 public class Mode extends SelfIdentifyingFeatureDefinition {
   private final MaterialData material;
@@ -39,18 +37,6 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
     this.componentName =
         text(name != null ? name : getPreformattedMaterialName(), NamedTextColor.RED);
     this.showBefore = showBefore;
-  }
-
-  public void load(
-      FilterMatchModule fmm, ModeChangeCountdown countdown, CountdownContext countdownContext) {
-    // if filter returns ALLOW at any time in the match, start countdown for mode change
-    fmm.onRise(
-        filter,
-        listener -> {
-          if (!countdownContext.isRunning(countdown)) {
-            countdownContext.start(countdown, countdown.getMode().getAfter());
-          }
-        });
   }
 
   public MaterialData getMaterialData() {

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -46,9 +46,7 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
     // if filter returns ALLOW at any time in the match, start countdown for mode change
     fmm.onRise(
         filter,
-        FilterListener -> {
-          countdownContext.start(countdown, countdown.getMode().getAfter());
-        });
+        listener -> countdownContext.start(countdown, countdown.getMode().getAfter()));
   }
 
   public MaterialData getMaterialData() {

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -7,32 +7,53 @@ import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.material.MaterialData;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+import tc.oc.pgm.filters.dynamic.FilterMatchModule;
 
 public class Mode extends SelfIdentifyingFeatureDefinition {
   private final MaterialData material;
   private final Duration after;
-  private final @Nullable String name;
+  private final Filter filter;
+  private final @Nullable
+  String name;
   private final Component componentName;
   private final Duration showBefore;
+  private boolean modeComplete = false;
 
   public Mode(final MaterialData material, final Duration after, Duration showBefore) {
-    this(null, material, after, null, showBefore);
+    this(null, material, after, null, null, showBefore);
   }
 
   public Mode(
-      final @Nullable String id,
-      final MaterialData material,
-      final Duration after,
-      final @Nullable String name,
-      Duration showBefore) {
+          final @Nullable String id,
+          final MaterialData material,
+          final Duration after,
+          final Filter filter,
+          final @Nullable String name,
+          Duration showBefore
+  ) {
     super(id);
     this.material = material;
     this.after = after;
+    this.filter = filter;
     this.name = name;
     this.componentName =
-        text(name != null ? name : getPreformattedMaterialName(), NamedTextColor.RED);
+            text(name != null ? name : getPreformattedMaterialName(), NamedTextColor.RED);
     this.showBefore = showBefore;
+  }
+
+  public void load(FilterMatchModule fmm, ModeChangeCountdown countdown, CountdownContext countdownContext, Match match) {
+    // if filter returns ALLOW at any time in the match, start countdown for mode change
+    fmm.onRise(filter, FilterListener -> {
+      if (match.isRunning() && !modeComplete) {
+        countdownContext.start(countdown, countdown.getMode().getAfter());
+        modeComplete = true;
+      }
+    }
+    );
   }
 
   public MaterialData getMaterialData() {
@@ -55,7 +76,20 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
     return this.showBefore;
   }
 
-  public @Nullable String getName() {
+  public Filter getFilter() {
+    return this.filter;
+  }
+
+  public boolean isModeComplete() {
+    return this.modeComplete;
+  }
+
+  public @Nullable
+  String getName() {
     return this.name;
+  }
+
+  public void setModeComplete() {
+    this.modeComplete = true;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -8,7 +8,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.filters.dynamic.FilterMatchModule;
@@ -43,7 +42,7 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
   }
 
   public void load(
-          FilterMatchModule fmm, ModeChangeCountdown countdown, CountdownContext countdownContext) {
+      FilterMatchModule fmm, ModeChangeCountdown countdown, CountdownContext countdownContext) {
     // if filter returns ALLOW at any time in the match, start countdown for mode change
     fmm.onRise(
         filter,

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -8,7 +8,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.filters.dynamic.FilterMatchModule;
@@ -20,7 +19,6 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
   private final @Nullable String name;
   private final Component componentName;
   private final Duration showBefore;
-  private boolean modeComplete = false;
 
   public Mode(final MaterialData material, final Duration after, Duration showBefore) {
     this(null, material, after, null, null, showBefore);
@@ -44,18 +42,12 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
   }
 
   public void load(
-      FilterMatchModule fmm,
-      ModeChangeCountdown countdown,
-      CountdownContext countdownContext,
-      Match match) {
+      FilterMatchModule fmm, ModeChangeCountdown countdown, CountdownContext countdownContext) {
     // if filter returns ALLOW at any time in the match, start countdown for mode change
     fmm.onRise(
         filter,
         FilterListener -> {
-          if (match.isRunning() && !modeComplete) {
-            countdownContext.start(countdown, countdown.getMode().getAfter());
-            modeComplete = true;
-          }
+          countdownContext.start(countdown, countdown.getMode().getAfter());
         });
   }
 
@@ -83,15 +75,7 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
     return this.filter;
   }
 
-  public boolean isModeComplete() {
-    return this.modeComplete;
-  }
-
   public @Nullable String getName() {
     return this.name;
-  }
-
-  public void setModeComplete() {
-    this.modeComplete = true;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.modes;
 
 import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.util.text.TemporalComponent.clock;
 
 import com.google.common.base.Preconditions;
@@ -17,6 +18,7 @@ public class ModesPaginatedResult extends PrettyPaginatedResult<ModeChangeCountd
   private final ObjectiveModesMatchModule modes;
 
   public ModesPaginatedResult(ObjectiveModesMatchModule modes) {
+    // TODO translate this
     super("Monument Modes");
     this.modes = Preconditions.checkNotNull(modes);
   }
@@ -25,16 +27,28 @@ public class ModesPaginatedResult extends PrettyPaginatedResult<ModeChangeCountd
   public Component format(ModeChangeCountdown countdown, int index) {
     String materialName = countdown.getMode().getPreformattedMaterialName();
     Duration timeFromStart = countdown.getMode().getAfter();
+    Duration remainingTime = countdown.getRemaining();
 
     TextComponent.Builder builder = text();
 
     builder.append(text((index + 1) + ". ", NamedTextColor.GOLD));
     builder.append(text(materialName + " - ", NamedTextColor.LIGHT_PURPLE));
     builder.append(clock(timeFromStart).color(NamedTextColor.AQUA));
+    if (!countdown.getMatch().isRunning() && countdown.getMode().getFilter() != null) {
+      builder.append(text(" ").append(translatable("misc.crossmark", NamedTextColor.DARK_RED)));
+    }
 
-    if (countdown.getMatch().isRunning()) {
+    if (countdown.getMatch().isRunning() && remainingTime != null) {
+      if (countdown.getMode().getFilter() != null) {
+        builder.append(text(" ").append(translatable("misc.checkmark", NamedTextColor.GREEN)));
+      }
       builder.append(text(" (", NamedTextColor.DARK_AQUA));
       builder.append(this.formatSingleCountdown(countdown).color(NamedTextColor.DARK_AQUA));
+      builder.append(text(")", NamedTextColor.DARK_AQUA));
+    } else if (countdown.getMatch().isRunning() && remainingTime == null) {
+      builder.append(text(" ").append(translatable("misc.crossmark", NamedTextColor.DARK_RED)));
+      builder.append(text(" (", NamedTextColor.DARK_AQUA));
+      builder.append(translatable("command.conditionUnmet", NamedTextColor.DARK_AQUA));
       builder.append(text(")", NamedTextColor.DARK_AQUA));
     }
 
@@ -51,7 +65,7 @@ public class ModesPaginatedResult extends PrettyPaginatedResult<ModeChangeCountd
   public TextComponent.Builder formatSingleCountdown(ModeChangeCountdown countdown) {
     Duration currentTimeLeft = modes.getCountdown().getTimeLeft(countdown);
 
-    if (countdown.getMatch().isRunning()) {
+    if (countdown.getMatch().isRunning() && currentTimeLeft != null) {
       return clock(currentTimeLeft).append(text(" left"));
     }
 

--- a/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
@@ -17,6 +17,9 @@ import tc.oc.pgm.util.PrettyPaginatedResult;
 public class ModesPaginatedResult extends PrettyPaginatedResult<ModeChangeCountdown> {
 
   private final ObjectiveModesMatchModule modes;
+  public static final TextComponent SYMBOL_INCOMPLETE =
+      text("\u2715", NamedTextColor.DARK_RED); // ✕
+  public static final TextComponent SYMBOL_COMPLETE = text("\u2714", NamedTextColor.GREEN); // ✔
 
   public ModesPaginatedResult(ObjectiveModesMatchModule modes) {
     // TODO translate this
@@ -37,18 +40,18 @@ public class ModesPaginatedResult extends PrettyPaginatedResult<ModeChangeCountd
     builder.append(text(materialName + " - ", NamedTextColor.LIGHT_PURPLE));
     builder.append(clock(timeFromStart).color(NamedTextColor.AQUA));
     if (!isRunning && countdown.getMode().getFilter() != null) {
-      builder.append(space()).append(translatable("misc.crossmark", NamedTextColor.DARK_RED));
+      builder.append(space()).append(SYMBOL_INCOMPLETE);
     }
 
     if (isRunning && remainingTime != null) {
       if (countdown.getMode().getFilter() != null) {
-        builder.append(space()).append(translatable("misc.checkmark", NamedTextColor.GREEN));
+        builder.append(space()).append(SYMBOL_COMPLETE);
       }
       builder.append(text(" (", NamedTextColor.DARK_AQUA));
       builder.append(this.formatSingleCountdown(countdown).color(NamedTextColor.DARK_AQUA));
       builder.append(text(")", NamedTextColor.DARK_AQUA));
     } else if (isRunning) {
-      builder.append(space()).append(translatable("misc.crossmark", NamedTextColor.DARK_RED));
+      builder.append(space()).append(SYMBOL_INCOMPLETE);
       builder.append(text(" (", NamedTextColor.DARK_AQUA));
       builder.append(translatable("command.conditionUnmet", NamedTextColor.DARK_AQUA));
       builder.append(text(")", NamedTextColor.DARK_AQUA));

--- a/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.modes;
 
+import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.util.text.TemporalComponent.clock;
@@ -28,25 +29,26 @@ public class ModesPaginatedResult extends PrettyPaginatedResult<ModeChangeCountd
     String materialName = countdown.getMode().getPreformattedMaterialName();
     Duration timeFromStart = countdown.getMode().getAfter();
     Duration remainingTime = countdown.getRemaining();
+    boolean isRunning = countdown.getMatch().isRunning();
 
     TextComponent.Builder builder = text();
 
     builder.append(text((index + 1) + ". ", NamedTextColor.GOLD));
     builder.append(text(materialName + " - ", NamedTextColor.LIGHT_PURPLE));
     builder.append(clock(timeFromStart).color(NamedTextColor.AQUA));
-    if (!countdown.getMatch().isRunning() && countdown.getMode().getFilter() != null) {
-      builder.append(text(" ").append(translatable("misc.crossmark", NamedTextColor.DARK_RED)));
+    if (!isRunning && countdown.getMode().getFilter() != null) {
+      builder.append(space()).append(translatable("misc.crossmark", NamedTextColor.DARK_RED));
     }
 
-    if (countdown.getMatch().isRunning() && remainingTime != null) {
+    if (isRunning && remainingTime != null) {
       if (countdown.getMode().getFilter() != null) {
-        builder.append(text(" ").append(translatable("misc.checkmark", NamedTextColor.GREEN)));
+        builder.append(space()).append(translatable("misc.checkmark", NamedTextColor.GREEN));
       }
       builder.append(text(" (", NamedTextColor.DARK_AQUA));
       builder.append(this.formatSingleCountdown(countdown).color(NamedTextColor.DARK_AQUA));
       builder.append(text(")", NamedTextColor.DARK_AQUA));
-    } else if (countdown.getMatch().isRunning() && remainingTime == null) {
-      builder.append(text(" ").append(translatable("misc.crossmark", NamedTextColor.DARK_RED)));
+    } else if (isRunning) {
+      builder.append(space()).append(translatable("misc.crossmark", NamedTextColor.DARK_RED));
       builder.append(text(" (", NamedTextColor.DARK_AQUA));
       builder.append(translatable("command.conditionUnmet", NamedTextColor.DARK_AQUA));
       builder.append(text(")", NamedTextColor.DARK_AQUA));

--- a/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
@@ -62,7 +62,7 @@ public class ModesPaginatedResult extends PrettyPaginatedResult<ModeChangeCountd
 
   /**
    * Formats a {@link tc.oc.pgm.modes.ModeChangeCountdown} to the following format 'm:ss' and
-   * appends 'left' to the text //TODO make translatable
+   * appends 'left' to the text
    *
    * @param countdown to format
    * @return Formatted text
@@ -71,7 +71,7 @@ public class ModesPaginatedResult extends PrettyPaginatedResult<ModeChangeCountd
     Duration currentTimeLeft = modes.getCountdown().getTimeLeft(countdown);
 
     if (countdown.getMatch().isRunning() && currentTimeLeft != null) {
-      return clock(currentTimeLeft).append(text(" left"));
+      return clock(currentTimeLeft).append(space().append(translatable("command.timeLeft")));
     }
 
     return text();

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -83,7 +83,16 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
 
   public List<ModeChangeCountdown> getSortedCountdowns() {
     List<ModeChangeCountdown> listClone = new ArrayList<>(this.countdowns);
+    List<ModeChangeCountdown> unstartedCountdowns = new ArrayList<>();
+    // places countdowns triggered by filter at the bottom of list
+    for (ModeChangeCountdown listCloneItem : listClone) {
+      if (listCloneItem.getRemaining() == null) {
+        unstartedCountdowns.add(listCloneItem);
+        listClone.remove(listCloneItem);
+      }
+    }
     Collections.sort(listClone);
+    listClone.addAll(unstartedCountdowns);
 
     return listClone;
   }

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -50,7 +50,14 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
       ModeChangeCountdown countdown = new ModeChangeCountdown(match, this, mode);
       this.countdowns.add(countdown);
       if (mode.getFilter() != null) {
-        mode.load(fmm, countdown, this.countdownContext);
+        // if filter returns ALLOW at any time in the match, start countdown for mode change
+        fmm.onRise(
+            mode.getFilter(),
+            listener -> {
+              if (!this.countdownContext.isRunning(countdown) && match.isRunning()) {
+                this.countdownContext.start(countdown, countdown.getMode().getAfter());
+              }
+            });
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -7,7 +7,6 @@ import static net.kyori.adventure.text.Component.text;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -60,7 +59,8 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
   public void enable() {
     for (ModeChangeCountdown countdown : this.countdowns) {
       Query query = new MatchQuery(match.getEvent(), match);
-      if (countdown.getMode().getFilter().query(query).isAllowed() || countdown.getMode().getFilter() == null) {
+      if (countdown.getMode().getFilter().query(query).isAllowed()
+          || countdown.getMode().getFilter() == null) {
         if (!countdown.getMode().isModeComplete()) {
           this.countdownContext.start(countdown, countdown.getMode().getAfter());
           countdown.getMode().setModeComplete();

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -81,7 +81,7 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
         .build();
   }
 
-  public List<ModeChangeCountdown> getSortedCountdowns() {
+  public List<ModeChangeCountdown> getSortedCountdowns(boolean includeUnstarted) {
     List<ModeChangeCountdown> listClone = new ArrayList<>(this.countdowns);
     List<ModeChangeCountdown> unstartedCountdowns = new ArrayList<>();
     // places countdowns triggered by filter at the bottom of list
@@ -92,7 +92,9 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
       }
     }
     Collections.sort(listClone);
-    listClone.addAll(unstartedCountdowns);
+    if (includeUnstarted) {
+      listClone.addAll(unstartedCountdowns);
+    }
 
     return listClone;
   }

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -17,7 +17,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
@@ -25,7 +24,6 @@ import tc.oc.pgm.api.module.exception.ModuleLoadException;
 import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.filters.dynamic.FilterMatchModule;
-import tc.oc.pgm.filters.query.MatchQuery;
 
 @ListenerScope(MatchScope.LOADED)
 public class ObjectiveModesMatchModule implements MatchModule, Listener {
@@ -51,20 +49,17 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
     for (Mode mode : this.modes) {
       ModeChangeCountdown countdown = new ModeChangeCountdown(match, this, mode);
       this.countdowns.add(countdown);
-      mode.load(fmm, countdown, this.countdownContext, match);
+      if (mode.getFilter() != null) {
+        mode.load(fmm, countdown, this.countdownContext);
+      }
     }
   }
 
   @Override
   public void enable() {
     for (ModeChangeCountdown countdown : this.countdowns) {
-      Query query = new MatchQuery(match.getEvent(), match);
-      if (countdown.getMode().getFilter().query(query).isAllowed()
-          || countdown.getMode().getFilter() == null) {
-        if (!countdown.getMode().isModeComplete()) {
-          this.countdownContext.start(countdown, countdown.getMode().getAfter());
-          countdown.getMode().setModeComplete();
-        }
+      if (countdown.getMode().getFilter() == null) {
+        this.countdownContext.start(countdown, countdown.getMode().getAfter());
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -74,7 +74,6 @@ public class ObjectiveModesModule implements MapModule {
         MaterialData material =
             XMLUtils.parseBlockMaterialData(Node.fromRequiredAttr(modeEl, "material"));
         Duration after = TextParser.parseDuration(modeEl.getAttributeValue("after"));
-        // default is not a dynamic filter so this causes issues
         Filter filter = factory.getFilters().parseFilterProperty(modeEl, "filter", null);
         String name = modeEl.getAttributeValue("name");
         if (name != null) {

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -8,18 +8,17 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
 import org.bukkit.material.MaterialData;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
-import tc.oc.pgm.filters.QueryTypeFilter;
 import tc.oc.pgm.filters.StaticFilter;
 import tc.oc.pgm.filters.dynamic.FilterMatchModule;
 import tc.oc.pgm.goals.GoalMatchModule;
@@ -27,8 +26,6 @@ import tc.oc.pgm.util.text.TextParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
-
-import javax.annotation.Nullable;
 
 public class ObjectiveModesModule implements MapModule {
 
@@ -78,7 +75,8 @@ public class ObjectiveModesModule implements MapModule {
         MaterialData material =
             XMLUtils.parseBlockMaterialData(Node.fromRequiredAttr(modeEl, "material"));
         Duration after = TextParser.parseDuration(modeEl.getAttributeValue("after"));
-        Filter filter = factory.getFilters().parseFilterProperty(modeEl, "filter", StaticFilter.ALLOW);
+        Filter filter =
+            factory.getFilters().parseFilterProperty(modeEl, "filter", StaticFilter.ALLOW);
         String name = modeEl.getAttributeValue("name");
         if (name != null) {
           name = ChatColor.translateAlternateColorCodes('`', name);

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -19,7 +19,6 @@ import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
-import tc.oc.pgm.filters.StaticFilter;
 import tc.oc.pgm.filters.dynamic.FilterMatchModule;
 import tc.oc.pgm.goals.GoalMatchModule;
 import tc.oc.pgm.util.text.TextParser;
@@ -75,8 +74,8 @@ public class ObjectiveModesModule implements MapModule {
         MaterialData material =
             XMLUtils.parseBlockMaterialData(Node.fromRequiredAttr(modeEl, "material"));
         Duration after = TextParser.parseDuration(modeEl.getAttributeValue("after"));
-        Filter filter =
-            factory.getFilters().parseFilterProperty(modeEl, "filter", StaticFilter.ALLOW);
+        // default is not a dynamic filter so this causes issues
+        Filter filter = factory.getFilters().parseFilterProperty(modeEl, "filter", null);
         String name = modeEl.getAttributeValue("name");
         if (name != null) {
           name = ChatColor.translateAlternateColorCodes('`', name);

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -74,14 +74,17 @@ command.nextMode = Next Mode:
 
 command.modesPushed = Affected modes have been pushed
 
+# time moved ahead (e.g. Affected modes have been pushed forwards by 2:32)
+command.modesPushedForwards = forwards
+
+# time moved backwards (e.g. Affected modes have been pushed back by 2:32)
+command.modesPushedBack = back
+
+# amount of time a mode was pushed (e.g. by 1:00)
+command.modesPushedBy = by
+
 # {0} = mode name (e.g. GOLD, Glass Mode)
 command.selectedModePushed = {0} will start in
-
-command.forwards = forwards
-
-command.backwards = backwards
-
-command.by = by
 
 # {0} = number of players online
 command.list.online = Total Online: {0}

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -24,6 +24,8 @@ command.onlyPlayers = You must be a player to use this command.
 # {0} = module name (proper noun)
 command.moduleNotFound = The {0} module is not in use for this match
 
+command.matchNotStarted = The match must start before using this command.
+
 command.noTeams = Teams are not in use for this match
 
 command.noPlayers = Players cannot join this match
@@ -67,6 +69,14 @@ command.simplePageHeader = {0} of {1}
 command.invalidPage = There is no page {0}. Pages run from 1 to {1}.
 
 command.conditionUnmet = Condition Unmet
+
+command.modesPushed = Affected modes have been pushed
+
+command.forwards = forwards
+
+command.backwards = backwards
+
+command.by = by
 
 # {0} = number of players online
 command.list.online = Total Online: {0}

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -70,13 +70,15 @@ command.invalidPage = There is no page {0}. Pages run from 1 to {1}.
 
 command.conditionUnmet = Condition Unmet
 
+command.nextMode = Next Mode:
+
 command.modesPushed = Affected modes have been pushed
+
+command.selectedModePushed = Selected mode will start in
 
 command.forwards = forwards
 
 command.backwards = backwards
-
-command.by = by
 
 # {0} = number of players online
 command.list.online = Total Online: {0}

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -74,11 +74,14 @@ command.nextMode = Next Mode:
 
 command.modesPushed = Affected modes have been pushed
 
-command.selectedModePushed = Selected mode will start in
+# {0} = mode name (e.g. GOLD, Glass Mode)
+command.selectedModePushed = {0} will start in
 
 command.forwards = forwards
 
 command.backwards = backwards
+
+command.by = by
 
 # {0} = number of players online
 command.list.online = Total Online: {0}

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -66,6 +66,8 @@ command.simplePageHeader = {0} of {1}
 # {1} = total number of pages
 command.invalidPage = There is no page {0}. Pages run from 1 to {1}.
 
+command.conditionUnmet = Condition Unmet
+
 # {0} = number of players online
 command.list.online = Total Online: {0}
 

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -86,6 +86,9 @@ command.modesPushedBy = by
 # {0} = mode name (e.g. GOLD, Glass Mode)
 command.selectedModePushed = {0} will start in
 
+# amount of time remaining (e.g. 1:00 left)
+command.timeLeft = left
+
 # {0} = number of players online
 command.list.online = Total Online: {0}
 

--- a/util/src/main/i18n/templates/misc.properties
+++ b/util/src/main/i18n/templates/misc.properties
@@ -120,6 +120,12 @@ misc.or = {0} or {1}
 # do not translate, keep as-is
 misc.snowman = ☃
 
+# do not translate, keep as-is
+misc.checkmark = ✔
+
+# do not translate, keep as-is
+misc.crossmark = ✘
+
 misc.unknown = Unknown
 
 misc.console = Console

--- a/util/src/main/i18n/templates/misc.properties
+++ b/util/src/main/i18n/templates/misc.properties
@@ -120,12 +120,6 @@ misc.or = {0} or {1}
 # do not translate, keep as-is
 misc.snowman = ☃
 
-# do not translate, keep as-is
-misc.checkmark = ✔
-
-# do not translate, keep as-is
-misc.crossmark = ✘
-
 misc.unknown = Unknown
 
 misc.console = Console


### PR DESCRIPTION
Call me Mr Monument Modes with how much PRs I make for it :sunglasses: 

This adds a `filter` attribute to `<mode>` which triggers when a dynamic filter is set to or changes to allow.

```xml
<modes>
    <!-- Activates 10 seconds after the condition in mode-filter is allow -->
    <mode id="glass-mode" filter="mode-filter" after="10s" material="glass" name="`eGlass Mode" show-before="10s"/>
    <!-- Activates 20 seconds after match start -->
    <mode id="gold-mode" after="20s" material="gold block" name="`eGold Mode" show-before="10s"/>
</modes>
<filters>
    <all id="mode-filter">
        <objective>red-mon</objective>
    </all>
</filters>
<cores material="obsidian" leak="2">
    <core team="red-team" region="left-core" name="Red Core" modes="gold-mode"/>
    <core team="blue-team" region="right-core" name="Blue Core" modes="gold-mode"/>
</cores>
<destroyables>
    <destroyable id="red-mon" name="Red Monument" owner="red-team" region="mon-red" materials="obsidian" modes="glass-mode"/>
    <destroyable id="blue-mon" name="Blue Monument" owner="blue-team" region="mon-blu" materials="obsidian" modes="glass-mode"/>
</destroyables>
```

Currently a few more small updates need to be made, such as updating the `/modes list`, and other mode commands which as of this post when used will stop the modes from activating. Special thanks for @KingOfSquares and @Pugzy for readding the dynamic filters making this all possible :)