### PR TITLE
Implement players filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/filter/Filter.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/Filter.java
@@ -32,6 +32,10 @@ public interface Filter {
     return ImmutableList.of();
   }
 
+  default boolean isDynamic() {
+    return !getRelevantEvents().isEmpty();
+  }
+
   /** Least-derived query type that this filter might not abstain from */
   Class<? extends Query> getQueryType();
 

--- a/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterParser.java
@@ -616,4 +616,18 @@ public abstract class FilterParser {
   public PlayerBlockQueryModifier parsePlayerFilter(Element el) throws InvalidXMLException {
     return new PlayerBlockQueryModifier(parseChild(el));
   }
+
+  @MethodParser("players")
+  public PlayerCountFilter parsePlayerCountFilter(Element el) throws InvalidXMLException {
+    Filter child =
+        el.getChildren().isEmpty()
+            ? parseFilterProperty(el, "filter", StaticFilter.ALLOW)
+            : parseChild(el);
+
+    return new PlayerCountFilter(
+        child,
+        XMLUtils.parseNumericRange(el, Integer.class, Range.atLeast(1)),
+        XMLUtils.parseBoolean(el.getAttribute("participants"), true),
+        XMLUtils.parseBoolean(el.getAttribute("observers"), false));
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/PlayerCountFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/PlayerCountFilter.java
@@ -1,0 +1,59 @@
+package tc.oc.pgm.filters;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Range;
+import java.util.Collection;
+import org.bukkit.event.Event;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.query.MatchQuery;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.PlayerPartyChangeEvent;
+
+public class PlayerCountFilter extends TypedFilter<MatchQuery> {
+  private final Filter filter;
+  private final int min, max;
+
+  public PlayerCountFilter(
+      Filter filter, Range<Integer> range, boolean participants, boolean observers) {
+    if (!observers) filter = AllFilter.of(ParticipatingFilter.PARTICIPATING, filter);
+    if (!participants) filter = AllFilter.of(ParticipatingFilter.OBSERVING, filter);
+    this.filter = filter;
+    this.min =
+        !range.hasLowerBound()
+            ? Integer.MIN_VALUE
+            : range.lowerEndpoint() + (range.lowerBoundType() == BoundType.CLOSED ? 0 : 1);
+    this.max =
+        !range.hasUpperBound()
+            ? Integer.MAX_VALUE
+            : range.upperEndpoint() - (range.upperBoundType() == BoundType.CLOSED ? 0 : 1);
+  }
+
+  @Override
+  public Collection<Class<? extends Event>> getRelevantEvents() {
+    return ImmutableList.copyOf(
+        Iterables.concat(
+            filter.getRelevantEvents(), ImmutableList.of(PlayerPartyChangeEvent.class)));
+  }
+
+  @Override
+  public Class<? extends MatchQuery> getQueryType() {
+    return MatchQuery.class;
+  }
+
+  @Override
+  protected QueryResponse queryTyped(MatchQuery query) {
+    Collection<MatchPlayer> allPlayers = query.getMatch().getPlayers();
+
+    int allowed = 0, potentialMax = allPlayers.size();
+    for (MatchPlayer player : allPlayers) {
+      if (allowed > max || potentialMax < min) return QueryResponse.DENY;
+      if (allowed >= min && potentialMax >= max) return QueryResponse.ALLOW;
+
+      if (filter.query(player).isAllowed()) allowed++;
+      else potentialMax--;
+    }
+    return QueryResponse.fromBoolean(allowed >= min && allowed <= max);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/filters/dynamic/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/dynamic/FilterMatchModule.java
@@ -97,7 +97,7 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
         .rowKeySet()
         .forEach(
             filter -> {
-              if (filter.getRelevantEvents().isEmpty()) {
+              if (!filter.isDynamic()) {
                 match
                     .getLogger()
                     .warning("Filter " + filter + " was submitted as a dynamic filter but is not!");


### PR DESCRIPTION
Re-introduces the <players> filter, which matches if the inner filter matches for a certain range of players

Example:
```xml
<players min="3" max="5">
  <crouching/>
</players>
```
Will match if there are between 3 and 5 players crouching. 

The filter defaults to always, meaning you can also use the following syntax to match if there's less than 5 players on the match:
```xml
<players max="5"/>
```

Max defaults to infinite, min defaults to 1.
It also has `participants` (defaults to true) and `observers` (defaults to false) for if participating players and observing players respectively should be included.

Note: this has not yet been tested
Note for @KingOfSquares, this will probably require extra work and a reactor to work, but that's reliant on monostable filters PR. Currently a player change party event invalidates the player, but not the current match, so i assume it won't actually make this filter re-compute when a player switches team, meaning it won't function dynamically as expected.