### PR TITLE
Expose displaced items in kit event

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/ApplyItemKitEvent.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ApplyItemKitEvent.java
@@ -13,8 +13,10 @@ import tc.oc.pgm.api.player.MatchPlayer;
 public class ApplyItemKitEvent extends ApplyKitEvent {
   private final Map<Slot, ItemStack> slotItems;
   private final List<ItemStack> freeItems;
+  private final List<ItemStack> displacedItems;
 
-  public ApplyItemKitEvent(MatchPlayer player, ItemKit kit, boolean force) {
+  public ApplyItemKitEvent(
+      MatchPlayer player, ItemKit kit, boolean force, List<ItemStack> displacedItems) {
     super(player, kit, force);
 
     this.slotItems = new HashMap<>(kit.getSlotItems().size());
@@ -26,6 +28,7 @@ public class ApplyItemKitEvent extends ApplyKitEvent {
     for (ItemStack stack : kit.getFreeItems()) {
       this.freeItems.add(stack.clone());
     }
+    this.displacedItems = displacedItems;
   }
 
   /**
@@ -38,6 +41,10 @@ public class ApplyItemKitEvent extends ApplyKitEvent {
 
   public List<ItemStack> getFreeItems() {
     return freeItems;
+  }
+
+  public List<ItemStack> getDisplacedItems() {
+    return displacedItems;
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/kits/ItemKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ItemKit.java
@@ -43,7 +43,7 @@ public class ItemKit implements KitDefinition {
    */
   @Override
   public void apply(MatchPlayer player, boolean force, List<ItemStack> displacedItems) {
-    ApplyItemKitEvent event = new ApplyItemKitEvent(player, this, force);
+    ApplyItemKitEvent event = new ApplyItemKitEvent(player, this, force, displacedItems);
     player.getMatch().callEvent(event);
     if (event.isCancelled()) {
       return;


### PR DESCRIPTION
This is required to be able to handle multiple kits being given at the same time (eg: when a kit has a parent kit). Without it it's impossible to remove or re-give a previous kit in the chain because all free items or items which couldn't cleanly give are in this list that cannot be reset, or reused, since it's not accessible.