### PR TITLE
Remove adventure library relocation

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,10 +68,6 @@
                             <shadedPattern>tc.oc.pgm.lib.app.ashcon.intake</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>net.kyori</pattern>
-                            <shadedPattern>tc.oc.pgm.lib.net.kyori</shadedPattern>
-                        </relocation>
-                        <relocation>
                             <pattern>fr.mrmicky</pattern>
                             <shadedPattern>tc.oc.pgm.lib.fr.mrmicky</shadedPattern>
                         </relocation>


### PR DESCRIPTION
This change has been in #722 since it was opened, but is likely a change that should be applied to upstream asap. 

At the moment PGM relocates all calls to the adventure text library. While this has the benefit of third party plugins not having to manage adventure directly, it's a practice that introduces limitations for plugins who may not wish to completely depend on PGM. Since adventure has matured into a rather standard library these days, I don't foresee developers having any issues managing this dependency manually. 


⚠️ **WARNING**: This is a breaking change for third-party plugins! If merged, it will require plugins who call the PGM api to fix their imports. Albeit, most should be relatively easy to fix such as changing `tc.oc.pgm.lib.net.kyori.` to `net.kyori.`


Signed-off-by: applenick <applenick@users.noreply.github.com>