### PR TITLE
Add filters for dead and alive states

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/PlayerStateFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/PlayerStateFilter.java
@@ -4,9 +4,11 @@ import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import org.bukkit.event.Event;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
+import tc.oc.pgm.api.match.event.MatchPhaseChangeEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
-import tc.oc.pgm.spawns.events.PlayerSpawnEvent;
+import tc.oc.pgm.events.PlayerPartyChangeEvent;
+import tc.oc.pgm.spawns.events.ParticipantDespawnEvent;
+import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
 
 public class PlayerStateFilter extends ParticipantFilter {
 
@@ -21,11 +23,15 @@ public class PlayerStateFilter extends ParticipantFilter {
 
   @Override
   public Collection<Class<? extends Event>> getRelevantEvents() {
-    return ImmutableList.of(PlayerSpawnEvent.class, MatchPlayerDeathEvent.class);
+    return ImmutableList.of(
+        ParticipantSpawnEvent.class,
+        ParticipantDespawnEvent.class,
+        MatchPhaseChangeEvent.class,
+        PlayerPartyChangeEvent.class);
   }
 
   @Override
   protected boolean matches(PlayerQuery query, MatchPlayer player) {
-    return this.alive ? player.isAlive() : player.isDead();
+    return player.isParticipating() && this.alive != player.isDead();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/PlayerStateFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/PlayerStateFilter.java
@@ -1,0 +1,31 @@
+package tc.oc.pgm.filters.matcher.player;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import org.bukkit.event.Event;
+import tc.oc.pgm.api.filter.query.PlayerQuery;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
+import tc.oc.pgm.spawns.events.PlayerSpawnEvent;
+
+public class PlayerStateFilter extends ParticipantFilter {
+
+  public static final PlayerStateFilter ALIVE = new PlayerStateFilter(true);
+  public static final PlayerStateFilter DEAD = new PlayerStateFilter(false);
+
+  private final boolean alive;
+
+  public PlayerStateFilter(boolean alive) {
+    this.alive = alive;
+  }
+
+  @Override
+  public Collection<Class<? extends Event>> getRelevantEvents() {
+    return ImmutableList.of(PlayerSpawnEvent.class, MatchPlayerDeathEvent.class);
+  }
+
+  @Override
+  protected boolean matches(PlayerQuery query, MatchPlayer player) {
+    return this.alive ? player.isAlive() : player.isDead();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -58,6 +58,7 @@ import tc.oc.pgm.filters.matcher.player.LivesFilter;
 import tc.oc.pgm.filters.matcher.player.ParticipatingFilter;
 import tc.oc.pgm.filters.matcher.player.PlayerClassFilter;
 import tc.oc.pgm.filters.matcher.player.PlayerMovementFilter;
+import tc.oc.pgm.filters.matcher.player.PlayerStateFilter;
 import tc.oc.pgm.filters.matcher.player.WearingItemFilter;
 import tc.oc.pgm.filters.modifier.LocationQueryModifier;
 import tc.oc.pgm.filters.modifier.PlayerBlockQueryModifier;
@@ -378,6 +379,16 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
   @MethodParser("grounded")
   public GroundedFilter parseGrounded(Element el) throws InvalidXMLException {
     return GroundedFilter.INSTANCE;
+  }
+
+  @MethodParser("alive")
+  public PlayerStateFilter parseAlive(Element el) throws InvalidXMLException {
+    return PlayerStateFilter.ALIVE;
+  }
+
+  @MethodParser("dead")
+  public PlayerStateFilter parseDead(Element el) throws InvalidXMLException {
+    return PlayerStateFilter.DEAD;
   }
 
   private Filter parseExplicitTeam(Element el, CompetitorFilter filter) throws InvalidXMLException {


### PR DESCRIPTION
Add filter for checking if a player is alive or dead.

Dynamic so that it's rise can be used to apply a kit.

Signed-off-by: Pugzy <pugzy@mail.com>