### PR TITLE
Optimize scoreboard & allow ratelimit

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchTabManager.java
@@ -33,6 +33,7 @@ import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.teams.events.TeamResizeEvent;
 import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.collection.DefaultMapAdapter;
+import tc.oc.pgm.util.concurrent.RateLimiter;
 import tc.oc.pgm.util.tablist.DynamicTabEntry;
 import tc.oc.pgm.util.tablist.PlayerTabEntry;
 import tc.oc.pgm.util.tablist.TabEntry;
@@ -57,7 +58,8 @@ public class MatchTabManager extends TabManager implements Listener {
 
   private Future<?> pingUpdateTask;
   private Future<?> renderTask;
-  private long lastUpdate = 0, renderTime = 0, loadingUntil = 0;
+  private final RateLimiter rateLimit =
+      new RateLimiter(MIN_DELAY, MAX_DELAY, TIME_RATIO, TPS_RATIO);
 
   public MatchTabManager(Plugin plugin) {
     this(
@@ -144,22 +146,14 @@ public class MatchTabManager extends TabManager implements Listener {
     if (this.renderTask == null) {
       Runnable render =
           () -> {
-            long start = System.currentTimeMillis();
+            rateLimit.beforeTask();
             MatchTabManager.this.renderTask = null;
             MatchTabManager.this.render();
-            lastUpdate = System.currentTimeMillis();
-            renderTime = lastUpdate - start;
+            rateLimit.afterTask();
           };
 
-      long now = System.currentTimeMillis();
-
-      long nextUpdate =
-          (lastUpdate - now)
-              + (renderTime * TIME_RATIO)
-              + (long) Math.max(0, (20 - Bukkit.getServer().spigot().getTPS()[0]) * TPS_RATIO)
-              + (loadingUntil > now ? MAX_DELAY : 0);
-      nextUpdate = Math.min(Math.max(MIN_DELAY, nextUpdate), MAX_DELAY);
-      this.renderTask = PGM.get().getExecutor().schedule(render, nextUpdate, TimeUnit.MILLISECONDS);
+      this.renderTask =
+          PGM.get().getExecutor().schedule(render, rateLimit.getDelay(), TimeUnit.MILLISECONDS);
     }
   }
 
@@ -238,12 +232,12 @@ public class MatchTabManager extends TabManager implements Listener {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchLoad(MatchLoadEvent event) {
-    loadingUntil = System.currentTimeMillis() + MATCH_LOAD_TIMEOUT;
+    rateLimit.setTimeout(System.currentTimeMillis() + MATCH_LOAD_TIMEOUT);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchUnload(MatchUnloadEvent event) {
-    loadingUntil = 0;
+    rateLimit.setTimeout(0);
     TeamMatchModule tmm = event.getMatch().getModule(TeamMatchModule.class);
     if (tmm != null) {
       for (Team team : tmm.getTeams()) {

--- a/util/src/main/java/tc/oc/pgm/util/concurrent/RateLimiter.java
+++ b/util/src/main/java/tc/oc/pgm/util/concurrent/RateLimiter.java
@@ -1,0 +1,43 @@
+package tc.oc.pgm.util.concurrent;
+
+import org.bukkit.Bukkit;
+
+public class RateLimiter {
+  private final int minDelay, maxDelay;
+  private final int timeRatio;
+  private final int tpsRatio;
+
+  private long startedAt = 0;
+  private long endedAt = 0;
+  private long timedOutUntil = 0;
+
+  public RateLimiter(int minDelay, int maxDelay, int timeRatio, int tpsRatio) {
+    this.minDelay = minDelay;
+    this.maxDelay = maxDelay;
+    this.timeRatio = timeRatio;
+    this.tpsRatio = tpsRatio;
+  }
+
+  public void beforeTask() {
+    startedAt = System.currentTimeMillis();
+  }
+
+  public void afterTask() {
+    endedAt = System.currentTimeMillis();
+  }
+
+  public void setTimeout(long until) {
+    this.timedOutUntil = until;
+  }
+
+  public long getDelay() {
+    long now = System.currentTimeMillis();
+
+    long nextUpdate =
+        (endedAt - now)
+            + ((endedAt - startedAt) * timeRatio)
+            + (long) Math.max(0, (20 - Bukkit.getServer().spigot().getTPS()[0]) * tpsRatio)
+            + (timedOutUntil > now ? maxDelay : 0);
+    return Math.min(Math.max(minDelay, nextUpdate), maxDelay);
+  }
+}


### PR DESCRIPTION
Allows scoreboard being rate-limiting under stress situations, in a similar fashion to tablist, where if the renders take long or if the server runs low on TPS it will debounce for longer periods (up to 1 second). This reuses logic originally used in tablist to debounce (in that case, up to 5s), which has now been put in a RateLimiter util, and reused in both places.

The reason for this change is that specifically for ffa, where sidebar renders player names, it can take a non-trivial amount of text serialization/deserialization, which can be costly. Additionally, names have been changed to use the simpler just-color version of the name, which should be faster than the full version with flairs and hover events etc.