### PR TITLE
Make sure the match is loaded when checking for initial dynamic filter responses

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/filter/Filter.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/Filter.java
@@ -44,7 +44,8 @@ public interface Filter {
       case DENY:
         return false;
       default:
-        throw new UnsupportedOperationException("Filter did not respond to the query");
+        throw new UnsupportedOperationException(
+            "Filter " + this + " did not respond to the query " + query);
     }
   }
 


### PR DESCRIPTION
The old implementation would query the filters at register time, but if some filter was looking for a match time object which was not yet loaded and therefore abstained it would throw an error during register. (e.g GoalFilter)

The new implementation postpones the initial dispatch of dynamic filter responses until the match is done loading to make sure the context is fully loaded.
Signed-off-by: KingSimon <19822231+KingOfSquares@users.noreply.github.com>