### PR TITLE
Fix logging NPE and change log level of BlockTransformListener

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -200,7 +200,7 @@ public class BlockTransformListener implements Listener {
         handleDoor(event, (Door) newData);
       }
     }
-    logger.fine("Generated event " + event);
+    logger.finest("Generated event " + event);
     currentEvents.put(event.getCause(), event);
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/ClassLogger.java
+++ b/util/src/main/java/tc/oc/pgm/util/ClassLogger.java
@@ -113,6 +113,17 @@ public final class ClassLogger extends Logger {
     this.setLevel(null);
   }
 
+  public Level getEffectiveLevel() {
+    Level level = this.getLevel();
+    Logger someParent = this.getParent();
+    while (level == null) {
+      level = someParent.getLevel();
+      someParent = someParent.getParent();
+    }
+
+    return level;
+  }
+
   @Override
   public void log(LogRecord record) {
     record.setMessage(this.prefix + record.getMessage());
@@ -121,7 +132,7 @@ public final class ClassLogger extends Logger {
     // Check the level ourselves and then promote the record
     // to make sure it gets through.
     if (record.getLevel().intValue() < Level.INFO.intValue()
-        && record.getLevel().intValue() >= this.getLevel().intValue()) {
+        && record.getLevel().intValue() >= this.getEffectiveLevel().intValue()) {
 
       record.setLevel(Level.INFO);
     }


### PR DESCRIPTION
Since ClassLoggers are always children of some parent Logger, the level will be null. (As specified in the javadocs)

The BlockTransformListener logging can spam a lot, so it made sense to me degrading it to finest, since fine includes more less spammy info.
Signed-off-by: KingSimon <19822231+KingOfSquares@users.noreply.github.com>