### PR TITLE
Add dynamic kit rules

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitModule.java
@@ -1,27 +1,47 @@
 package tc.oc.pgm.kits;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import java.util.Collection;
+import java.util.Set;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import tc.oc.pgm.api.feature.FeatureDefinition;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.filters.dynamic.FilterMatchModule;
 import tc.oc.pgm.itemmeta.ItemModifyModule;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.teams.TeamModule;
+import tc.oc.pgm.util.text.TextParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.XMLUtils;
 
 public class KitModule implements MapModule {
 
+  protected final Set<KitRule> kitRules;
+
+  public KitModule(Set<KitRule> kitRules) {
+    this.kitRules = ImmutableSet.copyOf(kitRules);
+  }
+
+  @Nullable
+  @Override
+  public Collection<Class<? extends MatchModule>> getHardDependencies() {
+    return ImmutableList.of(FilterMatchModule.class);
+  }
+
   @Override
   public MatchModule createMatchModule(Match match) {
-    return new KitMatchModule(match);
+    return new KitMatchModule(match, kitRules);
   }
 
   @Override
@@ -39,12 +59,27 @@ public class KitModule implements MapModule {
     @Override
     public KitModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
+      Set<KitRule> kitRules = Sets.newHashSet();
       for (Element kitsElement : doc.getRootElement().getChildren("kits")) {
         for (Element kitElement : kitsElement.getChildren("kit")) {
           factory.getKits().parse(kitElement);
         }
+        for (Element kitElement : XMLUtils.getChildren(kitsElement, "give", "take", "lend")) {
+          KitRule kitRule = parseRule(factory, kitElement);
+          kitRules.add(kitRule);
+          factory.getFeatures().addFeature(kitElement, kitRule);
+        }
       }
-      return new KitModule();
+
+      return new KitModule(kitRules);
+    }
+
+    private KitRule parseRule(MapFactory factory, Element el) throws InvalidXMLException {
+      KitRule.Action action = TextParser.parseEnum(el.getName(), KitRule.Action.class);
+      Kit kit = factory.getKits().parseKitProperty(el, "kit");
+      Filter filter = factory.getFilters().parseFilterProperty(el, "filter");
+
+      return new KitRule(action, kit, filter);
     }
   }
 
@@ -71,6 +106,14 @@ public class KitModule implements MapModule {
             imm.applyRules(armor.stack);
           }
         }
+      }
+    }
+
+    for (KitRule kitRule : this.kitRules) {
+      if ((kitRule.getAction() == KitRule.Action.TAKE || kitRule.getAction() == KitRule.Action.LEND)
+          && !kitRule.getKit().isRemovable()) {
+        throw new InvalidXMLException(
+            "kit is not removable", factory.getFeatures().getNode(kitRule));
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/kits/KitRule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitRule.java
@@ -1,0 +1,35 @@
+package tc.oc.pgm.kits;
+
+import tc.oc.pgm.api.feature.FeatureDefinition;
+import tc.oc.pgm.api.filter.Filter;
+
+public class KitRule implements FeatureDefinition {
+
+  enum Action {
+    GIVE,
+    TAKE,
+    LEND
+  }
+
+  private final Action action;
+  private final Kit kit;
+  private final Filter filter;
+
+  public KitRule(Action action, Kit kit, Filter filter) {
+    this.action = action;
+    this.kit = kit;
+    this.filter = filter;
+  }
+
+  public Action getAction() {
+    return action;
+  }
+
+  public Kit getKit() {
+    return kit;
+  }
+
+  public Filter getFilter() {
+    return filter;
+  }
+}


### PR DESCRIPTION
## Dynamic kits 🔮👕🎉  

The PR implements dynamic kits in the same fashion as Overcast Network Project Ares did.

Let's you `give`, `lend`, and `take` a kit based on a filter rising or falling.

```xml
<kits>
    <!-- Kit and Filter References -->
    <lend kit="jumper-kit" filter="carrying-gold" />
    <give kit="regen-kit" filter="holding-redstone" />
    <!-- Inline kit and filters -->
    <take>
        <kit>
            <fly/>
        </kit>
        <filter>
            <flag-carried>flag</flag-carried>
        </filter>
    </take>
    ...
</kits>
```

Not to be confused with the documented but 'deprecated' docs syntax http://docs.oc.tc/modules/kits confirmed as incorrect by Mitch (being the main user of the feature) and Pablo (checking the original commit history and PR to change).

Only a few maps used this on OCN (three total I believe) as it was a relatively new feature so if not implemented like for like the impact would be a couple of Arcade maps 🤷 that haven't been played in years.
 
Open to opinions on a better XML syntax if anyone has any ideas. I had wanted to use an `<apply>` to apply kit rules in the same way a filter is applied to a region but the above seemed like the simplest approach.

Signed-off-by: Pugzy <pugzy@mail.com>