### PR TITLE
Fix race condition loading core/destroyable modes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -70,7 +70,6 @@ public class CoreModule implements MapModule {
   }
 
   public static class Factory implements MapModuleFactory<CoreModule> {
-    private MapFactory factory;
 
     @Override
     public Collection<Class<? extends MapModule>> getWeakDependencies() {
@@ -85,7 +84,6 @@ public class CoreModule implements MapModule {
     @Override
     public CoreModule parse(MapFactory context, Logger logger, Document doc)
         throws InvalidXMLException {
-      this.factory = context;
       List<CoreFactory> coreFactories = Lists.newArrayList();
       HashMap<TeamFactory, Integer> serialNumbers = new HashMap<>();
 
@@ -133,7 +131,7 @@ public class CoreModule implements MapModule {
           if (coreEl.getAttribute("mode-changes") != null) {
             throw new InvalidXMLException("Cannot combine modes and mode-changes", coreEl);
           }
-          modeSet = parseModeSet(modes); // Specific set of modes
+          modeSet = parseModeSet(context, modes); // Specific set of modes
         } else if (XMLUtils.parseBoolean(coreEl.getAttribute("mode-changes"), false)) {
           modeSet = null; // All modes
         } else {
@@ -172,7 +170,8 @@ public class CoreModule implements MapModule {
       }
     }
 
-    public ImmutableSet<Mode> parseModeSet(Node node) throws InvalidXMLException {
+    public ImmutableSet<Mode> parseModeSet(MapFactory factory, Node node)
+        throws InvalidXMLException {
       ImmutableSet.Builder<Mode> modes = ImmutableSet.builder();
       for (String modeId : node.getValue().split("\\s")) {
         Mode mode = factory.getFeatures().get(modeId, Mode.class);

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -67,7 +67,6 @@ public class DestroyableModule implements MapModule {
   }
 
   public static class Factory implements MapModuleFactory<DestroyableModule> {
-    private MapFactory factory;
 
     @Override
     public Collection<Class<? extends MapModule>> getWeakDependencies() {
@@ -82,9 +81,7 @@ public class DestroyableModule implements MapModule {
     @Override
     public DestroyableModule parse(MapFactory context, Logger logger, Document doc)
         throws InvalidXMLException {
-      this.factory = context;
       List<DestroyableFactory> destroyables = Lists.newArrayList();
-      TeamModule teamModule = context.getModule(TeamModule.class);
       RegionParser regionParser = context.getRegions();
 
       for (Element destroyableEl :
@@ -124,7 +121,7 @@ public class DestroyableModule implements MapModule {
           if (destroyableEl.getAttribute("mode-changes") != null) {
             throw new InvalidXMLException("Cannot combine modes and mode-changes", destroyableEl);
           }
-          modeSet = parseModeSet(modes); // Specific set of modes
+          modeSet = parseModeSet(context, modes); // Specific set of modes
         } else if (XMLUtils.parseBoolean(destroyableEl.getAttribute("mode-changes"), false)) {
           modeSet = null; // All modes
         } else {
@@ -168,7 +165,8 @@ public class DestroyableModule implements MapModule {
       }
     }
 
-    public ImmutableSet<Mode> parseModeSet(Node node) throws InvalidXMLException {
+    public ImmutableSet<Mode> parseModeSet(MapFactory factory, Node node)
+        throws InvalidXMLException {
       ImmutableSet.Builder<Mode> modes = ImmutableSet.builder();
       for (String modeId : node.getValue().split("\\s")) {
         Mode mode = factory.getFeatures().get(modeId, Mode.class);


### PR DESCRIPTION
This PR restores statelessness to CoreModule and DestroyableModule factories to resolve a race condition when loading core and monument maps with modes. The race condition resulted in loading errors for these maps due to mismatching of modes between different maps. This issue is most easily observed on servers with a large amount of maps, such as OCC, where well over 1000 maps are loaded at one time.

Debugged and fixed with the help of @Pablete1234