### PR TITLE
Apply item mods to across modules

### DIFF
--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyMatchModule.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.itemmeta;
 
+import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDispenseEvent;
@@ -7,11 +8,13 @@ import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.LOADED)
 public class ItemModifyMatchModule implements MatchModule, Listener {
@@ -67,6 +70,21 @@ public class ItemModifyMatchModule implements MatchModule, Listener {
     ItemStack stack = event.getItem();
     if (applyRules(stack)) {
       event.setItem(stack);
+    }
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onItemPickup(PlayerPickupItemEvent event) {
+    // Needed for players picking up arrows stuck in blocks
+    if (!NMSHacks.isCraftItemArrowEntity(event.getItem())) return;
+
+    final Item item = event.getItem();
+    final ItemStack itemStack = item.getItemStack();
+
+    if (applyRules(itemStack)) {
+      event.setCancelled(true);
+      NMSHacks.fakePlayerItemPickup(event.getPlayer(), item);
+      event.getPlayer().getInventory().addItem(itemStack);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modules/ToolRepairMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ToolRepairMatchModule.java
@@ -4,7 +4,7 @@ import com.google.common.collect.Iterables;
 import java.util.Arrays;
 import java.util.Set;
 import org.bukkit.Material;
-import org.bukkit.Sound;
+import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -15,6 +15,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
 public class ToolRepairMatchModule implements MatchModule, Listener {
@@ -31,14 +32,14 @@ public class ToolRepairMatchModule implements MatchModule, Listener {
   }
 
   private void doRepair(PlayerPickupItemEvent event, ItemStack stack) {
-    ItemStack pickup = event.getItem().getItemStack();
+    Item item = event.getItem();
+    ItemStack pickup = item.getItemStack();
+
+    event.setCancelled(true);
+    NMSHacks.fakePlayerItemPickup(event.getPlayer(), item);
 
     int hitsLeft = pickup.getType().getMaxDurability() - pickup.getDurability() + 1;
     stack.setDurability((short) Math.max(stack.getDurability() - hitsLeft, 0));
-
-    event.setCancelled(true);
-    event.getItem().remove();
-    event.getPlayer().playSound(event.getPlayer().getLocation(), Sound.ITEM_PICKUP, 0.5f, 1f);
   }
 
   @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -1333,4 +1333,18 @@ public interface NMSHacks {
     setFireworksTicksFlown(firework, 2);
     sendEntityMetadataToViewers(firework, false);
   }
+
+  static boolean isCraftItemArrowEntity(org.bukkit.entity.Item item) {
+    return ((CraftItem) item).getHandle() instanceof EntityArrow;
+  }
+
+  static void fakePlayerItemPickup(Player player, org.bukkit.entity.Item item) {
+    float pitch = (((float) (Math.random() - Math.random()) * 0.7F + 1.0F) * 2.0F);
+    item.getWorld().playSound(item.getLocation(), org.bukkit.Sound.ITEM_PICKUP, 0.2F, pitch);
+
+    NMSHacks.sendPacketToViewers(
+        item, new PacketPlayOutCollect(item.getEntityId(), player.getEntityId()));
+
+    item.remove();
+  }
 }


### PR DESCRIPTION
### The Issue

Maps that use item mods can cause items (typically arrows and gapples) to be non-stackable.
If the item mod is applied to the items in the player's inventory but not on items picked up or given to them they will not stack.

### Background on Item Mods

Item mods work by checking all items to see if modifications are required, once checked all items are marked with meta (in the current case hidden lore). Items that are not checked and are received by a player are missing this extra data so the items do not match.

### The Solution(s)

There are a few elements fixed/changed to make this function as expected.

- Item mods rules applied to parsed kits inside the kill rewards and block drop modules.
- Adding an extra check for picking up arrows inside item mods (arrow pickup event doesn't exist in this version of Bukkit).
- Allowing the modification of picked up arrows by removing the arrow (faking the pickup) and giving the correct item.
- Applying that same logic to the `ToolRepairMatchModule` so items don't just disappear but look to be picked up (with the animation and world sound unlike before).

Thanks to @Pablete1234 and @PabloPintor for debugging and testing.

Signed-off-by: Pugzy <pugzy@mail.com>
