### PR TITLE
Fix missing death messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/player/event/MatchPlayerDeathEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/event/MatchPlayerDeathEvent.java
@@ -98,6 +98,7 @@ public class MatchPlayerDeathEvent extends MatchPlayerEvent {
    * @return Whether the {@link MatchPlayer} is involved.
    */
   public final boolean isInvolved(MatchPlayer player) {
+    if (player == null) return false;
     return isVictim(player) || isKiller(player);
   }
 


### PR DESCRIPTION
Caused by #840

Sometimes a spectator target may be null. When passed into death messages, this is currently throwing a NPE and preventing any pvp related death message from being broadcasted. 

This PR resolves that issue and restores death message functionality. 

If there are any alternative fixes for this bug let me know 👍 

Signed-off-by: applenick <applenick@users.noreply.github.com>