### PR TITLE
Allow triggers to support child definitions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -5,11 +5,11 @@ import static net.kyori.adventure.text.Component.empty;
 import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Method;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Element;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.action.actions.ActionNode;
 import tc.oc.pgm.action.actions.KillEntitiesAction;
@@ -91,7 +91,7 @@ public class ActionParser {
   }
 
   public <B extends Filterable<?>> Action<? super B> parseProperty(
-      @Nonnull Node node, Class<B> bound) throws InvalidXMLException {
+      @NotNull Node node, Class<B> bound) throws InvalidXMLException {
     if (node.isAttribute()) return this.parseReference(node, bound);
 
     ActionNode<? super B> result = this.parseAction(node.getElement(), bound);

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -5,6 +5,7 @@ import static net.kyori.adventure.text.Component.empty;
 import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Method;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
 import org.bukkit.inventory.ItemStack;
@@ -89,6 +90,17 @@ public class ActionParser {
     return action;
   }
 
+  public <B extends Filterable<?>> Action<? super B> parseProperty(
+      @Nonnull Node node, Class<B> bound) throws InvalidXMLException {
+    if (node.isAttribute()) return this.parseReference(node, bound);
+
+    ActionNode<? super B> result = this.parseAction(node.getElement(), bound);
+
+    if (bound != null) validate(result, ActionScopeValidation.of(bound), node);
+    features.addFeature(node.getElement(), result);
+    return result;
+  }
+
   @SuppressWarnings("rawtypes, unchecked")
   public void validate(
       Action<?> action, FeatureValidation<ActionDefinition<?>> validation, Node node)
@@ -126,8 +138,8 @@ public class ActionParser {
     Class<T> cls = Filterables.parse(Node.fromRequiredAttr(el, "scope"));
     return new Trigger<>(
         cls,
-        filters.parseReference(Node.fromRequiredAttr(el, "filter")),
-        parseReference(Node.fromRequiredAttr(el, "trigger", "action"), cls));
+        filters.parseProperty(el, "filter"),
+        parseProperty(Node.fromRequiredChildOrAttr(el, "trigger", "action"), cls));
   }
 
   private <B extends Filterable<?>> Class<B> parseScope(Element el, Class<B> scope)


### PR DESCRIPTION
Upgrades trigger's attributes to properties, meaning they can be used either as attributes or children:

```xml
<actions>
  <trigger scope="match">
    <filter>
      <variable var="something">0</variable>
    </filter>
    <action>
      <set var="something" value="1"/>
      <set var="something_else" value="something+5"/>
    </action>
  </trigger>
</actions>
```

Equivalent to:
```xml
<filters>
  <variable id="something-is-0" var="something">0</variable>
</filters>
<actions>
  <action id="set-something-to-1" scope="match">
    <set var="something" value="1"/>
    <set var="something_else" value="something+5"/>
  </action>
  <trigger filter="something-is-0" action="set-something-to-1" scope="match"/>
</action>
```

In some situations it's better to just inline them than to have different ids for each filter and action

The PR has been tested and works as intended.