### PR TITLE
Fix unsafe substring calls

### DIFF
--- a/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
@@ -50,6 +50,7 @@ import tc.oc.pgm.events.PlayerBlockTransformEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.kits.WalkSpeedKit;
 import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
+import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.attribute.Attribute;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.named.NameStyle;
@@ -298,8 +299,10 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
     // Ensure that the title of the inventory is <= 32 characters long to appease Minecraft's
     // restrictions on inventory titles
     String title =
-        TextTranslations.translateLegacy(player(holder, NameStyle.CONCISE, viewer), viewer)
-            .substring(0, 32);
+        StringUtils.substring(
+            TextTranslations.translateLegacy(player(holder, NameStyle.CONCISE, viewer), viewer),
+            0,
+            32);
 
     Inventory preview = Bukkit.getServer().createInventory(viewer, 45, title);
 

--- a/util/src/main/java/tc/oc/pgm/util/StringUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/StringUtils.java
@@ -102,9 +102,9 @@ public final class StringUtils {
     }
 
     // Split and truncate the text, and restore the color in the suffix
-    String prefix = text.substring(0, split);
+    String prefix = substring(text, 0, split);
     String lastColors = ChatColor.getLastColors(prefix);
-    String suffix = lastColors + text.substring(split, split + MAX_SUFFIX - lastColors.length());
+    String suffix = lastColors + substring(text, split, split + MAX_SUFFIX - lastColors.length());
     return new String[] {prefix, suffix};
   }
 }


### PR DESCRIPTION
These broke as a result of 96bed424, which replaced old apache commons' substring with java's. Apache commons substring was safe for arbitrary length strings, java's is not.

The change broke:
 - Tablist for 1.7 players when any entry is under 16 chars in length
 - The /inv command (or right-clicking as spectator) for any username under 32 chars in length