### PR TITLE
Fix fly kit checking wrong element

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -187,9 +187,9 @@ public abstract class KitParser {
    ~ <fly allowFlight="false"/>  {FlyKit: allowFlight = false, flying = null  }
    ~ <fly flying="true"/>        {FlyKit: allowFlight = true,  flying = true  }
   */
-  public FlyKit parseFlyKit(Element el) throws InvalidXMLException {
-    Element child = el.getChild("fly");
-    if (child == null) {
+  public FlyKit parseFlyKit(Element parent) throws InvalidXMLException {
+    Element el = parent.getChild("fly");
+    if (el == null) {
       return null;
     }
 


### PR DESCRIPTION
Fly kit is currently checking the parent element so the syntax being "applied" is the following:
```xml
<kit id="reset" can-fly="false" flying="false">
  <fly/>
</kit>
```

This makes no sense whatsoever, as per documentation, the syntax should be:
```xml
<kit id="reset">
  <fly can-fly="false" flying="false"/>
</kit>
```