### PR TITLE
Implement dye color option for teams

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/party/Party.java
+++ b/core/src/main/java/tc/oc/pgm/api/party/Party.java
@@ -6,6 +6,7 @@ import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
+import org.bukkit.DyeColor;
 import tc.oc.pgm.api.filter.query.PartyQuery;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.match.Match;
@@ -99,6 +100,13 @@ public interface Party extends Audience, Named, Filterable<PartyQuery>, PartyQue
    * @return a color
    */
   Color getFullColor();
+
+  /**
+   * Gets the {@link DyeColor} of the party.
+   *
+   * @return a dye color
+   */
+  DyeColor getDyeColor();
 
   /**
    * Gets a chat prefix for the party.

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointBlockDisplay.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointBlockDisplay.java
@@ -17,7 +17,6 @@ import tc.oc.pgm.filters.query.BlockQuery;
 import tc.oc.pgm.regions.FiniteBlockRegion;
 import tc.oc.pgm.regions.SectorRegion;
 import tc.oc.pgm.renewable.BlockImage;
-import tc.oc.pgm.util.bukkit.BukkitUtils;
 
 /** Displays the status of a ControlPoint by coloring blocks in specified regions */
 public class ControlPointBlockDisplay implements Listener {
@@ -87,7 +86,7 @@ public class ControlPointBlockDisplay implements Listener {
           this.controllerDisplayImage.restore(block);
         }
       } else {
-        byte blockData = BukkitUtils.chatColorToDyeColor(controllingTeam.getColor()).getWoolData();
+        byte blockData = controllingTeam.getDyeColor().getWoolData();
         for (Block block : this.controllerDisplayRegion.getBlocks()) {
           block.setData(blockData);
         }
@@ -104,7 +103,7 @@ public class ControlPointBlockDisplay implements Listener {
         .query(new BlockQuery(block))
         .isAllowed()) {
       if (team != null) {
-        block.setData(BukkitUtils.chatColorToDyeColor(team.getColor()).getWoolData());
+        block.setData(team.getDyeColor().getWoolData());
       } else {
         this.progressDisplayImage.restore(block);
       }

--- a/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
+++ b/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
@@ -1,7 +1,7 @@
 package tc.oc.pgm.ffa;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static net.kyori.adventure.text.Component.empty;
+import static net.kyori.adventure.text.Component.*;
 import static tc.oc.pgm.util.text.PlayerComponent.player;
 
 import java.util.Collection;
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
+import org.bukkit.DyeColor;
 import org.bukkit.scoreboard.NameTagVisibility;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.match.Match;
@@ -46,6 +47,7 @@ public class Tribute implements Competitor {
   private final String username;
   private final ChatColor chatColor;
   private final Color color;
+  private final DyeColor dyeColor;
   private final PartyQuery query;
 
   protected @Nullable MatchPlayer player;
@@ -58,6 +60,7 @@ public class Tribute implements Competitor {
     this.username = player.getBukkit().getName();
     this.chatColor = color == null ? ChatColor.YELLOW : color;
     this.color = BukkitUtils.colorOf(this.chatColor);
+    this.dyeColor = BukkitUtils.chatColorToDyeColor(this.chatColor);
     this.query = new PartyQuery(null, this);
   }
 
@@ -89,6 +92,11 @@ public class Tribute implements Competitor {
   @Override
   public Color getFullColor() {
     return this.color;
+  }
+
+  @Override
+  public DyeColor getDyeColor() {
+    return dyeColor;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/goals/OwnedGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/OwnedGoal.java
@@ -5,7 +5,6 @@ import org.bukkit.DyeColor;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
-import tc.oc.pgm.util.bukkit.BukkitUtils;
 
 /** A goal with an owning team. Match-time companion to {@link OwnedGoal} */
 public abstract class OwnedGoal<T extends OwnedGoalDefinition> extends SimpleGoal<T> {
@@ -26,6 +25,6 @@ public abstract class OwnedGoal<T extends OwnedGoalDefinition> extends SimpleGoa
 
   @Override
   public DyeColor getDyeColor() {
-    return owner != null ? BukkitUtils.chatColorToDyeColor(owner.getColor()) : DyeColor.WHITE;
+    return owner != null ? owner.getDyeColor() : DyeColor.WHITE;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/tag/ItemModifier.java
+++ b/core/src/main/java/tc/oc/pgm/kits/tag/ItemModifier.java
@@ -1,13 +1,12 @@
 package tc.oc.pgm.kits.tag;
 
 import com.google.common.collect.ImmutableSet;
-import org.bukkit.ChatColor;
+import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.inventory.tag.ItemTag;
 
 public class ItemModifier {
@@ -36,12 +35,12 @@ public class ItemModifier {
       leather.setColor(player.getParty().getFullColor());
       item.setItemMeta(meta);
     } else if (COLOR_AFFECTED.contains(item.getType())) {
-      item.setDurability(getWoolColor(player.getParty().getColor()));
+      item.setDurability(getWoolColor(player.getParty().getDyeColor()));
     }
   }
 
   @SuppressWarnings("deprecation")
-  private static byte getWoolColor(ChatColor color) {
-    return BukkitUtils.chatColorToDyeColor(color).getWoolData();
+  private static byte getWoolColor(DyeColor color) {
+    return color.getWoolData();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/match/ObserverParty.java
+++ b/core/src/main/java/tc/oc/pgm/match/ObserverParty.java
@@ -7,7 +7,7 @@ import tc.oc.pgm.api.match.Match;
 public class ObserverParty extends PartyImpl {
 
   public ObserverParty(final Match match) {
-    super(match, "Observers", ChatColor.AQUA);
+    super(match, "Observers", ChatColor.AQUA, null);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/match/PartyImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/PartyImpl.java
@@ -13,6 +13,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
+import org.bukkit.DyeColor;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.party.event.PartyRenameEvent;
@@ -33,12 +34,17 @@ public class PartyImpl implements Party, Audience {
   private final String id;
   private final ChatColor chatColor;
   private final Color color;
+  private final DyeColor dyeColor;
   private String legacyName;
   private Component name;
   private Component prefix;
   private boolean plural;
 
-  public PartyImpl(final Match match, final String name, final ChatColor chatColor) {
+  public PartyImpl(
+      final Match match,
+      final String name,
+      final ChatColor chatColor,
+      final @Nullable DyeColor dyeColor) {
     this.match = requireNonNull(match);
     this.query = new PartyQuery(null, this);
     this.memberMap = new HashMap<>();
@@ -47,6 +53,7 @@ public class PartyImpl implements Party, Audience {
     this.id = requireNonNull(name);
     this.chatColor = chatColor == null ? ChatColor.WHITE : chatColor;
     this.color = BukkitUtils.colorOf(this.chatColor);
+    this.dyeColor = dyeColor == null ? BukkitUtils.chatColorToDyeColor(this.chatColor) : dyeColor;
     this.setName(name);
   }
 
@@ -143,6 +150,11 @@ public class PartyImpl implements Party, Audience {
   @Override
   public Color getFullColor() {
     return this.color;
+  }
+
+  @Override
+  public DyeColor getDyeColor() {
+    return this.dyeColor;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/match/QueuedParty.java
+++ b/core/src/main/java/tc/oc/pgm/match/QueuedParty.java
@@ -26,7 +26,7 @@ public class QueuedParty extends PartyImpl {
   private List<MatchPlayer> memberOrder;
 
   public QueuedParty(final Match match) {
-    super(match, "Participants", ChatColor.YELLOW);
+    super(match, "Participants", ChatColor.YELLOW, null);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/payload/Payload.java
+++ b/core/src/main/java/tc/oc/pgm/payload/Payload.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.payload;
 
 import java.time.Duration;
-import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
@@ -17,7 +16,6 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.controlpoint.ControlPoint;
 import tc.oc.pgm.payload.track.Track;
-import tc.oc.pgm.util.bukkit.BukkitUtils;
 
 public class Payload extends ControlPoint {
 
@@ -144,8 +142,7 @@ public class Payload extends ControlPoint {
 
   private void updateWool() {
     Competitor display = getDisplayTeam();
-    DyeColor color =
-        BukkitUtils.chatColorToDyeColor(display != null ? display.getColor() : ChatColor.WHITE);
+    DyeColor color = display != null ? display.getDyeColor() : DyeColor.WHITE;
 
     Wool data = (Wool) minecart.getDisplayBlock();
     data.setColor(color);

--- a/core/src/main/java/tc/oc/pgm/teams/Team.java
+++ b/core/src/main/java/tc/oc/pgm/teams/Team.java
@@ -29,7 +29,7 @@ public class Team extends PartyImpl implements Competitor, Feature<TeamFactory> 
   private JoinMatchModule jmm;
 
   public Team(final TeamFactory info, final Match match) {
-    super(match, requireNonNull(info).getDefaultName(), info.getDefaultColor());
+    super(match, requireNonNull(info).getDefaultName(), info.getDefaultColor(), info.getDyeColor());
     this.info = info;
     this.min = info.getMinPlayers();
     this.max = info.getMaxPlayers();

--- a/core/src/main/java/tc/oc/pgm/teams/TeamFactory.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamFactory.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.teams;
 
 import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
+import org.bukkit.DyeColor;
 import org.bukkit.scoreboard.NameTagVisibility;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.match.Match;
@@ -13,7 +14,7 @@ public class TeamFactory extends SelfIdentifyingFeatureDefinition {
   protected final String defaultName;
   protected final boolean defaultNamePlural;
   protected final ChatColor defaultColor;
-  @Nullable protected final ChatColor overheadColor;
+  protected final @Nullable DyeColor dyeColor;
   protected final int minPlayers;
   protected final int maxPlayers;
   protected final int maxOverfill;
@@ -26,7 +27,7 @@ public class TeamFactory extends SelfIdentifyingFeatureDefinition {
    * @param defaultName Default name for the team.
    * @param defaultNamePlural Is the default name a plural word?
    * @param defaultColor Default color for the team.
-   * @param overheadColor Color to be displayed above the team members' avatars.
+   * @param dyeColor Dye color to be used for blocks on kits or control points
    * @param maxPlayers Maximum amount of players that may be on this team.
    * @param nameTagVisibility Who can see the name tags of players on this team
    */
@@ -35,7 +36,7 @@ public class TeamFactory extends SelfIdentifyingFeatureDefinition {
       String defaultName,
       boolean defaultNamePlural,
       ChatColor defaultColor,
-      @Nullable ChatColor overheadColor,
+      @Nullable DyeColor dyeColor,
       int minPlayers,
       int maxPlayers,
       int maxOverfill,
@@ -44,7 +45,7 @@ public class TeamFactory extends SelfIdentifyingFeatureDefinition {
     this.defaultName = defaultName;
     this.defaultNamePlural = defaultNamePlural;
     this.defaultColor = defaultColor;
-    this.overheadColor = overheadColor;
+    this.dyeColor = dyeColor;
     this.minPlayers = minPlayers;
     this.maxPlayers = maxPlayers;
     this.maxOverfill = maxOverfill;
@@ -94,12 +95,12 @@ public class TeamFactory extends SelfIdentifyingFeatureDefinition {
   }
 
   /**
-   * Gets the color to be displayed alongside the player's name above the player.
+   * Gets the dye color to use for blocks on kits or control points
    *
-   * @return Overhead color.
+   * @return Dye color for the team
    */
-  public ChatColor getOverheadColor() {
-    return this.overheadColor != null ? this.overheadColor : this.defaultColor;
+  public @Nullable DyeColor getDyeColor() {
+    return this.dyeColor;
   }
 
   public int getMinPlayers() {

--- a/core/src/main/java/tc/oc/pgm/teams/TeamModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamModule.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
+import org.bukkit.DyeColor;
 import org.bukkit.scoreboard.NameTagVisibility;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
@@ -120,7 +121,7 @@ public class TeamModule implements MapModule<TeamMatchModule> {
     boolean plural = XMLUtils.parseBoolean(el.getAttribute("plural"), false);
 
     ChatColor color = XMLUtils.parseChatColor(Node.fromAttr(el, "color"), ChatColor.WHITE);
-    ChatColor overheadColor = XMLUtils.parseChatColor(Node.fromAttr(el, "overhead-color"), null);
+    DyeColor dyeColor = XMLUtils.parseDyeColor(el.getAttribute("dye-color"), null);
     NameTagVisibility nameTagVisibility =
         XMLUtils.parseNameTagVisibility(
             Node.fromAttr(el, "show-name-tags"), NameTagVisibility.ALWAYS);
@@ -141,7 +142,7 @@ public class TeamModule implements MapModule<TeamMatchModule> {
             name,
             plural,
             color,
-            overheadColor,
+            dyeColor,
             minPlayers,
             maxPlayers,
             maxOverfill,


### PR DESCRIPTION
Before this PR, team's dye color is always automatically derived from the chat color specified in `color`, while those conversions are often good enough sometimes they don't allow enough flexibility. Teams may now override that default by setting the dye color directly:

```xml
<teams>
  <team id="blue" max="10"  color="blue" dye-color="light blue">Blue</team>
  <team id="red" max="10"  color="dark red" dye-color="pink">Red</team>
</teams>
```

It affects:
 - Control point display regions
 - Wool color inside the payload
 - Blocks given via kits using `team-color="true"` (eg: hardened clay, carpet, wool, stained glass...)
 
 It does not affect:
  - Armor given with `team-color="true"` (armor color continues to use chat color, as they're not tied to a list)
  
Side note: deleted "overhead-color" property on teams, it was undocumented and unused for very long, so it served no purpose whatsoever.

The PR has been tested and works as intended
