### PR TITLE
Add options for item kits being given to players

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -274,7 +274,13 @@ public abstract class KitParser {
       }
     }
 
-    return slotItems.isEmpty() && freeItems.isEmpty() ? null : new ItemKit(slotItems, freeItems);
+    if (slotItems.isEmpty() && freeItems.isEmpty()) return null;
+
+    boolean repairTools = XMLUtils.parseBoolean(Node.fromAttr(el, "repair-tools"), true);
+    boolean deductTools = XMLUtils.parseBoolean(Node.fromAttr(el, "deduct-tools"), true);
+    boolean deductItems = XMLUtils.parseBoolean(Node.fromAttr(el, "deduct-items"), true);
+
+    return new ItemKit(slotItems, freeItems, repairTools, deductTools, deductItems);
   }
 
   public Slot parseInventorySlot(Node node) throws InvalidXMLException {


### PR DESCRIPTION
Kits get added 3 new options:
`<kit repair-tools="true" deduct-tools="true" deduct-items="true">...</kit>`

By default, kits will deduct items already present in the inventory. Eg: giving a kit with 32 stone, if the player already has 10 stone, will deduct those 10 items from the kit, giving only 22 more (to fill the stack till the 32 that the kit has defined.

While this makes sense in some situations, it isn't necessarily nice behavior in all situations. An example is giving a golden apple to a player when something happens, you want it always given, not only given if they don't have one already.

Also tools in the player's inventory get repaired with tools given in the kit by default, and if the player already has the tool its not given a second time (the same logic as with deduct-items). 

With these 3 flags you can hold more fine-grained control over how kits are given to players