### PR TITLE
Add score changes on dynamic filters

### DIFF
--- a/core/src/main/java/tc/oc/pgm/score/ScoreOnFilter.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreOnFilter.java
@@ -1,0 +1,41 @@
+package tc.oc.pgm.score;
+
+import tc.oc.pgm.api.feature.FeatureDefinition;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.filters.dynamic.FilterMatchModule;
+
+public class ScoreOnFilter implements FeatureDefinition {
+
+  protected final Filter trigger;
+  protected final double score;
+  protected final ScoreOnFilterType type;
+
+  public ScoreOnFilter(Filter trigger, double score, ScoreOnFilterType type) {
+    this.trigger = trigger;
+    this.score = score;
+    this.type = type;
+  }
+
+  public void load(ScoreMatchModule smm, FilterMatchModule fmm) {
+    switch (type) {
+      case TEAM:
+        fmm.onRise(
+            Competitor.class,
+            trigger,
+            competitor -> {
+              smm.incrementScore(competitor, score);
+            });
+        break;
+      case PLAYER:
+        fmm.onRise(
+            MatchPlayer.class,
+            trigger,
+            player -> {
+              smm.incrementScore(player.getId(), player.getCompetitor(), score);
+            });
+        break;
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/score/ScoreOnFilterFactory.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreOnFilterFactory.java
@@ -1,0 +1,21 @@
+package tc.oc.pgm.score;
+
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+
+public class ScoreOnFilterFactory {
+
+  protected final Filter trigger;
+  protected final double score;
+  protected final ScoreOnFilterType type;
+
+  public ScoreOnFilterFactory(Filter trigger, double score, ScoreOnFilterType type) {
+    this.trigger = trigger;
+    this.score = score;
+    this.type = type;
+  }
+
+  public ScoreOnFilter createScoreOnFilter(Match match) {
+    return new ScoreOnFilter(trigger, score, type);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/score/ScoreOnFilterType.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreOnFilterType.java
@@ -1,0 +1,6 @@
+package tc.oc.pgm.score;
+
+public enum ScoreOnFilterType {
+  TEAM,
+  PLAYER
+}


### PR DESCRIPTION
This allows changing scores based on dynamic filters for teams like so:

```xml
<score>
    <on team="some-team-filter" score="2"/>
</score>
```

and for the team a player belongs to like so:

```xml
<score>
    <on player="some-player-filter" score="5"/>
</score>
```

I'm not too familiar with the naming conventions so I imagine my choices will not be the best. Let me know if they should be renamed.

Also, I did this rather on a whim, so I didn't realize it might make more sense as part of #1016. I thought I'd submit this just in case we want it in the score module too.