### PR TITLE
Prevent team balance broadcast when disabled

### DIFF
--- a/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
@@ -73,7 +74,9 @@ public class StartCountdown extends PreMatchCountdown {
       for (Team team : this.tmm.getParticipatingTeams()) {
         if (team.isStacked()) {
           this.balanceWarningSent = true;
-          getMatch().sendWarning(translatable("match.balanceTeams", team.getName()));
+          if (isBalanceBroadcasted()) {
+            getMatch().sendWarning(translatable("match.balanceTeams", team.getName()));
+          }
         }
       }
 
@@ -98,5 +101,9 @@ public class StartCountdown extends PreMatchCountdown {
 
   public boolean isForced() {
     return forced;
+  }
+
+  private boolean isBalanceBroadcasted() {
+    return PGM.get().getConfiguration().shouldBalanceJoin();
   }
 }


### PR DESCRIPTION
# Prevent team balance broadcast when disabled

Currently the team balance warning _always_ broadcasts when applicable, regardless of the `join.balance` config value. This is unintended behavior and may confuse players/server owners. As a remedy this PR adds a simple check to ensure the warning is only broadcasted when the feature is enabled 👍 


Signed-off-by: applenick <applenick@users.noreply.github.com>