### PR TITLE
Fix fluid damage values for BlockFromToEvents

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -316,7 +316,8 @@ public class BlockTransformListener implements Listener {
           // Data values 0-7 represent water on the ground, and increase by 1 as they spread
           newState.setRawData((byte) (oldData + 1));
         } else {
-          // Otherwise, the previous block must have been flowing down, so it spreads to a data value of 1
+          // Otherwise, the previous block must have been flowing down, so it spreads to a data
+          // value of 1
           newState.setRawData((byte) (1));
         }
       }

--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -305,6 +305,22 @@ public class BlockTransformListener implements Listener {
         newState.setRawData((byte) 0);
       }
 
+      // For some reason, the newState has the data value of the old source.
+      // This corrects for that manually.
+      if (isWater(newState.getType()) || isLava(newState.getType())) {
+        byte oldData = newState.getRawData();
+        if (event.getFace() == BlockFace.DOWN) {
+          // A data value of 8 (or higher) represents water flowing down
+          newState.setRawData((byte) (8));
+        } else if (oldData < 7) {
+          // Data values 0-7 represent water on the ground, and increase by 1 as they spread
+          newState.setRawData((byte) (oldData + 1));
+        } else {
+          // Otherwise, the previous block must have been flowing down, so it spreads to a data value of 1
+          newState.setRawData((byte) (1));
+        }
+      }
+
       // Check for lava ownership
       this.callEvent(event, oldState, newState, Trackers.getOwner(event.getBlock()));
     }


### PR DESCRIPTION
For some reason, SportPaper (and presumably other papers) use the wrong damage values in the `BlockFromToEvent`s, using the damage value of the originating block instead of the one formed as a result.

This makes it difficult to, for example, make water flow only 3 blocks through a filter, since it'll hang weirdly over edges or stop working entirely sometimes.

We could patch it in sportpaper (although I think it was difficult to do, when I checked) but I suspect other Papers have the same bug, so it's easier to handle it here, instead.

This PR fixes the damage value of these events, so flowing water can be correctly filtered.