### PR TITLE
Optimize player component rendering for titles

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
@@ -146,7 +146,7 @@ public class Dead extends Spawning {
     return translatable(
         "deathScreen.title" + (spectator ? ".spectator" : ""),
         NamedTextColor.RED,
-        player(this.player.getId(), NameStyle.COLOR));
+        player(this.player.getId(), NameStyle.SIMPLE_COLOR));
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/named/NameStyle.java
+++ b/util/src/main/java/tc/oc/pgm/util/named/NameStyle.java
@@ -10,6 +10,8 @@ import java.util.Set;
 public enum NameStyle {
   // No formatting
   PLAIN(EnumSet.noneOf(Flag.class)),
+  // Simple formatting, just team color. Used for non-clickable places
+  SIMPLE_COLOR(EnumSet.of(Flag.COLOR)),
   // Simple formatting, just team color & teleport
   COLOR(EnumSet.of(Flag.COLOR, Flag.TELEPORT)),
   // Fancy formatting, flairs, color and click to teleport

--- a/util/src/main/java/tc/oc/pgm/util/text/PlayerComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/PlayerComponent.java
@@ -97,6 +97,8 @@ public final class PlayerComponent {
     if (style.has(NameStyle.Flag.FLAIR) && !isOffline) {
       builder.append(provider.getSuffixComponent(uuid));
     }
+
+    if (builder.children().size() == 1) return name.build();
     return builder.build();
   }
 


### PR DESCRIPTION
When rendering player component on certain situations serialization/deserialization takes up a huge amount of the server time, this optimizes player components for the simpler cases (no flairs) removing one level of indents, and also simplifies that case on the title.

Before:
```json
{
  "color": "red",
  "translate": "deathScreen.title.spectator",
  "with": [
    {
      "extra": [
        {
          "color": "dark_red",
          "clickEvent": {
            "action": "run_command",
            "value": "/tp Pablete1234"
          },
          "hoverEvent": {
            "action": "show_text",
            "contents": {
              "color": "gray",
              "translate": "misc.teleportTo",
              "with": [
                {
                  "color": "dark_red",
                  "text": "Pablete1234"
                }
              ]
            },
            "value": {
              "color": "gray",
              "translate": "misc.teleportTo",
              "with": [
                {
                  "color": "dark_red",
                  "text": "Pablete1234"
                }
              ]
            }
          },
          "text": "Pablete1234"
        }
      ],
      "text": ""
    }
  ]
}
```

After:
```json
{
  "color": "red",
  "translate": "deathScreen.title.spectator",
  "with": [
    {
      "color": "dark_aqua",
      "text": "Pablete1234"
    }
  ]
}
```