### PR TITLE
Add Payload gamemode translatable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -15,6 +15,7 @@ public enum Gamemode {
   KING_OF_THE_HILL("koth"),
   KING_OF_THE_FLAG("kotf"),
   MIXED("mixed"),
+  PAYLOAD("pd"),
   RAGE("rage"),
   RACE_FOR_WOOL("rfw"),
   SCOREBOX("scorebox"),

--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -20,6 +20,8 @@ gamemode.cp.name = Control the Point
 
 gamemode.koth.name = King of the Hill
 
+gamemode.pd.name = Payload
+
 gamemode.blitz.name = Blitz
 
 gamemode.rage.name = Rage
@@ -59,6 +61,8 @@ gamemode.ad.acronym = A/D
 gamemode.cp.acronym = CP
 
 gamemode.koth.acronym = KotH
+
+gamemode.pd.acronym = PD
 
 gamemode.blitz.acronym = Blitz
 


### PR DESCRIPTION
Small oversight that was missed earlier. Payload is given the gamemode ID `pd` as it was mentioned in [ControlPointModule](https://github.com/PGMDev/PGM/blob/0cce36084b73e6cd1e025f1e5cd38301581b4d64/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointModule.java#L34):
```java
private static final MapTag PAYLOAD = new MapTag("pd", "payload", "Payload", true, false);
```

```xml
<!-- Payload gamemode -->
<gamemode>pd</gamemode>
```