### PR TITLE
Remove legacy aliases from pool command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
@@ -43,7 +43,7 @@ public final class MapPoolCommand {
   private static final DecimalFormat SCORE_FORMAT = new DecimalFormat("00.00%");
 
   @Command(
-      aliases = {"pool", "rotation", "rot"},
+      aliases = {"pool"},
       desc = "List the maps in the map pool",
       usage = "[page] [-p pool] [-s scores] [-c chance of vote]")
   public static void pool(
@@ -127,7 +127,7 @@ public final class MapPoolCommand {
   }
 
   @Command(
-      aliases = {"pools", "rotations", "rots"},
+      aliases = {"pools"},
       desc = "List all the map pools",
       flags = "d")
   public static void pools(


### PR DESCRIPTION
The legacy /rot or /rotation commands have long been deprecated since the introduction of pools, the most common type of pool has not been a rotation for a very long time now and i think it's time to move on from legacy naming and fully embrace pools