### PR TITLE
Implement after filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
@@ -26,7 +26,7 @@ public class MonostableFilter extends SingleFilterFunction
   private final Class<? extends Filterable<?>> scope;
 
   public static Filter afterMatchStart(Duration duration) {
-    return AllFilter.of(after(MatchPhaseFilter.RUNNING, duration), MatchPhaseFilter.RUNNING);
+    return after(MatchPhaseFilter.RUNNING, duration);
   }
 
   /**
@@ -36,7 +36,7 @@ public class MonostableFilter extends SingleFilterFunction
    * @param duration the duration to delay this filters rise
    */
   public static Filter after(Filter filter, Duration duration) {
-    return new InverseFilter(new MonostableFilter(filter, duration));
+    return AllFilter.of(filter, new InverseFilter(new MonostableFilter(filter, duration)));
   }
 
   public MonostableFilter(Filter filter, Duration duration) {

--- a/core/src/main/java/tc/oc/pgm/filters/parse/DynamicFilterValidation.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/DynamicFilterValidation.java
@@ -11,6 +11,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 
 public class DynamicFilterValidation implements FeatureValidation<FilterDefinition> {
+  public static final DynamicFilterValidation ANY = new DynamicFilterValidation(null);
   public static final DynamicFilterValidation PLAYER =
       new DynamicFilterValidation(MatchPlayer.class);
   public static final DynamicFilterValidation PARTY = new DynamicFilterValidation(Party.class);
@@ -25,7 +26,7 @@ public class DynamicFilterValidation implements FeatureValidation<FilterDefiniti
   @Override
   public void validate(FilterDefinition definition, Node node) throws InvalidXMLException {
     if (!definition.isDynamic()) throw new InvalidXMLException("Filter must be dynamic", node);
-    if (!definition.respondsTo(type))
+    if (type != null && !definition.respondsTo(type))
       throw new InvalidXMLException(
           "Expected a filter that can react to changes in "
               + type.getSimpleName()

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -503,12 +503,20 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
 
   @MethodParser("countdown")
   public Filter parseCountdownFilter(Element el) throws InvalidXMLException {
-    final Duration duration = XMLUtils.parseDuration(Node.fromRequiredAttr(el, "duration"), null);
-    if (!duration.isNegative() && !duration.isZero()) {
-      return new MonostableFilter(parseChild(el), duration);
-    } else {
-      return StaticFilter.DENY;
-    }
+    Duration duration = XMLUtils.parseDuration(Node.fromRequiredAttr(el, "duration"));
+    if (duration.isNegative() || duration.isZero()) return StaticFilter.DENY;
+
+    Filter child = parseProperty(Node.fromAttrOrSelf(el, "filter"), DynamicFilterValidation.ANY);
+    return new MonostableFilter(child, duration);
+  }
+
+  @MethodParser("after")
+  public Filter parseAfterFilter(Element el) throws InvalidXMLException {
+    Duration duration = XMLUtils.parseDuration(Node.fromRequiredAttr(el, "duration"));
+    Filter child = parseProperty(Node.fromAttrOrSelf(el, "filter"), DynamicFilterValidation.ANY);
+
+    if (duration.isNegative() || duration.isZero()) return child;
+    return MonostableFilter.after(child, duration);
   }
 
   @MethodParser("rank")
@@ -604,10 +612,9 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
 
   @MethodParser("players")
   public PlayerCountFilter parsePlayerCountFilter(Element el) throws InvalidXMLException {
-    Node node = Node.fromAttr(el, "filter");
-    if (node == null) node = new Node(el);
-
-    Filter child = parseProperty(node, StaticFilter.ALLOW, DynamicFilterValidation.PLAYER);
+    Filter child =
+        parseProperty(
+            Node.fromAttrOrSelf(el, "filter"), StaticFilter.ALLOW, DynamicFilterValidation.PLAYER);
 
     return new PlayerCountFilter(
         child,

--- a/util/src/main/java/tc/oc/pgm/util/xml/Node.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/Node.java
@@ -157,6 +157,17 @@ public class Node {
   }
 
   /**
+   * Return a new Node wrapping an Attribute of the given Element matching one of the given names,
+   * or the element itself if the given Element has no matching Attributes. Note: this is mostly
+   * useful for properties that are allowed as either refs or direct children.
+   */
+  public static Node fromAttrOrSelf(Element el, String... aliases) throws InvalidXMLException {
+    Node node = null;
+    for (String alias : aliases) node = wrapUnique(node, true, alias, el.getAttribute(alias));
+    return node != null ? node : new Node(el);
+  }
+
+  /**
    * Return a new Node wrapping the named Attribute of the given Element. If the Attribute does not
    * exist, throw an InvalidXMLException complaining about it.
    */

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -22,6 +22,7 @@ import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.Version;
@@ -520,7 +521,8 @@ public final class XMLUtils {
     }
   }
 
-  public static @Nullable Duration parseDuration(Node node) throws InvalidXMLException {
+  @Contract("null -> null; !null -> !null")
+  public static Duration parseDuration(Node node) throws InvalidXMLException {
     return parseDuration(node, null);
   }
 


### PR DESCRIPTION
Similar to the countdown filter, after will start matching a duration after the child starts matching:

```xml
<after duration="5s">
  <cuboid .../>
</after>
```

The filter will start matching players after they enter and stay in the cuboid for 5s.

This is feature-wise identical to:
```xml
<all>
  <cuboid .../>
  <not>
    <countdown duration="5s">
      <cuboid .../>
    </countdown>
  </not>
</all>
```

It also solves countdowns (and after) not supporting filter references neither as children nor as an attribute, so these are now possible and weren't before:

```xml
<countdown filter="some-other-filter" duration="5s"/>
<countdown duration="5s">
  <filter id="some-other-filter"/>
</countdown>
```

The PR has been tested and works as intended.