### PR TITLE
Check objective visibility on displaying mode change messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -155,11 +155,12 @@ public class CoreMatchModule implements MatchModule, Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.MONITOR)
+  @EventHandler(priority = EventPriority.HIGHEST)
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Core core : this.cores) {
       if (core.getModes() == null || core.getModes().contains(event.getMode())) {
         core.replaceBlocks(event.getMode().getMaterialData());
+        event.setVisible(core.isVisible());
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -160,7 +160,10 @@ public class CoreMatchModule implements MatchModule, Listener {
     for (Core core : this.cores) {
       if (core.getModes() == null || core.getModes().contains(event.getMode())) {
         core.replaceBlocks(event.getMode().getMaterialData());
-        event.setVisible(core.isVisible());
+        // if at least one of the cores are visible, the mode change message will be sent
+        if (core.isVisible()) {
+          event.setVisible(true);
+        }
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -42,6 +42,10 @@ public class CoreMatchModule implements MatchModule, Listener {
     this.cores = cores;
   }
 
+  public List<Core> getCores() {
+    return this.cores;
+  }
+
   @Override
   public void enable() {
     if (this.match.getMap().getProto().isOlderThan(MODES_IMPLEMENTATION_VERSION)) {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -119,12 +119,13 @@ public class DestroyableMatchModule implements MatchModule, Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.MONITOR)
+  @EventHandler(priority = EventPriority.HIGHEST)
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Destroyable destroyable : this.destroyables) {
       if (destroyable.getModes() == null || destroyable.getModes().contains(event.getMode())) {
         double oldCompletion = destroyable.getCompletion();
         destroyable.replaceBlocks(event.getMode().getMaterialData());
+        event.setVisible(destroyable.isVisible());
         if (oldCompletion != destroyable.getCompletion()) {
           // Multi-stage destroyables can have their total completion changed by this
           this.match.callEvent(new DestroyableHealthChangeEvent(this.match, destroyable, null));

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -125,7 +125,10 @@ public class DestroyableMatchModule implements MatchModule, Listener {
       if (destroyable.getModes() == null || destroyable.getModes().contains(event.getMode())) {
         double oldCompletion = destroyable.getCompletion();
         destroyable.replaceBlocks(event.getMode().getMaterialData());
-        event.setVisible(destroyable.isVisible());
+        // if at least one of the destroyables are visible, the mode change message will be sent
+        if (destroyable.isVisible()) {
+          event.setVisible(true);
+        }
         if (oldCompletion != destroyable.getCompletion()) {
           // Multi-stage destroyables can have their total completion changed by this
           this.match.callEvent(new DestroyableHealthChangeEvent(this.match, destroyable, null));

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModeChangeEvent.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModeChangeEvent.java
@@ -7,21 +7,20 @@ import org.bukkit.event.HandlerList;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.event.MatchEvent;
 import tc.oc.pgm.core.Core;
-import tc.oc.pgm.core.CoreMatchModule;
 import tc.oc.pgm.destroyable.Destroyable;
-import tc.oc.pgm.destroyable.DestroyableMatchModule;
 import tc.oc.pgm.goals.GoalMatchModule;
 
 public class ObjectiveModeChangeEvent extends MatchEvent {
 
   private final Mode mode;
   private String name;
-  private final boolean visible;
+  private boolean visible;
   private static final HandlerList handlers = new HandlerList();
 
   public ObjectiveModeChangeEvent(Match match, final Mode mode) {
     super(match);
     this.mode = mode;
+    this.visible = false;
 
     if (this.mode.getName() != null) {
       this.name = this.mode.getName();
@@ -43,37 +42,18 @@ public class ObjectiveModeChangeEvent extends MatchEvent {
         this.name = "Unknown Mode";
       }
     }
-
-    DestroyableMatchModule dmm = match.getModule(DestroyableMatchModule.class);
-    CoreMatchModule cmm = match.getModule(CoreMatchModule.class);
-    boolean displayModeChange = false;
-    if (dmm != null) {
-      for (Destroyable destroyable : dmm.getDestroyables()) {
-        // if one objective is visible (ie. show=true), then display mode change in chat and exit
-        // loop.
-        if (destroyable.getModes().contains(this.mode) && destroyable.isVisible()) {
-          displayModeChange = true;
-          break;
-        }
-      }
-    }
-    if (cmm != null && !displayModeChange) {
-      for (Core core : cmm.getCores()) {
-        if (core.getModes().contains(this.mode) && core.isVisible()) {
-          displayModeChange = true;
-          break;
-        }
-      }
-    }
-    this.visible = displayModeChange;
   }
 
-  public final boolean isVisible() {
+  public boolean isVisible() {
     return this.visible;
   }
 
   public final Mode getMode() {
     return this.mode;
+  }
+
+  public void setVisible(boolean visible) {
+    this.visible = visible;
   }
 
   public void setName(@Nonnull String name) {

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModeChangeEvent.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModeChangeEvent.java
@@ -7,13 +7,16 @@ import org.bukkit.event.HandlerList;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.event.MatchEvent;
 import tc.oc.pgm.core.Core;
+import tc.oc.pgm.core.CoreMatchModule;
 import tc.oc.pgm.destroyable.Destroyable;
+import tc.oc.pgm.destroyable.DestroyableMatchModule;
 import tc.oc.pgm.goals.GoalMatchModule;
 
 public class ObjectiveModeChangeEvent extends MatchEvent {
 
   private final Mode mode;
   private String name;
+  private final boolean visible;
   private static final HandlerList handlers = new HandlerList();
 
   public ObjectiveModeChangeEvent(Match match, final Mode mode) {
@@ -40,6 +43,33 @@ public class ObjectiveModeChangeEvent extends MatchEvent {
         this.name = "Unknown Mode";
       }
     }
+
+    DestroyableMatchModule dmm = match.getModule(DestroyableMatchModule.class);
+    CoreMatchModule cmm = match.getModule(CoreMatchModule.class);
+    boolean displayModeChange = false;
+    if (dmm != null) {
+      for (Destroyable destroyable : dmm.getDestroyables()) {
+        // if one objective is visible (ie. show=true), then display mode change in chat and exit
+        // loop.
+        if (destroyable.getModes().contains(this.mode) && destroyable.isVisible()) {
+          displayModeChange = true;
+          break;
+        }
+      }
+    }
+    if (cmm != null && !displayModeChange) {
+      for (Core core : cmm.getCores()) {
+        if (core.getModes().contains(this.mode) && core.isVisible()) {
+          displayModeChange = true;
+          break;
+        }
+      }
+    }
+    this.visible = displayModeChange;
+  }
+
+  public final boolean isVisible() {
+    return this.visible;
   }
 
   public final Mode getMode() {

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -21,11 +21,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
-import tc.oc.pgm.core.Core;
-import tc.oc.pgm.core.CoreMatchModule;
 import tc.oc.pgm.countdowns.CountdownContext;
-import tc.oc.pgm.destroyable.Destroyable;
-import tc.oc.pgm.destroyable.DestroyableMatchModule;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.filters.dynamic.FilterMatchModule;
 
@@ -132,35 +128,11 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onObjectiveModeChange(ObjectiveModeChangeEvent event) {
-    DestroyableMatchModule dmm = match.getModule(DestroyableMatchModule.class);
-    CoreMatchModule cmm = match.getModule(CoreMatchModule.class);
-    boolean modeChangeDisplayed = false;
-    if (dmm != null) {
-      for (Destroyable destroyable : dmm.getDestroyables()) {
-        if (destroyable.getModes().contains(event.getMode())) {
-          // only display message once
-          displayModeChangeMessage(event.getName(), destroyable.isVisible());
-          modeChangeDisplayed = true;
-          break;
-        }
-      }
-    }
-    if (cmm != null && !modeChangeDisplayed) {
-      for (Core core : cmm.getCores()) {
-        if (core.getModes().contains(event.getMode())) {
-          displayModeChangeMessage(event.getName(), core.isVisible());
-          break;
-        }
-      }
-    }
-  }
-
-  public void displayModeChangeMessage(String modeName, boolean visible) {
-    if (visible) {
+    if (event.isVisible()) {
       Component broadcast =
           text()
               .append(text("> > > > ", NamedTextColor.DARK_AQUA))
-              .append(text(modeName, NamedTextColor.DARK_RED))
+              .append(text(event.getName(), NamedTextColor.DARK_RED))
               .append(text(" < < < <", NamedTextColor.DARK_AQUA))
               .build();
       match.sendMessage(broadcast);

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -21,7 +21,11 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.core.Core;
+import tc.oc.pgm.core.CoreMatchModule;
 import tc.oc.pgm.countdowns.CountdownContext;
+import tc.oc.pgm.destroyable.Destroyable;
+import tc.oc.pgm.destroyable.DestroyableMatchModule;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.filters.dynamic.FilterMatchModule;
 
@@ -128,13 +132,39 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onObjectiveModeChange(ObjectiveModeChangeEvent event) {
-    Component broadcast =
-        text()
-            .append(text("> > > > ", NamedTextColor.DARK_AQUA))
-            .append(text(event.getName(), NamedTextColor.DARK_RED))
-            .append(text(" < < < <", NamedTextColor.DARK_AQUA))
-            .build();
-    event.getMatch().sendMessage(broadcast);
-    event.getMatch().playSound(SOUND);
+    DestroyableMatchModule dmm = match.getModule(DestroyableMatchModule.class);
+    CoreMatchModule cmm = match.getModule(CoreMatchModule.class);
+    boolean modeChangeDisplayed = false;
+    if (dmm != null) {
+      for (Destroyable destroyable : dmm.getDestroyables()) {
+        if (destroyable.getModes().contains(event.getMode())) {
+          // only display message once
+          displayModeChangeMessage(event.getName(), destroyable.isVisible());
+          modeChangeDisplayed = true;
+          break;
+        }
+      }
+    }
+    if (cmm != null && !modeChangeDisplayed) {
+      for (Core core : cmm.getCores()) {
+        if (core.getModes().contains(event.getMode())) {
+          displayModeChangeMessage(event.getName(), core.isVisible());
+          break;
+        }
+      }
+    }
+  }
+
+  public void displayModeChangeMessage(String modeName, boolean visible) {
+    if (visible) {
+      Component broadcast =
+          text()
+              .append(text("> > > > ", NamedTextColor.DARK_AQUA))
+              .append(text(modeName, NamedTextColor.DARK_RED))
+              .append(text(" < < < <", NamedTextColor.DARK_AQUA))
+              .build();
+      match.sendMessage(broadcast);
+      match.playSound(SOUND);
+    }
   }
 }


### PR DESCRIPTION
This PR fixes an ongoing issue that started strangely happening without any idea how. The mode change message in the chat would be repeated for each objective that changed mode, and would still appear even when the objective's `show` attribute is false. This adds a proper checker to make sure the mode message is only sent out once per mode change, and that it won't send the message if all objectives that use the mode has `show=false`. I first seen this yesterday when the message repeated 8 times on Death DeNile.

From the code this issue should've been a problem for a long time but has seemed to popup about two weeks ago :man_shrugging: 