### PR TITLE
Add contested-rate to control points

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
@@ -42,6 +42,9 @@ public class ControlPointDefinition extends GoalDefinition {
   // Time it takes for a point to decay while unowned. (Time is accurate when near 100% capture)
   private final double decayRate;
 
+  // Time it takes for a point to decay while contested. (Time is accurate when near 100% capture)
+  private final double contestedRate;
+
   // Time it takes for a point to recover to captured state. (Accurate when almost uncaptured)
   private final double recoveryRate;
 
@@ -101,6 +104,7 @@ public class ControlPointDefinition extends GoalDefinition {
       double decayRate,
       double recoveryRate,
       double ownedDecayRate,
+      double contestedRate,
       float timeMultiplier,
       @Nullable TeamFactory initialOwner,
       CaptureCondition captureCondition,
@@ -123,6 +127,7 @@ public class ControlPointDefinition extends GoalDefinition {
     this.decayRate = decayRate;
     this.recoveryRate = recoveryRate;
     this.ownedDecayRate = ownedDecayRate;
+    this.contestedRate = contestedRate;
     this.timeMultiplier = timeMultiplier;
     this.initialOwner = initialOwner;
     this.captureCondition = captureCondition;
@@ -148,6 +153,8 @@ public class ControlPointDefinition extends GoalDefinition {
         + this.getRecoveryRate()
         + " ownedDecayRate="
         + this.getOwnedDecayRate()
+        + " contestedRate="
+        + this.getContestedRate()
         + " timeMultiplier="
         + this.getTimeMultiplier()
         + " initialOwner="
@@ -216,6 +223,10 @@ public class ControlPointDefinition extends GoalDefinition {
 
   public double getOwnedDecayRate() {
     return this.ownedDecayRate;
+  }
+
+  public double getContestedRate() {
+    return this.contestedRate;
   }
 
   public float getTimeMultiplier() {

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -78,7 +78,7 @@ public abstract class ControlPointParser {
     Duration timeToCapture =
         XMLUtils.parseDuration(elControlPoint.getAttribute("capture-time"), Duration.ofSeconds(30));
 
-    final double decayRate, recoveryRate, ownedDecayRate;
+    final double decayRate, recoveryRate, ownedDecayRate, contestedRate;
     final Node attrIncremental = Node.fromAttr(elControlPoint, "incremental");
     final Node attrDecay = Node.fromAttr(elControlPoint, "decay", "decay-rate");
     final Node attrRecovery = Node.fromAttr(elControlPoint, "recovery", "recovery-rate");
@@ -100,6 +100,10 @@ public abstract class ControlPointParser {
       decayRate = incremental ? 0.0 : Double.POSITIVE_INFINITY;
       ownedDecayRate = 0.0;
     }
+
+    contestedRate =
+        XMLUtils.parseNumber(
+            Node.fromAttr(elControlPoint, "contested", "contested-rate"), Double.class, decayRate);
 
     float timeMultiplier =
         XMLUtils.parseNumber(
@@ -146,6 +150,7 @@ public abstract class ControlPointParser {
         decayRate,
         recoveryRate,
         ownedDecayRate,
+        contestedRate,
         timeMultiplier,
         initialOwner,
         captureCondition,

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -132,12 +132,6 @@ public abstract class ControlPointParser {
             "capture rule",
             ControlPointDefinition.CaptureCondition.EXCLUSIVE);
 
-    if (attrContested != null
-        && captureCondition != ControlPointDefinition.CaptureCondition.EXCLUSIVE) {
-      throw new InvalidXMLException(
-          "Contested rate may only apply to exclusive capture rule.", attrContested);
-    }
-
     return new ControlPointDefinition(
         id,
         name,

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -83,6 +83,7 @@ public abstract class ControlPointParser {
     final Node attrDecay = Node.fromAttr(elControlPoint, "decay", "decay-rate");
     final Node attrRecovery = Node.fromAttr(elControlPoint, "recovery", "recovery-rate");
     final Node attrOwnedDecay = Node.fromAttr(elControlPoint, "owned-decay", "owned-decay-rate");
+    final Node attrContested = Node.fromAttr(elControlPoint, "contested", "contested-rate");
     if (attrIncremental == null) {
       recoveryRate =
           XMLUtils.parseNumber(attrRecovery, Double.class, koth ? 1D : Double.POSITIVE_INFINITY);
@@ -100,10 +101,7 @@ public abstract class ControlPointParser {
       decayRate = incremental ? 0.0 : Double.POSITIVE_INFINITY;
       ownedDecayRate = 0.0;
     }
-
-    contestedRate =
-        XMLUtils.parseNumber(
-            Node.fromAttr(elControlPoint, "contested", "contested-rate"), Double.class, decayRate);
+    contestedRate = XMLUtils.parseNumber(attrContested, Double.class, decayRate);
 
     float timeMultiplier =
         XMLUtils.parseNumber(
@@ -111,7 +109,7 @@ public abstract class ControlPointParser {
     boolean neutralState =
         XMLUtils.parseBoolean(elControlPoint.getAttribute("neutral-state"), koth);
 
-    if (neutralState == false && ownedDecayRate > 0) {
+    if (!neutralState && ownedDecayRate > 0) {
       throw new InvalidXMLException("This attribute requires a neutral state.", attrOwnedDecay);
     }
     boolean permanent = XMLUtils.parseBoolean(elControlPoint.getAttribute("permanent"), false);
@@ -133,6 +131,12 @@ public abstract class ControlPointParser {
             ControlPointDefinition.CaptureCondition.class,
             "capture rule",
             ControlPointDefinition.CaptureCondition.EXCLUSIVE);
+
+    if (attrContested != null
+        && captureCondition != ControlPointDefinition.CaptureCondition.EXCLUSIVE) {
+      throw new InvalidXMLException(
+          "Contested rate may only apply to exclusive capture rule.", attrContested);
+    }
 
     return new ControlPointDefinition(
         id,


### PR DESCRIPTION
As per the proposal in #976, this PR adds contested-rate to control points. This allows hills to decay at a different rate when they are contested than when they are simply unoccupied.

I only implemented it for the `exclusive` capture-rule, since I don't think it's clear how it would work with the other capture rules.

For example:
```xml
<control-points decay-rate="1.25" recovery-rate="1" contested-rate="0" owned-decay-rate="23" capture-time="23s" show-progress="true" neutral-state="true" points="0" required="false">
    <control-point id="hill" name="Hill" capture="hill-region" progress="hill-region"/>
</control-points>
```
(from a modified version of Moonshine)

