### PR TITLE
Implement blitz join filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzConfig.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzConfig.java
@@ -10,13 +10,15 @@ public class BlitzConfig {
   private final int lives;
   private final boolean broadcastLives;
   private final Filter filter;
+  private final Filter joinFilter;
 
-  public BlitzConfig(int lives, boolean broadcastLives, Filter filter) {
+  public BlitzConfig(int lives, boolean broadcastLives, Filter filter, Filter joinFilter) {
     checkArgument(lives > 0, "lives must be greater than zero");
 
     this.lives = lives;
     this.broadcastLives = broadcastLives;
     this.filter = filter;
+    this.joinFilter = joinFilter;
   }
 
   /**
@@ -34,5 +36,9 @@ public class BlitzConfig {
 
   public Filter getFilter() {
     return this.filter;
+  }
+
+  public Filter getJoinFilter() {
+    return joinFilter;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -26,11 +26,13 @@ import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
+import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerParticipationStartEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
 import tc.oc.pgm.teams.TeamMatchModule;
 
+@ListenerScope(MatchScope.RUNNING)
 public class BlitzMatchModule implements MatchModule, Listener {
 
   private final Match match;
@@ -89,22 +91,25 @@ public class BlitzMatchModule implements MatchModule, Listener {
       if (event.getNewParty() != null && event.getNewParty() instanceof Competitor) {
         // Player switching teams, check if match needs to end
         checkEnd();
-      } else {
-        // Player is going to obs, eliminate them
+      } else if (config.getFilter().query(event.getPlayer()).isAllowed()) {
+        // Player is going to obs and filter allows, eliminate them
         this.handleElimination(event.getPlayer(), (Competitor) event.getOldParty());
       }
     }
   }
 
+  public boolean canJoin(MatchPlayer player) {
+    if (isPlayerEliminated(player.getId())) return false;
+
+    TeamMatchModule tmm = player.getMatch().getModule(TeamMatchModule.class);
+    if (!match.isRunning() || (tmm != null && tmm.isForced(player))) return true;
+
+    return config.getJoinFilter().query(player.getMatch()).isAllowed();
+  }
+
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void handleJoin(final PlayerParticipationStartEvent event) {
-    MatchPlayer player = event.getPlayer();
-    TeamMatchModule tmm = player.getMatch().getModule(TeamMatchModule.class);
-
-    if (!match.isRunning() || (tmm != null && tmm.isForced(player))) return;
-
-    int lives = this.lifeManager.getLives(event.getPlayer().getId());
-    if (config.getJoinFilter().query(player.getMatch()).isAllowed() && lives > 0) return;
+    if (canJoin(event.getPlayer())) return;
 
     event.cancel(
         translatable("blitz.joinDenied", translatable("gamemode.blitz.name", NamedTextColor.AQUA)));

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -100,11 +100,14 @@ public class BlitzMatchModule implements MatchModule, Listener {
   public void handleJoin(final PlayerParticipationStartEvent event) {
     MatchPlayer player = event.getPlayer();
     TeamMatchModule tmm = player.getMatch().getModule(TeamMatchModule.class);
-    if (match.isRunning() && (tmm == null || !tmm.isForced(player))) {
-      event.cancel(
-          translatable(
-              "blitz.joinDenied", translatable("gamemode.blitz.name", NamedTextColor.AQUA)));
-    }
+
+    if (!match.isRunning() || (tmm != null && tmm.isForced(player))) return;
+
+    int lives = this.lifeManager.getLives(event.getPlayer().getId());
+    if (config.getJoinFilter().query(player.getMatch()).isAllowed() && lives > 0) return;
+
+    event.cancel(
+        translatable("blitz.joinDenied", translatable("gamemode.blitz.name", NamedTextColor.AQUA)));
   }
 
   @EventHandler

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzModule.java
@@ -17,6 +17,7 @@ import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.matcher.StaticFilter;
+import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
@@ -56,17 +57,20 @@ public class BlitzModule implements MapModule {
       int lives = Integer.MAX_VALUE;
       boolean broadcastLives = false;
       Filter filter = null;
+      Filter joinFilter = null;
 
+      FilterParser filters = factory.getFilters();
       for (Element blitzEl : blitzElements) {
         broadcastLives = XMLUtils.parseBoolean(blitzEl.getChild("broadcastLives"), true);
         lives =
             XMLUtils.parseNumberInRange(
                 Node.fromChildOrAttr(blitzEl, "lives"), Integer.class, Range.atLeast(1), 1);
-        filter = factory.getFilters().parseFilterProperty(blitzEl, "filter", StaticFilter.ALLOW);
+        filter = filters.parseProperty(blitzEl, "filter", StaticFilter.ALLOW);
+        joinFilter = filters.parseProperty(blitzEl, "join-filter", StaticFilter.DENY);
       }
 
       if (lives != Integer.MAX_VALUE) {
-        return new BlitzModule(new BlitzConfig(lives, broadcastLives, filter));
+        return new BlitzModule(new BlitzConfig(lives, broadcastLives, filter, joinFilter));
       }
 
       return null;

--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -113,9 +113,9 @@ public class PickerMatchModule implements MatchModule, Listener {
 
   private final Match match;
   private final Set<MatchPlayer> picking = new HashSet<>();
-  private boolean hasTeams;
-  private boolean hasClasses;
-  private boolean isBlitz;
+  private final boolean hasTeams;
+  private final boolean hasClasses;
+  private final boolean isBlitz;
 
   private PickerMatchModule(Match match) {
     this.match = match;
@@ -174,17 +174,12 @@ public class PickerMatchModule implements MatchModule, Listener {
     return teams;
   }
 
-  /** Get if the player participated in blitz match and was eliminated * */
-  private boolean hasParticipated(MatchPlayer player) {
-    return isBlitz && match.getModule(BlitzMatchModule.class).isPlayerEliminated(player.getId());
-  }
-
   /** Does the player have any use for the picker? */
   private boolean canUse(MatchPlayer player) {
     if (player == null) return false;
 
     // Player is eliminated from Blitz
-    if (isBlitz && match.isRunning() && hasParticipated(player)) return false;
+    if (isBlitz && !match.needModule(BlitzMatchModule.class).canJoin(player)) return false;
 
     // Player is not observing or dead
     if (!(player.isObserving() || player.isDead())) return false;


### PR DESCRIPTION
A while ago blitz filters were implemented, where they can decide if blitz lives are subtracted or not, this additionally adds support for deciding if players should be prevented from joining the match based on a filter:

```xml
<blitz lives="3" filter="after-1m" join-filter="before-1m"/>
```
In the example, after 1 minute players start losing lives when they die. Joining is allowed during that first minute.

The `join-filter` defaults to always DENY, meaning it will not let anyone join after match start. You may change it to a filter that says when it is allowed to join. 

The PR has been tested and works as intended.