### PR TITLE
Adjust shop category pagination

### DIFF
--- a/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
@@ -52,7 +52,7 @@ public class ShopMenu extends InventoryMenu {
 
     this.category = shop.getVisibleCategories(viewer).get(0);
     this.categories = getCategoryItems();
-    this.highlight = 1;
+    this.highlight = getStartingIndex();
     open();
   }
 
@@ -71,18 +71,25 @@ public class ShopMenu extends InventoryMenu {
     this.renderIcons(contents);
   }
 
+  private int getStartingIndex() {
+    return categories.length == 1 ? 4 : (categories.length > 7 ? 0 : 1);
+  }
+
   private void renderHeader(InventoryContents contents) {
     Pagination page = contents.pagination();
     page.setItems(categories);
-    page.setItemsPerPage(7);
-    page.addToIterator(
-        contents.newIterator(SlotIterator.Type.HORIZONTAL, 0, categories.length == 1 ? 4 : 1));
+    page.setItemsPerPage(categories.length > 7 ? 9 : 7);
+    page.addToIterator(contents.newIterator(SlotIterator.Type.HORIZONTAL, 0, getStartingIndex()));
+
+    for (int i = 2; i < 6; i++) {
+      contents.fillRow(i, null);
+    }
 
     // Previous button
-    if (!page.isFirst()) contents.set(0, 0, getPageItem(getBukkit(), page.getPage() - 1, false));
+    if (!page.isFirst()) contents.set(2, 0, getPageItem(getBukkit(), page.getPage() - 1, false));
 
     // Next button
-    if (!page.isLast()) contents.set(0, 8, getPageItem(getBukkit(), page.getPage() + 1, true));
+    if (!page.isLast()) contents.set(2, 8, getPageItem(getBukkit(), page.getPage() + 1, true));
 
     if (categories.length == 1) {
       highlight = 4;
@@ -94,10 +101,6 @@ public class ShopMenu extends InventoryMenu {
   }
 
   private void renderIcons(InventoryContents contents) {
-    for (int i = 2; i < 6; i++) {
-      contents.fillRow(i, null);
-    }
-
     List<Icon> icons = getCategory().getVisibleIcons(getViewer());
 
     if (icons.isEmpty()) {

--- a/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
@@ -103,10 +103,6 @@ public class ShopMenu extends InventoryMenu {
       }
     }
 
-    if (categories.length == 1) {
-      highlight = 4;
-    }
-
     // Menu divider & highlight
     contents.fillRow(1, getMenuSeperator(DyeColor.GRAY));
     contents.set(1, highlight, getMenuSeperator(DyeColor.GREEN));

--- a/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
@@ -72,24 +72,36 @@ public class ShopMenu extends InventoryMenu {
   }
 
   private int getStartingIndex() {
-    return categories.length == 1 ? 4 : (categories.length > 7 ? 0 : 1);
+    return categories.length == 1 ? 4 : (categories.length <= 9 ? 0 : 1);
+  }
+
+  private boolean isPaginated() {
+    return categories.length > 9;
   }
 
   private void renderHeader(InventoryContents contents) {
-    Pagination page = contents.pagination();
-    page.setItems(categories);
-    page.setItemsPerPage(categories.length > 7 ? 9 : 7);
-    page.addToIterator(contents.newIterator(SlotIterator.Type.HORIZONTAL, 0, getStartingIndex()));
+    if (isPaginated()) {
+      Pagination page = contents.pagination();
+      page.setItems(categories);
+      page.setItemsPerPage(7);
+      page.addToIterator(contents.newIterator(SlotIterator.Type.HORIZONTAL, 0, getStartingIndex()));
 
-    for (int i = 2; i < 6; i++) {
-      contents.fillRow(i, null);
+      // Previous button
+      if (!page.isFirst()) contents.set(0, 0, getPageItem(getBukkit(), page.getPage() - 1, false));
+
+      // Next button
+      if (!page.isLast()) contents.set(0, 8, getPageItem(getBukkit(), page.getPage() + 1, true));
+    } else {
+
+      // Center icon if only one category is present
+      if (categories.length == 1) {
+        contents.set(0, 4, categories[0]);
+      } else {
+        for (ClickableItem item : categories) {
+          contents.add(item);
+        }
+      }
     }
-
-    // Previous button
-    if (!page.isFirst()) contents.set(2, 0, getPageItem(getBukkit(), page.getPage() - 1, false));
-
-    // Next button
-    if (!page.isLast()) contents.set(2, 8, getPageItem(getBukkit(), page.getPage() + 1, true));
 
     if (categories.length == 1) {
       highlight = 4;
@@ -102,6 +114,10 @@ public class ShopMenu extends InventoryMenu {
 
   private void renderIcons(InventoryContents contents) {
     List<Icon> icons = getCategory().getVisibleIcons(getViewer());
+
+    for (int i = 2; i < 6; i++) {
+      contents.fillRow(i, null);
+    }
 
     if (icons.isEmpty()) {
       contents.set(4, 4, getNoItemsItem());


### PR DESCRIPTION
Quick PR that aims to address concerns over category pagination. Now shops will support displaying up to 9 categories on the first page.

Signed-off-by: applenick <applenick@users.noreply.github.com>