### PR TITLE
Fix banner placement exception breaking flags

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/state/Uncarried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Uncarried.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -67,7 +68,9 @@ public abstract class Uncarried extends Spawned {
       oldBase.getBlock().setType(Material.ICE, false);
     }
 
-    Materials.placeStanding(this.location, this.flag.getBannerMeta());
+    if (!Materials.placeStanding(this.location, this.flag.getBannerMeta())) {
+      PGM.get().getGameLogger().severe("Failed to place banner at " + this.location);
+    }
 
     this.labelEntity =
         this.location.getWorld().spawn(this.location.clone().add(0, 1.7, 0), ArmorStand.class);

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -188,17 +188,22 @@ public interface Materials {
     block.setPatterns(meta.getPatterns());
   }
 
-  static void placeStanding(Location location, BannerMeta meta) {
+  static boolean placeStanding(Location location, BannerMeta meta) {
     Block block = location.getBlock();
-    block.setType(Material.STANDING_BANNER);
+    block.setType(Material.STANDING_BANNER, false);
 
-    Banner banner = (Banner) block.getState();
-    applyToBlock(banner, meta);
+    final BlockState state = block.getState();
+    if (state instanceof Banner) {
+      Banner banner = (Banner) block.getState();
+      applyToBlock(banner, meta);
 
-    org.bukkit.material.Banner material = (org.bukkit.material.Banner) banner.getData();
-    material.setFacingDirection(BlockFaces.yawToFace(location.getYaw()));
-    banner.setData(material);
-    banner.update(true);
+      org.bukkit.material.Banner material = (org.bukkit.material.Banner) banner.getData();
+      material.setFacingDirection(BlockFaces.yawToFace(location.getYaw()));
+      banner.setData(material);
+      banner.update(true, false);
+      return true;
+    }
+    return false;
   }
 
   static Location getLocationWithYaw(Banner block) {


### PR DESCRIPTION
Fixes #992 

The issue was that when a banner was placed, it caused block updates which could cause that newly placed banner to pop-out, causing a cast exception when trying to use the block metadata as a banner.

This pr addresses the issue in 2 ways:
 - Do not apply physics when placing banners, this removes the block updates that pop-out the banner
 - Check if the block state is a banner before doing anything with it. This prevents the exception that could cause the banner to become unpickable (since label entity doesn't get to initialize).