### PR TITLE
Reduce post match rocket iterations to 5 (10 seconds)

### DIFF
--- a/core/src/main/java/tc/oc/pgm/fireworks/FireworkMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/fireworks/FireworkMatchModule.java
@@ -48,7 +48,7 @@ public class FireworkMatchModule implements MatchModule, Listener {
   private static final int ROCKET_COUNT = 5; // Maximum rockets to launch at once, one per player
   private static final int INITIAL_DELAY = 2; // Seconds before starting to launch rockets
   private static final int FREQUENCY = 2; // Seconds between rocket launches
-  private static final int ITERATION_COUNT = 15; // Amount of times rockets are launched
+  private static final int ITERATION_COUNT = 5; // Amount of times rockets are launched
   private static final int ROCKET_POWER =
       2; // Power applied to rockets (how high they go), 1 = low, 2 = medium, 3 = high
 


### PR DESCRIPTION
This was discussed in Discord earlier in the week. After checking the code I found that the fireworks last for 30 seconds (15 iterations at 2 seconds apart), not the unlimited duration some people had thought. 

I have reduced it to 5 iterations (so 10 seconds of fireworks) as 30 seconds is still quite obnoxious. Open to discussion.

Signed-off-by: Pugzy <pugzy@mail.com>