### PR TITLE
Fix fireworks on non-finite regions crashing the server

### DIFF
--- a/core/src/main/java/tc/oc/pgm/fireworks/FireworkMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/fireworks/FireworkMatchModule.java
@@ -208,6 +208,7 @@ public class FireworkMatchModule implements MatchModule, Listener {
 
   public void spawnFireworkDisplay(
       Location center, Color color, int count, double radius, int power) {
+    if (Double.isInfinite(radius)) return;
     FireworkEffect effect =
         FireworkEffect.builder()
             .with(Type.BURST)
@@ -229,8 +230,8 @@ public class FireworkMatchModule implements MatchModule, Listener {
   public void spawnFireworkDisplay(
       World world, Region region, Color color, int count, double radiusMultiplier, int power) {
     final Bounds bound = region.getBounds();
-    final double radius = bound.getMax().subtract(bound.getMin()).multiply(0.5).length();
-    final Location center = bound.getMin().getMidpoint(bound.getMax()).toLocation(world);
+    final double radius = bound.getSize().setY(0).multiply(0.5).length();
+    final Location center = bound.getCenterPoint().toLocation(world);
     this.spawnFireworkDisplay(center, color, count, radiusMultiplier * radius, power);
   }
 
@@ -254,15 +255,18 @@ public class FireworkMatchModule implements MatchModule, Listener {
 
     Block block = location.getBlock();
 
-    int maxSearch = 5;
+    int maxSearch = 25;
     while (block != null && block.getType().isOccluding() && maxSearch-- > 0)
       block = block.getRelative(BlockFace.UP);
-    if (maxSearch < 0) return null;
+    if (maxSearch < 0 || block == null) return null;
 
-    maxSearch = 40;
+    maxSearch = 25;
     while (block != null && block.getType() != Material.AIR && maxSearch-- > 0)
       block = block.getRelative(BlockFace.UP);
+    if (maxSearch < 0 || block == null) return null;
 
-    return maxSearch < 0 || block == null ? null : block.getLocation();
+    // Returning original location ensure x & z are not affected.
+    location.setY(block.getY() + 0.5d);
+    return location;
   }
 }


### PR DESCRIPTION
Fixes a critical issue that crashes the server when trying to spawn fireworks for infinite regions, because they try to spawn at integer-limit x coordinate, and the server has a hard time finding bounding boxes there.

This was caused by a subtle change to behavior on getOpenSpace above, which returned the block's location instead of the location with a different Y, causing a Location with x=Infinity (a double) to turn into x=int limit (block.getLocation()'s result).

This has been fixed in 3 different ways:
 - The radius to spawn fireworks will now ignore Y offset (eg: rectangle). Just because the region is taller shouldn't mean fireworks spawn further away.
 - If even ignoring Y offset, radius is still infinite, it won't even try to spawn fireworks.
 - The original location will be used (modifying just the y's location, to the center of the open space block)

The changes have been tested across several gamemodes (ctw, dtc, dtm, ctf, cp) and work as intended.