### PR TITLE
Fix world border filter NPE

### DIFF
--- a/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
+++ b/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.features;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,6 +34,19 @@ public class FeatureDefinitionContext extends ContextStore<FeatureDefinition> {
   /** Return the XML element associated with the given feature */
   public Element getNode(FeatureDefinition definition) {
     return definitionNodes.get(definition);
+  }
+
+  @Override
+  public String add(FeatureDefinition obj) {
+    String id = super.add(obj);
+    definitions.add(obj);
+    return id;
+  }
+
+  @Override
+  public void add(String name, FeatureDefinition obj) {
+    super.add(name, obj);
+    this.definitions.add(obj);
   }
 
   /**
@@ -150,5 +164,10 @@ public class FeatureDefinitionContext extends ContextStore<FeatureDefinition> {
   @Override
   public Collection<FeatureDefinition> getAll() {
     return this.definitions;
+  }
+
+  @Override
+  public <T extends FeatureDefinition> Iterable<T> getAll(Class<T> type) {
+    return Iterables.filter(definitions, type);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
@@ -70,7 +70,7 @@ import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
 public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickable, Listener {
 
   private final Match match;
-  private final ContextStore<?> filterContext;
+  private final ContextStore<? super Filter> filterContext;
   private final List<Class<? extends Event>> listeningFor = new LinkedList<>();
 
   private final Map<ReactorFactory<?>, ReactorFactory.Reactor> activeReactors = new HashMap<>();
@@ -84,7 +84,7 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
    * @param filterContext the context where all {@link Filters} for the relevant match can be found.
    *     Important to find {@link ReactorFactory}s
    */
-  public FilterMatchModule(Match match, ContextStore<?> filterContext) {
+  public FilterMatchModule(Match match, ContextStore<? super Filter> filterContext) {
     this.match = match;
     this.filterContext = filterContext;
   }
@@ -110,7 +110,7 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
     // for dynamic listening. This could potentially result in a need to register a specific event
     // listener.
     this.filterContext // Check for any factories hidden in filter trees
-        .getAllUnchecked(Filter.class)
+        .getAll(Filter.class)
         .forEach(this::findAndCreateReactorFactories);
 
     // Then register all event listeners

--- a/core/src/main/java/tc/oc/pgm/filters/FilterModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterModule.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.ReactorFactory;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.MapProtos;
@@ -22,7 +23,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 
 public class FilterModule implements MapModule<FilterMatchModule> {
 
-  private final ContextStore<?> filterContext;
+  private final ContextStore<? super Filter> filterContext;
 
   /**
    * Create the FilterModule.
@@ -30,7 +31,7 @@ public class FilterModule implements MapModule<FilterMatchModule> {
    * @param filterContext the context where all {@link Filters} for the relevant match can be found.
    *     Important to find {@link ReactorFactory}s
    */
-  private FilterModule(ContextStore<?> filterContext) {
+  private FilterModule(ContextStore<? super Filter> filterContext) {
     this.filterContext = filterContext;
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -5,12 +5,12 @@ import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.FilterDefinition;
 import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.filters.XMLFilterReference;
 import tc.oc.pgm.filters.operator.AllowFilter;
 import tc.oc.pgm.filters.operator.DenyFilter;
 import tc.oc.pgm.filters.operator.InverseFilter;
 import tc.oc.pgm.util.MethodParser;
-import tc.oc.pgm.util.collection.ContextStore;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 
@@ -21,7 +21,7 @@ public class FeatureFilterParser extends FilterParser {
   }
 
   @Override
-  public ContextStore<?> getUsedContext() {
+  public FeatureDefinitionContext getUsedContext() {
     return factory.getFeatures();
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -96,13 +96,11 @@ public abstract class FilterParser {
   }
 
   /**
-   * Gets the context used by this parser to store filters/filter references. Must use {@code
-   * ?}(wildcard) since {@link Filter} does not extend {@link FeatureDefinition}.
-   * (ContextStore&lt;Filter&gt; vs ContextStore&lt;FeatureDefinition&gt;)
+   * Gets the context used by this parser to store filters/filter references.
    *
    * @return the context where this parser puts its parsed filters
    */
-  public abstract ContextStore<?> getUsedContext();
+  public abstract ContextStore<? super Filter> getUsedContext();
 
   /**
    * The top-level method for parsing an individual filter element. This method should call {@link

--- a/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
@@ -10,7 +10,6 @@ import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.matcher.block.BlockFilter;
 import tc.oc.pgm.filters.operator.FilterNode;
 import tc.oc.pgm.util.MethodParser;
-import tc.oc.pgm.util.collection.ContextStore;
 import tc.oc.pgm.util.material.matcher.SingleMaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
@@ -26,7 +25,7 @@ public class LegacyFilterParser extends FilterParser {
   }
 
   @Override
-  public ContextStore<?> getUsedContext() {
+  public FilterContext getUsedContext() {
     return this.filterContext;
   }
 

--- a/core/src/main/java/tc/oc/pgm/worldborder/WorldBorderModule.java
+++ b/core/src/main/java/tc/oc/pgm/worldborder/WorldBorderModule.java
@@ -56,6 +56,7 @@ public class WorldBorderModule implements MapModule {
                 "Cannot combine a filter and an explicit time for a world border", el);
           }
           filter = MonostableFilter.afterMatchStart(after);
+          factory.getFilters().getUsedContext().add(filter);
         }
 
         WorldBorder border =

--- a/util/src/main/java/tc/oc/pgm/util/collection/ContextStore.java
+++ b/util/src/main/java/tc/oc/pgm/util/collection/ContextStore.java
@@ -100,20 +100,7 @@ public class ContextStore<T> implements Iterable<Map.Entry<String, T>> {
   }
 
   @SuppressWarnings("unchecked")
-  public <V extends T> Collection<V> getAll(Class<V> clazz) {
-    Set<V> results = new HashSet<>();
-
-    for (T t : this.getAll()) {
-      if (clazz.isAssignableFrom(t.getClass())) {
-        results.add((V) t);
-      }
-    }
-
-    return results;
-  }
-
-  @SuppressWarnings("unchecked")
-  public <V> Collection<V> getAllUnchecked(Class<V> clazz) {
+  public <V extends T> Iterable<V> getAll(Class<V> clazz) {
     Set<V> results = new HashSet<>();
 
     for (T t : this.getAll()) {


### PR DESCRIPTION
World border creates a monostable filter but does not register it in the filter context, that means that on match load the reactor for it is not created, which causes it to NPE and not work.

The fix was supposed to be simple: add it to the context. However along the way i discovered significant issues with context not actually putting the added stuff in the correct lists, and getAll not properly returning it, making it still not work. After all these changes tho, it finally does work.

Fixes #1051 