### PR TITLE
Add InvalidXMLException for spawn regions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnParser.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnParser.java
@@ -44,13 +44,20 @@ public class SpawnParser {
 
     if (factory.getProto().isOlderThan(MapProtos.MODULE_SUBELEMENT_VERSION)) {
       providers = this.pointParser.parse(el, attributes.providerAttributes);
-    } else {
+    }
+    // Must have <regions>, <region> or region attribute in proto 1.3.6 and above
+    else if (el.getChild("regions") != null
+        || el.getChild("region") != null
+        || el.getAttribute("region") != null) {
       providers =
           new ArrayList<>(
               pointParser.parseMultiProperty(el, attributes.providerAttributes, "region"));
       for (Element elRegions : XMLUtils.getChildren(el, "regions")) {
         providers.addAll(this.pointParser.parseChildren(elRegions, attributes.providerAttributes));
       }
+    } else {
+      throw new InvalidXMLException(
+          "all spawn regions must be enclosed inside <regions>, or use region attribute", el);
     }
 
     PointProvider provider;


### PR DESCRIPTION
This PR fixes a minor issue where PGM will load a map that uses improper XML that has been deprecated in 1.3.6.
When a user attempts to load the map, PGM will fail to load it because it can't find the spawn region for it. The map will eventually load (in correct regions) after trying to cycle to it again, but it's still quite fiddly of a process.

# Invalid XML (for proto 1.4.0, valid below 1.3.6)
```xml
<spawns>
    <spawn id="red" team="red" kit="red" yaw="135">
        <region name="red-spawn"/>
    </spawn>
    <spawn id="blue" team="blue" kit="blue" yaw="-45">
        <region name="blue-spawn"/>
    </spawn>
    <default kit="obs" yaw="135">
        <point>-11.5,103,28.5</point>
    </default>
</spawns>
```
# Valid XML
```xml
<spawns>
    <spawn team="blue" kit="blue-kit" yaw="-90">
        <regions>
            <point>-336.5,42,0.5</point>
        </regions>
    </spawn>
    <spawn team="red" kit="red-kit" yaw="90">
        <region>
            <point>0.5,42,0.5</point>
        </region>
    </spawn>
    <default yaw="180">
        <region>
            <point>-167.5,59,97.5</point>
        </region>
    </default>
</spawns>
```

The new convention is to define the spawn regions inside a `<region>`, `<regions>` or a `region` attribute in `<spawn>`.

Merry Christmas everyone :-)