### PR TITLE
Reintroduce legacy map pool command aliases

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
@@ -43,7 +43,7 @@ public final class MapPoolCommand {
   private static final DecimalFormat SCORE_FORMAT = new DecimalFormat("00.00%");
 
   @Command(
-      aliases = {"pool"},
+      aliases = {"pool", "rotation", "rot"},
       desc = "List the maps in the map pool",
       usage = "[page] [-p pool] [-s scores] [-c chance of vote]")
   public static void pool(
@@ -127,7 +127,7 @@ public final class MapPoolCommand {
   }
 
   @Command(
-      aliases = {"pools"},
+      aliases = {"pools", "rotations", "rots"},
       desc = "List all the map pools",
       flags = "d")
   public static void pools(
@@ -204,7 +204,7 @@ public final class MapPoolCommand {
   }
 
   @Command(
-      aliases = {"setpool"},
+      aliases = {"setpool", "setrot"},
       desc = "Change the map pool",
       usage = "[pool name] -r (revert to dynamic) -t (time limit for map pool) -m (match # limit)",
       flags = "rtm",


### PR DESCRIPTION
Removing the "rotation", "rot", etc. aliases was a counterintuitive change. A rotation is still a supported type of organized map collection, and not all PGM servers may utilize map pools. There are also a lot of people who are familiar with using the old aliases.
Having the rotation versions of the commands available to use doesn't negatively impact the plugin in any way, either.