### PR TITLE
Implement exposed actions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionMatchModule.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.action;
 
 import com.google.common.collect.ImmutableList;
+import tc.oc.pgm.action.actions.ExposedAction;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
@@ -10,10 +11,15 @@ import tc.oc.pgm.filters.Filterable;
 public class ActionMatchModule implements MatchModule {
   private final Match match;
   private final ImmutableList<Trigger<?>> triggers;
+  private final ImmutableList<ExposedAction> exposedActions;
 
-  public ActionMatchModule(Match match, ImmutableList<Trigger<?>> triggers) {
+  public ActionMatchModule(
+      Match match,
+      ImmutableList<Trigger<?>> triggers,
+      ImmutableList<ExposedAction> exposedActions) {
     this.match = match;
     this.triggers = triggers;
+    this.exposedActions = exposedActions;
   }
 
   @Override
@@ -33,5 +39,9 @@ public class ActionMatchModule implements MatchModule {
           if (response) rule.getAction().trigger(filterable);
           else rule.getAction().untrigger(filterable);
         });
+  }
+
+  public ImmutableList<ExposedAction> getExposedActions() {
+    return exposedActions;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/ActionModule.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionModule.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.action.actions.ExposedAction;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
@@ -19,9 +20,16 @@ import tc.oc.pgm.variables.VariablesModule;
 public class ActionModule implements MapModule<ActionMatchModule> {
 
   private final ImmutableList<Trigger<?>> triggers;
+  private ImmutableList<ExposedAction> actions;
 
   public ActionModule(ImmutableList<Trigger<?>> triggers) {
     this.triggers = triggers;
+  }
+
+  @Override
+  public void postParse(MapFactory factory, Logger logger, Document doc) {
+    // Must be post-parsed, as other parts of the XML may create other actions
+    this.actions = ImmutableList.copyOf(factory.getFeatures().getAll(ExposedAction.class));
   }
 
   @Nullable
@@ -33,7 +41,7 @@ public class ActionModule implements MapModule<ActionMatchModule> {
   @Nullable
   @Override
   public ActionMatchModule createMatchModule(Match match) throws ModuleLoadException {
-    return new ActionMatchModule(match, triggers);
+    return new ActionMatchModule(match, triggers, actions);
   }
 
   public static class Factory implements MapModuleFactory<ActionModule> {

--- a/core/src/main/java/tc/oc/pgm/action/actions/ExposedAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/ExposedAction.java
@@ -1,0 +1,41 @@
+package tc.oc.pgm.action.actions;
+
+import tc.oc.pgm.action.ActionDefinition;
+import tc.oc.pgm.api.feature.Feature;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+
+/**
+ * Wraps an action definition to consider it exposed. This is an easy way to avoid needing each
+ * specialized action to implement a way to expose itself or not.
+ */
+public class ExposedAction extends SelfIdentifyingFeatureDefinition
+    implements ActionDefinition<Match>, Feature<ActionDefinition<? super Match>> {
+
+  private final ActionDefinition<? super Match> delegate;
+
+  public ExposedAction(String id, ActionDefinition<? super Match> delegate) {
+    super(id);
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ActionDefinition<? super Match> getDefinition() {
+    return delegate;
+  }
+
+  @Override
+  public Class<Match> getScope() {
+    return Match.class;
+  }
+
+  @Override
+  public void trigger(Match m) {
+    delegate.trigger(m);
+  }
+
+  @Override
+  public void untrigger(Match m) {
+    delegate.untrigger(m);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/ActionCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ActionCommand.java
@@ -1,0 +1,79 @@
+package tc.oc.pgm.command;
+
+import static net.kyori.adventure.text.Component.text;
+
+import cloud.commandframework.annotations.Argument;
+import cloud.commandframework.annotations.CommandDescription;
+import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.CommandPermission;
+import cloud.commandframework.annotations.Flag;
+import cloud.commandframework.annotations.specifier.Greedy;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.action.ActionMatchModule;
+import tc.oc.pgm.action.actions.ExposedAction;
+import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.PrettyPaginatedComponentResults;
+import tc.oc.pgm.util.text.TextFormatter;
+
+@CommandMethod("action|actions")
+public class ActionCommand {
+
+  @CommandMethod("list|page [page]")
+  @CommandDescription("Inspect variables for a player")
+  @CommandPermission(Permissions.GAMEPLAY)
+  public void showActions(
+      Audience audience,
+      CommandSender sender,
+      ActionMatchModule amm,
+      @Argument(value = "page", defaultValue = "1") int page,
+      @Flag(value = "query", aliases = "q") String query,
+      @Flag(value = "all", aliases = "a") boolean all) {
+
+    List<ExposedAction> actions =
+        amm.getExposedActions().stream()
+            .filter(a -> query == null || a.getId().contains(query))
+            .sorted(Comparator.comparing(ExposedAction::getId))
+            .collect(Collectors.toList());
+
+    int resultsPerPage = all ? actions.size() : 8;
+    int pages = all ? 1 : (actions.size() + resultsPerPage - 1) / resultsPerPage;
+
+    Component title =
+        TextFormatter.paginate(
+            text("Actions"), page, pages, NamedTextColor.DARK_AQUA, NamedTextColor.AQUA, true);
+    Component header = TextFormatter.horizontalLineHeading(sender, title, NamedTextColor.BLUE);
+
+    PrettyPaginatedComponentResults.display(
+        audience,
+        actions,
+        page,
+        resultsPerPage,
+        header,
+        (v, i) -> text((i + 1) + ". ").append(text(v.getId(), NamedTextColor.AQUA)));
+  }
+
+  @CommandMethod("trigger [action]")
+  @CommandDescription("Trigger a specific action")
+  @CommandPermission(Permissions.GAMEPLAY)
+  public void triggerAction(
+      Audience audience, Match match, @Argument("action") @Greedy ExposedAction action) {
+    action.trigger(match);
+    audience.sendMessage(text("Triggered " + action.getId()));
+  }
+
+  @CommandMethod("untrigger [action]")
+  @CommandDescription("Untrigger a specific action")
+  @CommandPermission(Permissions.GAMEPLAY)
+  public void untriggerAction(
+      Audience audience, Match match, @Argument("action") @Greedy ExposedAction action) {
+    action.untrigger(match);
+    audience.sendMessage(text("Untriggered " + action.getId()));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/parsers/ExposedActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/ExposedActionParser.java
@@ -1,0 +1,25 @@
+package tc.oc.pgm.command.parsers;
+
+import cloud.commandframework.arguments.parser.ParserParameters;
+import cloud.commandframework.paper.PaperCommandManager;
+import java.util.Collection;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.action.ActionMatchModule;
+import tc.oc.pgm.action.actions.ExposedAction;
+
+public class ExposedActionParser extends MatchObjectParser<ExposedAction, ActionMatchModule> {
+
+  public ExposedActionParser(PaperCommandManager<CommandSender> manager, ParserParameters options) {
+    super(manager, options, ExposedAction.class, ActionMatchModule.class, "actions");
+  }
+
+  @Override
+  protected Collection<ExposedAction> objects(ActionMatchModule module) {
+    return module.getExposedActions();
+  }
+
+  @Override
+  protected String getName(ExposedAction obj) {
+    return obj.getId();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
@@ -40,6 +40,7 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.util.ComponentMessageThrowable;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.action.actions.ExposedAction;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
@@ -53,6 +54,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.classes.PlayerClass;
+import tc.oc.pgm.command.ActionCommand;
 import tc.oc.pgm.command.AdminCommand;
 import tc.oc.pgm.command.CancelCommand;
 import tc.oc.pgm.command.ClassCommand;
@@ -84,6 +86,7 @@ import tc.oc.pgm.command.injectors.MatchProvider;
 import tc.oc.pgm.command.injectors.TeamMatchModuleProvider;
 import tc.oc.pgm.command.parsers.DurationParser;
 import tc.oc.pgm.command.parsers.EnumParser;
+import tc.oc.pgm.command.parsers.ExposedActionParser;
 import tc.oc.pgm.command.parsers.MapInfoParser;
 import tc.oc.pgm.command.parsers.MapPoolParser;
 import tc.oc.pgm.command.parsers.MatchPlayerParser;
@@ -200,6 +203,7 @@ public class CommandGraph {
 
   // Commands
   public void registerCommands() {
+    register(new ActionCommand());
     register(new AdminCommand());
     register(new CancelCommand());
     register(new ClassCommand());
@@ -210,6 +214,7 @@ public class CommandGraph {
     register(new JoinCommand());
     register(new ListCommand());
     register(new MapCommand());
+    register(new MapDevCommand());
     register(new MapOrderCommand());
     register(new MapPoolCommand());
     register(new MatchCommand());
@@ -222,7 +227,6 @@ public class CommandGraph {
     register(new TeamCommand());
     register(new TimeLimitCommand());
     register(new VotingCommand());
-    register(new MapDevCommand());
 
     if (pgm.getConfiguration().isCommunityMode()) {
       register(new ReportCommand());
@@ -284,6 +288,7 @@ public class CommandGraph {
     registerParser(TypeFactory.parameterizedClass(Collection.class, Team.class), TeamsParser::new);
     registerParser(PlayerClass.class, PlayerClassParser::new);
     registerParser(Mode.class, ModeParser::new);
+    registerParser(ExposedAction.class, ExposedActionParser::new);
     registerParser(
         TypeFactory.parameterizedClass(Optional.class, VictoryCondition.class),
         new VictoryConditionParser());


### PR DESCRIPTION
Adds a way for PGM `<action>`s to be exposed to trigger/untrigger via commands. This is somewhat equivalent to how staff can manage monument modes via `/mode start` or `/mode push`, but for actions.

The commands to manage actions are `/action` or `/actions`, and the 3 sub-commands are list, trigger and untrigger.
`/action list ` -> lists all exposed actions in the current match
`/action trigger [action]` -> triggers the action
`/action untrigger [action]` -> untriggers the action, keep in mind very few actions actually do anything when untriggering at all. However, it may be useful in combination with removable kits.

In order to be available to trigger by commands, actions must:
 - have an id
 - have the `expose="true"` attribute, 
 - support the match scope (eg: messages work too, as they work with any audience, and match is an audience) and have an id.

If you try to use expose="true" without meeting the other requirements, you'll get an XML exception with a descriptive message.

Dummy example, send a message (to everyone in the match):
```
<actions>
  <message id="send-message" expose="true">Chat message!</message>
</actions>
```

Full example, has 2 actions to start/end blitz mode. It utilizes a variable filter in blitz module, and changes the variable value in the actions, as well as broadcasting a message (could enhance it by sending a title in <message>).
```
<actions> 
  <action id="start-blitz" expose="true" scope="match">
    <message text="Blitz mode has been enabled!"/>
    <set var="blitz_enabled" value="1"/>
  </action>  

  <action id="end-blitz" expose="true" scope="match">
    <message text="Blitz mode has been disabled!"/>
    <set var="blitz_enabled" value="0"/>
  </action>
</actions>
<variables>
  <variable id="blitz_enabled" scope="match"/>
</variables>
<blitz>
  <filter>
    <variable var="blitz_enabled">1</variable>
  </filter>
</blitz>  
```

