### PR TITLE
Fix unknown players on join

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -134,6 +134,9 @@ public class PGMListener implements Listener {
 
   @EventHandler(priority = EventPriority.LOW)
   public void addPlayerOnJoin(final PlayerJoinEvent event) {
+    // Player already left. Because quit already happened, we must ignore the join.
+    if (!event.getPlayer().isOnline()) return;
+
     Match match = this.mm.getMatch(event.getPlayer().getWorld());
     if (match == null) {
       event


### PR DESCRIPTION
If a player is kicked in LOWEST priority, the kick & quit occur on LOWEST. Then *later* on LOW, pgm will add them to the match. 

This creates players who are part of the pgm match but are not online (because they already left).