### PR TITLE
Fix broadcast module unloading

### DIFF
--- a/core/src/main/java/tc/oc/pgm/broadcast/BroadcastMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/broadcast/BroadcastMatchModule.java
@@ -33,9 +33,4 @@ public class BroadcastMatchModule implements MatchModule {
   public void disable() {
     this.countdowns.cancelAll();
   }
-
-  @Override
-  public void unload() {
-    this.broadcasts.clear();
-  }
 }


### PR DESCRIPTION
Fixes https://github.com/PGMDev/PGM/issues/938 where reloading a map with tips/alerts would cause them to no longer display.

This was introduced in https://github.com/PGMDev/PGM/commit/529ab16cbbd7f283092460ebe748fee8b23d14a6#diff-02f93e0776e398491425d5c04f3cd44595d292c296dae08e0412e890d524c994.

The issue identified above is caused by the `unload` of the `BroadcastMatchModule` clearing the map of broadcasts which is actually in the `BroadcastModule` (MapModule) and not a locally created/used variable. When the map is replayed the map module is reused but no longer contains data. On `disable` already stops running countdowns so the unload doesn't need to do any extra clean up.

The match module could work on a copy of the data but it isn't mutated anyway (other than the current clearing of it 😆).


Signed-off-by: Pugzy <pugzy@mail.com>