### PR TITLE
Add break attribute to Block Drops Rule

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsModule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsModule.java
@@ -72,6 +72,7 @@ public class BlockDropsModule implements MapModule {
 
         boolean dropOnWrongTool =
             XMLUtils.parseBoolean(Node.fromChildOrAttr(elRule, "wrong-tool", "wrongtool"), false);
+        boolean breakable = XMLUtils.parseBoolean(Node.fromChildOrAttr(elRule, "break"), true);
         boolean punchable = XMLUtils.parseBoolean(Node.fromChildOrAttr(elRule, "punch"), false);
         boolean trample = XMLUtils.parseBoolean(Node.fromChildOrAttr(elRule, "trample"), false);
         Float fallChance =
@@ -105,6 +106,7 @@ public class BlockDropsModule implements MapModule {
                 filter,
                 region,
                 dropOnWrongTool,
+                breakable,
                 punchable,
                 trample,
                 new BlockDrops(

--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsRule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsRule.java
@@ -7,6 +7,7 @@ public class BlockDropsRule {
   public final Filter filter;
   public final Region region;
   public final boolean dropOnWrongTool;
+  public final boolean breakable;
   public final boolean punch;
   public final boolean trample;
   public final BlockDrops drops;
@@ -15,12 +16,14 @@ public class BlockDropsRule {
       Filter filter,
       Region region,
       boolean dropOnWrongTool,
+      boolean breakable,
       boolean punch,
       boolean trample,
       BlockDrops drops) {
     this.filter = filter;
     this.region = region;
     this.dropOnWrongTool = dropOnWrongTool;
+    this.breakable = breakable;
     this.punch = punch;
     this.trample = trample;
     this.drops = drops;

--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsRuleSet.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsRuleSet.java
@@ -13,6 +13,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MaterialData;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.player.ParticipantState;
@@ -100,12 +101,12 @@ public class BlockDropsRuleSet {
     if (event instanceof BlockBreakEvent) {
       rightToolUsed =
           NMSHacks.canMineBlock(material, ((BlockBreakEvent) event).getPlayer().getItemInHand());
-      ;
     } else {
       rightToolUsed = true;
     }
 
     for (BlockDropsRule rule : this.rules) {
+      if (event instanceof BlockTransformEvent && !rule.breakable) continue;
       if (event instanceof PlayerPunchBlockEvent && !rule.punch) continue;
       if (event instanceof PlayerTrampleBlockEvent && !rule.trample) continue;
       if (rule.region != null && !rule.region.contains(block)) continue;


### PR DESCRIPTION
This PR adds a `break` attribute to the Block Drops Rules that allows better fine tuning of block drops and fixes an issue described in #835 where only affecting trampled blocks stopped working. You used to be able to add `<cause>trample</cause>` into the filter to do the same effect, but this doesn't work anymore as mentioned in #796 (the filter always returns deny).

```xml
<block-drops>
    <!-- break defaults to true -->
    <!-- any stone blocks stepped on by the player turns into dirt -->
    <rule trample="true" break="false" region="everywhere">
        <filter>
            <all>
                <material>stone</material>
                <!-- <cause>trample</cause> stopped working -->
                <any>
                    <sprinting/>
                    <walking/>
                    <crouching/>
                </any>
            </all>
        </filter>
        <!-- Replaces the affected block -->
        <replacement>dirt</replacement>
        <!-- Drop emerald ore when player steps on stone block -->
        <drops>
            <item material="emerald ore"/>
        </drops>
    </rule>
</block-drops>
```