### PR TITLE
Fix tab-completion for /msg & cleanup chat dispatcher

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/SettingCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/SettingCommand.java
@@ -21,6 +21,14 @@ import tc.oc.pgm.util.text.TextFormatter;
 // TODO: remove some of these when settings UI is released
 public final class SettingCommand {
 
+  public static final SettingCommand INSTANCE = new SettingCommand();
+
+  public static SettingCommand getInstance() {
+    return INSTANCE;
+  }
+
+  private SettingCommand() {}
+
   @CommandMethod("settings")
   @CommandDescription("Open the settings menu")
   public void settings(MatchPlayer player) {

--- a/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
@@ -216,7 +216,7 @@ public class CommandGraph {
     register(new ModeCommand());
     register(new ProximityCommand());
     register(new RestartCommand());
-    register(new SettingCommand());
+    register(SettingCommand.getInstance());
     register(new StartCommand());
     register(new StatsCommand());
     register(new TeamCommand());

--- a/util/src/main/java/tc/oc/pgm/util/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/Audience.java
@@ -4,9 +4,13 @@ import static net.kyori.adventure.key.Key.key;
 import static net.kyori.adventure.sound.Sound.sound;
 import static net.kyori.adventure.text.Component.text;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Predicate;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
+
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.sound.Sound;
@@ -14,6 +18,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 
 /** Receiver of chat messages, sounds, titles, and other media. */
@@ -54,5 +59,10 @@ public interface Audience extends ForwardingAudience.Single {
 
   static Audience empty() {
     return net.kyori.adventure.audience.Audience::empty;
+  }
+
+  static @NotNull Collector<? super net.kyori.adventure.audience.Audience, ?, Audience> toAudience() {
+    return Collectors.collectingAndThen(Collectors.toCollection(ArrayList::new),
+        audiences -> get(Collections.unmodifiableCollection(audiences)));
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/Audience.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.function.Predicate;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
-
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.sound.Sound;
@@ -61,8 +60,10 @@ public interface Audience extends ForwardingAudience.Single {
     return net.kyori.adventure.audience.Audience::empty;
   }
 
-  static @NotNull Collector<? super net.kyori.adventure.audience.Audience, ?, Audience> toAudience() {
-    return Collectors.collectingAndThen(Collectors.toCollection(ArrayList::new),
+  static @NotNull Collector<? super net.kyori.adventure.audience.Audience, ?, Audience>
+      toAudience() {
+    return Collectors.collectingAndThen(
+        Collectors.toCollection(ArrayList::new),
         audiences -> get(Collections.unmodifiableCollection(audiences)));
   }
 }


### PR DESCRIPTION
Tab-completion for `/msg` currently shows all players, as the type is `Player`, and not `MatchPlayer` (which uses our custom parser, supporting vanish/nick as well as fuzzy-matching & filtering).

This PR fixes that, as well as doing a bit of a general clean-up of ChatDispatcher