### PR TITLE
Return all definitions instead of only definitions with ids from FeatureDefinitionContext

### DIFF
--- a/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
+++ b/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
@@ -137,4 +137,9 @@ public class FeatureDefinitionContext extends ContextStore<FeatureDefinition> {
     }
     return errors;
   }
+
+  @Override
+  public Collection<FeatureDefinition> getAll() {
+    return this.definitions;
+  }
 }


### PR DESCRIPTION
Title, 

before this PR calling this method for FeatureDefinitionContext would only return definitions registered with an id, resulting in a loss of stuff like this:

```xml
        <filter>
            <all>
                <time>2m</time>
                <team>hiders</team>
            </all>
        </filter>
```

Should probably be merged before #950 