### PR TITLE
Only set party when vanishing on a team

### DIFF
--- a/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/community/features/VanishManagerImpl.java
@@ -96,7 +96,9 @@ public class VanishManagerImpl implements VanishManager, Listener {
     final Match match = player.getMatch();
 
     // Ensure player is an observer
-    match.setParty(player, match.getDefaultParty());
+    if (vanish && player.getParty() instanceof Competitor) {
+      match.setParty(player, match.getDefaultParty());
+    }
 
     // Set vanish status in match player
     player.setVanished(vanish);


### PR DESCRIPTION
When un-vanishing a player doesn't need to have their team changed.
When vanishing a player they only need to be switched if they're a competitor.

The unnecessary call to `match.setParty` is causing a chain of events to trigger related to participation and parties.

Signed-off-by: Pugzy <pugzy@mail.com>