### PR TITLE
Implement payload (prototype)

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -420,4 +420,9 @@ public interface Config {
    * @return A map of experimental settings.
    */
   Map<String, Object> getExperiments();
+
+  default boolean getExperimentAsBool(String key, boolean def) {
+    Object exp = getExperiments().getOrDefault(key, def);
+    return exp instanceof Boolean ? (Boolean) exp : exp.toString().equals("true");
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -75,7 +75,8 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
           match.needModule(TeamMatchModule.class).getTeam(this.definition.getInitialOwner());
     }
 
-    this.centerPoint = this.getCaptureRegion().getBounds().getCenterPoint();
+    Region capture = this.getCaptureRegion();
+    this.centerPoint = capture == null ? null : capture.getBounds().getCenterPoint();
 
     this.playerTracker = new RegionPlayerTracker(match, this.getCaptureRegion());
 

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPoint.java
@@ -44,7 +44,7 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
   protected static final Sound BAD_SOUND =
       sound(key("mob.blaze.death"), Sound.Source.MASTER, 0.4f, 0.8f);
 
-  protected final ControlPointPlayerTracker playerTracker;
+  protected final RegionPlayerTracker playerTracker;
   protected final ControlPointBlockDisplay blockDisplay;
 
   protected final Vector centerPoint;
@@ -77,7 +77,7 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
 
     this.centerPoint = this.getCaptureRegion().getBounds().getCenterPoint();
 
-    this.playerTracker = new ControlPointPlayerTracker(match, this.getCaptureRegion());
+    this.playerTracker = new RegionPlayerTracker(match, this.getCaptureRegion());
 
     this.blockDisplay = new ControlPointBlockDisplay(match, this);
   }
@@ -98,7 +98,7 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
     return blockDisplay;
   }
 
