### PR TITLE
Add splash potions entity to Spawner module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.spawner;
 
+import java.util.Objects;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
@@ -36,7 +37,6 @@ public class Spawner implements Listener, Tickable {
   public Spawner(SpawnerDefinition definition, Match match) {
     this.definition = definition;
     this.match = match;
-
     this.lastTick = match.getTick().tick;
     this.players = new OnlinePlayerMapAdapter<>(PGM.get());
     calculateDelay();
@@ -51,7 +51,6 @@ public class Spawner implements Listener, Tickable {
             definition.spawnRegion.getRandom(match.getRandom()).toLocation(match.getWorld());
         spawnable.spawn(location, match);
         match.getWorld().spigot().playEffect(location, Effect.FLAME, 0, 0, 0, 0.15f, 0, 0, 40, 64);
-
         spawnedEntities = spawnedEntities + spawnable.getSpawnCount();
       }
       calculateDelay();
@@ -102,18 +101,18 @@ public class Spawner implements Listener, Tickable {
       return;
     }
 
-    int entitySpawnerID = -1;
-    int targetSpawnerID = -1;
+    String entitySpawnerId = "";
+    String targetSpawnerId = "";
     if (event.getEntity().hasMetadata(METADATA_KEY)) {
-      entitySpawnerID =
-          MetadataUtils.getMetadata(event.getEntity(), METADATA_KEY, PGM.get()).asInt();
+      entitySpawnerId =
+          MetadataUtils.getMetadata(event.getEntity(), METADATA_KEY, PGM.get()).toString();
     }
     if (event.getTarget().hasMetadata(METADATA_KEY)) {
-      targetSpawnerID =
-          MetadataUtils.getMetadata(event.getTarget(), METADATA_KEY, PGM.get()).asInt();
+      targetSpawnerId =
+          MetadataUtils.getMetadata(event.getTarget(), METADATA_KEY, PGM.get()).toString();
     }
     // Cancel the merge if the items are from different PGM spawners
-    if (entitySpawnerID != targetSpawnerID) {
+    if (!entitySpawnerId.equals(targetSpawnerId)) {
       event.setCancelled(true);
       return;
     }
@@ -121,8 +120,8 @@ public class Spawner implements Listener, Tickable {
 
   private void handleEntityRemoveEvent(Metadatable metadatable, int amount) {
     if (metadatable.hasMetadata(METADATA_KEY)) {
-      if (MetadataUtils.getMetadata(metadatable, METADATA_KEY, PGM.get()).asInt()
-          == definition.numericID) {
+      if (Objects.equals(
+          MetadataUtils.getMetadata(metadatable, METADATA_KEY, PGM.get()), definition.numericId)) {
         spawnedEntities -= amount;
         spawnedEntities = Math.max(0, spawnedEntities);
       }

--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -81,47 +81,23 @@ public class Spawner implements Listener, Tickable {
 
   @EventHandler(priority = EventPriority.HIGHEST)
   public void onItemMerge(ItemMergeEvent event) {
-    boolean entityTracked = false;
-    boolean targetTracked = false;
-    if (event.getEntity().hasMetadata(METADATA_KEY)) {
-      entityTracked = true;
-    }
-    if (event.getTarget().hasMetadata(METADATA_KEY)) {
-      targetTracked = true;
-    }
-
-    // Do nothing if neither item is from a PGM Spawner
-    if (!entityTracked && !targetTracked) {
-      return;
-    }
-
-    // Cancel the merge if only 1 of the items is from a PGM Spawner
-    if ((entityTracked && !targetTracked) || (!entityTracked && targetTracked)) {
-      event.setCancelled(true);
-      return;
-    }
-
-    String entitySpawnerId = "";
-    String targetSpawnerId = "";
-    if (event.getEntity().hasMetadata(METADATA_KEY)) {
-      entitySpawnerId =
+    boolean entityTracked = event.getEntity().hasMetadata(METADATA_KEY);
+    boolean targetTracked = event.getTarget().hasMetadata(METADATA_KEY);
+    if (!entityTracked && !targetTracked) return; // None affected
+    if (entityTracked && targetTracked) {
+      String entitySpawnerId =
           MetadataUtils.getMetadata(event.getEntity(), METADATA_KEY, PGM.get()).toString();
-    }
-    if (event.getTarget().hasMetadata(METADATA_KEY)) {
-      targetSpawnerId =
+      String targetSpawnerId =
           MetadataUtils.getMetadata(event.getTarget(), METADATA_KEY, PGM.get()).toString();
+      if (entitySpawnerId.equals(targetSpawnerId)) return; // Same spawner, allow merge
     }
-    // Cancel the merge if the items are from different PGM spawners
-    if (!entitySpawnerId.equals(targetSpawnerId)) {
-      event.setCancelled(true);
-      return;
-    }
+    event.setCancelled(true);
   }
 
   private void handleEntityRemoveEvent(Metadatable metadatable, int amount) {
     if (metadatable.hasMetadata(METADATA_KEY)) {
       if (Objects.equals(
-          MetadataUtils.getMetadata(metadatable, METADATA_KEY, PGM.get()), definition.numericId)) {
+          MetadataUtils.getMetadata(metadatable, METADATA_KEY, PGM.get()), definition.getId())) {
         spawnedEntities -= amount;
         spawnedEntities = Math.max(0, spawnedEntities);
       }

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
@@ -10,16 +10,16 @@ import tc.oc.pgm.api.region.Region;
 @FeatureInfo(name = "spawner")
 public class SpawnerDefinition implements FeatureDefinition {
 
+  public final String numericId;
   public final Region spawnRegion;
   public final Region playerRegion;
   public final int maxEntities;
   public final Duration minDelay, maxDelay, delay;
   public final List<Spawnable> objects;
   public final Filter playerFilter;
-  public final int numericID;
 
   public SpawnerDefinition(
-      int numericID,
+      String numericId,
       List<Spawnable> objects,
       Region spawnRegion,
       Region playerRegion,
@@ -28,7 +28,7 @@ public class SpawnerDefinition implements FeatureDefinition {
       Duration minDelay,
       Duration maxDelay,
       int maxEntities) {
-    this.numericID = numericID;
+    this.numericId = numericId;
     this.spawnRegion = spawnRegion;
     this.playerRegion = playerRegion;
     this.maxEntities = maxEntities;

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
@@ -19,6 +19,7 @@ public class SpawnerDefinition implements FeatureDefinition {
   public final int numericID;
 
   public SpawnerDefinition(
+      int numericID,
       List<Spawnable> objects,
       Region spawnRegion,
       Region playerRegion,
@@ -26,8 +27,8 @@ public class SpawnerDefinition implements FeatureDefinition {
       Duration delay,
       Duration minDelay,
       Duration maxDelay,
-      int maxEntities,
-      int numericID) {
+      int maxEntities) {
+    this.numericID = numericID;
     this.spawnRegion = spawnRegion;
     this.playerRegion = playerRegion;
     this.maxEntities = maxEntities;
@@ -36,6 +37,5 @@ public class SpawnerDefinition implements FeatureDefinition {
     this.delay = delay;
     this.objects = objects;
     this.playerFilter = playerFilter;
-    this.numericID = numericID;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
@@ -2,6 +2,8 @@ package tc.oc.pgm.spawner;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.region.Region;
@@ -35,5 +37,17 @@ public class SpawnerDefinition extends SelfIdentifyingFeatureDefinition {
     this.delay = delay;
     this.objects = objects;
     this.playerFilter = playerFilter;
+  }
+
+  @Override
+  protected String getDefaultId() {
+    return super.makeDefaultId();
+  }
+
+  public static String makeDefaultId(@Nullable String name, AtomicInteger serial) {
+    return "--"
+        + makeTypeName(SpawnerDefinition.class)
+        + "-"
+        + (name != null ? makeId(name) : serial.getAndIncrement());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
@@ -2,15 +2,13 @@ package tc.oc.pgm.spawner;
 
 import java.time.Duration;
 import java.util.List;
-import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 
 @FeatureInfo(name = "spawner")
-public class SpawnerDefinition implements FeatureDefinition {
-
-  public final String numericId;
+public class SpawnerDefinition extends SelfIdentifyingFeatureDefinition {
   public final Region spawnRegion;
   public final Region playerRegion;
   public final int maxEntities;
@@ -19,7 +17,7 @@ public class SpawnerDefinition implements FeatureDefinition {
   public final Filter playerFilter;
 
   public SpawnerDefinition(
-      String numericId,
+      String id,
       List<Spawnable> objects,
       Region spawnRegion,
       Region playerRegion,
@@ -28,7 +26,7 @@ public class SpawnerDefinition implements FeatureDefinition {
       Duration minDelay,
       Duration maxDelay,
       int maxEntities) {
-    this.numericId = numericId;
+    super(id);
     this.spawnRegion = spawnRegion;
     this.playerRegion = playerRegion;
     this.maxEntities = maxEntities;

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -89,11 +89,14 @@ public class SpawnerModule implements MapModule {
           objects.add(item);
         }
 
+        List<PotionEffect> thrownPotion = new ArrayList<>();
+        // All listed effects for a spawner will be included in one splash potion
         for (Element spawnable :
             XMLUtils.getChildren(element, "potion", "potions", "effect", "effects")) {
           PotionEffect potionEffect = XMLUtils.parsePotionEffect(spawnable);
-          List<PotionEffect> thrownPotion = new ArrayList<>();
           thrownPotion.add(potionEffect);
+        }
+        if (!thrownPotion.isEmpty()) {
           SpawnablePotion potion = new SpawnablePotion(thrownPotion, numericID);
           objects.add(potion);
         }

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -97,10 +97,10 @@ public class SpawnerModule implements MapModule {
           Duration duration = null;
           Integer amplifier = null;
           if (spawnable.getAttribute("duration") != null) {
-            duration = XMLUtils.parseSecondDuration(Node.fromAttr(spawnable), "duration");
+            duration = XMLUtils.parseSecondDuration(Node.fromAttr(spawnable, "duration"));
           }
           if (spawnable.getAttribute("amplifier") != null) {
-            amplifier = XMLUtils.parseNumber(spawnable, Integer.class);
+            amplifier = XMLUtils.parseNumber(spawnable.getAttribute("amplifier"), Integer.class) - 1;
           }
           for (Element effectEl : XMLUtils.getChildren(spawnable, "effect")) {
             Attribute presetDuration = effectEl.getAttribute("duration");
@@ -110,16 +110,16 @@ public class SpawnerModule implements MapModule {
               thrownPotion.add(XMLUtils.parsePotionEffect(effectEl));
             } else if (duration != null) {
               // if <effect> mentions duration and does not mention amplifier
-              if (presetAmplifier == null) {
+              if (presetDuration != null && presetAmplifier == null) {
                 PotionEffect potionEffect =
                     new PotionEffect(
                         presetPotion.getType(),
-                        (int) TimeUtils.toTicks(duration),
+                        (int) TimeUtils.toTicks(XMLUtils.parseSecondDuration(Node.fromAttr(effectEl, "duration"))),
                         presetPotion.getAmplifier());
                 thrownPotion.add(potionEffect);
               }
               // if <effect> does not have duration and has amplifier
-              else if (presetDuration == null) {
+              else if (presetDuration == null && presetAmplifier != null) {
                 PotionEffect potionEffect =
                     new PotionEffect(
                         presetPotion.getType(),
@@ -128,7 +128,7 @@ public class SpawnerModule implements MapModule {
                 thrownPotion.add(potionEffect);
               }
               // if <effect> has neither attributes
-              else if (amplifier != null) {
+              else if (presetDuration == null && amplifier != null) {
                 PotionEffect potionEffect =
                     new PotionEffect(
                         presetPotion.getType(), (int) TimeUtils.toTicks(duration), amplifier);

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -99,22 +99,22 @@ public class SpawnerModule implements MapModule {
           if (potionChildren.isEmpty()) {
             throw new InvalidXMLException("Expected child effects, but found none", spawnerEl);
           }
-          int potionName = 0;
+          int damageValue = 0;
           if (potionEl.getAttribute("damage") != null) {
-            potionName = XMLUtils.parseNumber(potionEl.getAttribute("damage"), Integer.class, 0);
+            damageValue = XMLUtils.parseNumber(potionEl.getAttribute("damage"), Integer.class, 0);
           } else {
             for (PotionEffect potionEffect : potionChildren) {
               // PotionType lists "true" potions, PotionEffectType "potionEffect.getType()" lists
               // all possible status effects (ie wither, blindness, etc)
               // Use the first listed PotionType for potion color
               if (PotionType.getByEffect(potionEffect.getType()) != null) {
-                potionName = PotionType.getByEffect(potionEffect.getType()).getDamageValue();
+                damageValue = PotionType.getByEffect(potionEffect.getType()).getDamageValue();
                 break;
               }
             }
           }
           objects.add(
-              new SpawnablePotion(potionChildren, potionName, "spawner-" + numericId.get()));
+              new SpawnablePotion(potionChildren, damageValue, "spawner-" + numericId.get()));
         }
 
         SpawnerDefinition spawnerDefinition =

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionType;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -98,7 +99,22 @@ public class SpawnerModule implements MapModule {
           if (potionChildren.isEmpty()) {
             throw new InvalidXMLException("Expected child effects, but found none", spawnerEl);
           }
-          objects.add(new SpawnablePotion(potionChildren, "spawner-" + numericId.get()));
+          int potionName = 0;
+          if (potionEl.getAttribute("damage") != null) {
+            potionName = XMLUtils.parseNumber(potionEl.getAttribute("damage"), Integer.class, 0);
+          } else {
+            for (PotionEffect potionEffect : potionChildren) {
+              // PotionType lists "true" potions, PotionEffectType lists all possible status effects
+              // (ie wither)
+              // Use the first listed PotionType for potion color
+              if (PotionType.getByEffect(potionEffect.getType()) != null) {
+                potionName = PotionType.getByEffect(potionEffect.getType()).getDamageValue();
+                break;
+              }
+            }
+          }
+          objects.add(
+              new SpawnablePotion(potionChildren, potionName, "spawner-" + numericId.get()));
         }
 
         SpawnerDefinition spawnerDefinition =

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -24,6 +25,7 @@ import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.spawner.objects.SpawnableItem;
+import tc.oc.pgm.spawner.objects.SpawnablePotion;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
@@ -85,6 +87,15 @@ public class SpawnerModule implements MapModule {
           ItemStack stack = kitParser.parseItem(spawnable, false);
           SpawnableItem item = new SpawnableItem(stack, numericID);
           objects.add(item);
+        }
+
+        for (Element spawnable :
+            XMLUtils.getChildren(element, "potion", "potions", "effect", "effects")) {
+          PotionEffect potionEffect = XMLUtils.parsePotionEffect(spawnable);
+          List<PotionEffect> thrownPotion = new ArrayList<>();
+          thrownPotion.add(potionEffect);
+          SpawnablePotion potion = new SpawnablePotion(thrownPotion, numericID);
+          objects.add(potion);
         }
 
         SpawnerDefinition spawnerDefinition =

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -22,16 +22,13 @@ import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.FilterParser;
 import tc.oc.pgm.filters.StaticFilter;
-import tc.oc.pgm.flag.post.SinglePost;
 import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.spawner.objects.SpawnableItem;
 import tc.oc.pgm.spawner.objects.SpawnablePotion;
-import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.xml.InheritingElement;
 import tc.oc.pgm.util.xml.InvalidXMLException;
-import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class SpawnerModule implements MapModule {

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -83,11 +83,9 @@ public class SpawnerModule implements MapModule {
             filterParser.parseFilterProperty(element, "filter", StaticFilter.ALLOW);
 
         List<Spawnable> objects = new ArrayList<>();
-        for (Element spawnable :
-            XMLUtils.getChildren(
-                element, "item")) { // TODO Add more types of spawnables once entity parser is built
+        for (Element spawnable : XMLUtils.getChildren(element, "item")) {
           ItemStack stack = kitParser.parseItem(spawnable, false);
-          SpawnableItem item = new SpawnableItem(stack, numericId);
+          SpawnableItem item = new SpawnableItem(stack, "spawner-" + numericId);
           objects.add(item);
         }
 
@@ -133,7 +131,7 @@ public class SpawnerModule implements MapModule {
                   effectEl);
             }
           }
-          objects.add(new SpawnablePotion(thrownPotion, numericId));
+          objects.add(new SpawnablePotion(thrownPotion, "spawner-" + numericId));
         }
 
         SpawnerDefinition spawnerDefinition =

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -58,11 +58,16 @@ public class SpawnerModule implements MapModule {
 
       for (Element spawnerEl :
           XMLUtils.flattenElements(doc.getRootElement(), "spawners", "spawner")) {
+        String id = spawnerEl.getAttributeValue("id");
         Region spawnRegion = regionParser.parseRequiredRegionProperty(spawnerEl, "spawn-region");
         Region playerRegion = regionParser.parseRequiredRegionProperty(spawnerEl, "player-region");
         Attribute delayAttr = spawnerEl.getAttribute("delay");
         Attribute minDelayAttr = spawnerEl.getAttribute("min-delay");
         Attribute maxDelayAttr = spawnerEl.getAttribute("max-delay");
+
+        if (spawnerEl.getAttributeValue("id") == null) {
+          id = "spawner-" + numericId.getAndIncrement();
+        }
 
         if ((minDelayAttr != null || maxDelayAttr != null) && delayAttr != null) {
           throw new InvalidXMLException(
@@ -86,12 +91,12 @@ public class SpawnerModule implements MapModule {
         List<Spawnable> objects = new ArrayList<>();
         for (Element itemEl : XMLUtils.getChildren(spawnerEl, "item")) {
           ItemStack stack = kitParser.parseItem(itemEl, false);
-          SpawnableItem item = new SpawnableItem(stack, "spawner-" + numericId.get());
+          SpawnableItem item = new SpawnableItem(stack, id);
           objects.add(item);
         }
 
-        ImmutableList.Builder<PotionEffect> chBuilder = ImmutableList.builder();
         for (Element potionEl : XMLUtils.getChildren(spawnerEl, "potion")) {
+          ImmutableList.Builder<PotionEffect> chBuilder = ImmutableList.builder();
           for (Element potionChild : potionEl.getChildren("effect")) {
             chBuilder.add(XMLUtils.parsePotionEffect(new InheritingElement(potionChild)));
           }
@@ -113,13 +118,12 @@ public class SpawnerModule implements MapModule {
               }
             }
           }
-          objects.add(
-              new SpawnablePotion(potionChildren, damageValue, "spawner-" + numericId.get()));
+          objects.add(new SpawnablePotion(potionChildren, damageValue, id));
         }
 
         SpawnerDefinition spawnerDefinition =
             new SpawnerDefinition(
-                "spawner-" + numericId.getAndIncrement(),
+                id,
                 objects,
                 spawnRegion,
                 playerRegion,

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -104,8 +104,8 @@ public class SpawnerModule implements MapModule {
             potionName = XMLUtils.parseNumber(potionEl.getAttribute("damage"), Integer.class, 0);
           } else {
             for (PotionEffect potionEffect : potionChildren) {
-              // PotionType lists "true" potions, PotionEffectType lists all possible status effects
-              // (ie wither)
+              // PotionType lists "true" potions, PotionEffectType "potionEffect.getType()" lists
+              // all possible status effects (ie wither, blindness, etc)
               // Use the first listed PotionType for potion color
               if (PotionType.getByEffect(potionEffect.getType()) != null) {
                 potionName = PotionType.getByEffect(potionEffect.getType()).getDamageValue();
@@ -119,7 +119,7 @@ public class SpawnerModule implements MapModule {
 
         SpawnerDefinition spawnerDefinition =
             new SpawnerDefinition(
-                numericId.getAndIncrement(),
+                "spawner-" + numericId.getAndIncrement(),
                 objects,
                 spawnRegion,
                 playerRegion,

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -52,7 +52,7 @@ public class SpawnerModule implements MapModule {
       KitParser kitParser = factory.getKits();
       FilterParser filterParser = factory.getFilters();
 
-      int numericID = 0;
+      int numericId = 0;
       for (Element element :
           XMLUtils.flattenElements(doc.getRootElement(), "spawners", "spawner")) {
         Region spawnRegion = regionParser.parseRequiredRegionProperty(element, "spawn-region");
@@ -85,20 +85,17 @@ public class SpawnerModule implements MapModule {
             XMLUtils.getChildren(
                 element, "item")) { // TODO Add more types of spawnables once entity parser is built
           ItemStack stack = kitParser.parseItem(spawnable, false);
-          SpawnableItem item = new SpawnableItem(stack, numericID);
+          SpawnableItem item = new SpawnableItem(stack, numericId);
           objects.add(item);
         }
 
         List<PotionEffect> thrownPotion = new ArrayList<>();
         // All listed effects for a spawner will be included in one splash potion
-        for (Element spawnable :
-            XMLUtils.getChildren(element, "potion", "potions", "effect", "effects")) {
-          PotionEffect potionEffect = XMLUtils.parsePotionEffect(spawnable);
-          thrownPotion.add(potionEffect);
+        for (Element spawnable : XMLUtils.getChildren(element, "potion")) {
+          thrownPotion.add(XMLUtils.parsePotionEffect(spawnable));
         }
         if (!thrownPotion.isEmpty()) {
-          SpawnablePotion potion = new SpawnablePotion(thrownPotion, numericID);
-          objects.add(potion);
+          objects.add(new SpawnablePotion(thrownPotion, numericId));
         }
 
         SpawnerDefinition spawnerDefinition =
@@ -111,10 +108,10 @@ public class SpawnerModule implements MapModule {
                 minDelay,
                 maxDelay,
                 maxEntities,
-                numericID);
+                numericId);
         factory.getFeatures().addFeature(element, spawnerDefinition);
         spawnerModule.spawnerDefinitions.add(spawnerDefinition);
-        numericID++;
+        numericId++;
       }
 
       return spawnerModule.spawnerDefinitions.isEmpty() ? null : spawnerModule;

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnableItem.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnableItem.java
@@ -11,18 +11,18 @@ import tc.oc.pgm.spawner.Spawner;
 
 public class SpawnableItem implements Spawnable {
 
-  private ItemStack stack;
-  private String METADATA_VALUE;
+  private final ItemStack stack;
+  private final String metadataValue;
 
   public SpawnableItem(ItemStack stack, int spawnerId) {
     this.stack = stack;
-    this.METADATA_VALUE = Integer.toString(spawnerId);
+    this.metadataValue = Integer.toString(spawnerId);
   }
 
   @Override
   public void spawn(Location location, Match match) {
     Item item = location.getWorld().dropItem(location, stack);
-    item.setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), METADATA_VALUE));
+    item.setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), metadataValue));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnableItem.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnableItem.java
@@ -14,9 +14,9 @@ public class SpawnableItem implements Spawnable {
   private ItemStack stack;
   private String METADATA_VALUE;
 
-  public SpawnableItem(ItemStack stack, int spawnerID) {
+  public SpawnableItem(ItemStack stack, int spawnerId) {
     this.stack = stack;
-    this.METADATA_VALUE = Integer.toString(spawnerID);
+    this.METADATA_VALUE = Integer.toString(spawnerId);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnableItem.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnableItem.java
@@ -12,17 +12,17 @@ import tc.oc.pgm.spawner.Spawner;
 public class SpawnableItem implements Spawnable {
 
   private final ItemStack stack;
-  private final String metadataValue;
+  private final String spawnerId;
 
-  public SpawnableItem(ItemStack stack, int spawnerId) {
+  public SpawnableItem(ItemStack stack, String spawnerId) {
     this.stack = stack;
-    this.metadataValue = Integer.toString(spawnerId);
+    this.spawnerId = spawnerId;
   }
 
   @Override
   public void spawn(Location location, Match match) {
     Item item = location.getWorld().dropItem(location, stack);
-    item.setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), metadataValue));
+    item.setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), spawnerId));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -15,15 +15,14 @@ import tc.oc.pgm.spawner.Spawner;
 
 public class SpawnablePotion implements Spawnable {
   private final ItemStack potionItem;
-  private final String metadataValue;
+  private final String spawnerId;
 
-  public SpawnablePotion(List<PotionEffect> potion, int spawnerId) {
-    this.metadataValue = Integer.toString(spawnerId);
+  public SpawnablePotion(List<PotionEffect> potion, String spawnerId) {
+    this.spawnerId = spawnerId;
     ItemStack potionItem = new ItemStack(Material.POTION);
     PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
     for (PotionEffect effect : potion) {
-      potionMeta.addCustomEffect(
-          new PotionEffect((effect.getType()), effect.getDuration(), effect.getAmplifier()), false);
+      potionMeta.addCustomEffect(effect, false);
     }
     potionItem.setItemMeta(potionMeta);
     this.potionItem = potionItem;
@@ -33,8 +32,7 @@ public class SpawnablePotion implements Spawnable {
   public void spawn(Location location, Match match) {
     ThrownPotion thrownPotion = location.getWorld().spawn(location, ThrownPotion.class);
     thrownPotion.setItem(potionItem);
-    thrownPotion.setMetadata(
-        Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), metadataValue));
+    thrownPotion.setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), spawnerId));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -1,0 +1,47 @@
+package tc.oc.pgm.spawner.objects;
+
+import java.util.List;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.ThrownPotion;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.potion.PotionEffect;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.spawner.Spawnable;
+import tc.oc.pgm.spawner.Spawner;
+
+public class SpawnablePotion implements Spawnable {
+  private ItemStack potionItem;
+  private String METADATA_VALUE;
+
+  public SpawnablePotion(List<PotionEffect> potion, int spawnerID) {
+    this.METADATA_VALUE = Integer.toString(spawnerID);
+    ItemStack potionItem = new ItemStack(Material.POTION);
+    PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
+    for (PotionEffect effect : potion) {
+      int level = effect.getAmplifier();
+      int duration = effect.getDuration();
+      // type, level, overwrite
+      potionMeta.addCustomEffect(new PotionEffect((effect.getType()), 20 * duration, level), false);
+    }
+    potionItem.setItemMeta(potionMeta);
+    this.potionItem = potionItem;
+  }
+
+  @Override
+  public void spawn(Location location, Match match) {
+    ThrownPotion thrownPotion = location.getWorld().spawn(location, ThrownPotion.class);
+    thrownPotion.setItem(potionItem);
+    thrownPotion.getEffects();
+    thrownPotion.setMetadata(
+        Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), METADATA_VALUE));
+  }
+
+  @Override
+  public int getSpawnCount() {
+    return 0;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -17,8 +17,8 @@ public class SpawnablePotion implements Spawnable {
   private ItemStack potionItem;
   private String METADATA_VALUE;
 
-  public SpawnablePotion(List<PotionEffect> potion, int spawnerID) {
-    this.METADATA_VALUE = Integer.toString(spawnerID);
+  public SpawnablePotion(List<PotionEffect> potion, int spawnerId) {
+    this.METADATA_VALUE = Integer.toString(spawnerId);
     ItemStack potionItem = new ItemStack(Material.POTION);
     PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
     for (PotionEffect effect : potion) {

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -2,11 +2,11 @@ package tc.oc.pgm.spawner.objects;
 
 import java.util.List;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionEffect;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
@@ -17,9 +17,10 @@ public class SpawnablePotion implements Spawnable {
   private final ItemStack potionItem;
   private final String spawnerId;
 
-  public SpawnablePotion(List<PotionEffect> potion, String spawnerId) {
+  public SpawnablePotion(List<PotionEffect> potion, int potionName, String spawnerId) {
     this.spawnerId = spawnerId;
-    ItemStack potionItem = new ItemStack(Material.POTION);
+    // Potion "name" determines potion color
+    ItemStack potionItem = new ItemStack(new Potion(potionName).splash().toItemStack(1));
     PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
     for (PotionEffect effect : potion) {
       potionMeta.addCustomEffect(effect, false);

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -14,11 +14,11 @@ import tc.oc.pgm.spawner.Spawnable;
 import tc.oc.pgm.spawner.Spawner;
 
 public class SpawnablePotion implements Spawnable {
-  private ItemStack potionItem;
-  private String METADATA_VALUE;
+  private final ItemStack potionItem;
+  private final String metadataValue;
 
   public SpawnablePotion(List<PotionEffect> potion, int spawnerId) {
-    this.METADATA_VALUE = Integer.toString(spawnerId);
+    this.metadataValue = Integer.toString(spawnerId);
     ItemStack potionItem = new ItemStack(Material.POTION);
     PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
     for (PotionEffect effect : potion) {
@@ -34,7 +34,7 @@ public class SpawnablePotion implements Spawnable {
     ThrownPotion thrownPotion = location.getWorld().spawn(location, ThrownPotion.class);
     thrownPotion.setItem(potionItem);
     thrownPotion.setMetadata(
-        Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), METADATA_VALUE));
+        Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), metadataValue));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -2,16 +2,14 @@ package tc.oc.pgm.spawner.objects;
 
 import java.util.List;
 import org.bukkit.Location;
-import org.bukkit.entity.ThrownPotion;
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
-import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionEffect;
-import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.spawner.Spawnable;
-import tc.oc.pgm.spawner.Spawner;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 public class SpawnablePotion implements Spawnable {
   private final ItemStack potionItem;
@@ -23,6 +21,7 @@ public class SpawnablePotion implements Spawnable {
     ItemStack potionItem = new Potion(damageValue).splash().toItemStack(1);
     PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
     for (PotionEffect effect : potion) {
+      // overwrite = false
       potionMeta.addCustomEffect(effect, false);
     }
     potionItem.setItemMeta(potionMeta);
@@ -31,9 +30,9 @@ public class SpawnablePotion implements Spawnable {
 
   @Override
   public void spawn(Location location, Match match) {
-    ThrownPotion thrownPotion = location.getWorld().spawn(location, ThrownPotion.class);
-    thrownPotion.setItem(potionItem.clone());
-    thrownPotion.setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), spawnerId));
+    NMSHacks.EntityPotion entityPotion = new NMSHacks.EntityPotion(location, potionItem);
+    // TODO set metadata when necessary
+    ((CraftWorld) location.getWorld()).getHandle().addEntity(entityPotion);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -22,10 +22,8 @@ public class SpawnablePotion implements Spawnable {
     ItemStack potionItem = new ItemStack(Material.POTION);
     PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
     for (PotionEffect effect : potion) {
-      int level = effect.getAmplifier();
-      int duration = effect.getDuration();
-      // type, level, overwrite
-      potionMeta.addCustomEffect(new PotionEffect((effect.getType()), 20 * duration, level), false);
+      potionMeta.addCustomEffect(
+          new PotionEffect((effect.getType()), effect.getDuration(), effect.getAmplifier()), false);
     }
     potionItem.setItemMeta(potionMeta);
     this.potionItem = potionItem;
@@ -35,13 +33,12 @@ public class SpawnablePotion implements Spawnable {
   public void spawn(Location location, Match match) {
     ThrownPotion thrownPotion = location.getWorld().spawn(location, ThrownPotion.class);
     thrownPotion.setItem(potionItem);
-    thrownPotion.getEffects();
     thrownPotion.setMetadata(
         Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), METADATA_VALUE));
   }
 
   @Override
   public int getSpawnCount() {
-    return 0;
+    return potionItem.getAmount();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -31,7 +31,7 @@ public class SpawnablePotion implements Spawnable {
   @Override
   public void spawn(Location location, Match match) {
     ThrownPotion thrownPotion = location.getWorld().spawn(location, ThrownPotion.class);
-    thrownPotion.setItem(potionItem);
+    thrownPotion.setItem(potionItem.clone());
     thrownPotion.setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), spawnerId));
   }
 

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -4,10 +4,13 @@ import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionEffect;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.spawner.Spawnable;
+import tc.oc.pgm.spawner.Spawner;
 import tc.oc.pgm.util.nms.NMSHacks;
 
 public class SpawnablePotion implements Spawnable {
@@ -20,7 +23,6 @@ public class SpawnablePotion implements Spawnable {
     ItemStack potionItem = new Potion(damageValue).splash().toItemStack(1);
     PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
     for (PotionEffect effect : potion) {
-      // overwrite = false
       potionMeta.addCustomEffect(effect, false);
     }
     potionItem.setItemMeta(potionMeta);
@@ -29,8 +31,11 @@ public class SpawnablePotion implements Spawnable {
 
   @Override
   public void spawn(Location location, Match match) {
-    new NMSHacks.EntityPotion(location, potionItem).spawn();
-    // TODO set metadata when necessary
+    NMSHacks.EntityPotion entityPotion = new NMSHacks.EntityPotion(location, potionItem);
+    entityPotion
+        .getBukkitEntity()
+        .setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), spawnerId));
+    entityPotion.spawn();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -29,9 +29,8 @@ public class SpawnablePotion implements Spawnable {
 
   @Override
   public void spawn(Location location, Match match) {
-    NMSHacks.EntityPotion entityPotion = new NMSHacks.EntityPotion(location, potionItem);
+    new NMSHacks.EntityPotion(location, potionItem).spawn();
     // TODO set metadata when necessary
-    entityPotion.spawn();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -17,10 +17,10 @@ public class SpawnablePotion implements Spawnable {
   private final ItemStack potionItem;
   private final String spawnerId;
 
-  public SpawnablePotion(List<PotionEffect> potion, int potionName, String spawnerId) {
+  public SpawnablePotion(List<PotionEffect> potion, int damageValue, String spawnerId) {
     this.spawnerId = spawnerId;
     // Potion "name" determines potion color
-    ItemStack potionItem = new ItemStack(new Potion(potionName).splash().toItemStack(1));
+    ItemStack potionItem = new Potion(damageValue).splash().toItemStack(1);
     PotionMeta potionMeta = (PotionMeta) potionItem.getItemMeta();
     for (PotionEffect effect : potion) {
       potionMeta.addCustomEffect(effect, false);

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.spawner.objects;
 
 import java.util.List;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.Potion;
@@ -32,7 +31,7 @@ public class SpawnablePotion implements Spawnable {
   public void spawn(Location location, Match match) {
     NMSHacks.EntityPotion entityPotion = new NMSHacks.EntityPotion(location, potionItem);
     // TODO set metadata when necessary
-    ((CraftWorld) location.getWorld()).getHandle().addEntity(entityPotion);
+    entityPotion.spawn();
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -1327,6 +1327,17 @@ public interface NMSHacks {
     public void wear(Player viewer, int slot, ItemStack item) {}
   }
 
+  class EntityPotion extends net.minecraft.server.v1_8_R3.EntityPotion {
+    public EntityPotion(Location location, ItemStack potionItem) {
+      super(
+          ((CraftWorld) location.getWorld()).getHandle(),
+          location.getX(),
+          location.getY(),
+          location.getZ(),
+          CraftItemStack.asNMSCopy(potionItem));
+    }
+  }
+
   static void setFireworksExpectedLifespan(Firework firework, int ticks) {
     ((CraftFirework) firework).getHandle().expectedLifespan = ticks;
   }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -1336,6 +1336,10 @@ public interface NMSHacks {
           location.getZ(),
           CraftItemStack.asNMSCopy(potionItem));
     }
+
+    public void spawn() {
+      world.addEntity(this);
+    }
   }
 
   static void setFireworksExpectedLifespan(Firework firework, int ticks) {


### PR DESCRIPTION
This PR adds falling potions (splash potions) as a droppable entity that can be configured with the XML spawner. These are automatically used when using `<effect> <effects> <potion> <potions>`. Some work needs to be done on it first, like fixing the positions that the potions spawn, flame effects, potion colour and so on.

```xml
<spawners>
    <!-- drops a slowness splash potion -->
    <spawner spawn-region="gold-apple" player-region="gold-apple" delay="5s">
        <effect duration="10" amplifier="1">slowness</effect>
    </spawner>
    <!-- drops a splash potion that contains both speed and jumpboost -->
    <spawner spawn-region="arrows" player-region="arrows" delay="5s">
        <effect duration="10" amplifier="3">speed</effect>
        <effect duration="10" amplifier="6">jump_boost</effect>
    </spawner>
</spawners>
```