### PR TITLE
Update legacy region parsing logic

### DIFF
--- a/core/src/main/java/tc/oc/pgm/regions/RegionFilterApplicationParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionFilterApplicationParser.java
@@ -86,13 +86,8 @@ public class RegionFilterApplicationParser {
 
   public void parseMaxBuildHeight(Element el) throws InvalidXMLException {
     final Region region =
-        new CuboidRegion(
-            new Vector(
-                Double.NEGATIVE_INFINITY,
-                XMLUtils.parseNumber(el, Integer.class),
-                Double.NEGATIVE_INFINITY),
-            new Vector(
-                Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY));
+        new HalfspaceRegion(
+            new Vector(0, XMLUtils.parseNumber(el, Integer.class), 0), new Vector(0, 1, 0));
     final Component message = translatable("match.maxBuildHeight");
 
     for (RFAScope scope : Lists.newArrayList(RFAScope.BLOCK_PLACE)) {

--- a/core/src/main/java/tc/oc/pgm/regions/RegionModule.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionModule.java
@@ -71,16 +71,18 @@ public class RegionModule implements MapModule {
         }
       }
 
-      // Support deprecated <lanes> syntax
+      // Support legacy <lanes> syntax
       for (Element laneEl : XMLUtils.flattenElements(doc.getRootElement(), "lanes", "lane")) {
         rfaParser.parseLane(laneEl);
       }
 
       // Support deprecated <playable> syntax
-      Element playableEl = XMLUtils.getUniqueChild(doc.getRootElement(), "playable");
-      if (playableEl != null) rfaParser.parsePlayable(playableEl);
+      if (factory.getProto().isOlderThan(MapProtos.MODULE_SUBELEMENT_VERSION)) {
+        Element playableEl = XMLUtils.getUniqueChild(doc.getRootElement(), "playable");
+        if (playableEl != null) rfaParser.parsePlayable(playableEl);
+      }
 
-      // Support deprecated <maxbuildheight> syntax
+      // Support <maxbuildheight> syntax
       Element heightEl = XMLUtils.getUniqueChild(doc.getRootElement(), "maxbuildheight");
       if (heightEl != null) rfaParser.parseMaxBuildHeight(heightEl);
 


### PR DESCRIPTION
This resolves some erroneous wording changes made by a certain king of shapes which has since made its way in to the [docs](https://github.com/PGMDev/Website/commit/f249af95901994995feec49078e6361d4af96ca6).

The `lanes` element was incorrectly listed as deprecated rather than legacy. Although true that lanes are no longer the recommended way to apply this logic it is still valid XML in the current protocol. 

The same extends to `maxbuildheight` which is still the recommended way of applying this logic. The creation of this feature is moved to a half-space region (as would be expected) rather than an infinitely sized cuboid.

The `playable` element is no longer supported in the current protocol (as of 1.3.6). This change adds a proto-check before parsing this element. As indicated on the following page http://docs.oc.tc/modules/proto.

![image](https://user-images.githubusercontent.com/8608892/195989952-e8369d81-470b-421e-acf6-41864977f1ae.png)

If accepted I can make a PR to the docs to resolve the deprecated notice of [Build Height](https://pgm.dev/docs/modules/environment/world/#build-height).

Signed-off-by: Pugzy <pugzy@mail.com>