### PR TITLE
Fix monostable filter scope forward reference

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/filter/query/MatchQuery.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/query/MatchQuery.java
@@ -28,4 +28,8 @@ public interface MatchQuery extends Query {
   default <T extends ReactorFactory.Reactor> T reactor(ReactorFactory<T> factory) {
     return getMatch().needModule(FilterMatchModule.class).getReactor(factory);
   }
+
+  default <F extends Filterable<?>> F filterable(Class<F> type) {
+    return extractFilterable().getFilterableAncestor(type);
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
@@ -20,10 +20,9 @@ import tc.oc.pgm.filters.operator.InverseFilter;
 import tc.oc.pgm.filters.operator.SingleFilterFunction;
 
 public class MonostableFilter extends SingleFilterFunction
-    implements TypedFilter<MatchQuery>, ReactorFactory<MonostableFilter.Reactor> {
+    implements TypedFilter<MatchQuery>, ReactorFactory<MonostableFilter.Reactor<?>> {
 
   private final Duration duration;
-  private final Class<? extends Filterable<?>> scope;
 
   public static Filter afterMatchStart(Duration duration) {
     return after(MatchPhaseFilter.RUNNING, duration);
@@ -42,7 +41,6 @@ public class MonostableFilter extends SingleFilterFunction
   public MonostableFilter(Filter filter, Duration duration) {
     super(filter);
     this.duration = duration;
-    this.scope = Filterables.scope(filter);
   }
 
   @Override
@@ -52,30 +50,35 @@ public class MonostableFilter extends SingleFilterFunction
 
   @Override
   public boolean matches(MatchQuery query) {
-    boolean response = this.filter.response(query);
-    final Filterable<?> filterable = query.extractFilterable().getFilterableAncestor(this.scope);
-    if (filterable == null)
-      throw new IllegalArgumentException(
-          "The scope of this filter does not match the query it received");
-
-    return query.reactor(this).matches(filterable, response);
+    return query.reactor(this).matches(query);
   }
 
   @Override
-  public MonostableFilter.Reactor createReactor(Match match, FilterMatchModule fmm) {
-    return new Reactor(match, fmm);
+  public Reactor<?> createReactor(Match match, FilterMatchModule fmm) {
+    return new Reactor<>(match, fmm, Filterables.scope(filter));
   }
 
-  protected final class Reactor extends ReactorFactory.Reactor implements Tickable {
+  protected final class Reactor<F extends Filterable<?>> extends ReactorFactory.Reactor
+      implements Tickable {
+
+    private final Class<F> scope;
 
     // Filterables that currently pass the inner filter, mapped to the instants that they expire.
     // They are not actually removed until the inner filter goes false.
     final Map<Filterable<?>, Instant> endTimes = new HashMap<>();
 
-    public Reactor(Match match, FilterMatchModule fmm) {
+    public Reactor(Match match, FilterMatchModule fmm, Class<F> scope) {
       super(match, fmm);
+      this.scope = scope;
       match.addTickable(this, MatchScope.LOADED);
       fmm.onChange(scope, filter, this::matches);
+    }
+
+    boolean matches(MatchQuery query) {
+      final Filterable<?> filterable = query.filterable(this.scope);
+      if (filterable == null) return false;
+
+      return matches(filterable, filter.response(query));
     }
 
     boolean matches(Filterable<?> filterable, boolean response) {


### PR DESCRIPTION
Monotsable filters (countdown and after) are failing when using forward references to filters not yet defined:

```xml
<!-- Has always been valid, has always errored out -->
<countdown duration="5s"> 
  <all>
    <filter id="defined-later"/>
  </all>
</countdown>

<!-- These are only valid since PR #1075, as direct child used to not support references -->
<after duration="5s"> 
    <filter id="defined-later"/>
</after>
<after duration="5s" filter="defined-later"/>

<!-- Defined later, so the above filters can't check the scope. Works fine if this is declared first -->
<variable id="defined-later" var="a">0</variable>
```

This resolves it by moving the scope-getting to the reactor, at match time instead of parse time.

This PR has been tested and works as intended