### PR TITLE
Make filter a required property of dynamic kits

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitModule.java
@@ -80,7 +80,7 @@ public class KitModule implements MapModule {
       KitRule.Action action = TextParser.parseEnum(el.getName(), KitRule.Action.class);
       Kit kit = factory.getKits().parseKitProperty(el, "kit");
       Filter filter =
-          factory.getFilters().parseProperty(el, "filter", DynamicFilterValidation.PLAYER);
+          factory.getFilters().parseRequiredProperty(el, "filter", DynamicFilterValidation.PLAYER);
 
       return new KitRule(action, kit, filter);
     }


### PR DESCRIPTION
Update the dynamic kit definition to require a `filter` property.
This is currently "optional" but the map will break if not defined. Whoops.

The below error message will now be shown when not provided or when provided as a non-dynamic filter.

![image](https://user-images.githubusercontent.com/8608892/196896061-16be7098-900c-4f97-a850-af378c554b03.png)

Signed-off-by: Pugzy <pugzy@mail.com>