### PR TITLE
Implement item matchers

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/module/exception/ModuleLoadException.java
+++ b/core/src/main/java/tc/oc/pgm/api/module/exception/ModuleLoadException.java
@@ -17,6 +17,10 @@ public class ModuleLoadException extends RuntimeException {
     return key;
   }
 
+  public String getFullMessage() {
+    return getMessage() + (key != null ? " @ " + key.getSimpleName() : "");
+  }
+
   public ModuleLoadException(Class<? extends Module> key, String message) {
     this(key, message, null);
   }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
@@ -8,10 +8,11 @@ import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
+import tc.oc.pgm.util.inventory.ItemMatcher;
 
 public class CarryingItemFilter extends ParticipantItemFilter {
-  public CarryingItemFilter(ItemStack base) {
-    super(base);
+  public CarryingItemFilter(ItemMatcher matcher) {
+    super(matcher);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/HoldingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/HoldingItemFilter.java
@@ -9,10 +9,11 @@ import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
+import tc.oc.pgm.util.inventory.ItemMatcher;
 
 public class HoldingItemFilter extends ParticipantItemFilter {
-  public HoldingItemFilter(ItemStack base) {
-    super(base);
+  public HoldingItemFilter(ItemMatcher matcher) {
+    super(matcher);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/ParticipantItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/ParticipantItemFilter.java
@@ -4,13 +4,13 @@ import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.util.inventory.ItemMatcher;
 
 public abstract class ParticipantItemFilter extends ParticipantFilter {
-  protected final ItemStack base;
+  protected final ItemMatcher matcher;
 
-  public ParticipantItemFilter(ItemStack base) {
-    this.base = Preconditions.checkNotNull(base, "item").clone();
-    this.base.setDurability((short) 0); // Filter ignores durability
+  public ParticipantItemFilter(ItemMatcher matcher) {
+    this.matcher = Preconditions.checkNotNull(matcher, "item");
   }
 
   protected abstract ItemStack[] getItems(MatchPlayer player);
@@ -19,16 +19,8 @@ public abstract class ParticipantItemFilter extends ParticipantFilter {
   public boolean matches(PlayerQuery query, MatchPlayer player) {
     for (ItemStack item : getItems(player)) {
       if (item == null) continue;
-
-      item = item.clone();
-      item.setDurability((short) 0);
-      if (this.base.isSimilar(item) && item.getAmount() >= base.getAmount()) {
-        // Match if items stack (ignoring durability) and player's stack is
-        // at least as big as the filter's.
-        return true;
-      }
+      if (matcher.matches(item)) return true;
     }
-
     return false;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/WearingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/WearingItemFilter.java
@@ -9,10 +9,11 @@ import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
+import tc.oc.pgm.util.inventory.ItemMatcher;
 
 public class WearingItemFilter extends ParticipantItemFilter {
-  public WearingItemFilter(ItemStack base) {
-    super(base);
+  public WearingItemFilter(ItemMatcher matcher) {
+    super(matcher);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -458,17 +458,17 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
 
   @MethodParser("carrying")
   public CarryingItemFilter parseHasItem(Element el) throws InvalidXMLException {
-    return new CarryingItemFilter(factory.getKits().parseRequiredItem(el));
+    return new CarryingItemFilter(factory.getKits().parseItemMatcher(el));
   }
 
   @MethodParser("holding")
   public HoldingItemFilter parseHolding(Element el) throws InvalidXMLException {
-    return new HoldingItemFilter(factory.getKits().parseRequiredItem(el));
+    return new HoldingItemFilter(factory.getKits().parseItemMatcher(el));
   }
 
   @MethodParser("wearing")
   public WearingItemFilter parseWearingItem(Element el) throws InvalidXMLException {
-    return new WearingItemFilter(factory.getKits().parseRequiredItem(el));
+    return new WearingItemFilter(factory.getKits().parseItemMatcher(el));
   }
 
   @MethodParser("effect")

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -120,8 +120,10 @@ public class MapFactoryImpl extends ModuleGraph<MapModule, MapModuleFactory<? ex
       throw e;
     } catch (IOException e) {
       throw new MapException(source, info, "Unable to read map document", e);
-    } catch (ModuleLoadException | InvalidXMLException e) {
+    } catch (InvalidXMLException e) {
       throw new MapException(source, info, e.getMessage(), e);
+    } catch (ModuleLoadException e) {
+      throw new MapException(source, info, e.getFullMessage(), e);
     } catch (JDOMParseException e) {
       final InvalidXMLException cause = InvalidXMLException.fromJDOM(e, source.getId());
       throw new MapException(source, info, cause.getMessage(), cause);

--- a/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
@@ -1,0 +1,54 @@
+package tc.oc.pgm.util.inventory;
+
+import com.google.common.collect.Range;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class ItemMatcher {
+
+  private final ItemStack base;
+  private final Range<Integer> amount;
+
+  private final boolean ignoreDurability;
+  private final boolean ignoreMetadata;
+  private final boolean ignoreName;
+  private final boolean ignoreEnchantments;
+
+  public ItemMatcher(
+      ItemStack base,
+      Range<Integer> amount,
+      boolean ignoreDurability,
+      boolean ignoreMetadata,
+      boolean ignoreName,
+      boolean ignoreEnchantments) {
+    if (ignoreMetadata && (!ignoreName || !ignoreEnchantments))
+      throw new UnsupportedOperationException(
+          "Cannot ignore metadata but respect name or enchantments");
+
+    this.ignoreDurability = ignoreDurability;
+
+    this.ignoreMetadata = ignoreMetadata;
+    this.ignoreName = ignoreName;
+    this.ignoreEnchantments = ignoreEnchantments;
+
+    this.amount = amount;
+    this.base = stripMeta(base);
+  }
+
+  private ItemStack stripMeta(ItemStack item) {
+    ItemMeta meta = item.getItemMeta();
+    if (meta == null || (!ignoreMetadata && !(ignoreEnchantments && meta.hasEnchants())))
+      return item;
+
+    item = item.clone();
+    if (ignoreMetadata) item.setItemMeta(null);
+    else item.getEnchantments().keySet().forEach(item::removeEnchantment);
+
+    return item;
+  }
+
+  public boolean matches(ItemStack query) {
+    return base.isSimilar(stripMeta(query), ignoreDurability, ignoreName)
+        && amount.contains(query.getAmount());
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -21,6 +21,7 @@ import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.Version;
 import tc.oc.pgm.util.attribute.AttributeModifier;
@@ -384,6 +385,12 @@ public final class XMLUtils {
   private static final Pattern RANGE_RE =
       Pattern.compile("\\s*(\\(|\\[)\\s*([^,]+)\\s*,\\s*([^\\)\\]]+)\\s*(\\)|\\])\\s*");
 
+  public static <T extends Number & Comparable<T>> Range<T> parseNumericRange(
+      @Nullable Node node, Class<T> type, @Nullable Range<T> fallback) throws InvalidXMLException {
+    if (node == null) return fallback;
+    return parseNumericRange(node, type);
+  }
+
   /**
    * Parse a range in the standard mathematical format e.g.
    *
@@ -394,7 +401,7 @@ public final class XMLUtils {
    * <p>Also supports singleton ranges derived from providing a number with no delimiter
    */
   public static <T extends Number & Comparable<T>> Range<T> parseNumericRange(
-      Node node, Class<T> type) throws InvalidXMLException {
+      @NotNull Node node, Class<T> type) throws InvalidXMLException {
     Matcher matcher = RANGE_RE.matcher(node.getValue());
     if (!matcher.matches()) {
       T value = parseNumber(node, node.getValue(), type, true);


### PR DESCRIPTION
Change item filters like `holding`, `carrying` and `wearing` with `ItemMatcher`s. Item matchers are a more generic way of matching items, supporting checking ignoring metadata, or amount ranges. 

Prior to this, item matching was always exact meta, always ignoring durability, and "at least X" amount matching, this is the default behavior if no extra flags are specified.

Examples:
```xml
<holding amount="[3,6]" ignore-durability="false" ignore-metadata="true">
  <item material="wool" damage="0"/>
</holding>
```
This will match if you're holding between 3 and 6 (inclusive) white wool, ignoring any other metadata (eg: enchantments, renaming, can-place-on, etc).

```xml
<holding ignore-enchantments="true">
  <item material="wool" amount="5"/>
</holding>
```
This will match at least 5 wool (legacy behavior) of any durability (any color)  (legacy behavior), and matching exact metadata (eg: name, can-place-on, etc), but will ignore enchantments.


The new available properties are: `ignore-durability` (default true), `ignore-metadata` (default false), `ignore-name` (default ignore-meta), `ignore-enchantments` (default to ignore-meta).
If `ignore-metadata` is set to true, `ignore-name` and `ignore-enchantments` cannot be false.
