### PR TITLE
Add item replace action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -3,11 +3,13 @@ package tc.oc.pgm.action;
 import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Method;
 import java.util.Map;
+import org.bukkit.inventory.ItemStack;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.action.actions.ActionNode;
 import tc.oc.pgm.action.actions.ChatMessageAction;
 import tc.oc.pgm.action.actions.KillEntitiesAction;
+import tc.oc.pgm.action.actions.ReplaceItemAction;
 import tc.oc.pgm.action.actions.ScopeSwitchAction;
 import tc.oc.pgm.action.actions.SetVariableAction;
 import tc.oc.pgm.api.feature.FeatureValidation;
@@ -22,6 +24,7 @@ import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
+import tc.oc.pgm.util.inventory.ItemMatcher;
 import tc.oc.pgm.util.math.Formula;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
@@ -210,5 +213,16 @@ public class ActionParser {
   public KillEntitiesAction parseKillEntities(Element el, Class<?> scope)
       throws InvalidXMLException {
     return new KillEntitiesAction(factory.getFilters().parseFilterProperty(el, "filter"));
+  }
+
+  @MethodParser("replace-item")
+  public ReplaceItemAction parseReplaceItem(Element el, Class<?> scope) throws InvalidXMLException {
+    ItemMatcher matcher = factory.getKits().parseItemMatcher(el, "find");
+    ItemStack item = factory.getKits().parseItem(el.getChild("replace"), true);
+
+    boolean keepAmount = XMLUtils.parseBoolean(el.getAttribute("keep-amount"), false);
+    boolean keepEnchants = XMLUtils.parseBoolean(el.getAttribute("keep-enchants"), false);
+
+    return new ReplaceItemAction(matcher, item, keepAmount, keepEnchants);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
@@ -1,0 +1,38 @@
+package tc.oc.pgm.action.actions;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.util.inventory.ItemMatcher;
+
+public class ReplaceItemAction extends AbstractAction<MatchPlayer> {
+
+  private final ItemMatcher matcher;
+  private final ItemStack item;
+  private final boolean keepAmount;
+  private final boolean keepEnchants;
+
+  public ReplaceItemAction(
+      ItemMatcher matcher, ItemStack item, boolean keepAmount, boolean keepEnchants) {
+    super(MatchPlayer.class);
+    this.matcher = matcher;
+    this.item = item;
+    this.keepAmount = keepAmount;
+    this.keepEnchants = keepEnchants;
+  }
+
+  @Override
+  public void trigger(MatchPlayer matchPlayer) {
+    Inventory inv = matchPlayer.getInventory();
+    for (int i = 0; i < inv.getSize(); i++) {
+      ItemStack current = inv.getItem(i);
+      if (current == null || !matcher.matches(current)) continue;
+
+      ItemStack newItem = item.clone();
+      if (keepAmount) newItem.setAmount(current.getAmount());
+      if (keepEnchants) newItem.addEnchantments(current.getEnchantments());
+
+      inv.setItem(i, newItem);
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
@@ -1,7 +1,7 @@
 package tc.oc.pgm.action.actions;
 
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.util.inventory.ItemMatcher;
 
@@ -23,16 +23,29 @@ public class ReplaceItemAction extends AbstractAction<MatchPlayer> {
 
   @Override
   public void trigger(MatchPlayer matchPlayer) {
-    Inventory inv = matchPlayer.getInventory();
+    PlayerInventory inv = matchPlayer.getInventory();
+
+    ItemStack[] armor = inv.getArmorContents();
+    for (int i = 0; i < armor.length; i++) {
+      ItemStack current = armor[i];
+      if (current == null || !matcher.matches(current)) continue;
+      armor[i] = replaceItem(current);
+    }
+    inv.setArmorContents(armor);
+
     for (int i = 0; i < inv.getSize(); i++) {
       ItemStack current = inv.getItem(i);
       if (current == null || !matcher.matches(current)) continue;
 
-      ItemStack newItem = item.clone();
-      if (keepAmount) newItem.setAmount(current.getAmount());
-      if (keepEnchants) newItem.addEnchantments(current.getEnchantments());
-
+      ItemStack newItem = replaceItem(current);
       inv.setItem(i, newItem);
     }
+  }
+
+  private ItemStack replaceItem(ItemStack current) {
+    ItemStack newItem = item.clone();
+    if (keepAmount) newItem.setAmount(current.getAmount());
+    if (keepEnchants) newItem.addEnchantments(current.getEnchantments());
+    return newItem;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.action.actions;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.kits.tag.ItemModifier;
 import tc.oc.pgm.util.inventory.ItemMatcher;
 
 public class ReplaceItemAction extends AbstractAction<MatchPlayer> {
@@ -22,30 +23,29 @@ public class ReplaceItemAction extends AbstractAction<MatchPlayer> {
   }
 
   @Override
-  public void trigger(MatchPlayer matchPlayer) {
-    PlayerInventory inv = matchPlayer.getInventory();
+  public void trigger(MatchPlayer player) {
+    PlayerInventory inv = player.getInventory();
 
     ItemStack[] armor = inv.getArmorContents();
     for (int i = 0; i < armor.length; i++) {
       ItemStack current = armor[i];
       if (current == null || !matcher.matches(current)) continue;
-      armor[i] = replaceItem(current);
+      armor[i] = replaceItem(current, player);
     }
     inv.setArmorContents(armor);
 
     for (int i = 0; i < inv.getSize(); i++) {
       ItemStack current = inv.getItem(i);
       if (current == null || !matcher.matches(current)) continue;
-
-      ItemStack newItem = replaceItem(current);
-      inv.setItem(i, newItem);
+      inv.setItem(i, replaceItem(current, player));
     }
   }
 
-  private ItemStack replaceItem(ItemStack current) {
+  private ItemStack replaceItem(ItemStack current, MatchPlayer player) {
     ItemStack newItem = item.clone();
     if (keepAmount) newItem.setAmount(current.getAmount());
     if (keepEnchants) newItem.addEnchantments(current.getEnchantments());
+    ItemModifier.apply(newItem, player);
     return newItem;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -3,7 +3,7 @@ package tc.oc.pgm.controlpoint;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.bukkit.Material;
+import java.util.stream.Collectors;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 import org.jdom2.Attribute;
@@ -16,6 +16,7 @@ import tc.oc.pgm.filters.matcher.block.BlockFilter;
 import tc.oc.pgm.filters.operator.AnyFilter;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.goals.ShowOptions;
+import tc.oc.pgm.kits.tag.ItemModifier;
 import tc.oc.pgm.payload.PayloadDefinition;
 import tc.oc.pgm.regions.BlockBoundedValidation;
 import tc.oc.pgm.regions.EverywhereRegion;
@@ -30,11 +31,7 @@ import tc.oc.pgm.util.xml.XMLUtils;
 public abstract class ControlPointParser {
   private static final Filter VISUAL_MATERIALS =
       AnyFilter.of(
-          new BlockFilter(Material.WOOL),
-          new BlockFilter(Material.CARPET),
-          new BlockFilter(Material.STAINED_CLAY),
-          new BlockFilter(Material.STAINED_GLASS),
-          new BlockFilter(Material.STAINED_GLASS_PANE));
+          ItemModifier.COLOR_AFFECTED.stream().map(BlockFilter::new).collect(Collectors.toList()));
 
   public enum Type {
     HILL,

--- a/core/src/main/java/tc/oc/pgm/filters/operator/AllFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/AllFilter.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.filters.operator;
 
-import java.util.List;
+import java.util.Collection;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 
@@ -29,7 +29,7 @@ public class AllFilter extends MultiFilterFunction {
     return MultiFilterFunction.of(AllFilter::new, filters);
   }
 
-  public static Filter of(List<Filter> filters) {
+  public static Filter of(Collection<Filter> filters) {
     return MultiFilterFunction.of(AllFilter::new, filters);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/AnyFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/AnyFilter.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.filters.operator;
 
-import java.util.List;
+import java.util.Collection;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 
@@ -29,7 +29,7 @@ public class AnyFilter extends MultiFilterFunction {
     return MultiFilterFunction.of(AnyFilter::new, filters);
   }
 
-  public static Filter of(List<Filter> filters) {
+  public static Filter of(Collection<Filter> filters) {
     return MultiFilterFunction.of(AnyFilter::new, filters);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/OneFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/OneFilter.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.filters.operator;
 
-import java.util.List;
+import java.util.Collection;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 
@@ -32,7 +32,7 @@ public class OneFilter extends MultiFilterFunction {
     return MultiFilterFunction.of(OneFilter::new, filters);
   }
 
-  public static Filter of(List<Filter> filters) {
+  public static Filter of(Collection<Filter> filters) {
     return MultiFilterFunction.of(OneFilter::new, filters);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/killreward/KillRewardMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/killreward/KillRewardMatchModule.java
@@ -27,6 +27,7 @@ import tc.oc.pgm.api.tracker.info.DamageInfo;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.filters.query.DamageQuery;
+import tc.oc.pgm.kits.tag.ItemModifier;
 import tc.oc.pgm.util.collection.DefaultMapAdapter;
 import tc.oc.pgm.util.event.ItemTransferEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
@@ -75,6 +76,7 @@ public class KillRewardMatchModule implements MatchModule, Listener {
 
       for (ItemStack stack : items) {
         ItemStack clone = stack.clone();
+        ItemModifier.apply(clone, killer);
         PlayerItemTransferEvent event =
             new PlayerItemTransferEvent(
                 null,

--- a/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
@@ -4,19 +4,17 @@ import java.util.List;
 import java.util.Map;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.kits.tag.ItemModifier;
 
 public class ArmorKit extends AbstractKit {
   public static class ArmorItem {
     public final ItemStack stack;
     public final boolean locked;
-    public final boolean teamColor;
 
-    public ArmorItem(ItemStack stack, boolean locked, boolean teamColor) {
+    public ArmorItem(ItemStack stack, boolean locked) {
       this.stack = stack;
       this.locked = locked;
-      this.teamColor = teamColor;
     }
   }
 
@@ -41,12 +39,7 @@ public class ArmorKit extends AbstractKit {
       int slot = entry.getKey().ordinal();
       if (force || wearing[slot] == null || wearing[slot].getType() == Material.AIR) {
         wearing[slot] = entry.getValue().stack.clone();
-
-        if (entry.getValue().teamColor) {
-          LeatherArmorMeta meta = (LeatherArmorMeta) wearing[slot].getItemMeta();
-          meta.setColor(player.getParty().getFullColor());
-          wearing[slot].setItemMeta(meta);
-        }
+        ItemModifier.apply(wearing[slot], player);
 
         KitMatchModule kitMatchModule = player.getMatch().getModule(KitMatchModule.class);
         if (kitMatchModule != null) {

--- a/core/src/main/java/tc/oc/pgm/kits/ItemKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ItemKit.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.kits.tag.ItemModifier;
 import tc.oc.pgm.util.inventory.InventoryUtils;
 
 public class ItemKit implements KitDefinition {
@@ -69,6 +70,11 @@ public class ItemKit implements KitDefinition {
 
     final HumanEntity holder = player.getBukkit();
     final PlayerInventory inv = player.getBukkit().getInventory();
+
+    // Apply all item modifications (eg: team-colors)
+    for (ItemStack item : event.getItems()) {
+      ItemModifier.apply(item, player);
+    }
 
     if (force) {
       for (Entry<Slot, ItemStack> kitEntry : event.getSlotItems().entrySet()) {

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -43,6 +43,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.doublejump.DoubleJumpKit;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.kits.tag.Grenade;
+import tc.oc.pgm.kits.tag.ItemModifier;
 import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.projectile.ProjectileDefinition;
 import tc.oc.pgm.shield.ShieldKit;
@@ -219,10 +220,7 @@ public abstract class KitParser {
     ItemStack stack = parseItem(el, true);
     boolean locked = XMLUtils.parseBoolean(el.getAttribute("locked"), false);
 
-    boolean teamColor =
-        stack.getItemMeta() instanceof LeatherArmorMeta
-            && XMLUtils.parseBoolean(el.getAttribute("team-color"), false);
-    return new ArmorKit.ArmorItem(stack, locked, teamColor);
+    return new ArmorKit.ArmorItem(stack, locked);
   }
 
   public ArmorKit parseArmorKit(Element el) throws InvalidXMLException {
@@ -571,6 +569,9 @@ public abstract class KitParser {
   }
 
   public void parseCustomNBT(Element el, ItemStack itemStack) throws InvalidXMLException {
+    if (XMLUtils.parseBoolean(el.getAttribute("team-color"), false))
+      ItemModifier.TEAM_COLOR.set(itemStack, true);
+
     if (XMLUtils.parseBoolean(el.getAttribute("grenade"), false)) {
       Grenade.ITEM_TAG.set(
           itemStack,

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -400,8 +400,13 @@ public abstract class KitParser {
   }
 
   public ItemMatcher parseItemMatcher(Element parent) throws InvalidXMLException {
-    ItemStack stack = parseItem(parent.getChild("item"), false);
-    if (stack == null) throw new InvalidXMLException("Item expected", parent);
+    return parseItemMatcher(parent, "item");
+  }
+
+  public ItemMatcher parseItemMatcher(Element parent, String childName) throws InvalidXMLException {
+    ItemStack stack = parseItem(parent.getChild(childName), false);
+    if (stack == null)
+      throw new InvalidXMLException("Child " + childName + " element expected", parent);
 
     Range<Integer> amount =
         XMLUtils.parseNumericRange(Node.fromAttr(parent, "amount"), Integer.class, null);

--- a/core/src/main/java/tc/oc/pgm/kits/tag/ItemModifier.java
+++ b/core/src/main/java/tc/oc/pgm/kits/tag/ItemModifier.java
@@ -1,0 +1,47 @@
+package tc.oc.pgm.kits.tag;
+
+import com.google.common.collect.ImmutableSet;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.inventory.tag.ItemTag;
+
+public class ItemModifier {
+
+  public static final ItemTag<Boolean> TEAM_COLOR = ItemTag.newBoolean("team-color");
+
+  public static final ImmutableSet<Material> COLOR_AFFECTED =
+      ImmutableSet.of(
+          Material.WOOL,
+          Material.CARPET,
+          Material.STAINED_CLAY,
+          Material.STAINED_GLASS,
+          Material.STAINED_GLASS_PANE);
+
+  // Apply per-player customizations of items.
+  // This may be expanded on the future but currently only handles coloring armor & blocks.
+  // The method is explicitly mutate-only, if you don't want side effects pass a clone.
+  public static void apply(ItemStack item, MatchPlayer player) {
+    if (!TEAM_COLOR.has(item)) return;
+    TEAM_COLOR.clear(item);
+
+    ItemMeta meta = item.getItemMeta();
+
+    if (meta instanceof LeatherArmorMeta) {
+      LeatherArmorMeta leather = (LeatherArmorMeta) meta;
+      leather.setColor(player.getParty().getFullColor());
+      item.setItemMeta(meta);
+    } else if (COLOR_AFFECTED.contains(item.getType())) {
+      item.setDurability(getWoolColor(player.getParty().getColor()));
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private static byte getWoolColor(ChatColor color) {
+    return BukkitUtils.chatColorToDyeColor(color).getWoolData();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
@@ -24,6 +24,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.kits.tag.ItemModifier;
 import tc.oc.pgm.menu.InventoryMenu;
 import tc.oc.pgm.shops.Shop;
 import tc.oc.pgm.util.inventory.ItemBuilder;
@@ -221,6 +222,7 @@ public class ShopMenu extends InventoryMenu {
     String clickLore = TextTranslations.translateLegacy(click, getBukkit());
 
     ItemStack item = icon.getItem().clone();
+    ItemModifier.apply(item, getViewer());
     ItemMeta meta = item.getItemMeta();
     List<String> lore = Lists.newArrayList();
     if (meta.getLore() != null) {


### PR DESCRIPTION
An action that will find item-stacks on the player inventory matching a certain item matcher, and will replace it with a replacement.
You may keep-amount (meaning you get as much as the new item as you had of the previous), and/or keep-enchants (meaning the enchants on the old item will be applied to the replacement before giving it to the user.

```xml
<replace-item keep-amount="false" keep-enchants="false" ignore-metadata="true" amount="2..5">
  <find material="stone"/>
  <replace material="dirt" amount="8"/>
</replace-item>
```

The item-matcher rules are the same as for `<holding ignore-metadata="true"> <item ...> </holding>` since the item-matchers pr #1055 , but the inner matcher is called "find" instead of "item", so it supports things like matching for amount-ranges. 

~~This PR has not once been ran, do not merge until it is tested.~~