### PR TITLE
Use getType in trackers rather than SportPaper's getMaterial

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/CactiTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/CactiTracker.java
@@ -30,9 +30,10 @@ public class CactiTracker extends AbstractTracker<BlockInfo> implements DamageRe
     return null;
   }
 
+  @SuppressWarnings("deprecation")
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPlace(ParticipantBlockTransformEvent event) {
-    if (event.getNewState().getMaterial() == Material.CACTUS) {
+    if (event.getNewState().getType() == Material.CACTUS) {
       blocks()
           .trackBlockState(
               event.getNewState(),

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/DispenserTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/DispenserTracker.java
@@ -18,6 +18,7 @@ public class DispenserTracker extends AbstractTracker<DispenserInfo> {
     super(DispenserInfo.class, tmm, match);
   }
 
+  @SuppressWarnings("deprecation")
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPlace(ParticipantBlockTransformEvent event) {
     if (event.getNewState().getType() == Material.DISPENSER) {

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/FallingBlockTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/FallingBlockTracker.java
@@ -39,9 +39,10 @@ public class FallingBlockTracker extends AbstractTracker<BlockInfo> implements D
     return null;
   }
 
+  @SuppressWarnings("deprecation")
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPlace(ParticipantBlockTransformEvent event) {
-    if (event.getNewState().getMaterial().hasGravity()) {
+    if (event.getNewState().getType().hasGravity()) {
       blocks()
           .trackBlockState(
               event.getNewState(),

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/TNTTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/TNTTracker.java
@@ -21,6 +21,7 @@ public class TNTTracker extends AbstractTracker<TNTInfo> {
     super(TNTInfo.class, tmm, match);
   }
 
+  @SuppressWarnings("deprecation")
   @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void onPlace(ParticipantBlockTransformEvent event) {
     if (event.getNewState().getType() == Material.TNT) {


### PR DESCRIPTION
While testing a different change to ensure functionality on Spigot/Paper, I discovered that CactiTracker and FallingBlockTracker were using `getMaterial` from SportPaper as opposed to `getType`; despite deprecation we use this instead with DispenserTracker and TNTTracker since it does the same thing. As a result, switch usage in CactiTracker and FallingBlockTracker, and suppress relevant deprecation warnings. 