### PR TITLE
#939 Bring back PGM objective filters

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -432,7 +432,10 @@ public abstract class FilterParser {
         this.factory.getFeatures().createReference(new Node(el), GoalDefinition.class);
 
     Attribute attrTeam = el.getAttribute("team");
-    XMLFeatureReference<TeamFactory> team = attrTeam != null ? this.factory.getFeatures().createReference(new Node(attrTeam), TeamFactory.class) : null;
+    XMLFeatureReference<TeamFactory> team =
+        attrTeam != null
+            ? this.factory.getFeatures().createReference(new Node(attrTeam), TeamFactory.class)
+            : null;
 
     return new GoalFilter(goal, team, false);
   }

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -418,6 +418,31 @@ public abstract class FilterParser {
     return new GoalFilter(goal, team, anyTeam);
   }
 
+  @MethodParser("completed")
+  public GoalFilter parseCompleted(Element el) throws InvalidXMLException {
+    XMLFeatureReference<? extends GoalDefinition> goal =
+        this.factory.getFeatures().createReference(new Node(el), GoalDefinition.class);
+
+    return new GoalFilter(goal, null, true);
+  }
+
+  @MethodParser("captured")
+  public GoalFilter parseCaptured(Element el) throws InvalidXMLException {
+    XMLFeatureReference<? extends GoalDefinition> goal =
+        this.factory.getFeatures().createReference(new Node(el), GoalDefinition.class);
+
+    Attribute attrTeam = el.getAttribute("team");
+    XMLFeatureReference<TeamFactory> team;
+    if (attrTeam != null) {
+      team = this.factory.getFeatures().createReference(new Node(attrTeam), TeamFactory.class);
+
+    } else {
+      team = null;
+    }
+
+    return new GoalFilter(goal, team, false);
+  }
+
   protected FlagStateFilter parseFlagState(Element el, Class<? extends State> state)
       throws InvalidXMLException {
     Node postAttr = Node.fromAttr(el, "post");

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -432,13 +432,7 @@ public abstract class FilterParser {
         this.factory.getFeatures().createReference(new Node(el), GoalDefinition.class);
 
     Attribute attrTeam = el.getAttribute("team");
-    XMLFeatureReference<TeamFactory> team;
-    if (attrTeam != null) {
-      team = this.factory.getFeatures().createReference(new Node(attrTeam), TeamFactory.class);
-
-    } else {
-      team = null;
-    }
+    XMLFeatureReference<TeamFactory> team = attrTeam != null ? this.factory.getFeatures().createReference(new Node(attrTeam), TeamFactory.class) : null;
 
     return new GoalFilter(goal, team, false);
   }


### PR DESCRIPTION
Completes #939
tested with a locally modified [ballot box(for `completed` tag)](https://github.com/OvercastCommunity/CommunityMaps/tree/master/scorebox/standard/ballot_box) and [cherokee (for `captured` tag)](https://github.com/Xerocoles/stratus-maps/tree/master/competitive/cherokee)

while i did only test with control points, considering it's just calling the same `GoalFilter` constructor with set values it should function the same, i was unsure whether to throw an exception for attributes that `completed` and `captured` don't support but decided it realistically wasn't necessary. 