### PR TITLE
Implement spread-teammates for spawns

### DIFF
--- a/core/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
+++ b/core/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
@@ -14,8 +14,12 @@ public class SpreadPointProvider extends AggregatePointProvider {
 
   private static final int SAMPLE_COUNT = 16;
 
-  public SpreadPointProvider(Collection<? extends PointProvider> children) {
+  private final boolean spreadTeammates;
+
+  public SpreadPointProvider(
+      Collection<? extends PointProvider> children, boolean spreadTeammates) {
     super(children);
+    this.spreadTeammates = spreadTeammates;
   }
 
   @Override
@@ -34,7 +38,9 @@ public class SpreadPointProvider extends AggregatePointProvider {
         for (MatchPlayer enemy : match.getParticipants()) {
           if (enemy.isParticipating()
               && !enemy.isDead()
-              && (player == null || player.getParty() != enemy.getParty())) {
+              && (player == null
+                  || player.getParty() != enemy.getParty()
+                  || this.spreadTeammates)) {
             nearest = Math.min(nearest, pos.distanceSquared(enemy.getBukkit().getLocation()));
           }
         }

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnAttributes.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnAttributes.java
@@ -11,6 +11,7 @@ public class SpawnAttributes {
   public final Kit kit;
   public final boolean sequential;
   public final boolean spread;
+  public final boolean spreadTeammates;
   public final boolean exclusive;
   public final boolean persistent;
 
@@ -20,6 +21,7 @@ public class SpawnAttributes {
       Kit kit,
       boolean sequential,
       boolean spread,
+      boolean spreadTeammates,
       boolean exclusive,
       boolean persistent) {
     this.filter = filter;
@@ -27,11 +29,20 @@ public class SpawnAttributes {
     this.kit = kit;
     this.sequential = sequential;
     this.spread = spread;
+    this.spreadTeammates = spreadTeammates;
     this.exclusive = exclusive;
     this.persistent = persistent;
   }
 
   public SpawnAttributes() {
-    this(StaticFilter.ABSTAIN, new PointProviderAttributes(), null, false, false, false, false);
+    this(
+        StaticFilter.ABSTAIN,
+        new PointProviderAttributes(),
+        null,
+        false,
+        false,
+        false,
+        false,
+        false);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnParser.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnParser.java
@@ -63,8 +63,8 @@ public class SpawnParser {
     PointProvider provider;
     if (attributes.sequential) {
       provider = new SequentialPointProvider(providers);
-    } else if (attributes.spread) {
-      provider = new SpreadPointProvider(providers);
+    } else if (attributes.spread || attributes.spreadTeammates) {
+      provider = new SpreadPointProvider(providers, attributes.spreadTeammates);
     } else {
       provider = new RandomPointProvider(providers);
     }
@@ -101,6 +101,8 @@ public class SpawnParser {
 
     boolean sequential = XMLUtils.parseBoolean(el.getAttribute("sequential"), parent.sequential);
     boolean spread = XMLUtils.parseBoolean(el.getAttribute("spread"), parent.spread);
+    boolean spreadTeammates =
+        XMLUtils.parseBoolean(el.getAttribute("spread-teammates"), parent.spreadTeammates);
     boolean exclusive = XMLUtils.parseBoolean(el.getAttribute("exclusive"), parent.exclusive);
     boolean persistent = XMLUtils.parseBoolean(el.getAttribute("persistent"), parent.persistent);
 
@@ -130,6 +132,7 @@ public class SpawnParser {
         && kit == parent.kit
         && sequential == parent.sequential
         && spread == parent.spread
+        && spreadTeammates == parent.spreadTeammates
         && exclusive == parent.exclusive
         && persistent == parent.persistent
         && !newFilters) {
@@ -142,6 +145,7 @@ public class SpawnParser {
           kit,
           sequential,
           spread,
+          spreadTeammates,
           exclusive,
           persistent);
     }


### PR DESCRIPTION
There are some map concepts where to ability to set `spread="true"` for team spawns is desirable. This PR permits that functionality as a separate attribute titled `spread-teammates`.