### PR TITLE
Fix flag state filters on load

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/match/FlagStateFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/match/FlagStateFilter.java
@@ -41,7 +41,8 @@ public class FlagStateFilter extends TypedFilter.Impl<MatchQuery> {
   @Override
   public boolean matches(MatchQuery query) {
     Flag flag = this.flag.get().getGoal(query.getMatch());
-    if (flag == null) throw new IllegalStateException("Flag not found");
+    // FIXME: This may occur at load time. We need a better fix for this.
+    if (flag == null) return false;
 
     return flag.isCurrent(this.state) && (this.post == null || flag.isAtPost(this.post.get()));
   }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -29,7 +29,7 @@ public class FeatureFilterParser extends FilterParser {
   public Filter parse(Element el) throws InvalidXMLException {
     Filter filter = this.parseDynamic(el);
     if (!(filter instanceof FeatureReference)) {
-      factory.getFeatures().addFeature(el, (FilterDefinition) filter);
+      factory.getFeatures().addFeature(el, filter);
     }
     return filter;
   }


### PR DESCRIPTION
At this time flag state filters break a map on cycle due to goals not yet being registered at the time this is first checked (if used as a net filter, which is called on flag initialization code)