### PR TITLE
Prevent double queueing of setnext maps in shuffled rotations

### DIFF
--- a/core/src/main/java/tc/oc/pgm/rotation/RandomMapOrder.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/RandomMapOrder.java
@@ -67,11 +67,9 @@ public class RandomMapOrder implements MapOrder {
     return getNextMap();
   }
 
+  // Setting a map requires no special actions from the RandomMapOrder
   @Override
-  public void setNextMap(MapInfo map) {
-    // Set next maps are sent to the front of the deque
-    deque.addFirst(new WeakReference<>(map));
-  }
+  public void setNextMap(MapInfo map) {}
 
   @Override
   public void resetNextMap() {

--- a/core/src/main/java/tc/oc/pgm/rotation/RandomMapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/RandomMapPool.java
@@ -24,11 +24,6 @@ public class RandomMapPool extends MapPool {
   }
 
   @Override
-  public void setNextMap(MapInfo map) {
-    order.setNextMap(map);
-  }
-
-  @Override
   public void resetNextMap() {
     order.resetNextMap();
   }


### PR DESCRIPTION
There has been a long-standing bug where if you setnext a map during a shuffled rotation (RandomMapPool), the setnexted map plays twice. This was because the shuffled pool added the map to its queue, on top of the map already being handled by the overriderMap variable in MapPoolManager. This pull request removes the queue addition, so that the setnexted map simply gets handled normally by the overriding map setup.