### PR TITLE
Update dynamic filters immediately on sneak

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/PlayerMovementFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/PlayerMovementFilter.java
@@ -1,8 +1,9 @@
 package tc.oc.pgm.filters;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Collection;
-import java.util.Collections;
 import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
@@ -18,7 +19,7 @@ public class PlayerMovementFilter extends ParticipantFilter {
 
   @Override
   public Collection<Class<? extends Event>> getRelevantEvents() {
-    return Collections.singleton(PlayerCoarseMoveEvent.class);
+    return ImmutableList.of(PlayerCoarseMoveEvent.class, PlayerToggleSneakEvent.class);
   }
 
   @Override


### PR DESCRIPTION
Currently, if you sneak, dynamic filters don't update when players sneak immediately — only after they've moved a block. Dynamic filters happening immediately when you press shift may be desirable — perhaps a glass spawn platform where players can press shift to activate a portal to drop down where they want.

This PR makes it so that when a player presses shift, dynamic filters are updated immediately.