### PR TITLE
Fix objective filter not reacting dynamically

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
@@ -188,6 +188,16 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
       throw new IllegalStateException("Cannot register filter listener after match has started");
     }
 
+    // Ideally this should never happen. All features that try to register a dynamic filter should
+    // have ensured that the filter can respond dynamically to the scope, at XML parse time.
+    // However, that does not occur, nothing is validating dynamic filters' scopes at all.
+    // The proper fix is to have a validation, using FeatureValidation and all features
+    // that will use a filter dynamically to validate the scope.
+    if (!filter.respondsTo(scope)) {
+      throw new IllegalStateException(
+          "Filter " + filter + " does not respond to " + scope.getSimpleName() + " scope");
+    }
+
     final ListenerSet listenerSet =
         this.listeners.row(filter).computeIfAbsent(scope, s -> new ListenerSet());
 

--- a/core/src/main/java/tc/oc/pgm/filters/operator/TeamFilterAdapter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/TeamFilterAdapter.java
@@ -1,6 +1,8 @@
 package tc.oc.pgm.filters.operator;
 
+import java.util.Collection;
 import java.util.Optional;
+import org.bukkit.event.Event;
 import tc.oc.pgm.api.filter.query.MatchQuery;
 import tc.oc.pgm.features.XMLFeatureReference;
 import tc.oc.pgm.filters.matcher.TypedFilter;
@@ -39,6 +41,11 @@ public class TeamFilterAdapter extends TypedFilter.Impl<MatchQuery> {
   @Override
   public boolean isDynamic() {
     return filter.isDynamic();
+  }
+
+  @Override
+  public Collection<Class<? extends Event>> getRelevantEvents() {
+    return filter.getRelevantEvents();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -52,6 +52,7 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
       if (mode.getFilter() != null) {
         // if filter returns ALLOW at any time in the match, start countdown for mode change
         fmm.onRise(
+            Match.class,
             mode.getFilter(),
             listener -> {
               if (!this.countdownContext.isRunning(countdown) && match.isRunning()) {


### PR DESCRIPTION
Objective filter when wrapped around a TeamFilterAdapter does no longer react dynamically because they did not rely the getRelevantEvents().

Additionally, when using an objective filter without an any=true on monument modes, those will throw an exception when trying to activate, as the filterable was not correct. While a better fix should be done down the line to properly manage those at parse time, for the time being the map will fail to load and report it on console instead, which is better than it just not working reliably