### PR TITLE
Fix garbage collected references

### DIFF
--- a/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
+++ b/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
@@ -127,14 +127,23 @@ public class FeatureDefinitionContext extends ContextStore<FeatureDefinition> {
     List<InvalidXMLException> errors = new ArrayList<>();
     for (XMLFeatureReference<?> reference : references) {
       try {
-        reference.resolve();
-        for (FeatureValidation validation : validations.get(reference)) {
-          validation.validate(reference.get(), reference.getNode());
-        }
+        resolveReference(reference);
       } catch (InvalidXMLException e) {
         errors.add(e);
       }
     }
     return errors;
+  }
+
+  private <T extends FeatureDefinition> void resolveReference(XMLFeatureReference<T> reference)
+      throws InvalidXMLException {
+    Node node = reference.getNode(); // Get node prior to resolving
+    reference.resolve();
+
+    T value = reference.get();
+    for (FeatureValidation<?> validation : validations.get(reference)) {
+      //noinspection unchecked
+      ((FeatureValidation<T>) validation).validate(value, node);
+    }
   }
 }


### PR DESCRIPTION
XML references are often created in the code passing a `new Node(attribute)` (or element) as parameter for the node, this is only ever stored inside the WeakReference created inside the XMLFeatureReference. What this effectively means is this variable is *always* up for garbage collection, and if any validation needs to run on it, it's possible that the GC has already wiped the variable even just a few MS after creation (in a posterior state of map loading).

This change makes it so it stays a strong reference, because that's required for validation properly reporting what node an exception was on, and wipes it after the node is referenced and resolved, since it no longer is needed after that point.

```
[01:20:55] [ForkJoinPool.commonPool-worker-10/INFO]: [PGM] XML changes detected, reloading
[01:20:55] [ForkJoinPool.commonPool-worker-10/INFO]: [PGM] <home>/maps/github-com-overcastcommunity-publicmaps/fun/arcade/among_us: Unhandled java.lang.IllegalStateException, caused by: Unknown RegionDefinition ID 'spawn' (garbage collected)
[01:20:55] [ForkJoinPool.commonPool-worker-10/WARN]: [PGM] Unhandled java.lang.IllegalStateException
java.lang.IllegalStateException: Unknown RegionDefinition ID 'spawn' (garbage collected)
	at tc.oc.pgm.features.XMLFeatureReference.getNode(XMLFeatureReference.java:51) ~[?:?]
	at tc.oc.pgm.features.FeatureDefinitionContext.resolveReferences(FeatureDefinitionContext.java:132) ~[?:?]
	at tc.oc.pgm.map.MapFactoryImpl.postLoad(MapFactoryImpl.java:118) ~[?:?]
	at tc.oc.pgm.map.MapFactoryImpl.load(MapFactoryImpl.java:100) ~[?:?]
	at tc.oc.pgm.map.MapLibraryImpl.loadMap(MapLibraryImpl.java:191) ~[?:?]
	at tc.oc.pgm.map.MapLibraryImpl.loadMapSafe(MapLibraryImpl.java:218) ~[?:?]
	at tc.oc.pgm.map.MapLibraryImpl.lambda$loadExistingMap$4(MapLibraryImpl.java:184) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604) [?:1.8.0_322]
	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1596) [?:1.8.0_322]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289) [?:1.8.0_322]
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056) [?:1.8.0_322]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692) [?:1.8.0_322]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175) [?:1.8.0_322]
```
