### PR TITLE
Fix missing dependency on jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,6 +52,7 @@
                             <include>org.eclipse.jgit:org.eclipse.jgit:*</include>
                             <include>org.slf4j:slf4j-api:*</include>
                             <include>fr.minuskube.inv:smart-invs</include>
+                            <include>net.objecthunter:exp4j:*</include>
                         </includes>
                     </artifactSet>
                     <filters>


### PR DESCRIPTION
Running PGM from the IDE works just fine, but compiling a jar and trying to run it is missing a dependency that isn't being shaded ATM. This is a side effect from pools rework that were recently merged.