### PR TITLE
Add Skywars Gamemode

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -18,6 +18,7 @@ public enum Gamemode {
   RAGE("rage"),
   RACE_FOR_WOOL("rfw"),
   SCOREBOX("scorebox"),
+  SKYWARS("skywars"),
   DEATHMATCH("tdm");
 
   private final String id;

--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -30,6 +30,8 @@ gamemode.rfw.name = Race for Wool
 
 gamemode.scorebox.name = Scorebox
 
+gamemode.skywars.name = Skywars
+
 gamemode.arcade.name = Arcade
 
 gamemode.ffa.name = Free for All
@@ -67,6 +69,8 @@ gamemode.br.acronym = Blitz: Rage
 gamemode.rfw.acronym = RFW
 
 gamemode.scorebox.acronym = Scorebox
+
+gamemode.skywars.acronym = Skywars
 
 gamemode.arcade.acronym = Arcade
 


### PR DESCRIPTION
Once the Lootables module is reintroduced, a lot of old Skywars maps used the include `skywars.xml` which contained skywars as a gamemode will become useable. This PR is for compatibility.

```xml
<gamemode>skywars</gamemode>
```

https://github.com/OvercastNetwork/maps.oc.tc/blob/master/Include/skywars.xml