### PR TITLE
Reduce compact wool scoreboard component length

### DIFF
--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -481,22 +481,17 @@ public class SidebarMatchModule implements MatchModule, Listener {
           boolean horizontalCompact =
               MAX_LENGTH < (3 * sortedWools.size()) + (3 * (sortedWools.size() - 1)) + 1;
           TextComponent.Builder woolText = text();
-          if (!horizontalCompact) {
-            // If there is extra room, add another space to the left of the wools to make them
-            // appear more centered.
-            woolText.append(space());
-          }
-
           for (Goal<?> goal : sortedWools) {
             if (goal instanceof MonumentWool && goal.hasShowOption(ShowOption.SHOW_SIDEBAR)) {
               MonumentWool wool = (MonumentWool) goal;
-              woolText.append(space());
+              TextComponent spacer = space();
               if (!firstWool && !horizontalCompact) {
-                woolText.append(space()).append(space());
+                spacer = spacer.append(space()).append(space());
               }
               firstWool = false;
               woolText.append(
-                  wool.renderSidebarStatusText(competitor, party)
+                  spacer
+                      .append(wool.renderSidebarStatusText(competitor, party))
                       .color(wool.renderSidebarStatusColor(competitor, party)));
             }
           }


### PR DESCRIPTION
The recent changes migrating the scoreboard to use components has an unintended side effect of increasing the character count of the lines due to the use of `space()`. When these components are translated back to legacy format the extra spaces add unnecessary resets to the string. This causes the line to be sliced in order to be compact enough for scoreboard display causing wools to be cut off where they had previously not.

An example of this is below.
` §1⬜§r §3⬜§r §2⬜§r §a⬜§r §6⬜§r §e⬜`

Each set of spaces causes the `§r` characters to be added after each wool which increases its final display length.

This change appends the spaces in a way that does not require the resets and produces the below.
`§1 ⬜§2 ⬜§6 ⬜§c ⬜§5 ⬜§4 ⬜§7 ⬜` which is 10 characters shorter.

Examples of compact scoreboards with many wools.

![image](https://user-images.githubusercontent.com/8608892/196240578-96737982-14d5-4258-9a84-7415b779ed3f.png)

This commit also removes an extra space that was added at the start of the wool line which caused it to start with two spaces rather than the previous one. Looking back at the commits prior to this change and old OCN videos one space seems to be correct.

If there's a better way to do this let me know.