### PR TITLE
Throttle tablist based on tps & match cycle

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
@@ -1,7 +1,7 @@
 package tc.oc.pgm.util.bukkit;
 
+import com.viaversion.viaversion.api.Via;
 import org.bukkit.entity.Player;
-import us.myles.ViaVersion.api.Via;
 
 public class ViaUtils {
   /** Minecraft 1.7.6 &ndash; 1.7.10 */
@@ -11,15 +11,15 @@ public class ViaUtils {
   /** Minecraft 1.9 &ndash; 1.9.1-pre1 */
   public static final int VERSION_1_9 = 107;
 
-  private static final boolean ENABLED;
+  private static final boolean ENABLED = isViaLoaded();
 
-  static {
-    boolean viaLoaded = false;
+  private static boolean isViaLoaded() {
     try {
-      viaLoaded = Class.forName("us.myles.ViaVersion.api.Via") != null;
+      Class.forName("com.viaversion.viaversion.api.Via");
+      return true;
     } catch (ClassNotFoundException ignored) {
+      return false;
     }
-    ENABLED = viaLoaded;
   }
 
   public static boolean enabled() {

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabView.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabView.java
@@ -74,7 +74,7 @@ public class TabView {
     if (this.manager != null) disable();
     this.manager = manager;
 
-    if (ViaUtils.getProtocolVersion(viewer) < ViaUtils.VERSION_1_8)
+    if (ViaUtils.getProtocolVersion(viewer) <= ViaUtils.VERSION_1_7)
       this.display = new TabDisplay(viewer, WIDTH);
 
     this.setup();


### PR DESCRIPTION
Adds tablist throttling based on tps (if server is running at 19.5tps, tablist won't render more often than once every 500ms, at 19.0tps, more than once every second, etc), as well as completely throttling (the max delay of one render per 5 seconds) while the a match transfer is going on (players are being moved from match A to match B).

This should help with the lag on high playercounts on cycle, where tablist re-renders so many times, and the tablist render time is not necessarily impacted but many packets get queued up and take up to 30s to get dispatched, making everyone feel very laggy.

This has been tested and works correctly.