### PR TITLE
Rewrite flag posts to support more configurations

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -28,7 +28,7 @@ import tc.oc.pgm.filters.modifier.relation.AttackerQueryModifier;
 import tc.oc.pgm.filters.modifier.relation.SameTeamQueryModifier;
 import tc.oc.pgm.filters.modifier.relation.VictimQueryModifier;
 import tc.oc.pgm.flag.FlagDefinition;
-import tc.oc.pgm.flag.Post;
+import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.flag.state.Captured;
 import tc.oc.pgm.flag.state.Carried;
 import tc.oc.pgm.flag.state.Dropped;
@@ -445,7 +445,9 @@ public abstract class FilterParser {
     Node postAttr = Node.fromAttr(el, "post");
     return new FlagStateFilter(
         this.factory.getFeatures().createReference(new Node(el), FlagDefinition.class),
-        postAttr == null ? null : this.factory.getFeatures().createReference(postAttr, Post.class),
+        postAttr == null
+            ? null
+            : this.factory.getFeatures().createReference(postAttr, PostDefinition.class),
         state);
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/FlagStateFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FlagStateFilter.java
@@ -8,19 +8,19 @@ import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.filter.query.MatchQuery;
 import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.flag.FlagDefinition;
-import tc.oc.pgm.flag.Post;
 import tc.oc.pgm.flag.event.FlagStateChangeEvent;
+import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.flag.state.State;
 
 public class FlagStateFilter extends TypedFilter<MatchQuery> {
 
   private final FeatureReference<? extends FlagDefinition> flag;
-  private final @Nullable FeatureReference<? extends Post> post;
+  private final @Nullable FeatureReference<? extends PostDefinition> post;
   private final Class<? extends State> state;
 
   public FlagStateFilter(
       FeatureReference<? extends FlagDefinition> flag,
-      @Nullable FeatureReference<? extends Post> post,
+      @Nullable FeatureReference<? extends PostDefinition> post,
       Class<? extends State> state) {
     this.flag = flag;
     this.post = post;

--- a/core/src/main/java/tc/oc/pgm/filters/query/GoalQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/GoalQuery.java
@@ -7,8 +7,14 @@ import tc.oc.pgm.goals.Goal;
  * have filters that respond specifically to goal queries, but currently we do not.
  */
 public class GoalQuery extends MatchQuery {
+  private final Goal<?> goal;
 
-  public GoalQuery(Goal goal) {
+  public GoalQuery(Goal<?> goal) {
     super(null, goal.getMatch());
+    this.goal = goal;
+  }
+
+  public Goal<?> getGoal() {
+    return goal;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -88,7 +88,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
   public static final Sound RETURN_SOUND =
       sound(key("entity.firework_rocket.twinkle_far"), Sound.Source.MASTER, 1f, 1f);
 
-  private final ImmutableSet<Net> nets;
+  private final ImmutableSet<NetDefinition> nets;
   private final Location bannerLocation;
   private final BannerMeta bannerMeta;
   private final ItemStack bannerItem;
@@ -101,7 +101,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
   private BaseState state;
   private boolean transitioning;
 
-  protected Flag(Match match, FlagDefinition definition, ImmutableSet<Net> nets)
+  protected Flag(Match match, FlagDefinition definition, ImmutableSet<NetDefinition> nets)
       throws ModuleLoadException {
     super(definition, match);
     this.nets = nets;
@@ -127,7 +127,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
 
     ImmutableSet.Builder<Team> controllersBuilder = ImmutableSet.builder();
     ImmutableSet.Builder<Team> completersBuilder = ImmutableSet.builder();
-    for (Net net : nets) {
+    for (NetDefinition net : nets) {
       PostDefinition netPost = net.getReturnPost();
       if (netPost != null && netPost.getFallback().getOwner() != null && tmm != null) {
         Team controller = tmm.getTeam(netPost.getFallback().getOwner());
@@ -211,7 +211,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     return TextTranslations.translateLegacy(getComponentName(), null);
   }
 
-  public ImmutableSet<Net> getNets() {
+  public ImmutableSet<NetDefinition> getNets() {
     return nets;
   }
 
@@ -378,7 +378,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     return canPickup(query, state.getPost());
   }
 
-  public boolean canCapture(Query query, Net net) {
+  public boolean canCapture(Query query, NetDefinition net) {
     return getDefinition().getCaptureFilter().query(query).isAllowed()
         && net.getCaptureFilter().query(query).isAllowed();
   }

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -322,9 +322,9 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
 
   // Misc
 
-  public void load() {
+  public void load(FlagMatchModule fmm) {
     this.state =
-        new Returned(this, getPost(this.getDefinition().getDefaultPost()), this.bannerLocation);
+        new Returned(this, fmm.getPost(this.getDefinition().getDefaultPost()), this.bannerLocation);
     this.state.enterState();
   }
 

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -128,12 +128,12 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     ImmutableSet.Builder<Team> controllersBuilder = ImmutableSet.builder();
     ImmutableSet.Builder<Team> completersBuilder = ImmutableSet.builder();
     for (Net net : nets) {
-      Post netPost = getPost(net.getReturnPost());
-      if (netPost != null && netPost.getOwner() != null && tmm != null) {
-        Team controller = tmm.getTeam(netPost.getOwner());
+      PostDefinition netPost = net.getReturnPost();
+      if (netPost != null && netPost.getFallback().getOwner() != null && tmm != null) {
+        Team controller = tmm.getTeam(netPost.getFallback().getOwner());
         controllersBuilder.add(controller);
 
-        if (getPost(net.getReturnPost()).isPermanent()) {
+        if (net.getReturnPost().getFallback().isPermanent()) {
           completersBuilder.add(controller);
         }
       }
@@ -143,7 +143,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
 
     Banner banner = null;
     pointLoop:
-    for (PointProvider returnPoint : getPost(definition.getDefaultPost()).getReturnPoints()) {
+    for (PointProvider returnPoint : definition.getDefaultPost().getFallback().getReturnPoints()) {
       Region region = returnPoint.getRegion();
       if (region instanceof PointRegion) {
         // Do not require PointRegions to be at the exact center of the block.

--- a/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
@@ -192,9 +192,9 @@ public class FlagDefinition extends ProximityGoalDefinition {
         && getDefaultPost().getFallback().getPickupFilter().query(query).isAllowed();
   }
 
-  public boolean canCapture(Query query, Collection<Net> nets) {
+  public boolean canCapture(Query query, Collection<NetDefinition> nets) {
     if (getCaptureFilter().query(query).isDenied()) return false;
-    for (Net net : nets) {
+    for (NetDefinition net : nets) {
       if (net.getCaptureFilter().query(query).isAllowed()) return true;
     }
     return false;

--- a/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.flag;
 
-import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
@@ -10,6 +9,7 @@ import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.goals.ProximityGoalDefinition;
 import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.kits.Kit;
@@ -28,8 +28,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
   private final @Nullable DyeColor
       color; // Flag color, null detects color from the banner at match load time
-  private final Post defaultPost; // Flag starts the match at this post
-  private final ImmutableList<Post> posts;
+  private final PostDefinition defaultPost; // Flag starts the match at this post
   private final @Nullable FeatureReference<TeamFactory>
       owner; // Team that owns the flag, affects various things
   private final double
@@ -46,10 +45,8 @@ public class FlagDefinition extends ProximityGoalDefinition {
   private final @Nullable Component carryMessage; // Custom message to show flag carrier
   private final boolean dropOnWater; // Flag can freeze water to drop on it
   private final boolean showBeam;
-  private final boolean sequential;
-  private boolean
-      showRespawnOnPickup; // When a flag is picked up, if true, it will display where it will
-  // respawn. Will be set to false if a net defines a different respawn post.
+  private final boolean
+      showRespawnOnPickup; // Display where the flag will respawn when it is picked up.
 
   public FlagDefinition(
       @Nullable String id,
@@ -57,8 +54,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
       @Nullable Boolean required,
       boolean visible,
       @Nullable DyeColor color,
-      Post defaultPost,
-      ImmutableList<Post> posts,
+      PostDefinition defaultPost,
       @Nullable FeatureReference<TeamFactory> owner,
       double pointsPerCapture,
       double pointsPerSecond,
@@ -74,7 +70,6 @@ public class FlagDefinition extends ProximityGoalDefinition {
       boolean showBeam,
       @Nullable ProximityMetric flagProximityMetric,
       @Nullable ProximityMetric netProximityMetric,
-      boolean sequential,
       boolean showRespawnOnPickup) {
 
     // We can't use the owner field in OwnedGoal because our owner
@@ -90,7 +85,6 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
     this.color = color;
     this.defaultPost = defaultPost;
-    this.posts = posts;
     this.owner = owner;
     this.pointsPerCapture = pointsPerCapture;
     this.pointsPerSecond = pointsPerSecond;
@@ -104,7 +98,6 @@ public class FlagDefinition extends ProximityGoalDefinition {
     this.carryMessage = carryMessage;
     this.dropOnWater = dropOnWater;
     this.showBeam = showBeam;
-    this.sequential = sequential;
     this.showRespawnOnPickup = showRespawnOnPickup;
   }
 
@@ -121,12 +114,8 @@ public class FlagDefinition extends ProximityGoalDefinition {
     }
   }
 
-  public Post getDefaultPost() {
+  public PostDefinition getDefaultPost() {
     return this.defaultPost;
-  }
-
-  public ImmutableList<Post> getPosts() {
-    return this.posts;
   }
 
   @Override
@@ -189,19 +178,10 @@ public class FlagDefinition extends ProximityGoalDefinition {
     return showBeam;
   }
 
-  public boolean isSequential() {
-    return sequential;
-  }
-
   public boolean willShowRespawnOnPickup() {
     return showRespawnOnPickup;
   }
 
-  public void setShowRespawnOnPickup(boolean value) {
-    this.showRespawnOnPickup = value;
-  }
-
-  @SuppressWarnings("unchecked")
   @Override
   public Flag getGoal(Match match) {
     return (Flag) super.getGoal(match);
@@ -209,7 +189,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
   public boolean canPickup(Query query) {
     return getPickupFilter().query(query).isAllowed()
-        && getDefaultPost().getPickupFilter().query(query).isAllowed();
+        && getDefaultPost().getFallback().getPickupFilter().query(query).isAllowed();
   }
 
   public boolean canCapture(Query query, Collection<Net> nets) {

--- a/core/src/main/java/tc/oc/pgm/flag/FlagMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagMatchModule.java
@@ -7,15 +7,28 @@ import com.google.common.collect.ImmutableSet;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.goals.GoalMatchModule;
 
 public class FlagMatchModule implements MatchModule {
 
+  private final ImmutableMap<PostDefinition, Post> posts;
   private final ImmutableMap<FlagDefinition, Flag> flags;
 
   public FlagMatchModule(
-      Match match, ImmutableList<Net> nets, ImmutableList<FlagDefinition> flagDefinitions)
+      Match match,
+      ImmutableList<PostDefinition> postDefinitions,
+      ImmutableList<Net> nets,
+      ImmutableList<FlagDefinition> flagDefinitions)
       throws ModuleLoadException {
+
+    ImmutableMap.Builder<PostDefinition, Post> posts = ImmutableMap.builder();
+    for (PostDefinition definition : postDefinitions) {
+      Post post = new Post(match, definition);
+      posts.put(definition, post);
+      match.getFeatureContext().add(post);
+    }
+    this.posts = posts.build();
 
     ImmutableMap.Builder<FlagDefinition, Flag> flags = ImmutableMap.builder();
     for (FlagDefinition definition : flagDefinitions) {
@@ -43,5 +56,13 @@ public class FlagMatchModule implements MatchModule {
 
   public ImmutableCollection<Flag> getFlags() {
     return flags.values();
+  }
+
+  public Post getPost(PostDefinition postDefinition) {
+    return posts.get(postDefinition);
+  }
+
+  public ImmutableCollection<Post> getPosts() {
+    return posts.values();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/flag/FlagMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagMatchModule.java
@@ -18,7 +18,7 @@ public class FlagMatchModule implements MatchModule {
   public FlagMatchModule(
       Match match,
       ImmutableList<PostDefinition> postDefinitions,
-      ImmutableList<Net> nets,
+      ImmutableList<NetDefinition> nets,
       ImmutableList<FlagDefinition> flagDefinitions)
       throws ModuleLoadException {
 
@@ -32,8 +32,8 @@ public class FlagMatchModule implements MatchModule {
 
     ImmutableMap.Builder<FlagDefinition, Flag> flags = ImmutableMap.builder();
     for (FlagDefinition definition : flagDefinitions) {
-      ImmutableSet.Builder<Net> netsBuilder = ImmutableSet.builder();
-      for (Net net : nets) {
+      ImmutableSet.Builder<NetDefinition> netsBuilder = ImmutableSet.builder();
+      for (NetDefinition net : nets) {
         if (net.getCapturableFlags().contains(definition)) {
           netsBuilder.add(net);
         }

--- a/core/src/main/java/tc/oc/pgm/flag/FlagMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagMatchModule.java
@@ -50,7 +50,7 @@ public class FlagMatchModule implements MatchModule {
   @Override
   public void load() {
     for (Flag flag : this.flags.values()) {
-      flag.load();
+      flag.load(this);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/flag/FlagMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagMatchModule.java
@@ -26,7 +26,7 @@ public class FlagMatchModule implements MatchModule {
     for (PostDefinition definition : postDefinitions) {
       Post post = new Post(match, definition);
       posts.put(definition, post);
-      match.getFeatureContext().add(post);
+      if (definition.getId() != null) match.getFeatureContext().add(post);
     }
     this.posts = posts.build();
 

--- a/core/src/main/java/tc/oc/pgm/flag/FlagModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagModule.java
@@ -24,10 +24,11 @@ public class FlagModule implements MapModule {
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("ctf", "flag", "Capture the Flag", true, false));
   private final ImmutableList<PostDefinition> posts;
-  private final ImmutableList<Net> nets;
+  private final ImmutableList<NetDefinition> nets;
   private final ImmutableList<FlagDefinition> flags;
 
-  public FlagModule(List<PostDefinition> posts, List<Net> nets, List<FlagDefinition> flags) {
+  public FlagModule(
+      List<PostDefinition> posts, List<NetDefinition> nets, List<FlagDefinition> flags) {
     this.posts = ImmutableList.copyOf(posts);
     this.nets = ImmutableList.copyOf(nets);
     this.flags = ImmutableList.copyOf(flags);

--- a/core/src/main/java/tc/oc/pgm/flag/FlagModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagModule.java
@@ -13,6 +13,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
 import tc.oc.pgm.filters.FilterModule;
+import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.goals.GoalMatchModule;
 import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.teams.TeamModule;
@@ -22,11 +23,11 @@ public class FlagModule implements MapModule {
 
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("ctf", "flag", "Capture the Flag", true, false));
-  private final ImmutableList<Post> posts;
+  private final ImmutableList<PostDefinition> posts;
   private final ImmutableList<Net> nets;
   private final ImmutableList<FlagDefinition> flags;
 
-  public FlagModule(List<Post> posts, List<Net> nets, List<FlagDefinition> flags) {
+  public FlagModule(List<PostDefinition> posts, List<Net> nets, List<FlagDefinition> flags) {
     this.posts = ImmutableList.copyOf(posts);
     this.nets = ImmutableList.copyOf(nets);
     this.flags = ImmutableList.copyOf(flags);
@@ -39,7 +40,7 @@ public class FlagModule implements MapModule {
 
   @Override
   public MatchModule createMatchModule(Match match) throws ModuleLoadException {
-    return new FlagMatchModule(match, this.nets, this.flags);
+    return new FlagMatchModule(match, this.posts, this.nets, this.flags);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import org.bukkit.DyeColor;
@@ -36,6 +37,7 @@ public class FlagParser {
   private final FilterParser filterParser;
   private final PointParser pointParser;
 
+  private final AtomicInteger postIdSerial = new AtomicInteger(1);
   private final List<PostDefinition> posts = new ArrayList<>();
   private final List<Net> nets = new ArrayList<>();
   private final List<FlagDefinition> flags = new ArrayList<>();
@@ -68,6 +70,8 @@ public class FlagParser {
 
   private CompositePost parseCompositePost(Element el) throws InvalidXMLException {
     String id = el.getAttributeValue("id");
+    if (id == null) id = PostDefinition.makeDefaultId(null, postIdSerial);
+
     boolean sequential = XMLUtils.parseBoolean(el.getAttribute("sequential"), false);
 
     ImmutableList.Builder<SinglePost> chBuilder = ImmutableList.builder();
@@ -97,6 +101,7 @@ public class FlagParser {
   private SinglePost parseSinglePost(Element el) throws InvalidXMLException {
     String id = el.getAttributeValue("id");
     @Nullable String name = el.getAttributeValue("name");
+    if (id == null) id = PostDefinition.makeDefaultId(name, postIdSerial);
 
     FeatureReference<TeamFactory> owner =
         factory.getFeatures().createReference(Node.fromAttr(el, "owner"), TeamFactory.class, null);

--- a/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
@@ -17,12 +17,16 @@ import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.FilterParser;
 import tc.oc.pgm.filters.StaticFilter;
+import tc.oc.pgm.flag.post.CompositePost;
+import tc.oc.pgm.flag.post.PostDefinition;
+import tc.oc.pgm.flag.post.SinglePost;
 import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.points.PointParser;
 import tc.oc.pgm.points.PointProvider;
 import tc.oc.pgm.points.PointProviderAttributes;
 import tc.oc.pgm.teams.TeamFactory;
+import tc.oc.pgm.util.xml.InheritingElement;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
@@ -32,7 +36,7 @@ public class FlagParser {
   private final FilterParser filterParser;
   private final PointParser pointParser;
 
-  private final List<Post> posts = new ArrayList<>();
+  private final List<PostDefinition> posts = new ArrayList<>();
   private final List<Net> nets = new ArrayList<>();
   private final List<FlagDefinition> flags = new ArrayList<>();
 
@@ -50,21 +54,62 @@ public class FlagParser {
     }
   }
 
-  public Post parsePost(Element el) throws InvalidXMLException {
+  public PostDefinition parsePost(Element el) throws InvalidXMLException {
     checkDeprecatedFilter(el);
 
-    @Nullable String name = el.getAttributeValue("name");
+    PostDefinition post =
+        el.getChildren("post").isEmpty() ? parseSinglePost(el) : parseCompositePost(el);
+
+    posts.add(post);
+    factory.getFeatures().addFeature(el, post);
+
+    return post;
+  }
+
+  private CompositePost parseCompositePost(Element el) throws InvalidXMLException {
     String id = el.getAttributeValue("id");
+    boolean sequential = XMLUtils.parseBoolean(el.getAttribute("sequential"), false);
+
+    ImmutableList.Builder<SinglePost> chBuilder = ImmutableList.builder();
+    for (Element child : el.getChildren("post")) {
+      chBuilder.add(parseSinglePost(new InheritingElement(child)));
+    }
+    ImmutableList<SinglePost> children = chBuilder.build();
+    // This should never happen, since it should've parsed single post instead.
+    if (children.isEmpty())
+      throw new InvalidXMLException("Expected children posts, but found none", el);
+
+    SinglePost fallback = null;
+    Node fallbackAttr = Node.fromAttr(el, "fallback");
+    if (fallbackAttr != null) {
+      fallback = factory.getFeatures().get(fallbackAttr.getValue(), SinglePost.class);
+      if (fallback == null) {
+        throw new InvalidXMLException(
+            "No post with ID '" + fallbackAttr.getValue() + "'", fallbackAttr);
+      }
+    }
+
+    // Even it had a single child, we still require composite for filtering and id referencing (if
+    // any)
+    return new CompositePost(id, sequential, children, fallback);
+  }
+
+  private SinglePost parseSinglePost(Element el) throws InvalidXMLException {
+    String id = el.getAttributeValue("id");
+    @Nullable String name = el.getAttributeValue("name");
+
     FeatureReference<TeamFactory> owner =
         factory.getFeatures().createReference(Node.fromAttr(el, "owner"), TeamFactory.class, null);
     boolean sequential = XMLUtils.parseBoolean(el.getAttribute("sequential"), false);
     boolean permanent = XMLUtils.parseBoolean(el.getAttribute("permanent"), false);
     double pointsPerSecond = XMLUtils.parseNumber(el.getAttribute("points-rate"), Double.class, 0D);
     Filter pickupFilter = filterParser.parseFilterProperty(el, "pickup-filter", StaticFilter.ALLOW);
+    Filter respawnFilter =
+        filterParser.parseFilterProperty(el, "respawn-filter", StaticFilter.ALLOW);
 
     Duration recoverTime =
         XMLUtils.parseDuration(
-            Node.fromAttr(el, "recover-time", "return-time"), Post.DEFAULT_RETURN_TIME);
+            Node.fromAttr(el, "recover-time", "return-time"), PostDefinition.DEFAULT_RETURN_TIME);
     Duration respawnTime = XMLUtils.parseDuration(el.getAttribute("respawn-time"), null);
     Double respawnSpeed =
         XMLUtils.parseNumber(el.getAttribute("respawn-speed"), Double.class, (Double) null);
@@ -72,7 +117,7 @@ public class FlagParser {
         ImmutableList.copyOf(pointParser.parse(el, new PointProviderAttributes()));
 
     if (respawnTime == null && respawnSpeed == null) {
-      respawnSpeed = Post.DEFAULT_RESPAWN_SPEED;
+      respawnSpeed = PostDefinition.DEFAULT_RESPAWN_SPEED;
     }
 
     if (respawnTime != null && respawnSpeed != null) {
@@ -83,23 +128,19 @@ public class FlagParser {
       throw new InvalidXMLException("post must have at least one point provider", el);
     }
 
-    Post post =
-        new Post(
-            id,
-            name, // Can be null
-            owner,
-            recoverTime,
-            respawnTime,
-            respawnSpeed,
-            returnPoints,
-            sequential,
-            permanent,
-            pointsPerSecond,
-            pickupFilter);
-    posts.add(post);
-    factory.getFeatures().addFeature(el, post);
-
-    return post;
+    return new SinglePost(
+        id,
+        name,
+        owner,
+        recoverTime,
+        respawnTime,
+        respawnSpeed,
+        returnPoints,
+        sequential,
+        permanent,
+        pointsPerSecond,
+        pickupFilter,
+        respawnFilter);
   }
 
   public ImmutableSet<FlagDefinition> parseFlagSet(Node node) throws InvalidXMLException {
@@ -132,15 +173,13 @@ public class FlagParser {
     Component denyMessage = XMLUtils.parseFormattedText(el, "deny-message");
     Vector proximityLocation = XMLUtils.parseVector(el.getAttribute("location"), (Vector) null);
 
-    Post returnPost = null;
+    PostDefinition returnPost = null;
     Node postAttr = Node.fromAttr(el, "post");
     if (postAttr != null) {
       // Posts are all parsed at this point, so we can do an immediate lookup
-      returnPost = factory.getFeatures().get(postAttr.getValue(), Post.class);
+      returnPost = factory.getFeatures().get(postAttr.getValue(), PostDefinition.class);
       if (returnPost == null) {
         throw new InvalidXMLException("No post with ID '" + postAttr.getValue() + "'", postAttr);
-      } else {
-        returnPost.setSpecifiedPost(true);
       }
     }
 
@@ -156,14 +195,6 @@ public class FlagParser {
       capturableFlags = ImmutableSet.of(parentFlag);
     } else {
       capturableFlags = ImmutableSet.copyOf(this.flags);
-    }
-
-    if (capturableFlags.size() != 0 && returnPost != null) {
-      for (FlagDefinition flagDef : flags) {
-        if (capturableFlags.contains(flagDef)) {
-          flagDef.setShowRespawnOnPickup(false);
-        }
-      }
     }
 
     ImmutableSet<FlagDefinition> returnableFlags;
@@ -218,10 +249,9 @@ public class FlagParser {
     Kit dropKit = factory.getKits().parseKitProperty(el, "drop-kit", null);
     Kit carryKit = factory.getKits().parseKitProperty(el, "carry-kit", null);
     boolean multiCarrier = XMLUtils.parseBoolean(el.getAttribute("shared"), false);
-    boolean sequential = XMLUtils.parseBoolean(el.getAttribute("sequential"), false);
     Component carryMessage = XMLUtils.parseFormattedText(el, "carry-message");
     boolean showRespawnOnPickup =
-        XMLUtils.parseBoolean(el.getAttribute("show-respawn-on-pickup"), true);
+        XMLUtils.parseBoolean(el.getAttribute("show-respawn-on-pickup"), false);
     boolean dropOnWater = XMLUtils.parseBoolean(el.getAttribute("drop-on-water"), true);
     boolean showBeam = XMLUtils.parseBoolean(el.getAttribute("beam"), true);
     ProximityMetric flagProximityMetric =
@@ -230,19 +260,14 @@ public class FlagParser {
     ProximityMetric netProximityMetric =
         ProximityMetric.parse(
             el, "net", new ProximityMetric(ProximityMetric.Type.CLOSEST_PLAYER, false));
-    Post defaultPost;
-    List<Post> flagPosts = new ArrayList<>();
-    for (Element elPost : el.getChildren("post")) {
-      flagPosts.add(this.parsePost(elPost));
-    }
 
-    if (!flagPosts.isEmpty()) {
-      // Parse nested <post>
-      defaultPost = flagPosts.get(0);
+    PostDefinition defaultPost;
+    Element elPost = XMLUtils.getUniqueChild(el, "post", "posts");
+    if (elPost != null) {
+      defaultPost = this.parsePost(elPost);
     } else {
       Node postAttr = Node.fromRequiredAttr(el, "post");
-      defaultPost = factory.getFeatures().get(postAttr.getValue(), Post.class);
-      flagPosts.add(defaultPost);
+      defaultPost = factory.getFeatures().get(postAttr.getValue(), PostDefinition.class);
       if (defaultPost == null) {
         throw new InvalidXMLException("No post with ID '" + postAttr.getValue() + "'", postAttr);
       }
@@ -256,7 +281,6 @@ public class FlagParser {
             visible,
             color,
             defaultPost,
-            ImmutableList.copyOf(flagPosts),
             owner,
             pointsPerCapture,
             pointsPerSecond,
@@ -272,7 +296,6 @@ public class FlagParser {
             showBeam,
             flagProximityMetric,
             netProximityMetric,
-            sequential,
             showRespawnOnPickup);
     flags.add(flag);
     factory.getFeatures().addFeature(el, flag);

--- a/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
@@ -39,7 +39,7 @@ public class FlagParser {
 
   private final AtomicInteger postIdSerial = new AtomicInteger(1);
   private final List<PostDefinition> posts = new ArrayList<>();
-  private final List<Net> nets = new ArrayList<>();
+  private final List<NetDefinition> nets = new ArrayList<>();
   private final List<FlagDefinition> flags = new ArrayList<>();
 
   public FlagParser(MapFactory factory) {
@@ -54,6 +54,14 @@ public class FlagParser {
       throw new InvalidXMLException(
           "'filter' is no longer supported, be more specific e.g. 'pickup-filter'", node);
     }
+  }
+
+  private void checkDeprecatedMultiPost(Element el) throws InvalidXMLException {
+    if (el.getChildren("post").size() <= 1) return;
+    throw new InvalidXMLException(
+        "Multiple 'post' elements inside 'flag' are no longer supported, use a single 'post' with multiple inner 'post' elements instead.\n"
+            + "Check the docs at https://pgm.dev or PR #984 on github for more details.",
+        el);
   }
 
   public PostDefinition parsePost(Element el) throws InvalidXMLException {
@@ -160,7 +168,8 @@ public class FlagParser {
     return flags.build();
   }
 
-  public Net parseNet(Element el, @Nullable FlagDefinition parentFlag) throws InvalidXMLException {
+  public NetDefinition parseNet(Element el, @Nullable FlagDefinition parentFlag)
+      throws InvalidXMLException {
     checkDeprecatedFilter(el);
 
     String id = el.getAttributeValue("id");
@@ -210,8 +219,8 @@ public class FlagParser {
       returnableFlags = ImmutableSet.of();
     }
 
-    Net net =
-        new Net(
+    NetDefinition net =
+        new NetDefinition(
             id,
             region,
             captureFilter,
@@ -234,6 +243,7 @@ public class FlagParser {
 
   public FlagDefinition parseFlag(Element el) throws InvalidXMLException {
     checkDeprecatedFilter(el);
+    checkDeprecatedMultiPost(el);
 
     String id = el.getAttributeValue("id");
     String name = el.getAttributeValue("name");

--- a/core/src/main/java/tc/oc/pgm/flag/Net.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Net.java
@@ -9,6 +9,7 @@ import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.teams.TeamFactory;
 
 @FeatureInfo(name = "net")
@@ -26,7 +27,7 @@ public class Net extends SelfIdentifyingFeatureDefinition {
       denyMessage; // Message to show carrier when capture is prevented by filter
   private final @Nullable Component
       respawnMessage; // Message to broadcast when respawn is prevented by filter or respawnTogether
-  private final @Nullable Post
+  private final @Nullable PostDefinition
       returnPost; // Post to send flags after capture, null to send to their current post
   private final ImmutableSet<FlagDefinition>
       capturableFlags; // Flags that can be captured in this net
@@ -46,7 +47,7 @@ public class Net extends SelfIdentifyingFeatureDefinition {
       boolean sticky,
       @Nullable Component denyMessage,
       @Nullable Component respawnMessage,
-      @Nullable Post returnPost,
+      @Nullable PostDefinition returnPost,
       ImmutableSet<FlagDefinition> capturableFlags,
       ImmutableSet<FlagDefinition> recoverableFlags,
       boolean respawnTogether,
@@ -100,7 +101,7 @@ public class Net extends SelfIdentifyingFeatureDefinition {
     return denyMessage;
   }
 
-  public @Nullable Post getReturnPost() {
+  public @Nullable PostDefinition getReturnPost() {
     return this.returnPost;
   }
 

--- a/core/src/main/java/tc/oc/pgm/flag/NetDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/NetDefinition.java
@@ -13,7 +13,7 @@ import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.teams.TeamFactory;
 
 @FeatureInfo(name = "net")
-public class Net extends SelfIdentifyingFeatureDefinition {
+public class NetDefinition extends SelfIdentifyingFeatureDefinition {
 
   private final Region region; // Region flag carrier must enter to capture
   private final Filter captureFilter; // Carrier must pass this filter to capture
@@ -37,7 +37,7 @@ public class Net extends SelfIdentifyingFeatureDefinition {
   private final boolean respawnTogether; // Delay respawn until all capturableFlags are captured
   private @Nullable Vector proximityLocation;
 
-  public Net(
+  public NetDefinition(
       @Nullable String id,
       Region region,
       Filter captureFilter,

--- a/core/src/main/java/tc/oc/pgm/flag/Post.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Post.java
@@ -1,178 +1,94 @@
 package tc.oc.pgm.flag;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.collect.ImmutableList;
 import java.time.Duration;
-import java.util.Random;
 import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import tc.oc.pgm.api.feature.FeatureInfo;
-import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.api.feature.Feature;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.flag.post.PostDefinition;
+import tc.oc.pgm.flag.post.PostResolver;
+import tc.oc.pgm.flag.post.SinglePost;
 import tc.oc.pgm.points.AngleProvider;
 import tc.oc.pgm.points.PointProvider;
-import tc.oc.pgm.points.PointProviderLocation;
 import tc.oc.pgm.teams.TeamFactory;
 
-@FeatureInfo(name = "post")
-public class Post extends SelfIdentifyingFeatureDefinition {
-  public static final Duration DEFAULT_RETURN_TIME = Duration.ofSeconds(30);
-  public static final double DEFAULT_RESPAWN_SPEED = 8;
+public class Post implements Feature<PostDefinition> {
+  private final Match match;
+  private final PostDefinition definition;
+  private final PostResolver singleDefinition;
 
-  private static final int MAX_SPAWN_ATTEMPTS = 100;
+  public Post(Match match, PostDefinition definition) {
+    this.match = match;
+    this.definition = definition;
+    this.singleDefinition = definition.createResolver(match);
+  }
 
-  private final @Nullable FeatureReference<TeamFactory>
-      owner; // Team that owns the post, affects various things
-  private final Duration
-      recoverTime; // Time between a flag dropping and being recovered, can be infinite
-  private final @Nullable Duration
-      respawnTime; // Fixed time between a flag being recovered and respawning at the post
-  private final @Nullable Double
-      respawnSpeed; // Makes respawn time proportional to distance, flag "moves" back at this m/s
-  private final ImmutableList<PointProvider> returnPoints; // Spawn points for the flag
-  private final boolean
-      sequential; // Search for spawn points sequentially, see equivalent field in SpawnInfo
-  private final boolean permanent; // Flag enters Completed state when at this post
-  private final double pointsPerSecond; // Points awarded while any flag is at this post
-  private final Filter pickupFilter; // Filter players who can pickup a flag at this post
-  private final @Nullable String
-      postName; // The name of the post to be shown in chat when the flag is respawning
+  @Override
+  public String getId() {
+    return getDefinition().getId();
+  }
 
-  private boolean specifiedPost = false;
+  @Override
+  public PostDefinition getDefinition() {
+    return definition;
+  }
 
-  public Post(
-      @Nullable String id,
-      @Nullable String name,
-      @Nullable FeatureReference<TeamFactory> owner,
-      Duration recoverTime,
-      @Nullable Duration respawnTime,
-      @Nullable Double respawnSpeed,
-      ImmutableList<PointProvider> returnPoints,
-      boolean sequential,
-      boolean permanent,
-      double pointsPerSecond,
-      Filter pickupFilter) {
+  public SinglePost peekNext(Flag flag) {
+    return singleDefinition.peekNext(flag);
+  }
 
-    super(id);
-    checkArgument(respawnTime == null || respawnSpeed == null);
-    if (respawnSpeed != null) checkArgument(respawnSpeed > 0);
+  public SinglePost getNext(Flag flag) {
+    return singleDefinition.getNext(flag);
+  }
 
-    this.owner = owner;
-    this.recoverTime = recoverTime;
-    this.respawnTime = respawnTime;
-    this.respawnSpeed = respawnSpeed;
-    this.returnPoints = returnPoints;
-    this.sequential = sequential;
-    this.permanent = permanent;
-    this.pointsPerSecond = pointsPerSecond;
-    this.pickupFilter = pickupFilter;
-    this.postName = name;
+  public SinglePost getCurrent() {
+    return singleDefinition.get();
   }
 
   public @Nullable String getPostName() {
-    return this.postName;
+    return getCurrent().getPostName();
   }
 
   public @Nullable TeamFactory getOwner() {
-    return this.owner == null ? null : this.owner.get();
+    return getCurrent().getOwner();
   }
 
   public ChatColor getColor() {
-    return this.owner == null ? ChatColor.WHITE : this.owner.get().getDefaultColor();
+    return getCurrent().getColor();
   }
 
   public Duration getRecoverTime() {
-    return this.recoverTime;
+    return getCurrent().getRecoverTime();
   }
 
   public Duration getRespawnTime(double distance) {
-    if (respawnTime != null) {
-      return respawnTime;
-    } else if (respawnSpeed != null) {
-      return Duration.ofSeconds(Math.round(distance / respawnSpeed));
-    } else {
-      return Duration.ZERO;
-    }
+    return getCurrent().getRespawnTime(distance);
   }
 
   public ImmutableList<PointProvider> getReturnPoints() {
-    return this.returnPoints;
+    return getCurrent().getReturnPoints();
   }
 
   public boolean isSequential() {
-    return this.sequential;
+    return getCurrent().isSequential();
   }
 
   public Boolean isPermanent() {
-    return this.permanent;
+    return getCurrent().isPermanent();
   }
 
   public double getPointsPerSecond() {
-    return this.pointsPerSecond;
+    return getCurrent().getPointsPerSecond();
   }
 
   public Filter getPickupFilter() {
-    return this.pickupFilter;
+    return getCurrent().getPickupFilter();
   }
 
   public Location getReturnPoint(Flag flag, AngleProvider yawProvider) {
-    Location location = getReturnPoint(flag);
-    if (location instanceof PointProviderLocation && !((PointProviderLocation) location).hasYaw()) {
-      location.setYaw(yawProvider.getAngle(location.toVector()));
-    }
-    return location;
-  }
-
-  public boolean isSpecifiedPost() {
-    return this.specifiedPost;
-  }
-
-  public void setSpecifiedPost(boolean value) {
-    this.specifiedPost = value;
-  }
-
-  private Location getReturnPoint(Flag flag) {
-    if (this.sequential) {
-      for (PointProvider provider : this.returnPoints) {
-        for (int i = 0; i < MAX_SPAWN_ATTEMPTS; i++) {
-          Location loc = roundToBlock(provider.getPoint(flag.getMatch(), null));
-          if (flag.canDropAt(loc)) {
-            return loc;
-          }
-        }
-      }
-
-      // could not find a good spot, fallback to the last provider
-      return this.returnPoints.get(this.returnPoints.size() - 1).getPoint(flag.getMatch(), null);
-
-    } else {
-      Random random = new Random();
-      for (int i = 0; i < MAX_SPAWN_ATTEMPTS * this.returnPoints.size(); i++) {
-        PointProvider provider = this.returnPoints.get(random.nextInt(this.returnPoints.size()));
-        Location loc = roundToBlock(provider.getPoint(flag.getMatch(), null));
-        if (flag.canDropAt(loc)) {
-          return loc;
-        }
-      }
-
-      // could not find a good spot, settle for any spot
-      PointProvider provider = this.returnPoints.get(random.nextInt(this.returnPoints.size()));
-      return this.returnPoints
-          .get(random.nextInt(this.returnPoints.size()))
-          .getPoint(flag.getMatch(), null);
-    }
-  }
-
-  private Location roundToBlock(Location loc) {
-    Location newLoc = loc.clone();
-
-    newLoc.setX(Math.floor(loc.getX()) + 0.5);
-    newLoc.setY(Math.floor(loc.getY()));
-    newLoc.setZ(Math.floor(loc.getZ()) + 0.5);
-
-    return newLoc;
+    return getNext(flag).getReturnPoint(flag, yawProvider);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/flag/event/FlagCaptureEvent.java
+++ b/core/src/main/java/tc/oc/pgm/flag/event/FlagCaptureEvent.java
@@ -7,16 +7,16 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.flag.FlagDefinition;
-import tc.oc.pgm.flag.Net;
+import tc.oc.pgm.flag.NetDefinition;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 
 public class FlagCaptureEvent extends GoalCompleteEvent {
 
-  private final Net net;
+  private final NetDefinition net;
   private final MatchPlayer carrier;
   private final boolean allFlagsCaptured;
 
-  public FlagCaptureEvent(Flag flag, MatchPlayer carrier, Net net) {
+  public FlagCaptureEvent(Flag flag, MatchPlayer carrier, NetDefinition net) {
     super(flag.getMatch(), flag, (Competitor) checkNotNull(carrier).getParty(), true);
     this.net = net;
     this.carrier = carrier;
@@ -33,7 +33,7 @@ public class FlagCaptureEvent extends GoalCompleteEvent {
     return (Flag) super.getGoal();
   }
 
-  public Net getNet() {
+  public NetDefinition getNet() {
     return net;
   }
 

--- a/core/src/main/java/tc/oc/pgm/flag/post/CompositePost.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/CompositePost.java
@@ -1,0 +1,43 @@
+package tc.oc.pgm.flag.post;
+
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+import tc.oc.pgm.api.match.Match;
+
+public class CompositePost extends PostDefinition {
+
+  private final ImmutableList<SinglePost> posts;
+  private final SinglePost fallback;
+  private final boolean sequential;
+
+  public CompositePost(
+      String id,
+      boolean sequential,
+      ImmutableList<SinglePost> posts,
+      @Nullable SinglePost fallback) {
+    super(id);
+
+    this.sequential = sequential;
+    this.posts = posts;
+    this.fallback = fallback != null ? fallback : posts.get(0);
+  }
+
+  public boolean isSequential() {
+    return sequential;
+  }
+
+  public ImmutableList<SinglePost> getPosts() {
+    return posts;
+  }
+
+  public SinglePost getFallback() {
+    return fallback;
+  }
+
+  @Override
+  public PostResolver createResolver(Match match) {
+    return sequential
+        ? new SequentialPostResolver(posts, fallback)
+        : new RandomOrderPostResolver(posts, fallback);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/flag/post/PostDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/PostDefinition.java
@@ -1,0 +1,20 @@
+package tc.oc.pgm.flag.post;
+
+import java.time.Duration;
+import tc.oc.pgm.api.feature.FeatureInfo;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+
+@FeatureInfo(name = "post")
+public abstract class PostDefinition extends SelfIdentifyingFeatureDefinition {
+  public static final Duration DEFAULT_RETURN_TIME = Duration.ofSeconds(30);
+  public static final double DEFAULT_RESPAWN_SPEED = 8;
+
+  public PostDefinition(String id) {
+    super(id);
+  }
+
+  public abstract PostResolver createResolver(Match match);
+
+  public abstract SinglePost getFallback();
+}

--- a/core/src/main/java/tc/oc/pgm/flag/post/PostDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/PostDefinition.java
@@ -1,6 +1,8 @@
 package tc.oc.pgm.flag.post;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
@@ -14,7 +16,19 @@ public abstract class PostDefinition extends SelfIdentifyingFeatureDefinition {
     super(id);
   }
 
+  @Override
+  protected String getDefaultId() {
+    return super.makeDefaultId();
+  }
+
   public abstract PostResolver createResolver(Match match);
 
   public abstract SinglePost getFallback();
+
+  public static String makeDefaultId(@Nullable String name, AtomicInteger serial) {
+    return "--"
+        + makeTypeName(PostDefinition.class)
+        + "-"
+        + (name != null ? makeId(name) : serial.getAndIncrement());
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/flag/post/PostResolver.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/PostResolver.java
@@ -1,0 +1,16 @@
+package tc.oc.pgm.flag.post;
+
+import java.util.function.Supplier;
+import tc.oc.pgm.flag.Flag;
+
+public interface PostResolver extends Supplier<SinglePost> {
+  SinglePost get();
+
+  default SinglePost peekNext(Flag flag) {
+    return get();
+  }
+
+  default SinglePost getNext(Flag flag) {
+    return get();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/flag/post/RandomOrderPostResolver.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/RandomOrderPostResolver.java
@@ -1,0 +1,52 @@
+package tc.oc.pgm.flag.post;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import tc.oc.pgm.filters.query.GoalQuery;
+import tc.oc.pgm.flag.Flag;
+
+public class RandomOrderPostResolver implements PostResolver {
+  private final List<SinglePost> posts;
+  private final SinglePost fallback;
+  private SinglePost current, next;
+
+  public RandomOrderPostResolver(ImmutableList<SinglePost> posts, SinglePost fallback) {
+    this.posts = new ArrayList<>(posts);
+    this.fallback = fallback;
+    this.current = fallback;
+  }
+
+  @Override
+  public SinglePost get() {
+    return current;
+  }
+
+  @Override
+  public SinglePost peekNext(Flag flag) {
+    this.next = findNext(flag);
+    return next == null ? fallback : next;
+  }
+
+  @Override
+  public SinglePost getNext(Flag flag) {
+    this.next = findNext(flag);
+    if (this.next == null) return this.current = fallback;
+
+    this.current = this.next;
+    this.next = null;
+    return this.current;
+  }
+
+  private SinglePost findNext(Flag flag) {
+    GoalQuery query = new GoalQuery(flag);
+    if (next != null && next.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) return next;
+
+    Collections.shuffle(posts);
+    for (SinglePost p : posts) {
+      if (p.getRespawnFilter().query(query).isAllowed()) return p;
+    }
+    return null;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/flag/post/RandomOrderPostResolver.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/RandomOrderPostResolver.java
@@ -44,8 +44,8 @@ public class RandomOrderPostResolver implements PostResolver {
     if (next != null && next.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) return next;
 
     Collections.shuffle(posts);
-    for (SinglePost p : posts) {
-      if (p.getRespawnFilter().query(query).isAllowed()) return p;
+    for (SinglePost post : posts) {
+      if (post.getRespawnFilter().query(query).isAllowed()) return post;
     }
     return null;
   }

--- a/core/src/main/java/tc/oc/pgm/flag/post/SequentialPostResolver.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/SequentialPostResolver.java
@@ -24,8 +24,8 @@ public class SequentialPostResolver implements PostResolver {
   @Override
   public SinglePost peekNext(Flag flag) {
     for (int offset = 1; offset < posts.size(); offset++) {
-      SinglePost p = posts.get((currentIdx + offset) % posts.size());
-      if (p.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) return p;
+      final SinglePost post = posts.get((currentIdx + offset) % posts.size());
+      if (post.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) return post;
     }
     return fallback;
   }
@@ -33,10 +33,10 @@ public class SequentialPostResolver implements PostResolver {
   @Override
   public SinglePost getNext(Flag flag) {
     for (int offset = 1; offset < posts.size(); offset++) {
-      SinglePost p = posts.get((currentIdx + offset) % posts.size());
-      if (p.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) {
+      final SinglePost post = posts.get((currentIdx + offset) % posts.size());
+      if (post.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) {
         this.currentIdx = (currentIdx + offset) % posts.size();
-        return p;
+        return post;
       }
     }
     return fallback;

--- a/core/src/main/java/tc/oc/pgm/flag/post/SequentialPostResolver.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/SequentialPostResolver.java
@@ -1,0 +1,44 @@
+package tc.oc.pgm.flag.post;
+
+import com.google.common.collect.ImmutableList;
+import tc.oc.pgm.filters.query.GoalQuery;
+import tc.oc.pgm.flag.Flag;
+
+public class SequentialPostResolver implements PostResolver {
+  private final ImmutableList<SinglePost> posts;
+  private final SinglePost fallback;
+  private int currentIdx;
+
+  public SequentialPostResolver(ImmutableList<SinglePost> posts, SinglePost fallback) {
+    this.posts = posts;
+    this.fallback = fallback;
+    this.currentIdx = posts.get(0) == fallback ? 0 : -1;
+  }
+
+  @Override
+  public SinglePost get() {
+    if (currentIdx == -1) return fallback;
+    return posts.get(currentIdx);
+  }
+
+  @Override
+  public SinglePost peekNext(Flag flag) {
+    for (int offset = 1; offset < posts.size(); offset++) {
+      SinglePost p = posts.get((currentIdx + offset) % posts.size());
+      if (p.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) return p;
+    }
+    return fallback;
+  }
+
+  @Override
+  public SinglePost getNext(Flag flag) {
+    for (int offset = 1; offset < posts.size(); offset++) {
+      SinglePost p = posts.get((currentIdx + offset) % posts.size());
+      if (p.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) {
+        this.currentIdx = (currentIdx + offset) % posts.size();
+        return p;
+      }
+    }
+    return fallback;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/flag/post/SinglePost.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/SinglePost.java
@@ -21,23 +21,28 @@ public class SinglePost extends PostDefinition {
 
   private static final int MAX_SPAWN_ATTEMPTS = 100;
 
-  private final @Nullable FeatureReference<TeamFactory>
-      owner; // Team that owns the post, affects various things
-  private final Duration
-      recoverTime; // Time between a flag dropping and being recovered, can be infinite
-  private final @Nullable Duration
-      respawnTime; // Fixed time between a flag being recovered and respawning at the post
-  private final @Nullable Double
-      respawnSpeed; // Makes respawn time proportional to distance, flag "moves" back at this m/s
-  private final ImmutableList<PointProvider> returnPoints; // Spawn points for the flag
-  private final boolean
-      sequential; // Search for spawn points sequentially, see equivalent field in SpawnInfo
-  private final boolean permanent; // Flag enters Completed state when at this post
-  private final double pointsPerSecond; // Points awarded while any flag is at this post
-  private final Filter pickupFilter; // Filter players who can pickup a flag at this post
-  private final Filter respawnFilter; // Filter if a flag can respawn to this post
-  private final @Nullable String
-      postName; // The post's name, shown in chat when the flag is respawning
+  // The post's name, shown in chat when the flag is respawning
+  private final @Nullable String postName;
+  // Team that owns the post, affects various things
+  private final @Nullable FeatureReference<TeamFactory> owner;
+  // Time between a flag dropping and being recovered, can be infinite
+  private final Duration recoverTime;
+  // Fixed time between a flag being recovered and respawning at the post
+  private final @Nullable Duration respawnTime;
+  // Makes respawn time proportional to distance, flag "moves" back at this m/s
+  private final @Nullable Double respawnSpeed;
+  // Spawn points for the flag
+  private final ImmutableList<PointProvider> returnPoints;
+  // Search for spawn points sequentially, see equivalent field in SpawnInfo
+  private final boolean sequential;
+  // Flag enters Completed state when at this post
+  private final boolean permanent;
+  // Points awarded while any flag is at this post
+  private final double pointsPerSecond;
+  // Filter players who can pick up a flag at this post
+  private final Filter pickupFilter;
+  // Filter if a flag can respawn to this post
+  private final Filter respawnFilter;
 
   public SinglePost(
       @Nullable String id,

--- a/core/src/main/java/tc/oc/pgm/flag/post/SinglePost.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/SinglePost.java
@@ -1,0 +1,182 @@
+package tc.oc.pgm.flag.post;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Duration;
+import java.util.Random;
+import javax.annotation.Nullable;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.flag.Flag;
+import tc.oc.pgm.points.AngleProvider;
+import tc.oc.pgm.points.PointProvider;
+import tc.oc.pgm.points.PointProviderLocation;
+import tc.oc.pgm.teams.TeamFactory;
+
+public class SinglePost extends PostDefinition {
+
+  private static final int MAX_SPAWN_ATTEMPTS = 100;
+
+  private final @Nullable FeatureReference<TeamFactory>
+      owner; // Team that owns the post, affects various things
+  private final Duration
+      recoverTime; // Time between a flag dropping and being recovered, can be infinite
+  private final @Nullable Duration
+      respawnTime; // Fixed time between a flag being recovered and respawning at the post
+  private final @Nullable Double
+      respawnSpeed; // Makes respawn time proportional to distance, flag "moves" back at this m/s
+  private final ImmutableList<PointProvider> returnPoints; // Spawn points for the flag
+  private final boolean
+      sequential; // Search for spawn points sequentially, see equivalent field in SpawnInfo
+  private final boolean permanent; // Flag enters Completed state when at this post
+  private final double pointsPerSecond; // Points awarded while any flag is at this post
+  private final Filter pickupFilter; // Filter players who can pickup a flag at this post
+  private final Filter respawnFilter; // Filter if a flag can respawn to this post
+  private final @Nullable String
+      postName; // The post's name, shown in chat when the flag is respawning
+
+  public SinglePost(
+      @Nullable String id,
+      @Nullable String name,
+      @Nullable FeatureReference<TeamFactory> owner,
+      Duration recoverTime,
+      @Nullable Duration respawnTime,
+      @Nullable Double respawnSpeed,
+      ImmutableList<PointProvider> returnPoints,
+      boolean sequential,
+      boolean permanent,
+      double pointsPerSecond,
+      Filter pickupFilter,
+      Filter respawnFilter) {
+    super(id);
+
+    checkArgument(respawnTime == null || respawnSpeed == null);
+    if (respawnSpeed != null) checkArgument(respawnSpeed > 0);
+
+    this.owner = owner;
+    this.recoverTime = recoverTime;
+    this.respawnTime = respawnTime;
+    this.respawnSpeed = respawnSpeed;
+    this.returnPoints = returnPoints;
+    this.sequential = sequential;
+    this.permanent = permanent;
+    this.pointsPerSecond = pointsPerSecond;
+    this.pickupFilter = pickupFilter;
+    this.respawnFilter = respawnFilter;
+    this.postName = name;
+  }
+
+  @Override
+  public SinglePost getFallback() {
+    return this;
+  }
+
+  @Override
+  public PostResolver createResolver(Match match) {
+    return () -> this;
+  }
+
+  public @Nullable String getPostName() {
+    return this.postName;
+  }
+
+  public @Nullable TeamFactory getOwner() {
+    return this.owner == null ? null : this.owner.get();
+  }
+
+  public ChatColor getColor() {
+    return this.owner == null ? ChatColor.WHITE : this.owner.get().getDefaultColor();
+  }
+
+  public Duration getRecoverTime() {
+    return this.recoverTime;
+  }
+
+  public Duration getRespawnTime(double distance) {
+    if (respawnTime != null) {
+      return respawnTime;
+    } else if (respawnSpeed != null) {
+      return Duration.ofSeconds(Math.round(distance / respawnSpeed));
+    } else {
+      return Duration.ZERO;
+    }
+  }
+
+  public ImmutableList<PointProvider> getReturnPoints() {
+    return this.returnPoints;
+  }
+
+  public boolean isSequential() {
+    return this.sequential;
+  }
+
+  public Boolean isPermanent() {
+    return this.permanent;
+  }
+
+  public double getPointsPerSecond() {
+    return this.pointsPerSecond;
+  }
+
+  public Filter getPickupFilter() {
+    return this.pickupFilter;
+  }
+
+  public Filter getRespawnFilter() {
+    return respawnFilter;
+  }
+
+  public Location getReturnPoint(Flag flag, AngleProvider yawProvider) {
+    Location location = getReturnPoint(flag);
+    if (location instanceof PointProviderLocation && !((PointProviderLocation) location).hasYaw()) {
+      location.setYaw(yawProvider.getAngle(location.toVector()));
+    }
+    return location;
+  }
+
+  private Location getReturnPoint(Flag flag) {
+    if (this.sequential) {
+      for (PointProvider provider : this.returnPoints) {
+        for (int i = 0; i < MAX_SPAWN_ATTEMPTS; i++) {
+          Location loc = roundToBlock(provider.getPoint(flag.getMatch(), null));
+          if (flag.canDropAt(loc)) {
+            return loc;
+          }
+        }
+      }
+
+      // could not find a good spot, fallback to the last provider
+      return this.returnPoints.get(this.returnPoints.size() - 1).getPoint(flag.getMatch(), null);
+
+    } else {
+      Random random = new Random();
+      for (int i = 0; i < MAX_SPAWN_ATTEMPTS * this.returnPoints.size(); i++) {
+        PointProvider provider = this.returnPoints.get(random.nextInt(this.returnPoints.size()));
+        Location loc = roundToBlock(provider.getPoint(flag.getMatch(), null));
+        if (flag.canDropAt(loc)) {
+          return loc;
+        }
+      }
+
+      // could not find a good spot, settle for any spot
+      PointProvider provider = this.returnPoints.get(random.nextInt(this.returnPoints.size()));
+      return this.returnPoints
+          .get(random.nextInt(this.returnPoints.size()))
+          .getPoint(flag.getMatch(), null);
+    }
+  }
+
+  private Location roundToBlock(Location loc) {
+    Location newLoc = loc.clone();
+
+    newLoc.setX(Math.floor(loc.getX()) + 0.5);
+    newLoc.setY(Math.floor(loc.getY()));
+    newLoc.setZ(Math.floor(loc.getZ()) + 0.5);
+
+    return newLoc;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/flag/state/BaseState.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/BaseState.java
@@ -156,11 +156,6 @@ public abstract class BaseState implements Runnable, State {
   }
 
   @Override
-  public boolean isAtPost(Post post) {
-    return post == this.post;
-  }
-
-  @Override
   public @Nullable Team getController() {
     if (this.post.getOwner() != null) {
       return this.flag.getMatch().needModule(TeamMatchModule.class).getTeam(this.post.getOwner());

--- a/core/src/main/java/tc/oc/pgm/flag/state/Captured.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Captured.java
@@ -6,7 +6,7 @@ import org.bukkit.Location;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.filters.query.GoalQuery;
 import tc.oc.pgm.flag.Flag;
-import tc.oc.pgm.flag.Net;
+import tc.oc.pgm.flag.NetDefinition;
 import tc.oc.pgm.flag.Post;
 import tc.oc.pgm.flag.event.FlagCaptureEvent;
 import tc.oc.pgm.flag.event.FlagStateChangeEvent;
@@ -17,11 +17,11 @@ import tc.oc.pgm.flag.event.FlagStateChangeEvent;
  */
 public class Captured extends BaseState implements Returning {
 
-  protected final Net net;
+  protected final NetDefinition net;
   protected final Location lastLocation;
   protected boolean wasDelayed;
 
-  protected Captured(Flag flag, Post post, Net net, Location lastLocation) {
+  protected Captured(Flag flag, Post post, NetDefinition net, Location lastLocation) {
     super(flag, post);
     this.net = net;
     this.lastLocation = lastLocation;

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -35,7 +35,7 @@ import tc.oc.pgm.filters.query.PlayerQuery;
 import tc.oc.pgm.filters.query.PlayerStateQuery;
 import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.flag.FlagDefinition;
-import tc.oc.pgm.flag.Net;
+import tc.oc.pgm.flag.NetDefinition;
 import tc.oc.pgm.flag.Post;
 import tc.oc.pgm.flag.event.FlagCaptureEvent;
 import tc.oc.pgm.flag.event.FlagStateChangeEvent;
@@ -57,7 +57,7 @@ public class Carried extends Spawned implements Missing {
   protected final MatchPlayer carrier;
   protected ItemStack helmetItem;
   protected boolean helmetLocked;
-  protected @Nullable Net deniedByNet;
+  protected @Nullable NetDefinition deniedByNet;
   protected @Nullable Flag deniedByFlag;
   protected @Nullable Component lastMessage;
 
@@ -248,7 +248,7 @@ public class Carried extends Spawned implements Missing {
     this.recover();
   }
 
-  protected void captureFlag(Net net) {
+  protected void captureFlag(NetDefinition net) {
     this.carrier.sendMessage(translatable("flag.capture.you", this.flag.getComponentName()));
 
     this.flag
@@ -378,7 +378,7 @@ public class Carried extends Spawned implements Missing {
       this.deniedByNet = null;
     }
 
-    for (Net net : this.flag.getNets()) {
+    for (NetDefinition net : this.flag.getNets()) {
       if (net.getRegion().contains(to)) {
         if (tryCapture(net)) {
           return;
@@ -393,7 +393,7 @@ public class Carried extends Spawned implements Missing {
     }
   }
 
-  protected boolean tryCapture(Net net) {
+  protected boolean tryCapture(NetDefinition net) {
     for (FlagDefinition returnableDef : net.getRecoverableFlags()) {
       Flag returnable = returnableDef.getGoal(this.flag.getMatch());
       if (returnable.isCurrent(Carried.class)) {

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -69,18 +69,6 @@ public class Carried extends Spawned implements Missing {
     this.carrier = carrier;
     this.dropLocations.add(
         dropLocation); // Need an initial dropLocation in case the carrier never generates ones
-    if (this.flag.getDefinition().willShowRespawnOnPickup()) {
-      String postName = this.flag.predeterminePost(this.post);
-      if (postName != null) { // The post needs a name in order to display the message.
-        this.flag
-            .getMatch()
-            .sendMessage(
-                translatable(
-                    "flag.willRespawn.next",
-                    this.flag.getComponentName(),
-                    text(postName, NamedTextColor.AQUA)));
-      }
-    }
   }
 
   @Override
@@ -139,6 +127,19 @@ public class Carried extends Spawned implements Missing {
 
     SidebarMatchModule smm = this.flag.getMatch().getModule(SidebarMatchModule.class);
     if (smm != null) smm.blinkGoal(this.flag, 2, null);
+
+    if (this.flag.getDefinition().willShowRespawnOnPickup()) {
+      String postName = post.peekNext(flag).getPostName();
+      if (postName != null) { // The post needs a name in order to display the message.
+        this.flag
+            .getMatch()
+            .sendMessage(
+                translatable(
+                    "flag.willRespawn.next",
+                    this.flag.getComponentName(),
+                    text(postName, NamedTextColor.AQUA)));
+      }
+    }
   }
 
   @Override
@@ -274,7 +275,9 @@ public class Carried extends Spawned implements Missing {
       }
     }
 
-    Post post = net.getReturnPost() != null ? net.getReturnPost() : this.post;
+    Post post = this.post;
+    if (net.getReturnPost() != null) post = this.flag.getPost(net.getReturnPost());
+
     if (post.isPermanent()) {
       this.flag.transition(new Completed(this.flag, post));
     } else {

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -276,7 +276,7 @@ public class Carried extends Spawned implements Missing {
     }
 
     Post post = this.post;
-    if (net.getReturnPost() != null) post = this.flag.getPost(net.getReturnPost());
+    if (net.getReturnPost() != null) post = flag.getPost(net.getReturnPost());
 
     if (post.isPermanent()) {
       this.flag.transition(new Completed(this.flag, post));

--- a/core/src/main/java/tc/oc/pgm/flag/state/State.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/State.java
@@ -18,8 +18,6 @@ public interface State {
 
   boolean isCarrying(Party team);
 
-  boolean isAtPost(Post post);
-
   Post getPost();
 
   @Nullable


### PR DESCRIPTION
Fixes a few issues introduced in earlier changes to posts (#524 and #528), and adds a proper implementation ground for filtered posts (#759), main fixes:
 - Flag no longer needs to hold a list of posts, this is undesirable as what post is used next may change with a net. This can create some nasty side-effects (eg: a flag which is captured on a net that sets specific post, later returning to a previous post in the list instead of staying in the net-defined post).
 - Flag no longer needs to keep track of sequential posts and other convoluted logic
 - Removed the introduced direct dependency of "Flag" to "Post predeterminedPost"
 - Removed the behavior change of flags showing next spawn on pickup by default.
 - Removed introduced mutability in both Post and FlagDefinition. Those classes should & must stay immutable.
 - and a few others...
 
 Changes:
  - Flags will (again) require a *unique* post, as they always should have
  - Posts can have children posts (named), and those children posts can be filtered and traversed either sequentially or randomly
  - The old Post is now PostDefinition (the map-level feature) and Post is now a match-time feature, which holds the required state to know which post definition to use at each time.
  - A Post may rely directly on a SinglePost, or in a CompositePost (which contains several single posts inside)
  
  
Example XMLs:
Simple flag with one post
```xml
<flag ...>
    <post>x,y,z</post>
</flag>
```

Flag with 3 posts, will randomly use one of them. The first post defined must contain the flag on match load, it is the fallback post.
```xml
<flag ... >
    <post>
        <post name="Center">x,y,z</post>
        <post name="East">x,y,z</post>
        <post name="West">x,y,z</post>
    </post>
</flag>
```

Flag with 3 posts, center is the default and start position, but the flag won't respawn on it after match start due to the filter.
In this case fallback was specified, but otherwise it would just pick the first post.

If all filters disallow, the fallback WILL be used even if its filter denies.
Because of sequential = true, the flag will always bounce between east and west (center isn't used)
```xml
<flag ... >
    <post sequential="true" fallback="center-post">
        <post id="center-post" name="Center" respawn-filter="never">x,y,z</post>
        <post name="East">x,y,z</post>
        <post name="West">x,y,z</post>
    </post>
</flag>
```

The same as above, but the post is defined separately, and referenced as a flag attribute instead of embedded.
```xml
<flags>
    <post id="flag-post" sequential="true">
        <post name="Center" respawn-filter="never">x,y,z</post>
        <post name="East">x,y,z</post>
        <post name="West">x,y,z</post>
    </post>
    <flag post="flag-post"/>
</flags>
 ```

 Note: this still requires testing.
 Note 2: while this PR implements most of the functionality in #759, it does not implement the last-post filter. If it still is required it can be added in a future PR.
 
 Special thanks to @calcastor for testing the feature
 
## Edit:
Also renamed Net to NetDefinition, now all 3 flag-related-definitions are suffixed with Definition, while Flag and Post refer to the match-time objects. Also added a specific deprecation notice that points to the documentation as well as this issue.