-  public ControlPointPlayerTracker getPlayerTracker() {
+  public RegionPlayerTracker getPlayerTracker() {
     return playerTracker;
   }
 
@@ -292,7 +292,7 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
     // team
     int defenderCount = 0;
 
-    for (MatchPlayer player : this.playerTracker.getPlayersOnPoint()) {
+    for (MatchPlayer player : this.playerTracker.getPlayers()) {
       Competitor team = player.getCompetitor();
       if (this.canDominate(player)) {
         defenderCount++;
@@ -405,7 +405,7 @@ public class ControlPoint extends SimpleGoal<ControlPointDefinition>
    * <p>If there is no neutral state, then the point is always either being captured by a specific
    * team, or not being captured at all.
    */
-  private void dominate(Competitor dominantTeam, Duration dominantTime, boolean contested) {
+  protected void dominate(Competitor dominantTeam, Duration dominantTime, boolean contested) {
     if (dominantTeam != null && contested) {
       throw new IllegalArgumentException(
           "Control point cannot be contested if there is a dominant team.");

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointDefinition.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import org.bukkit.util.BlockVector;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.goals.GoalDefinition;
 import tc.oc.pgm.goals.ShowOptions;
@@ -137,6 +138,10 @@ public class ControlPointDefinition extends GoalDefinition {
     this.pointsOwner = pointsOwner;
     this.pointsGrowth = pointsGrowth;
     this.showProgress = progress;
+  }
+
+  public ControlPoint build(Match match) {
+    return new ControlPoint(match, this);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointMatchModule.java
@@ -6,24 +6,28 @@ import org.bukkit.event.HandlerList;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.payload.PayloadListener;
 
 public class ControlPointMatchModule implements MatchModule {
 
   private final Match match;
   private final List<ControlPoint> controlPoints = new ArrayList<>();
   private final ControlPointAnnouncer announcer;
+  private final PayloadListener payloadListener;
 
   public ControlPointMatchModule(Match match, List<ControlPoint> points) {
     this.match = match;
     this.controlPoints.addAll(points);
 
     this.announcer = new ControlPointAnnouncer(this.match);
+    this.payloadListener = new PayloadListener();
     match.addTickable(new ControlPointTickTask(this.controlPoints), MatchScope.RUNNING);
   }
 
   @Override
   public void load() {
     this.match.addListener(this.announcer, MatchScope.RUNNING);
+    this.match.addListener(this.payloadListener, MatchScope.RUNNING);
     for (ControlPoint controlPoint : this.controlPoints) {
       controlPoint.registerEvents();
     }
@@ -35,5 +39,6 @@ public class ControlPointMatchModule implements MatchModule {
       controlPoint.unregisterEvents();
     }
     HandlerList.unregisterAll(this.announcer);
+    HandlerList.unregisterAll(this.payloadListener);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointModule.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointModule.java
@@ -3,17 +3,21 @@ package tc.oc.pgm.controlpoint;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.controlpoint.ControlPointParser.Type;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.goals.GoalMatchModule;
 import tc.oc.pgm.regions.RegionModule;
@@ -23,16 +27,18 @@ import tc.oc.pgm.util.xml.XMLUtils;
 
 public class ControlPointModule implements MapModule<ControlPointMatchModule> {
 
-  private static final Collection<MapTag> TAGS_CP =
-      ImmutableList.of(new MapTag("cp", "controlpoint", "Control the Point", true, false));
-  private static final Collection<MapTag> TAGS_KOTH =
-      ImmutableList.of(new MapTag("koth", "controlpoint", "King of the Hill", true, false));
-  private final List<ControlPointDefinition> definitions;
-  private final boolean koth;
+  private static final MapTag CP =
+      new MapTag("cp", "controlpoint", "Control the Point", true, false);
+  private static final MapTag KOTH =
+      new MapTag("koth", "controlpoint", "King of the Hill", true, false);
+  private static final MapTag PAYLOAD = new MapTag("pd", "payload", "Payload", true, false);
 
-  public ControlPointModule(List<ControlPointDefinition> definitions, boolean koth) {
+  private final List<ControlPointDefinition> definitions;
+  private final Collection<MapTag> tags;
+
+  public ControlPointModule(List<ControlPointDefinition> definitions, Collection<MapTag> tags) {
     this.definitions = definitions;
-    this.koth = koth;
+    this.tags = tags;
   }
 
   @Override
@@ -56,7 +62,7 @@ public class ControlPointModule implements MapModule<ControlPointMatchModule> {
 
   @Override
   public Collection<MapTag> getTags() {
-    return this.koth ? TAGS_KOTH : TAGS_CP;
+    return this.tags;
   }
 
   public static class Factory implements MapModuleFactory<ControlPointModule> {
@@ -74,40 +80,47 @@ public class ControlPointModule implements MapModule<ControlPointMatchModule> {
     public ControlPointModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
       List<ControlPointDefinition> definitions = new ArrayList<>();
+      Set<MapTag> tags = new HashSet<>();
       AtomicInteger serialNumber = new AtomicInteger(1);
-      boolean koth = false;
 
       for (Element elControlPoint :
           XMLUtils.flattenElements(doc.getRootElement(), "control-points", "control-point")) {
+        tags.add(CP);
         ControlPointDefinition definition =
-            ControlPointParser.parseControlPoint(
-                factory, elControlPoint, ControlPointParser.Type.POINT, serialNumber);
+            ControlPointParser.parseControlPoint(factory, elControlPoint, Type.POINT, serialNumber);
         factory.getFeatures().addFeature(elControlPoint, definition);
         definitions.add(definition);
       }
 
       for (Element kingEl : doc.getRootElement().getChildren("king")) {
         for (Element hillEl : XMLUtils.flattenElements(kingEl, "hills", "hill")) {
-          koth = true;
+          tags.add(KOTH);
           ControlPointDefinition definition =
-              ControlPointParser.parseControlPoint(
-                  factory, hillEl, ControlPointParser.Type.KING, serialNumber);
+              ControlPointParser.parseControlPoint(factory, hillEl, Type.HILL, serialNumber);
           factory.getFeatures().addFeature(kingEl, definition);
           definitions.add(definition);
         }
       }
 
+      boolean payloadEnabled = PGM.get().getConfiguration().getExperimentAsBool("payload", false);
+
       for (Element payloadEl :
           XMLUtils.flattenElements(doc.getRootElement(), "payloads", "payload")) {
+        if (!payloadEnabled)
+          throw new InvalidXMLException(
+              "Payload is in experimental & unfinished game-mode, everything bound to change, including XML syntax."
+                  + "To enable the feature, change experiments.payload to true in pgm config.",
+              payloadEl);
+
+        tags.add(PAYLOAD);
         ControlPointDefinition definition =
-            ControlPointParser.parseControlPoint(
-                factory, payloadEl, ControlPointParser.Type.PAYLOAD, serialNumber);
+            ControlPointParser.parseControlPoint(factory, payloadEl, Type.PAYLOAD, serialNumber);
         factory.getFeatures().addFeature(payloadEl, definition);
         definitions.add(definition);
       }
 
       if (!definitions.isEmpty()) {
-        return new ControlPointModule(definitions, koth);
+        return new ControlPointModule(definitions, tags);
       } else {
         return null;
       }

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -11,12 +11,14 @@ import org.jdom2.Element;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.matcher.block.BlockFilter;
 import tc.oc.pgm.filters.operator.AnyFilter;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.goals.ShowOptions;
 import tc.oc.pgm.payload.PayloadDefinition;
 import tc.oc.pgm.regions.BlockBoundedValidation;
+import tc.oc.pgm.regions.EverywhereRegion;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.teams.TeamModule;
@@ -35,35 +37,37 @@ public abstract class ControlPointParser {
           new BlockFilter(Material.STAINED_GLASS_PANE));
 
   public enum Type {
-    KING,
+    HILL,
     POINT,
     PAYLOAD
-  };
+  }
 
   public static ControlPointDefinition parseControlPoint(
-      MapFactory factory, Element elControlPoint, Type type, AtomicInteger serialNumber)
+      MapFactory factory, Element el, Type type, AtomicInteger serialNumber)
       throws InvalidXMLException {
-    String id = elControlPoint.getAttributeValue("id");
+    String id = el.getAttributeValue("id");
     RegionParser regionParser = factory.getRegions();
     FilterParser filterParser = factory.getFilters();
 
     Region captureRegion =
-        regionParser.parseProperty(
-            Node.fromRequiredChildOrAttr(elControlPoint, "capture-region", "capture"));
+        type == Type.PAYLOAD
+            ? EverywhereRegion.INSTANCE
+            : regionParser.parseProperty(
+                Node.fromRequiredChildOrAttr(el, "capture-region", "capture"));
     Region progressDisplayRegion =
         regionParser.parseProperty(
-            Node.fromChildOrAttr(elControlPoint, "progress-display-region", "progress"),
+            Node.fromChildOrAttr(el, "progress-display-region", "progress"),
             BlockBoundedValidation.INSTANCE);
     Region ownerDisplayRegion =
         regionParser.parseProperty(
-            Node.fromChildOrAttr(elControlPoint, "owner-display-region", "captured"),
+            Node.fromChildOrAttr(el, "owner-display-region", "captured"),
             BlockBoundedValidation.INSTANCE);
 
-    Filter captureFilter = filterParser.parseFilterProperty(elControlPoint, "capture-filter");
-    Filter playerFilter = filterParser.parseFilterProperty(elControlPoint, "player-filter");
+    Filter captureFilter = filterParser.parseFilterProperty(el, "capture-filter");
+    Filter playerFilter = filterParser.parseFilterProperty(el, "player-filter");
 
     Filter visualMaterials;
-    List<Filter> filters = filterParser.parseFiltersProperty(elControlPoint, "visual-materials");
+    List<Filter> filters = filterParser.parseFiltersProperty(el, "visual-materials");
     if (filters.isEmpty()) {
       visualMaterials = VISUAL_MATERIALS;
     } else {
@@ -71,7 +75,7 @@ public abstract class ControlPointParser {
     }
 
     String name;
-    Attribute attrName = elControlPoint.getAttribute("name");
+    Attribute attrName = el.getAttribute("name");
 
     if (attrName != null) {
       name = attrName.getValue();
@@ -83,25 +87,27 @@ public abstract class ControlPointParser {
 
     TeamModule teams = factory.getModule(TeamModule.class);
     TeamFactory initialOwner =
-        teams == null
-            ? null
-            : teams.parseTeam(elControlPoint.getAttribute("initial-owner"), factory);
-    Vector capturableDisplayBeacon = XMLUtils.parseVector(elControlPoint.getAttribute("beacon"));
+        teams == null ? null : teams.parseTeam(el.getAttribute("initial-owner"), factory);
+    Vector capturableDisplayBeacon = XMLUtils.parseVector(el.getAttribute("beacon"));
     Duration timeToCapture =
-        XMLUtils.parseDuration(elControlPoint.getAttribute("capture-time"), Duration.ofSeconds(30));
+        XMLUtils.parseDuration(el.getAttribute("capture-time"), Duration.ofSeconds(30));
 
     final double decayRate, recoveryRate, ownedDecayRate, contestedRate;
-    final Node attrIncremental = Node.fromAttr(elControlPoint, "incremental");
-    final Node attrDecay = Node.fromAttr(elControlPoint, "decay", "decay-rate");
-    final Node attrRecovery = Node.fromAttr(elControlPoint, "recovery", "recovery-rate");
-    final Node attrOwnedDecay = Node.fromAttr(elControlPoint, "owned-decay", "owned-decay-rate");
-    final Node attrContested = Node.fromAttr(elControlPoint, "contested", "contested-rate");
-    boolean koth = type == Type.KING;
+    final Node attrIncremental = Node.fromAttr(el, "incremental");
+    final Node attrDecay = Node.fromAttr(el, "decay", "decay-rate");
+    final Node attrRecovery = Node.fromAttr(el, "recovery", "recovery-rate");
+    final Node attrOwnedDecay = Node.fromAttr(el, "owned-decay", "owned-decay-rate");
+    final Node attrContested = Node.fromAttr(el, "contested", "contested-rate");
+    boolean koth = type == Type.HILL;
+    boolean pd = type == Type.PAYLOAD;
+
     if (attrIncremental == null) {
       recoveryRate =
-          XMLUtils.parseNumber(attrRecovery, Double.class, koth ? 1D : Double.POSITIVE_INFINITY);
+          XMLUtils.parseNumber(
+              attrRecovery, Double.class, koth || pd ? 1D : Double.POSITIVE_INFINITY);
       decayRate =
-          XMLUtils.parseNumber(attrDecay, Double.class, koth ? 0.0 : Double.POSITIVE_INFINITY);
+          XMLUtils.parseNumber(
+              attrDecay, Double.class, koth || pd ? 0.0 : Double.POSITIVE_INFINITY);
       ownedDecayRate = XMLUtils.parseNumber(attrOwnedDecay, Double.class, 0.0);
     } else {
       if (attrDecay != null || attrRecovery != null || attrOwnedDecay != null)
@@ -109,7 +115,7 @@ public abstract class ControlPointParser {
             "Cannot combine this attribute with incremental",
             attrDecay != null ? attrDecay : attrRecovery != null ? attrRecovery : attrOwnedDecay);
 
-      final boolean incremental = XMLUtils.parseBoolean(attrIncremental, koth);
+      final boolean incremental = XMLUtils.parseBoolean(attrIncremental, koth || pd);
       recoveryRate = incremental ? 1.0 : Double.POSITIVE_INFINITY;
       decayRate = incremental ? 0.0 : Double.POSITIVE_INFINITY;
       ownedDecayRate = 0.0;
@@ -117,40 +123,37 @@ public abstract class ControlPointParser {
     contestedRate = XMLUtils.parseNumber(attrContested, Double.class, decayRate);
 
     float timeMultiplier =
-        XMLUtils.parseNumber(
-            elControlPoint.getAttribute("time-multiplier"), Float.class, koth ? 0.1f : 0f);
-    boolean neutralState =
-        XMLUtils.parseBoolean(elControlPoint.getAttribute("neutral-state"), koth);
+        XMLUtils.parseNumber(el.getAttribute("time-multiplier"), Float.class, koth ? 0.1f : 0f);
+    boolean neutralState = XMLUtils.parseBoolean(el.getAttribute("neutral-state"), koth || pd);
 
     if (!neutralState && ownedDecayRate > 0) {
       throw new InvalidXMLException("This attribute requires a neutral state.", attrOwnedDecay);
     }
-    boolean permanent = XMLUtils.parseBoolean(elControlPoint.getAttribute("permanent"), false);
+    boolean permanent = XMLUtils.parseBoolean(el.getAttribute("permanent"), false);
     float pointsPerSecond =
-        XMLUtils.parseNumber(elControlPoint.getAttribute("points"), Float.class, 1f);
+        XMLUtils.parseNumber(el.getAttribute("points"), Float.class, pd ? 0f : 1f);
     float pointsOwner =
-        XMLUtils.parseNumber(elControlPoint.getAttribute("owner-points"), Float.class, 0f);
+        XMLUtils.parseNumber(el.getAttribute("owner-points"), Float.class, pd ? 1f : 0f);
     float pointsGrowth =
         XMLUtils.parseNumber(
-            elControlPoint.getAttribute("points-growth"), Float.class, Float.POSITIVE_INFINITY);
-    boolean showProgress =
-        XMLUtils.parseBoolean(elControlPoint.getAttribute("show-progress"), koth);
-    ShowOptions options = ShowOptions.parse(elControlPoint);
-    Boolean required = XMLUtils.parseBoolean(elControlPoint.getAttribute("required"), null);
+            el.getAttribute("points-growth"), Float.class, Float.POSITIVE_INFINITY);
+    boolean showProgress = XMLUtils.parseBoolean(el.getAttribute("show-progress"), koth || pd);
+    ShowOptions options = ShowOptions.parse(el);
+    Boolean required = XMLUtils.parseBoolean(el.getAttribute("required"), null);
 
     ControlPointDefinition.CaptureCondition captureCondition =
         XMLUtils.parseEnum(
-            Node.fromAttr(elControlPoint, "capture-rule"),
+            Node.fromAttr(el, "capture-rule"),
             ControlPointDefinition.CaptureCondition.class,
             "capture rule",
             ControlPointDefinition.CaptureCondition.EXCLUSIVE);
 
-    if (type == Type.PAYLOAD) {
+    if (pd) {
       BlockVector location =
-          BlockVectors.center(
-              XMLUtils.parseVector(Node.fromRequiredAttr(elControlPoint, "location")));
-      double radius =
-          XMLUtils.parseNumber(Node.fromRequiredAttr(elControlPoint, "radius"), Double.class);
+          BlockVectors.center(XMLUtils.parseVector(Node.fromRequiredAttr(el, "location")));
+      double radius = XMLUtils.parseNumber(Node.fromRequiredAttr(el, "radius"), Double.class);
+      Filter displayFilter =
+          filterParser.parseFilterProperty(el, "display-filter", StaticFilter.ALLOW);
       return new PayloadDefinition(
           id,
           name,
@@ -178,8 +181,10 @@ public abstract class ControlPointParser {
           pointsGrowth,
           showProgress,
           location,
-          radius);
+          radius,
+          displayFilter);
     }
+
     return new ControlPointDefinition(
         id,
         name,

--- a/core/src/main/java/tc/oc/pgm/controlpoint/RegionPlayerTracker.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/RegionPlayerTracker.java
@@ -16,18 +16,26 @@ import tc.oc.pgm.util.MatchPlayers;
 import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
 
 /** Tracks which players are on a control point and answers some queries about them */
-public class ControlPointPlayerTracker implements Listener {
-  protected final Match match;
-  protected final Region captureRegion;
-  protected final Set<MatchPlayer> playersOnPoint = Sets.newHashSet();
+public class RegionPlayerTracker implements Listener {
+  private final Match match;
+  private final Set<MatchPlayer> playersOnPoint = Sets.newHashSet();
 
-  public ControlPointPlayerTracker(Match match, Region captureRegion) {
+  private Region region;
+
+  public RegionPlayerTracker(Match match, Region region) {
     this.match = match;
-    this.captureRegion = captureRegion;
+    this.region = region;
   }
 
-  public Set<MatchPlayer> getPlayersOnPoint() {
+  public Set<MatchPlayer> getPlayers() {
     return this.playersOnPoint;
+  }
+
+  public void setRegion(Region region) {
+    this.region = region;
+    for (MatchPlayer player : match.getPlayers()) {
+      handlePlayerMove(player.getBukkit(), player.getLocation().toVector());
+    }
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -40,11 +48,11 @@ public class ControlPointPlayerTracker implements Listener {
     this.handlePlayerMove(event.getPlayer(), event.getTo().toVector());
   }
 
-  private void handlePlayerMove(Player bukkit, Vector to) {
+  public void handlePlayerMove(Player bukkit, Vector to) {
     MatchPlayer player = this.match.getPlayer(bukkit);
     if (!MatchPlayers.canInteract(player)) return;
 
-    if (!player.getBukkit().isDead() && this.captureRegion.contains(to.toBlockVector())) {
+    if (!player.getBukkit().isDead() && this.region.contains(to.toBlockVector())) {
       this.playersOnPoint.add(player);
     } else {
       this.playersOnPoint.remove(player);

--- a/core/src/main/java/tc/oc/pgm/controlpoint/RegionPlayerTracker.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/RegionPlayerTracker.java
@@ -18,7 +18,7 @@ import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
 /** Tracks which players are on a control point and answers some queries about them */
 public class RegionPlayerTracker implements Listener {
   private final Match match;
-  private final Set<MatchPlayer> playersOnPoint = Sets.newHashSet();
+  private final Set<MatchPlayer> players = Sets.newHashSet();
 
   private Region region;
 
@@ -28,7 +28,7 @@ public class RegionPlayerTracker implements Listener {
   }
 
   public Set<MatchPlayer> getPlayers() {
-    return this.playersOnPoint;
+    return this.players;
   }
 
   public void setRegion(Region region) {
@@ -53,14 +53,14 @@ public class RegionPlayerTracker implements Listener {
     if (!MatchPlayers.canInteract(player)) return;
 
     if (!player.getBukkit().isDead() && this.region.contains(to.toBlockVector())) {
-      this.playersOnPoint.add(player);
+      this.players.add(player);
     } else {
-      this.playersOnPoint.remove(player);
+      this.players.remove(player);
     }
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerDespawn(final ParticipantDespawnEvent event) {
-    playersOnPoint.remove(event.getPlayer());
+    players.remove(event.getPlayer());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/match/MatchManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchManagerImpl.java
@@ -51,8 +51,7 @@ public class MatchManagerImpl implements MatchManager, Listener {
     this.matchByWorld = new HashMap<>();
 
     final Config config = PGM.get().getConfiguration();
-    this.unloadNonMatches =
-        config.getExperiments().getOrDefault("unload-non-match-worlds", "false").equals("true");
+    this.unloadNonMatches = config.getExperimentAsBool("unload-non-match-worlds", false);
 
     long delaySecs = (config.getStartTime().getSeconds() + 1) / 2;
     try {

--- a/core/src/main/java/tc/oc/pgm/payload/Payload.java
+++ b/core/src/main/java/tc/oc/pgm/payload/Payload.java
@@ -1,0 +1,110 @@
+package tc.oc.pgm.payload;
+
+import java.time.Duration;
+import org.bukkit.Color;
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.controlpoint.ControlPoint;
+import tc.oc.pgm.payload.track.Track;
+
+public class Payload extends ControlPoint {
+
+  private static final int PARTICLE_AMOUNT = 6; // 6 particles
+  private static final int PARTICLE_ROTATION = 20; // ticks per full rotation
+
+  private final Match match;
+  private final PayloadDefinition definition;
+
+  private final Track track;
+  private final PayloadRegion region;
+
+  private Competitor dominantTeam;
+  private Vector position;
+
+  public Payload(Match match, PayloadDefinition definition) {
+    super(match, definition);
+    this.match = match;
+    this.definition = definition;
+
+    this.track = new Track(match, definition.getLocation());
+    this.region = new PayloadRegion(this);
+    this.playerTracker.setRegion(region);
+
+    this.position = definition.getLocation();
+  }
+
+  @Override
+  public void tick(Duration duration) {
+    super.tick(duration);
+
+    Vector oldPos = position;
+    position = track.getVector(getCompletion());
+
+    if (!oldPos.toBlockVector().equals(position.toBlockVector())) playerTracker.setRegion(region);
+
+    tickDisplay(match.getTick().tick);
+  }
+
+  private void tickDisplay(long tick) {
+    Color color = dominantTeam == null ? Color.WHITE : dominantTeam.getFullColor();
+
+    Location loc = position.toLocation(match.getWorld()).add(0, 0.5, 0);
+    spawnParticle(loc, color);
+
+    double diff = Math.PI * 2 / PARTICLE_AMOUNT;
+    double offset = (double) tick * diff / PARTICLE_ROTATION;
+
+    // Each iteration of this loop is one particle
+    for (int i = 0; i < PARTICLE_AMOUNT; i++) {
+      double angle = i * diff + offset;
+      // Height between 0.2 and 0.8
+      double height = 0.5d + 0.3d * Math.sin(0.1d * tick + 0.5d * i);
+
+      loc.set(
+          definition.getRadius() * Math.cos(angle),
+          height,
+          definition.getRadius() * Math.sin(angle));
+      loc.add(position);
+      spawnParticle(loc, color);
+    }
+  }
+
+  private void spawnParticle(Location loc, Color color) {
+    match
+        .getWorld()
+        .spigot()
+        .playEffect(
+            loc,
+            Effect.COLOURED_DUST,
+            0,
+            (byte) 0,
+            rgbToParticle(color.getRed()),
+            rgbToParticle(color.getGreen()),
+            rgbToParticle(color.getBlue()),
+            1,
+            0,
+            200);
+  }
+
+  private float rgbToParticle(int rgb) {
+    return (float) Math.max(0.001, rgb / 255.0);
+  }
+
+  @Override
+  public PayloadDefinition getDefinition() {
+    return (PayloadDefinition) super.getDefinition();
+  }
+
+  public Vector getCurrentPosition() {
+    return position;
+  }
+
+  @Override
+  protected void dominate(Competitor dominantTeam, Duration dominantTime, boolean contested) {
+    this.dominantTeam = dominantTeam;
+    super.dominate(dominantTeam, dominantTime, contested);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/Payload.java
+++ b/core/src/main/java/tc/oc/pgm/payload/Payload.java
@@ -1,25 +1,39 @@
 package tc.oc.pgm.payload;
 
 import java.time.Duration;
+import org.bukkit.ChatColor;
 import org.bukkit.Color;
+import org.bukkit.DyeColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Minecart;
+import org.bukkit.material.Wool;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.Vector;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.controlpoint.ControlPoint;
 import tc.oc.pgm.payload.track.Track;
+import tc.oc.pgm.util.bukkit.BukkitUtils;
 
 public class Payload extends ControlPoint {
 
   private static final int PARTICLE_AMOUNT = 6; // 6 particles
   private static final int PARTICLE_ROTATION = 20; // ticks per full rotation
 
+  private static final String METADATA_KEY = "payload";
+
+  private static final Vector MINECART_OFFSET = new Vector(0, 0.0625, 0);
+  private static final double MAX_OFFSET_SQ = Math.pow(0.25, 2); // Max offset of 0.25
+
   private final Match match;
   private final PayloadDefinition definition;
 
   private final Track track;
+  private final Minecart minecart;
   private final PayloadRegion captureRegion;
 
   private Competitor dominantTeam;
@@ -30,10 +44,23 @@ public class Payload extends ControlPoint {
     this.match = match;
     this.definition = definition;
 
-    this.track = new Track(match, definition.getLocation());
     this.position = definition.getLocation();
+
+    this.track = new Track(match, definition.getLocation());
+    this.minecart = spawnMinecart();
     this.captureRegion = new PayloadRegion(this::getCenterPoint, definition.getRadius());
+
     this.playerTracker.setRegion(captureRegion);
+  }
+
+  private Minecart spawnMinecart() {
+    Minecart minecart =
+        match.getWorld().spawn(position.toLocation(match.getWorld()), Minecart.class);
+
+    minecart.setDisplayBlock(new Wool(DyeColor.WHITE));
+    minecart.setSlowWhenEmpty(true);
+    minecart.setMetadata(METADATA_KEY, new FixedMetadataValue(PGM.get(), true));
+    return minecart;
   }
 
   @Override
@@ -58,23 +85,23 @@ public class Payload extends ControlPoint {
     if (!oldPos.toBlockVector().equals(position.toBlockVector()))
       playerTracker.setRegion(captureRegion);
 
-    tickDisplay(match.getTick().tick);
+    tickParticles(match.getTick().tick);
+    tickMinecart();
   }
 
-  private void tickDisplay(long tick) {
-    if (!definition.getDisplayFilter().query(match).isAllowed()) return;
-    Color color =
-        dominantTeam != null
-            ? dominantTeam.getFullColor()
-            : controllingTeam != null ? controllingTeam.getFullColor() : Color.WHITE;
+  private Competitor getDisplayTeam() {
+    return dominantTeam != null ? dominantTeam : controllingTeam != null ? controllingTeam : null;
+  }
 
-    Location loc = position.toLocation(match.getWorld()).add(0, 0.5, 0);
-    spawnParticle(loc, color);
+  private void tickParticles(long tick) {
+    if (!definition.getDisplayFilter().query(match).isAllowed()) return;
+    Competitor display = getDisplayTeam();
+    Color color = display != null ? display.getFullColor() : Color.WHITE;
 
     double diff = Math.PI * 2 / PARTICLE_AMOUNT;
     double offset = (double) tick * diff / PARTICLE_ROTATION;
 
-    // Each iteration of this loop is one particle
+    Location loc = new Location(match.getWorld(), 0, 0, 0);
     for (int i = 0; i < PARTICLE_AMOUNT; i++) {
       double angle = i * diff + offset;
       // Height between 0.2 and 0.8
@@ -85,34 +112,56 @@ public class Payload extends ControlPoint {
           height,
           definition.getRadius() * Math.sin(angle));
       loc.add(position);
-      spawnParticle(loc, color);
+      match
+          .getWorld()
+          .spigot()
+          .playEffect(
+              loc,
+              Effect.COLOURED_DUST,
+              0,
+              (byte) 0,
+              rgbToParticle(color.getRed()),
+              rgbToParticle(color.getGreen()),
+              rgbToParticle(color.getBlue()),
+              1,
+              0,
+              50);
     }
-  }
-
-  private void spawnParticle(Location loc, Color color) {
-    match
-        .getWorld()
-        .spigot()
-        .playEffect(
-            loc,
-            Effect.COLOURED_DUST,
-            0,
-            (byte) 0,
-            rgbToParticle(color.getRed()),
-            rgbToParticle(color.getGreen()),
-            rgbToParticle(color.getBlue()),
-            1,
-            0,
-            200);
   }
 
   private float rgbToParticle(int rgb) {
     return (float) Math.max(0.001, rgb / 255.0);
   }
 
+  private void tickMinecart() {
+    Vector current = minecart.getLocation().toVector();
+    Vector desired = position.clone().add(MINECART_OFFSET);
+
+    if (current.distanceSquared(desired) > MAX_OFFSET_SQ)
+      minecart.teleport(desired.toLocation(minecart.getWorld()));
+    else minecart.setVelocity(desired.subtract(current));
+  }
+
+  private void updateWool() {
+    Competitor display = getDisplayTeam();
+    DyeColor color =
+        BukkitUtils.chatColorToDyeColor(display != null ? display.getColor() : ChatColor.WHITE);
+
+    Wool data = (Wool) minecart.getDisplayBlock();
+    data.setColor(color);
+    minecart.setDisplayBlock(data);
+  }
+
   @Override
   protected void dominate(Competitor dominantTeam, Duration dominantTime, boolean contested) {
-    this.dominantTeam = dominantTeam;
+    if (this.dominantTeam != dominantTeam) {
+      this.dominantTeam = dominantTeam;
+      updateWool();
+    }
     super.dominate(dominantTeam, dominantTime, contested);
+  }
+
+  public static boolean isPayload(Entity entity) {
+    return entity.hasMetadata(METADATA_KEY);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/payload/PayloadDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/payload/PayloadDefinition.java
@@ -1,0 +1,87 @@
+package tc.oc.pgm.payload;
+
+import java.time.Duration;
+import org.bukkit.util.BlockVector;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.controlpoint.ControlPointDefinition;
+import tc.oc.pgm.goals.ShowOptions;
+import tc.oc.pgm.teams.TeamFactory;
+
+public class PayloadDefinition extends ControlPointDefinition {
+
+  private final BlockVector location;
+  private final double radius;
+
+  public PayloadDefinition(
+      @Nullable String id,
+      String name,
+      @Nullable Boolean required,
+      ShowOptions showOptions,
+      Region captureRegion,
+      Filter captureFilter,
+      Filter playerFilter,
+      Region progressDisplayRegion,
+      Region ownerDisplayRegion,
+      Filter visualMaterials,
+      BlockVector capturableDisplayBeacon,
+      Duration timeToCapture,
+      double decayRate,
+      double recoveryRate,
+      double ownedDecayRate,
+      double contestedRate,
+      float timeMultiplier,
+      @Nullable TeamFactory initialOwner,
+      CaptureCondition captureCondition,
+      boolean neutralState,
+      boolean permanent,
+      float pointsPerSecond,
+      float pointsOwner,
+      float pointsGrowth,
+      boolean progress,
+      BlockVector location,
+      double radius) {
+    super(
+        id,
+        name,
+        required,
+        showOptions,
+        captureRegion,
+        captureFilter,
+        playerFilter,
+        progressDisplayRegion,
+        ownerDisplayRegion,
+        visualMaterials,
+        capturableDisplayBeacon,
+        timeToCapture,
+        decayRate,
+        recoveryRate,
+        ownedDecayRate,
+        contestedRate,
+        timeMultiplier,
+        initialOwner,
+        captureCondition,
+        neutralState,
+        permanent,
+        pointsPerSecond,
+        pointsOwner,
+        pointsGrowth,
+        progress);
+    this.location = location;
+    this.radius = radius;
+  }
+
+  public BlockVector getLocation() {
+    return location;
+  }
+
+  public double getRadius() {
+    return radius;
+  }
+
+  public Payload build(Match match) {
+    return new Payload(match, this);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/PayloadDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/payload/PayloadDefinition.java
@@ -14,6 +14,7 @@ public class PayloadDefinition extends ControlPointDefinition {
 
   private final BlockVector location;
   private final double radius;
+  private final Filter displayFilter;
 
   public PayloadDefinition(
       @Nullable String id,
@@ -42,7 +43,8 @@ public class PayloadDefinition extends ControlPointDefinition {
       float pointsGrowth,
       boolean progress,
       BlockVector location,
-      double radius) {
+      double radius,
+      Filter displayFilter) {
     super(
         id,
         name,
@@ -71,6 +73,7 @@ public class PayloadDefinition extends ControlPointDefinition {
         progress);
     this.location = location;
     this.radius = radius;
+    this.displayFilter = displayFilter;
   }
 
   public BlockVector getLocation() {
@@ -79,6 +82,10 @@ public class PayloadDefinition extends ControlPointDefinition {
 
   public double getRadius() {
     return radius;
+  }
+
+  public Filter getDisplayFilter() {
+    return displayFilter;
   }
 
   public Payload build(Match match) {

--- a/core/src/main/java/tc/oc/pgm/payload/PayloadListener.java
+++ b/core/src/main/java/tc/oc/pgm/payload/PayloadListener.java
@@ -1,0 +1,25 @@
+package tc.oc.pgm.payload;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.vehicle.VehicleDamageEvent;
+import org.bukkit.event.vehicle.VehicleDestroyEvent;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
+
+public class PayloadListener implements Listener {
+
+  @EventHandler
+  public void onVehicleDamage(final VehicleDamageEvent event) {
+    if (Payload.isPayload(event.getVehicle())) event.setCancelled(true);
+  }
+
+  @EventHandler
+  public void onVehicleEnter(final VehicleEnterEvent event) {
+    if (Payload.isPayload(event.getVehicle())) event.setCancelled(true);
+  }
+
+  @EventHandler
+  public void onVehicleDestroy(final VehicleDestroyEvent event) {
+    if (Payload.isPayload(event.getVehicle())) event.setCancelled(true);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/PayloadRegion.java
+++ b/core/src/main/java/tc/oc/pgm/payload/PayloadRegion.java
@@ -1,26 +1,46 @@
 package tc.oc.pgm.payload;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.function.Supplier;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.regions.AbstractRegion;
 import tc.oc.pgm.regions.Bounds;
 
+/** This is a region that is not immutable. The origin point of the sphere can move. */
 public class PayloadRegion extends AbstractRegion {
 
-  private final Payload payload;
-  private final double distanceSquared;
+  private final Supplier<Vector> origin;
+  private final double radius;
+  private final double radiusSq;
 
-  public PayloadRegion(Payload payload) {
-    this.payload = payload;
-    this.distanceSquared = Math.pow(payload.getDefinition().getRadius(), 2);
+  public PayloadRegion(Supplier<Vector> origin, double radius) {
+    checkArgument(radius >= 0);
+
+    this.origin = origin;
+    this.radius = radius;
+    this.radiusSq = Math.pow(radius, 2);
   }
 
   @Override
   public boolean contains(Vector point) {
-    return payload.getCurrentPosition().distanceSquared(point) <= distanceSquared;
+    return origin.get().distanceSquared(point) <= radiusSq;
+  }
+
+  @Override
+  public boolean isBlockBounded() {
+    return !Double.isInfinite(radius);
   }
 
   @Override
   public Bounds getBounds() {
-    return Bounds.unbounded();
+    Vector diagonal = new Vector(this.radius, this.radius, this.radius);
+    return new Bounds(
+        origin.get().clone().subtract(diagonal), this.origin.get().clone().add(diagonal));
+  }
+
+  @Override
+  public String toString() {
+    return "PayloadRegion{origin=[" + this.origin.get() + "],radiusSq=" + this.radiusSq + "}";
   }
 }

--- a/core/src/main/java/tc/oc/pgm/payload/PayloadRegion.java
+++ b/core/src/main/java/tc/oc/pgm/payload/PayloadRegion.java
@@ -7,24 +7,29 @@ import org.bukkit.util.Vector;
 import tc.oc.pgm.regions.AbstractRegion;
 import tc.oc.pgm.regions.Bounds;
 
-/** This is a region that is not immutable. The origin point of the sphere can move. */
+/** This is a region that is not immutable. The origin point of the cylinder can move. */
 public class PayloadRegion extends AbstractRegion {
 
-  private final Supplier<Vector> origin;
+  private final Supplier<Vector> base;
   private final double radius;
   private final double radiusSq;
 
-  public PayloadRegion(Supplier<Vector> origin, double radius) {
+  public PayloadRegion(Supplier<Vector> base, double radius) {
     checkArgument(radius >= 0);
 
-    this.origin = origin;
+    this.base = base;
     this.radius = radius;
     this.radiusSq = Math.pow(radius, 2);
   }
 
   @Override
   public boolean contains(Vector point) {
-    return origin.get().distanceSquared(point) <= radiusSq;
+    Vector base = this.base.get();
+
+    return point.getY() >= (base.getY() - 2.5)
+        && point.getY() <= (base.getY() + 2.5)
+        && Math.pow(point.getX() - base.getX(), 2) + Math.pow(point.getZ() - base.getZ(), 2)
+            < this.radiusSq;
   }
 
   @Override
@@ -34,13 +39,14 @@ public class PayloadRegion extends AbstractRegion {
 
   @Override
   public Bounds getBounds() {
-    Vector diagonal = new Vector(this.radius, this.radius, this.radius);
+    Vector base = this.base.get();
     return new Bounds(
-        origin.get().clone().subtract(diagonal), this.origin.get().clone().add(diagonal));
+        new Vector(base.getX() - this.radius, base.getY() - 2.5, base.getZ() - this.radius),
+        new Vector(base.getX() + this.radius, base.getY() + 2.5, base.getZ() + this.radius));
   }
 
   @Override
   public String toString() {
-    return "PayloadRegion{origin=[" + this.origin.get() + "],radiusSq=" + this.radiusSq + "}";
+    return "PayloadRegion{base=[" + this.base.get() + "],radiusSq=" + this.radiusSq + "}";
   }
 }

--- a/core/src/main/java/tc/oc/pgm/payload/PayloadRegion.java
+++ b/core/src/main/java/tc/oc/pgm/payload/PayloadRegion.java
@@ -1,0 +1,26 @@
+package tc.oc.pgm.payload;
+
+import org.bukkit.util.Vector;
+import tc.oc.pgm.regions.AbstractRegion;
+import tc.oc.pgm.regions.Bounds;
+
+public class PayloadRegion extends AbstractRegion {
+
+  private final Payload payload;
+  private final double distanceSquared;
+
+  public PayloadRegion(Payload payload) {
+    this.payload = payload;
+    this.distanceSquared = Math.pow(payload.getDefinition().getRadius(), 2);
+  }
+
+  @Override
+  public boolean contains(Vector point) {
+    return payload.getCurrentPosition().distanceSquared(point) <= distanceSquared;
+  }
+
+  @Override
+  public Bounds getBounds() {
+    return Bounds.unbounded();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/track/BackwardsRail.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/BackwardsRail.java
@@ -1,0 +1,33 @@
+package tc.oc.pgm.payload.track;
+
+import org.bukkit.block.BlockFace;
+import org.bukkit.util.Vector;
+
+public class BackwardsRail implements RailOffset {
+
+  private final RailOffset other;
+
+  public BackwardsRail(RailOffset other) {
+    this.other = other;
+  }
+
+  @Override
+  public Vector getOffset(double progress) {
+    return other.getOffset(1 - progress);
+  }
+
+  @Override
+  public BlockFace getNext() {
+    return other.getPrevious();
+  }
+
+  @Override
+  public BlockFace getPrevious() {
+    return other.getNext();
+  }
+
+  @Override
+  public RailOffset reverse() {
+    return other;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/track/CurvedRail.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/CurvedRail.java
@@ -1,0 +1,32 @@
+package tc.oc.pgm.payload.track;
+
+import org.bukkit.block.BlockFace;
+import org.bukkit.util.Vector;
+
+class CurvedRail implements RailOffset {
+  private final BlockFace from;
+  private final BlockFace to;
+
+  public CurvedRail(BlockFace from, BlockFace to) {
+    this.from = from;
+    this.to = to;
+  }
+
+  @Override
+  public Vector getOffset(double progress) {
+    BlockFace direction = progress < 0.5 ? from : to;
+    // Frame progress between 0.5 -> 0 -> 0.5, but in different directions
+    progress = Math.abs(progress - 0.5);
+    return new Vector(direction.getModX(), 0, direction.getModZ()).multiply(progress).setY(-0.5);
+  }
+
+  @Override
+  public BlockFace getNext() {
+    return to;
+  }
+
+  @Override
+  public BlockFace getPrevious() {
+    return from;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/track/CurvedRail.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/CurvedRail.java
@@ -14,10 +14,15 @@ class CurvedRail implements RailOffset {
 
   @Override
   public Vector getOffset(double progress) {
-    BlockFace direction = progress < 0.5 ? from : to;
-    // Frame progress between 0.5 -> 0 -> 0.5, but in different directions
-    progress = Math.abs(progress - 0.5);
-    return new Vector(direction.getModX(), 0, direction.getModZ()).multiply(progress).setY(-0.5);
+    double remaining = 1 - progress;
+
+    progress *= 0.5;
+    remaining *= 0.5;
+
+    return new Vector(
+        remaining * from.getModX() + progress * to.getModX(),
+        -0.5,
+        remaining * from.getModZ() + progress * to.getModZ());
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/payload/track/RailDirection.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/RailDirection.java
@@ -1,0 +1,56 @@
+package tc.oc.pgm.payload.track;
+
+import javax.annotation.Nullable;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.material.MaterialData;
+import org.bukkit.material.Rails;
+
+public enum RailDirection {
+  SOUTH(new StraightRail(BlockFace.SOUTH), new StraightRail(BlockFace.NORTH)),
+  EAST(new StraightRail(BlockFace.EAST), new StraightRail(BlockFace.WEST)),
+  EAST_SLOPE(new SlopedRail(BlockFace.EAST)),
+  WEST_SLOPE(new SlopedRail(BlockFace.WEST)),
+  NORTH_SLOPE(new SlopedRail(BlockFace.NORTH)),
+  SOUTH_SLOPE(new SlopedRail(BlockFace.SOUTH)),
+  SOUTH_EAST(new CurvedRail(BlockFace.SOUTH, BlockFace.EAST)),
+  SOUTH_WEST(new CurvedRail(BlockFace.SOUTH, BlockFace.WEST)),
+  NORTH_WEST(new CurvedRail(BlockFace.NORTH, BlockFace.WEST)),
+  NORTH_EAST(new CurvedRail(BlockFace.NORTH, BlockFace.EAST));
+
+  private static final RailDirection[] DIRECTIONS = values();
+
+  public final RailOffset forwards;
+  public final RailOffset backwards;
+
+  RailDirection(RailOffset forwards) {
+    this(forwards, forwards.reverse());
+  }
+
+  RailDirection(RailOffset forwards, RailOffset backwards) {
+    this.forwards = forwards;
+    this.backwards = backwards;
+  }
+
+  public static RailOffset of(Block block, @Nullable BlockFace previous) {
+    RailDirection direction = getRail(block);
+    if (direction == null) return null;
+
+    if (previous == null) return direction.forwards;
+    return previous.getOppositeFace() == direction.forwards.getPrevious()
+        ? direction.forwards
+        : direction.backwards;
+  }
+
+  public static @Nullable RailDirection getRail(Block block) {
+    MaterialData md = block.getState().getMaterialData();
+    if (!(md instanceof Rails)) return null;
+
+    byte data = md.getData();
+    if (data < 0 || data >= DIRECTIONS.length)
+      throw new IllegalStateException(
+          "Invalid rail metadata: " + data + " @ " + block.getLocation());
+
+    return DIRECTIONS[data];
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/track/RailOffset.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/RailOffset.java
@@ -1,0 +1,35 @@
+package tc.oc.pgm.payload.track;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.material.Rails;
+import org.bukkit.util.Vector;
+
+public interface RailOffset {
+
+  /**
+   * Return a normal-like vector for where the position is for the specific progress.
+   *
+   * @param progress a number between 0 and 1, for 0% to 100% progress within the block
+   * @return A vector with values between -0.5 and 0.5. They represent the offset from center.
+   */
+  Vector getOffset(double progress);
+
+  BlockFace getNext();
+
+  default Block getNextRail(Block current) {
+    BlockFace face = getNext();
+    Block next = current.getRelative(face);
+
+    if (!(next.getState().getMaterialData() instanceof Rails))
+      next = next.getRelative(BlockFace.DOWN);
+
+    return next;
+  }
+
+  BlockFace getPrevious();
+
+  default RailOffset reverse() {
+    return new BackwardsRail(this);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/track/SlopedRail.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/SlopedRail.java
@@ -1,0 +1,26 @@
+package tc.oc.pgm.payload.track;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
+
+class SlopedRail extends StraightRail {
+
+  public SlopedRail(BlockFace direction) {
+    super(direction);
+  }
+
+  @Override
+  public Vector getOffset(double progress) {
+    Vector offset = super.getOffset(progress);
+    offset.setY(progress - 0.5);
+    return offset;
+  }
+
+  @Nullable
+  @Override
+  public Block getNextRail(Block current) {
+    return current.getRelative(getNext()).getRelative(BlockFace.UP);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/track/StraightRail.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/StraightRail.java
@@ -1,0 +1,32 @@
+package tc.oc.pgm.payload.track;
+
+import org.bukkit.block.BlockFace;
+import org.bukkit.util.Vector;
+
+class StraightRail implements RailOffset {
+  private final BlockFace direction;
+
+  protected StraightRail(BlockFace direction) {
+    this.direction = direction;
+  }
+
+  @Override
+  public Vector getOffset(double progress) {
+    // Frame progress between -0.5 and 0.5
+    progress -= 0.5;
+
+    return new Vector(direction.getModX(), direction.getModY(), direction.getModZ())
+        .multiply(progress)
+        .setY(-0.5);
+  }
+
+  @Override
+  public BlockFace getNext() {
+    return direction;
+  }
+
+  @Override
+  public BlockFace getPrevious() {
+    return direction.getOppositeFace();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/payload/track/Track.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/Track.java
@@ -1,0 +1,60 @@
+package tc.oc.pgm.payload.track;
+
+import com.google.common.collect.ImmutableList;
+import org.bukkit.block.Block;
+import org.bukkit.util.BlockVector;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.util.block.BlockVectors;
+
+public class Track {
+
+  private final ImmutableList<Rail> track;
+
+  public Track(Match match, BlockVector start) {
+    ImmutableList.Builder<Rail> builder = ImmutableList.builder();
+
+    Block nextBlock = start.toLocation(match.getWorld()).getBlock();
+    RailOffset nextOffset = RailDirection.of(nextBlock, null);
+
+    if (nextOffset == null) throw new ModuleLoadException("Start must be a rail @ " + start);
+
+    // No rail that way, go the opposite way instead
+    if (RailDirection.getRail(nextOffset.getNextRail(nextBlock)) == null)
+      nextOffset = nextOffset.reverse();
+
+    while (nextOffset != null) {
+      builder.add(new Rail(BlockVectors.position(nextBlock.getState()), nextOffset));
+
+      nextBlock = nextOffset.getNextRail(nextBlock);
+      nextOffset = RailDirection.of(nextBlock, nextOffset.getNext());
+    }
+
+    this.track = builder.build();
+  }
+
+  public Vector getVector(double progress) {
+    // Remove 1 from overall size, and shift 0.5 forwards
+    // A track with 3 blocks goes from 0.5 to 2.5, because start & end occurs at the center of the
+    // block.
+    double scaledProgress = (progress * (track.size() - 1)) + 0.5;
+    Rail rail = track.get((int) scaledProgress);
+
+    return rail.getOffset(scaledProgress % 1d);
+  }
+
+  private static class Rail {
+    private final BlockVector position;
+    private final RailOffset offset;
+
+    public Rail(BlockVector position, RailOffset offset) {
+      this.position = BlockVectors.center(position);
+      this.offset = offset;
+    }
+
+    public Vector getOffset(double progress) {
+      return offset.getOffset(progress).add(position);
+    }
+  }
+}

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -200,4 +200,6 @@ database-uri: ""
 database-max-connections: 5
 
 # Experimental features that are not yet stable.
-experiments: {}
+experiments:
+  # Enable payload preview. This is not fully finished and xml syntax is likely to change at a later time.
+  payload: false


### PR DESCRIPTION
This is an experimental prototype for payload, not a final PR, however, it can be merged for playtesting.

It piggybacks off of ControlPoints entirely, to the point Payloads are "a type of control point" internally, they just use a different region to capture and display some particles on the world. 0% completion is the start of the track (set with location="x,y,z" in xml) and 100% completion is wherever the track ends.

```xml
<payloads>
  <payload location="x,y,z" radius="3" display-filter="filter" capture-time="1m" decay-rate="0.25" .../>
</payloads>
```
Note: In its current state it only properly supports A/D payload. If both teams can capture it, it *works* but it will go towards the same destination for both teams (going back when the non-dominating team goes in it), which is likely undesired behavior.

It supports *literally* everything that control points support (including absurd ones like a progress region, even tho they're unlikely to be of any use with a payload). So things like filtering players, multiple payloads chained (5-cp style), permanent="true", capture-time, decay-rate, contested-rate, recovery-rate, etc, all work.

On top of the control point stuff, it supports `display-filter` which filters if particles are shown. This is useful when combining multiple payloads to signify if they're active or not (this is likely to get removed, changed or reworked in the future when checkpoints are introduced).

How the payload currently looks like:

https://user-images.githubusercontent.com/11789291/192090427-8c315f9d-0442-40fe-a63a-d3f13d37ff12.mp4


