### PR TITLE
Cleanup timelock module check in the start of a match

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -292,20 +292,15 @@ public class PGMListener implements Listener {
 
   @EventHandler
   public void unlockTime(final MatchStartEvent event) {
-    // if there is a timelock module and it is off, unlock time
-    boolean unlockTime = !event.getMatch().getModule(WorldTimeModule.class).isTimeLocked();
-
-    GameRulesMatchModule gameRulesMatchModule =
-        event.getMatch().getModule(GameRulesMatchModule.class);
-    if (gameRulesMatchModule != null
-        && Boolean.parseBoolean(
-            gameRulesMatchModule.getGameRule(GameRule.DO_DAYLIGHT_CYCLE.getId()))) {
-      unlockTime = true;
-    }
     event
         .getMatch()
         .getWorld()
-        .setGameRuleValue(GameRule.DO_DAYLIGHT_CYCLE.getId(), Boolean.toString(unlockTime));
+        .setGameRuleValue(
+            GameRule.DO_DAYLIGHT_CYCLE.getId(),
+            event
+                .getMatch()
+                .needModule(GameRulesMatchModule.class)
+                .getGameRule(GameRule.DO_DAYLIGHT_CYCLE.getId()));
   }
 
   @EventHandler


### PR DESCRIPTION
Because GameRulesMatchModule already sets the value of doDaylightCycle based on the setting of `<timelock>` (defaults on, so always set) or doDaylightCycle in `<gamerules>` (overrides `<timelock>` if present), there's some unnecessary steps taken in PGMListener that have been simplified here. This changes PGMListener to only check for the value of the rule in GameRulesMatchModule directly, consistent with how rules for fire tick are set.