### PR TITLE
Properly parse legacy formatting in XMLUtils

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/text/TextParser.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextParser.java
@@ -31,6 +31,9 @@ import org.bukkit.util.Vector;
 import tc.oc.pgm.util.LiquidMetal;
 import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.Version;
+import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLUtils;
 
 /** A string parser that generates user-friendly error messages. */
 public final class TextParser {
@@ -424,6 +427,26 @@ public final class TextParser {
     }
 
     return LegacyComponentSerializer.legacyAmpersand().deserialize(text);
+  }
+
+  /**
+   * Parses text into a component
+   *
+   * <p>Accepts legacy formatting with "§" as the color character.
+   *
+   * <p>This method is mainly for backwards compatability for {@link
+   * XMLUtils#parseFormattedText(Node, Component)}. Previously using {@link #parseComponent(String)}
+   * with the result from {@code parseFormattedText} would bug out when sent to older clients, since
+   * the LegacyComponentSerializer expects "&" but {@link BukkitUtils#colorize(String)}(Used in the
+   * XMLUtils method) results in using "§".
+   *
+   * @param text The text.
+   * @return a Component.
+   */
+  public static Component parseComponentSection(String text) {
+    checkNotNull(text, "cannot parse component from null");
+
+    return LegacyComponentSerializer.legacySection().deserialize(text);
   }
 
   /**

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -865,7 +865,7 @@ public final class XMLUtils {
       throws InvalidXMLException {
     return node == null
         ? def
-        : TextParser.parseComponent(BukkitUtils.colorize(node.getValueNormalize()));
+        : TextParser.parseComponentSection(BukkitUtils.colorize(node.getValueNormalize()));
   }
 
   /**


### PR DESCRIPTION
For testing i used:
 - Client 1.8.9
 - XML: 
```xml
<tip after="3s">`3WOWOWOWOWOWO `kWOOWWOWOOWOWOWOWOW OWOWOWOWOWOWOWOWOW OWOWOWOWOWOWOWOW `r`5OWOWOWOWOWOOWOWOWOWOWOWOWOWOWOOWOWOWO WOWOW</tip>
```
Before:
<img width="560" alt="Skjermbilde 2021-12-21 kl  18 28 54" src="https://user-images.githubusercontent.com/19822231/146974218-29bf870d-a76f-48b1-9dfe-9b78e5a3e313.png">

After:
<img width="676" alt="Skjermbilde 2021-12-21 kl  18 36 50" src="https://user-images.githubusercontent.com/19822231/146974231-ed3cec17-9e22-456a-b264-434665595608.png">
 