### PR TITLE
Add bowDamageTaken

### DIFF
--- a/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
@@ -20,6 +20,7 @@ public class PlayerStats {
   // Bow
   private int longestBowKill;
   private double bowDamage;
+  private double bowDamageTaken;
   private int shotsTaken;
   private int shotsHit;
 
@@ -59,8 +60,11 @@ public class PlayerStats {
     }
   }
 
-  protected void onDamaged(double damage) {
+  protected void onDamaged(double damage, boolean bow) {
     damageTaken += damage;
+    if (bow) {
+      bowDamageTaken += damage;
+    }
   }
 
   protected void onDestroyablePieceBroken(int change) {
@@ -142,6 +146,10 @@ public class PlayerStats {
 
   public double getBowDamage() {
     return bowDamage;
+  }
+
+  public double getBowDamageTaken() {
+    return bowDamageTaken;
   }
 
   public int getShotsTaken() {

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -107,7 +107,7 @@ public class StatsMatchModule implements MatchModule, Listener {
             + absorptionHearts;
 
     if (damager != null) getPlayerStat(damager).onDamage(realFinalDamage, bow);
-    getPlayerStat(damaged).onDamaged(realFinalDamage);
+    if (damaged != null) getPlayerStat(damaged).onDamaged(realFinalDamage, bow);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -107,7 +107,7 @@ public class StatsMatchModule implements MatchModule, Listener {
             + absorptionHearts;
 
     if (damager != null) getPlayerStat(damager).onDamage(realFinalDamage, bow);
-    if (damaged != null) getPlayerStat(damaged).onDamaged(realFinalDamage, bow);
+    getPlayerStat(damaged).onDamaged(realFinalDamage, bow);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/tc/oc/pgm/stats/TeamStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/TeamStats.java
@@ -11,6 +11,7 @@ public class TeamStats {
   private double damageDone = 0;
   private double damageTaken = 0;
   private double bowDamage = 0;
+  private double bowDamageTaken = 0;
   private int shotsTaken = 0;
   private int shotsHit = 0;
 
@@ -26,6 +27,7 @@ public class TeamStats {
       damageDone += stats.getDamageDone();
       damageTaken += stats.getDamageTaken();
       bowDamage += stats.getBowDamage();
+      bowDamageTaken += stats.getBowDamageTaken();
       shotsTaken += stats.getShotsTaken();
       shotsHit += stats.getShotsHit();
     }
@@ -52,6 +54,10 @@ public class TeamStats {
 
   public double getBowDamage() {
     return bowDamage;
+  }
+
+  public double getBowDamageTaken() {
+    return bowDamageTaken;
   }
 
   public int getShotsTaken() {

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
@@ -77,7 +77,8 @@ public class PlayerStatsMenuItem implements MenuItem {
         translatable(
             "match.stats.damage.received",
             RESET,
-            damageComponent(stats.getDamageTaken(), NamedTextColor.RED));
+            damageComponent(stats.getDamageTaken(), NamedTextColor.RED),
+            damageComponent(stats.getBowDamageTaken(), NamedTextColor.GOLD));
     Component bowLore =
         translatable(
             "match.stats.bow",

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/TeamStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/TeamStatsMenuItem.java
@@ -108,7 +108,8 @@ public class TeamStatsMenuItem implements MenuItem {
         translatable(
             "match.stats.damage.received",
             RESET,
-            damageComponent(stats.getDamageTaken(), NamedTextColor.RED));
+            damageComponent(stats.getDamageTaken(), NamedTextColor.RED),
+            damageComponent(stats.getBowDamageTaken(), NamedTextColor.GOLD));
     Component bowLore =
         translatable(
             "match.stats.bow",

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -91,7 +91,8 @@ match.stats.damage = Damage: {1} by {0}
 match.stats.damage.dealt = Damage Dealt (Bow): {0} ({1})
 
 # {0} = an amount of damage
-match.stats.damage.received = Damage Received: {0}
+# {1} = an amount of damage
+match.stats.damage.received = Damage Received (Bow): {0} ({1})
 
 # {0} = number of arrows hit
 # {1} = number of arrows shot
@@ -211,4 +212,3 @@ admin.start.unknownState = Match could not be started at this time.
 admin.end.unknownError = Match could not be ended at this time.
 
 admin.setPool.activeCycle = You may not adjust the pool while match is cycling.
-

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -212,3 +212,4 @@ admin.start.unknownState = Match could not be started at this time.
 admin.end.unknownError = Match could not be ended at this time.
 
 admin.setPool.activeCycle = You may not adjust the pool while match is cycling.
+


### PR DESCRIPTION
This PR distinguishes between damage taken and damage taken by bow, similarly to how damage dealt and bow damage dealt are separated.

The first commit in this PR is from the version of PGM deployed on Stratus (originally https://github.com/ShinyDialga/PGM/tree/stratus, currently https://github.com/calcastor/PGM/tree/stratus). I expanded on the change to add it to PGM's verbose stats menu.

I spoke with @dentmaged about this a few months back and he was pretty sure a change like this would incur API breakage, so that is something to note. I am also unaware of any potential reasoning for this being left out intentionally, beyond speculation.