### PR TITLE
Fix dispatching cancelled item transfer events

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -240,7 +240,7 @@ public class PGMListener implements Listener {
   }
 
   // fix item pickup to work the way it should
-  @EventHandler(priority = EventPriority.HIGHEST)
+  @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
   public void handleItemPickup(final PlayerPickupItemEvent event) {
     Player nearestPlayer = event.getPlayer();
     double closestDistance =

--- a/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
@@ -22,7 +22,7 @@ public class ItemTransferListener implements Listener {
   private boolean ignoreNextDropEvent;
   private boolean collectToCursor;
 
-  @EventHandler
+  @EventHandler(ignoreCancelled = true)
   public void onPlayerPickupItem(final PlayerPickupItemEvent event) {
     // When this event is fired, the ItemStack in the Item being picked up is temporarily
     // set to the amount that will actually be picked up, while the difference from the
@@ -47,7 +47,7 @@ public class ItemTransferListener implements Listener {
 
     int quantity = Math.min(transferEvent.getQuantity(), initialQuantity);
 
-    if (!event.isCancelled() && quantity < initialQuantity) {
+    if (quantity < initialQuantity) {
       event.setCancelled(true);
       if (quantity > 0) {
         ItemStack stack = event.getItem().getItemStack().clone();


### PR DESCRIPTION
Resolves https://github.com/PGMDev/PGM/issues/782 reported in January by a very active contributor who definitely didn't wait until Hacktober to fix.

- Adds an `ignoreCancelled` check to in the `ItemTransferListener` which falsely dispatched `PlayerItemTransferEvent` events.
- Also changes the `PGMListener`'s `PlayerPickupItemEvent` event handler to priority `LOW` and to `ignoreCancelled`, this allows the [EventFilterMatchModule](https://github.com/PGMDev/PGM/blob/dev/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java#L343-L346) to receive the event first and cancel if required.

Signed-off-by: Pugzy <pugzy@mail.com>