### PR TITLE
Fix issue with repeating shop menu icons

### DIFF
--- a/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
@@ -97,8 +97,8 @@ public class ShopMenu extends InventoryMenu {
       if (categories.length == 1) {
         contents.set(0, 4, categories[0]);
       } else {
-        for (ClickableItem item : categories) {
-          contents.add(item);
+        for (int i = 0; i < categories.length; i++) {
+          contents.set(0, i, categories[i]);
         }
       }
     }


### PR DESCRIPTION
Quick fix! This PR resolves an issue where category icons in the shop menu would repeat between renderings. The source of the issue came from the non-paginated header section using the `InventoryContents#add` method, which does not override old slot items. The new solution forces the header items into their correct slots. 


Signed-off-by: applenick <applenick@users.noreply.github.com>