### PR TITLE
Prevent relogging to avoid respawn timers

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.spawns;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
@@ -8,6 +10,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import javax.annotation.Nullable;
 import org.bukkit.Location;
@@ -45,8 +49,11 @@ import tc.oc.pgm.spawns.states.State;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.event.player.PlayerAttackEntityEvent;
 
+@SuppressWarnings("UnstableApiUsage")
 @ListenerScope(MatchScope.LOADED)
 public class SpawnMatchModule implements MatchModule, Listener, Tickable {
+
+  private static final long PREDICTED_EXTRA_TICKS = 10 * 20;
 
   private final Match match;
   private final SpawnModule module;
@@ -55,6 +62,8 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
   private final Map<Competitor, Spawn> unique = new HashMap<>();
   private final Set<Spawn> failed = new HashSet<>();
   private final ObserverToolFactory observerToolFactory;
+  private final Cache<UUID, Long> deathTicks =
+      CacheBuilder.newBuilder().expireAfterWrite(60, TimeUnit.SECONDS).build();
 
   public SpawnMatchModule(Match match, SpawnModule module) {
     this.match = match;
@@ -169,12 +178,20 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
     }
   }
 
+  public long getDeathTick(MatchPlayer player) {
+    Long deathTick = deathTicks.getIfPresent(player.getId());
+    return deathTick != null ? deathTick : 0;
+  }
+
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPartyChange(final PlayerPartyChangeEvent event) {
     if (event.getOldParty() == null) {
       // Join match
       if (event.getNewParty().isParticipating()) {
-        transition(event.getPlayer(), null, new Joining(this, event.getPlayer()));
+        transition(
+            event.getPlayer(),
+            null,
+            new Joining(this, event.getPlayer(), getDeathTick(event.getPlayer())));
       } else {
         transition(event.getPlayer(), null, new Observing(this, event.getPlayer(), true, true));
       }
@@ -304,6 +321,17 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
         unique.remove(competitor);
       }
     }
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onPlayerDeath(MatchPlayerDeathEvent event) {
+    long tick = event.getMatch().getTick().tick;
+
+    if (event.isPredicted()) {
+      tick = tick + PREDICTED_EXTRA_TICKS;
+    }
+
+    deathTicks.put(event.getPlayer().getId(), tick);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Joining.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Joining.java
@@ -12,7 +12,11 @@ import tc.oc.pgm.spawns.SpawnMatchModule;
 public class Joining extends Spawning {
 
   public Joining(SpawnMatchModule smm, MatchPlayer player) {
-    super(smm, player);
+    this(smm, player, 0);
+  }
+
+  public Joining(SpawnMatchModule smm, MatchPlayer player, long deathTick) {
+    super(smm, player, deathTick);
     this.spawnRequested = true;
   }
 

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
@@ -121,7 +121,7 @@ public class Observing extends State {
   @Override
   public void onEvent(PlayerJoinPartyEvent event) {
     if (event.getNewParty() instanceof Competitor && event.getMatch().isRunning()) {
-      transition(new Joining(smm, player));
+      transition(new Joining(smm, player, smm.getDeathTick(event.getPlayer())));
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.spawns.states;
 
+import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.title.Title.title;
 import static tc.oc.pgm.util.TimeUtils.fromTicks;
@@ -13,6 +14,7 @@ import org.bukkit.Location;
 import org.bukkit.event.entity.EntityDamageEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.ObserverInteractEvent;
+import tc.oc.pgm.spawns.RespawnOptions;
 import tc.oc.pgm.spawns.Spawn;
 import tc.oc.pgm.spawns.SpawnMatchModule;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
@@ -21,11 +23,15 @@ import tc.oc.pgm.util.event.player.PlayerAttackEntityEvent;
 /** Player is waiting to spawn as a participant */
 public abstract class Spawning extends Participating {
 
+  protected final RespawnOptions options;
   protected boolean spawnRequested;
+  protected final long deathTick;
 
-  public Spawning(SpawnMatchModule smm, MatchPlayer player) {
+  public Spawning(SpawnMatchModule smm, MatchPlayer player, long deathTick) {
     super(smm, player);
+    this.options = smm.getRespawnOptions(player);
     this.spawnRequested = options.auto;
+    this.deathTick = deathTick;
   }
 
   @Override
@@ -66,6 +72,10 @@ public abstract class Spawning extends Participating {
     event.setCancelled(true);
   }
 
+  protected long age() {
+    return player.getMatch().getTick().tick - deathTick;
+  }
+
   @Override
   public void tick() {
     if (!trySpawn()) {
@@ -89,15 +99,17 @@ public abstract class Spawning extends Participating {
     return true;
   }
 
+  protected long ticksUntilRespawn() {
+    return Math.max(0, options.delayTicks - age());
+  }
+
   public @Nullable Spawn chooseSpawn() {
-    if (spawnRequested) {
+    if (ticksUntilRespawn() <= 0 && spawnRequested) {
       return smm.chooseSpawn(player);
     } else {
       return null;
     }
   }
-
-  public void sendMessage() {}
 
   public void updateTitle() {
     Title.Times times = Title.Times.of(Duration.ZERO, fromTicks(3), fromTicks(3));
@@ -111,15 +123,30 @@ public abstract class Spawning extends Participating {
   protected abstract Component getTitle(boolean spectator);
 
   protected Component getSubtitle(boolean spectator) {
-    if (!spawnRequested) {
+    long ticks = ticksUntilRespawn();
+    if (ticks > 0) {
+      return translatable(
+          spawnRequested
+              ? "death.respawn.confirmed.time"
+              : "death.respawn.unconfirmed.time" + (spectator ? ".spectator" : ""),
+          NamedTextColor.GREEN,
+          text(String.format("%.1f", (ticks / (float) 20)), NamedTextColor.AQUA));
+    } else if (!spawnRequested) {
       return translatable(
           "death.respawn.unconfirmed" + (spectator ? ".spectator" : ""), NamedTextColor.GREEN);
     } else if (options.message != null) {
-      return options.message;
+      return options.message.colorIfAbsent(NamedTextColor.GREEN);
     } else {
       return translatable(
           "death.respawn.confirmed.waiting" + (spectator ? ".spectator" : ""),
           NamedTextColor.GREEN);
+    }
+  }
+
+  public void sendMessage() {
+    long ticks = options.delayTicks - age();
+    if (ticks % (ticks > 0 ? 20 : 100) == 0) {
+      player.sendMessage(getSubtitle(false));
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawns/states/State.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/State.java
@@ -12,7 +12,6 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
 import tc.oc.pgm.api.player.event.ObserverInteractEvent;
 import tc.oc.pgm.events.PlayerJoinPartyEvent;
-import tc.oc.pgm.spawns.RespawnOptions;
 import tc.oc.pgm.spawns.SpawnMatchModule;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.event.player.PlayerAttackEntityEvent;
@@ -20,7 +19,6 @@ import tc.oc.pgm.util.event.player.PlayerAttackEntityEvent;
 public abstract class State {
 
   protected final SpawnMatchModule smm;
-  protected final RespawnOptions options;
   protected final MatchPlayer player;
   protected final Player bukkit;
 
@@ -30,7 +28,6 @@ public abstract class State {
     this.smm = smm;
     this.player = player;
     this.bukkit = player.getBukkit();
-    this.options = smm.getRespawnOptions(player);
   }
 
   public boolean isCurrent() {


### PR DESCRIPTION
Apply respawn timers to players who leave to avoid the death process and respawn countdown. Players are leaving the server `/hub` or disconnect when they have died to avoid a respawn timer, if they can return to the match in less time than the death plus respawn timer would've taken then they have an advantage and can circumvent longer respawn timers.

An example under this new logic, if a player is killed and tries to leave to avoid a 10-second respawn timer, if they leave the server and return within 5 seconds they will be required to wait out the remaining 5 seconds before they respawn. If that same player leaves whilst they're falling in the void (or any other predicted death) they will be made to wait an extra 10 seconds to account for this.

![image](https://user-images.githubusercontent.com/8608892/194711710-1518385f-95d1-4351-ae1f-a0d3e5f136c3.png)

- Track the tick a player last died for use in joining respawning countdown.
- Add 10 seconds to the tracked tick if a predicted death to account for combat logging (typically falling in to void).
- Move `RespawnOptions` out of abstract `State` to abstract `Spawning` class (only children of this need it).
- Move ticking countdown logic from `Dead` to `Spawning` (so logic can be used in both locations `Dead` and `Joining`).
 - Fix custom respawn message not having a color (brings back the green text).

Thanks to @Pablete1234 for assisting with these changes which were on a stale branch of mine from earlier this year.

Signed-off-by: Pugzy <pugzy@mail.com>