### PR TITLE
Fixes & improvements to action parsing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionScopeValidation.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionScopeValidation.java
@@ -1,0 +1,34 @@
+package tc.oc.pgm.action;
+
+import java.util.HashMap;
+import java.util.Map;
+import tc.oc.pgm.api.feature.FeatureValidation;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+
+public class ActionScopeValidation implements FeatureValidation<ActionDefinition<?>> {
+
+  private static final Map<Class<?>, ActionScopeValidation> INSTANCES = new HashMap<>();
+
+  public static ActionScopeValidation of(Class<?> scope) {
+    return INSTANCES.computeIfAbsent(scope, ActionScopeValidation::new);
+  }
+
+  private final Class<?> scope;
+
+  private ActionScopeValidation(Class<?> scope) {
+    this.scope = scope;
+  }
+
+  @Override
+  public void validate(ActionDefinition<?> definition, Node node) throws InvalidXMLException {
+    Class<?> scope = definition.getScope();
+    if (!scope.isAssignableFrom(this.scope))
+      throw new InvalidXMLException(
+          "Wrong action scope, got "
+              + scope.getSimpleName()
+              + " but expected "
+              + scope.getSimpleName(),
+          node);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/action/XMLActionReference.java
+++ b/core/src/main/java/tc/oc/pgm/action/XMLActionReference.java
@@ -3,40 +3,14 @@ package tc.oc.pgm.action;
 import javax.annotation.Nullable;
 import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.features.XMLFeatureReference;
-import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class XMLActionReference<S> extends XMLFeatureReference<ActionDefinition>
     implements Action<S> {
 
-  private final Class<? super S> scope;
-
-  public XMLActionReference(
-      FeatureDefinitionContext context, Node node, @Nullable String id, Class<S> scope) {
+  public XMLActionReference(FeatureDefinitionContext context, Node node, @Nullable String id) {
     super(context, node, id, ActionDefinition.class);
-    this.scope = scope;
-  }
-
-  @Override
-  public void resolve() throws InvalidXMLException {
-    Node node = this.node; // In case we need to report an error
-
-    super.resolve();
-
-    if (super.referent == null) return;
-
-    Class<?> ref = super.referent.getScope();
-    if (!ref.isAssignableFrom(this.scope)) {
-      throw new InvalidXMLException(
-          "Wrong trigger target for ID '"
-              + id
-              + "': expected "
-              + scope.getSimpleName()
-              + " rather than "
-              + ref.getSimpleName(),
-          node);
-    }
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/action/actions/ActionNode.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/ActionNode.java
@@ -8,12 +8,18 @@ import tc.oc.pgm.filters.Filterable;
 public class ActionNode<B extends Filterable<?>> extends AbstractAction<B> {
   private final ImmutableList<Action<? super B>> actions;
   private final Filter filter;
+  private final Filter untrigerFilter;
   private final Class<B> bound;
 
-  public ActionNode(ImmutableList<Action<? super B>> actions, Filter filter, Class<B> bound) {
+  public ActionNode(
+      ImmutableList<Action<? super B>> actions,
+      Filter filter,
+      Filter untriggerFilter,
+      Class<B> bound) {
     super(bound);
     this.actions = actions;
     this.filter = filter;
+    this.untrigerFilter = untriggerFilter;
     this.bound = bound;
   }
 
@@ -27,6 +33,14 @@ public class ActionNode<B extends Filterable<?>> extends AbstractAction<B> {
     if (filter.query(t).isAllowed()) {
       for (Action<? super B> action : actions) {
         action.trigger(t);
+      }
+    }
+  }
+
+  public void untrigger(B t) {
+    if (untrigerFilter.query(t).isAllowed()) {
+      for (Action<? super B> action : actions) {
+        action.untrigger(t);
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/filters/XMLFilterReference.java
+++ b/core/src/main/java/tc/oc/pgm/filters/XMLFilterReference.java
@@ -15,17 +15,8 @@ import tc.oc.pgm.util.xml.Node;
 /** A {@link Filter} that delegates all methods to an XML reference */
 public class XMLFilterReference extends XMLFeatureReference<FilterDefinition> implements Filter {
 
-  public XMLFilterReference(
-      FeatureDefinitionContext context, Node node, Class<FilterDefinition> type) {
-    this(context, node, null, type);
-  }
-
-  public XMLFilterReference(
-      FeatureDefinitionContext context,
-      Node node,
-      @Nullable String id,
-      Class<FilterDefinition> type) {
-    super(context, node, id, type);
+  public XMLFilterReference(FeatureDefinitionContext context, Node node, @Nullable String id) {
+    super(context, node, id, FilterDefinition.class);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -36,11 +36,8 @@ public class FeatureFilterParser extends FilterParser {
   }
 
   @Override
-  public Filter parseReference(Node node, String value) throws InvalidXMLException {
-    return factory
-        .getFeatures()
-        .addReference(
-            new XMLFilterReference(factory.getFeatures(), node, value, FilterDefinition.class));
+  public Filter parseReference(Node node, String id) throws InvalidXMLException {
+    return features.addReference(new XMLFilterReference(factory.getFeatures(), node, id));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -128,7 +128,7 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
    * Return the filter referenced by the given name/id, and assume it appears in the given {@link
    * Node} for error reporting purposes.
    */
-  public abstract Filter parseReference(Node node, String value) throws InvalidXMLException;
+  public abstract Filter parseReference(Node node, String id) throws InvalidXMLException;
 
   public boolean isFilter(Element el) {
     return methodParsers.containsKey(el.getName()) || factory.getRegions().isRegion(el);

--- a/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
@@ -90,10 +90,10 @@ public class LegacyFilterParser extends FilterParser {
   }
 
   @Override
-  public Filter parseReference(Node node, String value) throws InvalidXMLException {
-    Filter filter = this.filterContext.get(value);
+  public Filter parseReference(Node node, String id) throws InvalidXMLException {
+    Filter filter = this.filterContext.get(id);
     if (filter == null) {
-      throw new InvalidXMLException("No filter named '" + value + "'", node);
+      throw new InvalidXMLException("No filter named '" + id + "'", node);
     }
     return filter;
   }

--- a/core/src/main/java/tc/oc/pgm/kits/ActionKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ActionKit.java
@@ -20,4 +20,11 @@ public class ActionKit extends AbstractKit {
       t.trigger(player);
     }
   }
+
+  @Override
+  public void remove(MatchPlayer player) {
+    for (Action<? super MatchPlayer> t : actions) {
+      t.untrigger(player);
+    }
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/KitModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitModule.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import tc.oc.pgm.action.ActionModule;
 import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
@@ -54,7 +55,7 @@ public class KitModule implements MapModule {
 
     @Override
     public Collection<Class<? extends MapModule>> getWeakDependencies() {
-      return ImmutableList.of(TeamModule.class);
+      return ImmutableList.of(ActionModule.class, TeamModule.class);
     }
 
     @Override

--- a/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/FeatureRegionParser.java
@@ -25,11 +25,11 @@ public class FeatureRegionParser extends RegionParser {
   }
 
   @Override
-  public Region parseReference(Node node, String val) throws InvalidXMLException {
+  public Region parseReference(Node node, String id) throws InvalidXMLException {
     return factory
         .getFeatures()
         .addReference(
-            new XMLRegionReference(factory.getFeatures(), node, val, RegionDefinition.class));
+            new XMLRegionReference(factory.getFeatures(), node, id, RegionDefinition.class));
   }
 
   @MethodParser("region")

--- a/core/src/main/java/tc/oc/pgm/regions/LegacyRegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/LegacyRegionParser.java
@@ -38,10 +38,10 @@ public class LegacyRegionParser extends RegionParser {
   }
 
   @Override
-  public Region parseReference(Node node, String name) throws InvalidXMLException {
-    Region region = this.regionContext.get(name);
+  public Region parseReference(Node node, String id) throws InvalidXMLException {
+    Region region = this.regionContext.get(id);
     if (region == null) {
-      throw new InvalidXMLException("Unknown region '" + name + "'", node);
+      throw new InvalidXMLException("Unknown region '" + id + "'", node);
     } else {
       return region;
     }

--- a/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
@@ -39,7 +39,7 @@ public abstract class RegionParser implements XMLParser<Region, RegionDefinition
    */
   public abstract Region parse(Element el) throws InvalidXMLException;
 
-  public abstract Region parseReference(Node node, String value) throws InvalidXMLException;
+  public abstract Region parseReference(Node node, String id) throws InvalidXMLException;
 
   public Region parseReference(Attribute attribute) throws InvalidXMLException {
     return parseReference(new Node(attribute));

--- a/core/src/main/java/tc/oc/pgm/util/XMLParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/XMLParser.java
@@ -34,7 +34,7 @@ public interface XMLParser<F, FD extends FeatureDefinition> {
     return parseReference(node, node.getValue());
   }
 
-  F parseReference(Node node, String value) throws InvalidXMLException;
+  F parseReference(Node node, String id) throws InvalidXMLException;
 
   void validate(F f, FeatureValidation<FD> validation, Node node) throws InvalidXMLException;
 


### PR DESCRIPTION
Minor fixes and improvements to action parsing.

Added `untrigger-filter` to `action` which lets you decide when untriggering is allowed (before this, untriggering never happened)
Scope validations are now performed as feature validations, meaning forward-references are better handled
Added validation for scope mismatching, before it would be silently ignored instead.
Fixed a couple places referencing actions as "triggers" (old syntax), the legacy format is still supported. eg:
`<trigger filter="dynamic-filter-id" action="action-id" scope="player"/>`


