### PR TITLE
Fix shading of cloud's libs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -62,7 +62,8 @@
                             <include>org.jdom:jdom2:*</include>
                             <include>net.kyori:*:*</include>
                             <include>cloud.commandframework:cloud-*:*</include>
-                            <include>me.lucko:commodore:*</include>
+                            <include>io.leangen.geantyref:*:*</include>
+                            <include>me.lucko:commodore</include>
                             <include>fr.mrmicky:*:*</include>
                             <include>org.eclipse.jgit:org.eclipse.jgit:*</include>
                             <include>org.slf4j:slf4j-api:*</include>
@@ -84,8 +85,12 @@
                             <shadedPattern>tc.oc.pgm.lib.cloud.commandframework</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>me.lucko</pattern>
-                            <shadedPattern>tc.oc.pgm.lib.me.lucko</shadedPattern>
+                            <pattern>io.leangen.geantyref</pattern>
+                            <shadedPattern>tc.oc.pgm.lib.io.leangen.geantyref</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>me.lucko.commodore</pattern>
+                            <shadedPattern>tc.oc.pgm.lib.me.lucko.commodore</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>fr.mrmicky</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -134,27 +134,32 @@
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-core</artifactId>
             <version>1.7.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-annotations</artifactId>
             <version>1.7.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-paper</artifactId>
             <version>1.7.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-minecraft-extras</artifactId>
             <version>1.7.1</version>
+            <scope>compile</scope>
         </dependency>
         <!-- Allows registering brigadier mappings -->
         <dependency>
             <groupId>me.lucko</groupId>
             <artifactId>commodore</artifactId>
             <version>1.9</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- Small reflection library for Scoreboards -->


### PR DESCRIPTION
Currently PGM will run just fine from the IDE, but when packaged as a jar it was not including a required sub-dependency from cloud (type-ref stuff). This fixes the issue.