### PR TITLE
Refactor FeatureDefinitionContext to extend ContextStore

### DIFF
--- a/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
+++ b/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
@@ -1,21 +1,26 @@
 package tc.oc.pgm.features;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.jdom2.Element;
 import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.feature.FeatureValidation;
+import tc.oc.pgm.util.collection.ContextStore;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 
-public class FeatureDefinitionContext {
+public class FeatureDefinitionContext extends ContextStore<FeatureDefinition> {
 
   private final Set<FeatureDefinition> definitions = new HashSet<>();
-  private final Map<String, FeatureDefinition> byId = new HashMap<>();
   private final Map<FeatureDefinition, Element> definitionNodes = new HashMap<>();
   private final List<XMLFeatureReference<?>> references = new ArrayList<>();
   private final SetMultimap<FeatureReference<?>, FeatureValidation<?>> validations =
@@ -23,23 +28,6 @@ public class FeatureDefinitionContext {
 
   public static String parseId(Element node) {
     return node.getAttributeValue("id");
-  }
-
-  public FeatureDefinition get(String id) {
-    return byId.get(id);
-  }
-
-  /**
-   * Return a feature with the given ID and type, or null if no such feature exists. If the ID
-   * exists but is the wrong type, this method will still return null.
-   */
-  public <T extends FeatureDefinition> T get(String id, Class<T> type) {
-    FeatureDefinition definition = get(id);
-    return type.isInstance(definition) ? type.cast(definition) : null;
-  }
-
-  public <T extends FeatureDefinition> Iterable<T> getAll(Class<T> type) {
-    return Iterables.filter(definitions, type);
   }
 
   /** Return the XML element associated with the given feature */
@@ -56,9 +44,9 @@ public class FeatureDefinitionContext {
       throws InvalidXMLException {
     if (definitions.add(definition)) {
       if (id != null) {
-        FeatureDefinition old = byId.put(id, definition);
+        FeatureDefinition old = this.store.put(id, definition);
         if (old != null && old != definition) {
-          byId.put(id, old);
+          this.store.put(id, old);
           throw new InvalidXMLException(
               "The ID '" + id + "' is already in use by a different feature", node);
         }

--- a/util/src/main/java/tc/oc/pgm/util/collection/ContextStore.java
+++ b/util/src/main/java/tc/oc/pgm/util/collection/ContextStore.java
@@ -79,6 +79,22 @@ public class ContextStore<T> implements Iterable<Map.Entry<String, T>> {
     return null;
   }
 
+  /**
+   * Gets an object by the id it was registered with as {@code type}.
+   *
+   * @param id id to look up.
+   * @param type the type to return this object as
+   * @return Object that was registered to the given id cast to {@code type}. Is null if the cast
+   *     fails or if none exists
+   */
+  public <C extends T> C get(String id, Class<C> type) {
+    try {
+      return type.cast(this.get(id));
+    } catch (ClassCastException e) {
+      return null;
+    }
+  }
+
   public Collection<T> getAll() {
     return this.store.values();
   }


### PR DESCRIPTION
In preparation for finalizing #950 I decided to split out this part into its own PR. 

The idea behind the change is to be able to depend on the general `ContextStore` in places where you need some `FeatureDefinition` that may be in its own context on legacy maps(proto 1.3), e.g `FilterContext` or in the general `FeatureDefinitionContext` on newer maps(1.4 proto). Then the correct context can be passed without having to instance check for different types of contexts or other hackery.

I also decided to update naming in the `ContextStore`, as it is now used in newer protos where `id` is the proper term.(in contrast to `name`)

Also other small changes...

Note: The `Map` used to store feature definitions is now a `TreeMap`(Same as `ContextStore` has been using until now), which technically could reduce performance but its so small that I think its negligible.