### PR TITLE
Fix early hits stealing fall kills

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tracker/info/FallState.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/FallState.java
@@ -141,6 +141,19 @@ public class FallState implements FallInfo {
             || (isClimbing && now.tick - climbingTick > MAX_CLIMBING_TICKS));
   }
 
+  /**
+   * A new fall can't be initiated if the victim is already falling, unless:
+   * <li>The fall never started (i.e. they were never knocked into the air)
+   * <li>The player touched the ground at least once since the previous hit (they landed)
+   * <li>The player is not burning from this fall
+   *
+   *     <p>This function indicates if the fall is still ongoing and may not be replaced
+   */
+  public boolean isOngoing(Tick now) {
+    return (isStarted && groundTouchCount == 0)
+        || (isInLava || now.tick - outLavaTick <= MAX_BURNING_TICKS);
+  }
+
   @Override
   public String toString() {
     return getClass().getSimpleName()

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/FallTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/FallTracker.java
@@ -170,9 +170,10 @@ public class FallTracker implements Listener, DamageResolver {
     MatchPlayer victim = match.getParticipant(event.getEntity());
     if (victim == null) return;
 
-    if (this.falls.containsKey(victim)) {
-      // A new fall can't be initiated if the victim is already falling
-      return;
+    FallState previousFall = this.falls.get(victim);
+    if (previousFall != null) {
+      if (previousFall.isOngoing(match.getTick())) return;
+      else endFall(previousFall);
     }
 
     Location loc = victim.getBukkit().getLocation();


### PR DESCRIPTION
Currently in PGM a fall may never be overriden by a new fall, unless it's completely finished.

With this change, a fall would be allowed to be overriden in certain situations, such as if the player touched the ground at least once or if they didn't left the ground (yet) (maybe they were under a roof).

Testing confirms this works much better than currently, where essentially the first to hit someone would get the fall kill almost always, even if it's someone else who actually punches them off (a couple seconds later).

PS: the formatting in the comment is a bit odd, but it's what the formatter enforces