### PR TITLE
Force location queries to check center of block

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/filter/query/LocationQuery.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/query/LocationQuery.java
@@ -1,7 +1,12 @@
 package tc.oc.pgm.api.filter.query;
 
 import org.bukkit.Location;
+import tc.oc.pgm.util.block.BlockVectors;
 
 public interface LocationQuery extends MatchQuery {
   Location getLocation();
+
+  default Location getBlockCenter() {
+    return BlockVectors.center(getLocation());
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/api/region/Region.java
+++ b/core/src/main/java/tc/oc/pgm/api/region/Region.java
@@ -11,6 +11,7 @@ import org.bukkit.event.Event;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.query.LocationQuery;
 import tc.oc.pgm.regions.Bounds;
 
 /** Represents an arbitrary region in a Bukkit world. */
@@ -32,6 +33,9 @@ public interface Region extends Filter {
 
   /** Test if the region contains the given entity */
   boolean contains(Entity entity);
+
+  /** Test if the region contains the queried location */
+  boolean contains(LocationQuery query);
 
   /** Test if moving from the first point to the second crosses into the region */
   boolean enters(Location from, Location to);

--- a/core/src/main/java/tc/oc/pgm/filters/dynamic/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/dynamic/FilterMatchModule.java
@@ -436,7 +436,6 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
     // We can't wait until the end of the tick because the player could move several
     // more times by then (i.e. if we received multiple packets from them in the same
     // tick) which would make region checks highly unreliable.
-    PGM.get().getMatchManager().getPlayer(event.getPlayer());
     MatchPlayer player = match.getPlayer(event.getPlayer());
 
     if (player != null) {

--- a/core/src/main/java/tc/oc/pgm/filters/query/PlayerQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/PlayerQuery.java
@@ -3,7 +3,6 @@ package tc.oc.pgm.filters.query;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.bukkit.Location;
@@ -17,14 +16,14 @@ import tc.oc.pgm.api.player.MatchPlayer;
 public class PlayerQuery extends Query implements tc.oc.pgm.api.filter.query.PlayerQuery {
 
   private final MatchPlayer player;
-  private final Optional<Location> location;
+  private final Location location;
+  private final Location blockCenter;
 
-  // TODO: remove this implementation? only needed usage if for a query where the location is not
-  // the location of the player
   public PlayerQuery(@Nullable Event event, MatchPlayer player, @Nullable Location location) {
     super(event);
     this.player = checkNotNull(player);
-    this.location = Optional.ofNullable(location);
+    this.location = location != null ? location : player.getBukkit().getLocation();
+    this.blockCenter = this.location.getBlock().getLocation();
   }
 
   public PlayerQuery(@Nullable Event event, MatchPlayer player) {
@@ -58,7 +57,12 @@ public class PlayerQuery extends Query implements tc.oc.pgm.api.filter.query.Pla
 
   @Override
   public Location getLocation() {
-    return location.orElse(player.getBukkit().getLocation());
+    return location;
+  }
+
+  @Override
+  public Location getBlockCenter() {
+    return blockCenter;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/regions/AbstractRegion.java
+++ b/core/src/main/java/tc/oc/pgm/regions/AbstractRegion.java
@@ -48,6 +48,11 @@ public abstract class AbstractRegion extends TypedFilter<LocationQuery>
   }
 
   @Override
+  public boolean contains(LocationQuery query) {
+    return this.contains(query.getBlockCenter());
+  }
+
+  @Override
   public boolean enters(Location from, Location to) {
     return !this.contains(from) && this.contains(to);
   }
@@ -122,6 +127,6 @@ public abstract class AbstractRegion extends TypedFilter<LocationQuery>
 
   @Override
   protected QueryResponse queryTyped(LocationQuery query) {
-    return QueryResponse.fromBoolean(contains(query.getLocation()));
+    return QueryResponse.fromBoolean(contains(query));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/regions/XMLRegionReference.java
+++ b/core/src/main/java/tc/oc/pgm/regions/XMLRegionReference.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
+import tc.oc.pgm.api.filter.query.LocationQuery;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.api.region.RegionDefinition;
@@ -63,6 +64,11 @@ public class XMLRegionReference extends XMLFeatureReference<RegionDefinition> im
   @Override
   public boolean contains(Entity entity) {
     return get().contains(entity);
+  }
+
+  @Override
+  public boolean contains(LocationQuery query) {
+    return get().contains(query);
   }
 
   @Override


### PR DESCRIPTION
This makes a `LocationQuery` use the center of a block when checking if the player is inside a region. Region checks use the PlayerCoarseMoveEvent which happens when a player enters or leaves a whole block, when combined with a  `contains` check using the player's actual coordinates results in counting them as being in a region below them when they're not.

This was noticed when shifting/standing above a scorebox/portal that shared the same region.  Take the below example:

```xml
<cuboid id="blue-scorebox" min="1825,7,-1361" max="1828,9,-1364"/>
```
If a player was stood on top of the block at the max of this region (y = 9.0 exactly) then the portal's `contains` check matches but the scoreboxes `enters` check does not. Portals (dynamic)(and other region `contains` LocationQuery checks) are currently using the players location to detect if they are in the region which triggers the portal when they're not inside the region causing them to be prematurely teleport and not receive points.

This can be seen here: https://discord.com/channels/86514356862320640/172382420954251264/962731072234328214

Whilst tinkering with the above checking through the stack of events and methods the below changes were also identified.

~~- Replace the usage of `PlayerQuery` (without location) in the `RegionMatchModule` with the player itself as the player is already a query (due to the dynamic changes). This allows the `PlayerQuery` to be changed to be a `PlayerWithLocationQuery` used only for checking locations that are not the player's current location (only used in flag drop locations atm).~~

~~- The above change also means that the `event` is passed with the `rfa` check and `query` as it is no longer contained in the `PlayerQuery` wrapper (so needs to be passed so it can be cancelled if needed).~~

- Removes a duplicate call to get the PGM player inside the `FilterMatchModule`.

Signed-off-by: Pugzy <pugzy@mail.com>