### PR TITLE
Display shared cores & destroyables as shared

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
@@ -7,16 +7,18 @@ import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.util.text.TemporalComponent.clock;
 
 import app.ashcon.intake.Command;
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.api.match.Match;
@@ -114,51 +116,56 @@ public final class MatchCommand {
 
     viewer.sendMessage(join(text(" | ", NamedTextColor.DARK_GRAY), teamCountParts));
 
+    if (!haveGameInfo) return;
+
     GoalMatchModule gmm = match.getModule(GoalMatchModule.class);
-    if (haveGameInfo && gmm != null) {
-      if (tmm != null && gmm.getGoalsByCompetitor().size() > 0) {
-        Multimap<Team, Component> teamGoalTexts = HashMultimap.create();
+    if (gmm != null && tmm != null && gmm.getGoalsByCompetitor().size() > 0) {
+      Multimap<Team, Component> teamGoalTexts = LinkedHashMultimap.create();
+      Map<Goal<?>, Component> sharedGoalTexts = new LinkedHashMap<>();
 
-        MatchPlayer player = getMatchPlayer(sender, match);
+      MatchPlayer player = getMatchPlayer(sender, match);
+      Party viewingParty = player == null ? match.getDefaultParty() : player.getParty();
 
-        for (Team team : tmm.getParticipatingTeams()) {
-          for (Goal<?> goal : gmm.getGoals(team)) {
-            if (goal.isVisible()) {
-              if (player != null) {
-                teamGoalTexts.put(
-                    team, renderGoal(goal, player.getCompetitor(), player.getParty()));
-              } else {
-                teamGoalTexts.put(team, renderGoal(goal, null, match.getDefaultParty()));
-              }
+      for (Team team : tmm.getParticipatingTeams()) {
+        for (Goal<?> goal : gmm.getGoals(team)) {
+          if (goal.isVisible()) {
+            if (goal.isShared()) {
+              sharedGoalTexts.computeIfAbsent(goal, g -> renderGoal(g, null, viewingParty));
+            } else if (player != null) {
+              teamGoalTexts.put(team, renderGoal(goal, player.getCompetitor(), viewingParty));
+            } else {
+              teamGoalTexts.put(team, renderGoal(goal, null, viewingParty));
             }
           }
         }
-
-        if (!teamGoalTexts.isEmpty()) {
-          viewer.sendMessage(
-              translatable("match.info.goals").append(text(":")).color(NamedTextColor.DARK_PURPLE));
-
-          for (Map.Entry<Team, Collection<Component>> entry : teamGoalTexts.asMap().entrySet()) {
-            Team team = entry.getKey();
-            Collection<Component> goalTexts = entry.getValue();
-
-            viewer.sendMessage(
-                text()
-                    .append(space())
-                    .append(space())
-                    .append(team.getName())
-                    .append(text(": ", NamedTextColor.GRAY))
-                    .append(join(text("  "), goalTexts))
-                    .build());
-          }
-        }
-      } else {
-        // FIXME: this is not the best way to handle scores
-        ScoreMatchModule smm = match.getModule(ScoreMatchModule.class);
-        if (smm != null) {
-          viewer.sendMessage(smm.getStatusMessage(getMatchPlayer(sender, match)));
-        }
       }
+
+      if (!teamGoalTexts.isEmpty() || !sharedGoalTexts.isEmpty()) {
+        viewer.sendMessage(
+            translatable("match.info.goals").append(text(":")).color(NamedTextColor.DARK_PURPLE));
+
+        // Team goals
+        for (Map.Entry<Team, Collection<Component>> entry : teamGoalTexts.asMap().entrySet()) {
+          Team team = entry.getKey();
+          Collection<Component> goalTexts = entry.getValue();
+
+          viewer.sendMessage(
+              text()
+                  .append(space())
+                  .append(space())
+                  .append(team.getName())
+                  .append(text(": ", NamedTextColor.GRAY))
+                  .append(join(text("  "), goalTexts))
+                  .build());
+        }
+        // Shared goals
+        viewer.sendMessage(join(text("  "), sharedGoalTexts.values()));
+      }
+    }
+
+    ScoreMatchModule smm = match.getModule(ScoreMatchModule.class);
+    if (smm != null) {
+      viewer.sendMessage(smm.getStatusMessage(getMatchPlayer(sender, match)));
     }
   }
 
@@ -176,13 +183,17 @@ public final class MatchCommand {
             goal.renderSidebarStatusText(competitor, viewingParty),
             TextFormatter.convert(goal.renderSidebarStatusColor(competitor, viewingParty))));
 
+    sb.append(space());
     if (goal instanceof ProximityGoal) {
-      sb.append(space());
-      // Show teams their own proximity on shared goals
-      sb.append(text(((ProximityGoal) goal).renderProximity(competitor, viewingParty)));
+      ProximityGoal<?> proxGoal = (ProximityGoal<?>) goal;
+      String proximityText = proxGoal.renderProximity(competitor, viewingParty);
+      if (proximityText != null && !proximityText.isEmpty()) {
+        ChatColor proximityColor = proxGoal.renderProximityColor(competitor, viewingParty);
+        sb.append(text(proximityText, TextFormatter.convert(proximityColor)));
+        sb.append(space());
+      }
     }
 
-    sb.append(space());
     sb.append(
         goal.renderSidebarLabelText(competitor, viewingParty)
             .color(TextFormatter.convert(goal.renderSidebarLabelColor(competitor, viewingParty))));

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -45,6 +45,7 @@ public class Core extends TouchableGoal<CoreFactory>
   protected final FiniteBlockRegion lavaRegion;
   protected final Region leakRegion;
   protected final int leakRequired;
+  protected final boolean isShared;
 
   protected MaterialData material;
   protected int leak = 0;
@@ -88,6 +89,7 @@ public class Core extends TouchableGoal<CoreFactory>
     this.leakRegion = new CuboidRegion(min, max);
 
     this.leakRequired = lavaRegion.getBounds().getMin().getBlockY() - max.getBlockY() + 1;
+    this.isShared = match.getCompetitors().stream().filter(this::canComplete).count() != 1;
   }
 
   // Remove @Nullable
@@ -172,7 +174,7 @@ public class Core extends TouchableGoal<CoreFactory>
 
   @Override
   public boolean isShared() {
-    return false;
+    return isShared;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -67,6 +67,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
   protected final FiniteBlockRegion blockRegion;
   protected final Set<SingleMaterialMatcher> materialPatterns = new HashSet<>();
   protected final Set<MaterialData> materials = new HashSet<>();
+  protected final boolean isShared;
 
   // The percentage of blocks that must be broken for the entire Destroyable to be destroyed.
   protected double destructionRequired;
@@ -127,6 +128,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     }
 
     this.recalculateHealth();
+    this.isShared = match.getCompetitors().stream().filter(this::canComplete).count() != 1;
   }
 
   // Remove @Nullable
@@ -517,7 +519,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
 
   @Override
   public String renderSidebarStatusText(@Nullable Competitor competitor, Party viewer) {
-    if (this.getShowProgress() || viewer.isObserving()) {
+    if (this.getShowProgress() || (viewer.isObserving() && this.getBreaksRequired() > 1)) {
       String text = this.renderCompletion();
       if (PGM.get().getConfiguration().showProximity()) {
         String precise = this.renderPreciseCompletion();
@@ -542,7 +544,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
 
   @Override
   public boolean isShared() {
-    return false;
+    return isShared;
   }
 
   @Override


### PR DESCRIPTION
Fixes #967 

Additionally, it fixes shared objectives not showing in /match correctly (showing under each team instead), shows them in a non-arbitrary order, and prevents observers getting a % completion for destroyables with a single block.