### PR TITLE
Update adventure to 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.2</version>
             <scope>compile</scope>
             <!-- Exclude Spigot APIs since we already provide Bukkit -->
             <exclusions>


### PR DESCRIPTION
I assume this is the only thing that needs to be done for chat to work on 1.19?

I will sign off when I figure out how to.