### PR TITLE
Remove chest protection inventory check

### DIFF
--- a/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
@@ -51,7 +51,6 @@ import tc.oc.pgm.events.PlayerBlockTransformEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.kits.WalkSpeedKit;
 import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
-import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.attribute.Attribute;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.named.NameStyle;
@@ -60,12 +59,6 @@ import tc.oc.pgm.util.text.TextTranslations;
 
 @ListenerScope(MatchScope.LOADED)
 public class ViewInventoryMatchModule implements MatchModule, Listener {
-
-  /**
-   * Amount of milliseconds after the match begins where players may not add / remove items from
-   * chests.
-   */
-  public static final Duration CHEST_PROTECT_TIME = Duration.ofSeconds(2);
 
   public static final Duration TICK = Duration.ofMillis(50);
 
@@ -106,26 +99,6 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
       }
 
       iterator.remove();
-    }
-  }
-
-  @EventHandler(ignoreCancelled = true)
-  public void checkInventoryClick(final InventoryClickEvent event) {
-    if (event.getWhoClicked() instanceof Player) {
-      MatchPlayer player = this.match.getPlayer((Player) event.getWhoClicked());
-      if (player == null) {
-        return;
-      }
-      // we only cancel when the view is a chest because the other views tend to crash
-      if (!allowedInventoryType(event.getInventory().getType())) {
-        // cancel the click if the player cannot interact with the world or if the match has just
-        // started
-        if (!player.canInteract()
-            || (player.getMatch().isRunning()
-                && TimeUtils.isShorterThan(player.getMatch().getDuration(), CHEST_PROTECT_TIME))) {
-          event.setCancelled(true);
-        }
-      }
     }
   }
 
@@ -291,16 +264,6 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
 
   public boolean canPreviewInventory(MatchPlayer viewer, MatchPlayer holder) {
     return viewer.isObserving() && holder.isAlive();
-  }
-
-  protected static boolean allowedInventoryType(InventoryType type) {
-    switch (type) {
-      case CREATIVE:
-      case PLAYER:
-        return true;
-      default:
-        return false;
-    }
   }
 
   protected void scheduleCheck(Player updater) {

--- a/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
@@ -26,6 +26,7 @@ import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
@@ -332,6 +333,13 @@ public class EventFilterMatchModule implements MatchModule, Listener {
   // -----------------------------------
   // -- Player item/inventory actions --
   // -----------------------------------
+
+  @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+  public void onInventoryClick(final InventoryClickEvent event) {
+    if (!event.getInventory().equals(event.getWhoClicked().getInventory())) {
+      cancelUnlessInteracting(event, event.getWhoClicked());
+    }
+  }
 
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onPlayerDropItem(final PlayerDropItemEvent event) {


### PR DESCRIPTION
To replicate, join a team, start the match and try to change your inventory within the first 2 seconds, the event is cancelled.

For the first 2 seconds of a match non-player inventory interactions are cancelled with the aim of preventing modifications with chests for some unknown reason (maybe a bug of the past). The way this check is written currently prevents regular player inventory actions as the inventory type of a player is set as `CRAFTING` (a legacy (craft/sport)bukkit issue) this causes the event to cancel as it does not match the allowed types of `PLAYER` and `CREATIVE`.

This check is not present within the [OvercastNetwork ProjectAres final release](https://github.com/OvercastNetwork/ProjectAres/blob/master/PGM/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java) and was removed in the same way as this commit. The inventory interact event check aimed mainly at observers which is mixed in with this random chest feature is also moved to the `EventFilterMatchModule` with other similar purpose listners.

Signed-off-by: Pugzy <pugzy@mail.com>