### PR TITLE
Add kit option to block drops

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDrops.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDrops.java
@@ -5,10 +5,12 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MaterialData;
+import tc.oc.pgm.kits.Kit;
 
 /** The result of breaking a block */
 public class BlockDrops {
   public final ImmutableMap<ItemStack, Double> items; // probability -> item
+  public final Kit kit;
   public final int experience;
   public final @Nullable MaterialData replacement;
   public final @Nullable Float fallChance;
@@ -17,12 +19,14 @@ public class BlockDrops {
 
   public BlockDrops(
       Map<ItemStack, Double> items,
+      Kit kit,
       int experience,
       @Nullable MaterialData replacement,
       @Nullable Float fallChance,
       @Nullable Float landChance,
       @Nullable Double fallSpeed) {
     this.items = ImmutableMap.copyOf(items);
+    this.kit = kit;
     this.experience = experience;
     this.replacement = replacement;
     this.fallChance = fallChance;
@@ -37,6 +41,8 @@ public class BlockDrops {
         + this.replacement
         + " items.size="
         + this.items.size()
+        + " kit="
+        + this.kit
         + " experience="
         + this.experience
         + " fallChance="

--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsModule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsModule.java
@@ -23,7 +23,9 @@ import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.FilterParser;
 import tc.oc.pgm.itemmeta.ItemModifyModule;
+import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.kits.KitModule;
+import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -55,6 +57,7 @@ public class BlockDropsModule implements MapModule {
       List<BlockDropsRule> rules = new ArrayList<>();
       FilterParser filterParser = factory.getFilters();
       RegionParser regionParser = factory.getRegions();
+      KitParser kitParser = factory.getKits();
       final Optional<ItemModifyModule> itemModifier =
           Optional.ofNullable(factory.getModule(ItemModifyModule.class));
 
@@ -65,6 +68,7 @@ public class BlockDropsModule implements MapModule {
               ImmutableSet.of("rule"))) {
         Filter filter = filterParser.parseFilterProperty(elRule, "filter");
         Region region = regionParser.parseRegionProperty(elRule, "region");
+        Kit kit = kitParser.parseKitProperty(elRule, "kit", null);
 
         boolean dropOnWrongTool =
             XMLUtils.parseBoolean(Node.fromChildOrAttr(elRule, "wrong-tool", "wrongtool"), false);
@@ -103,7 +107,8 @@ public class BlockDropsModule implements MapModule {
                 dropOnWrongTool,
                 punchable,
                 trample,
-                new BlockDrops(items, experience, replacement, fallChance, landChance, fallSpeed)));
+                new BlockDrops(
+                    items, kit, experience, replacement, fallChance, landChance, fallSpeed)));
       }
 
       return rules.isEmpty() ? null : new BlockDropsModule(new BlockDropsRuleSet(rules));

--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsRuleSet.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsRuleSet.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.blockdrops;
 
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,8 +16,11 @@ import org.bukkit.material.MaterialData;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.player.ParticipantState;
+import tc.oc.pgm.filters.StaticFilter;
 import tc.oc.pgm.filters.query.MaterialQuery;
 import tc.oc.pgm.filters.query.Queries;
+import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.kits.KitNode;
 import tc.oc.pgm.regions.FiniteBlockRegion;
 import tc.oc.pgm.util.block.BlockStates;
 import tc.oc.pgm.util.event.PlayerPunchBlockEvent;
@@ -83,6 +87,7 @@ public class BlockDropsRuleSet {
       MaterialData material,
       @Nullable ParticipantState playerState) {
     Map<ItemStack, Double> items = new LinkedHashMap<>();
+    List<Kit> kits = new ArrayList<>();
     MaterialData replacement = null;
     Float fallChance = null;
     Float landChance = null;
@@ -112,6 +117,10 @@ public class BlockDropsRuleSet {
 
       custom = true;
 
+      if (rule.drops.kit != null) {
+        kits.add(rule.drops.kit);
+      }
+
       if (rule.drops.replacement != null) {
         replacement = rule.drops.replacement;
       }
@@ -135,7 +144,14 @@ public class BlockDropsRuleSet {
     }
 
     return custom
-        ? new BlockDrops(items, experience, replacement, fallChance, landChance, fallSpeed)
+        ? new BlockDrops(
+            items,
+            new KitNode(kits, StaticFilter.ALLOW, null, null),
+            experience,
+            replacement,
+            fallChance,
+            landChance,
+            fallSpeed)
         : null;
   }
 }


### PR DESCRIPTION
As defined in https://pgm.dev/docs/modules/blocks/blockdrops/. Went to test a map that used blockdrop kits only to find they don't exist in this version of PGM. @Pablete1234 forced me to add this back.

Signed-off-by: Pugzy <pugzy@mail.com>