### PR TITLE
Implement fill action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -285,6 +285,7 @@ public class ActionParser {
     return new FillAction(
         regions.parseProperty(Node.fromAttrOrSelf(el, "region"), BlockBoundedValidation.INSTANCE),
         XMLUtils.parseMaterialData(Node.fromRequiredAttr(el, "material")),
+        filters.parseProperty(Node.fromAttr(el, "filter")),
         XMLUtils.parseBoolean(el.getAttribute("events"), false));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/FillAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/FillAction.java
@@ -1,0 +1,38 @@
+package tc.oc.pgm.action.actions;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.event.block.BlockFormEvent;
+import org.bukkit.material.MaterialData;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.region.Region;
+
+public class FillAction extends AbstractAction<Match> {
+
+  private final Region region;
+  private final MaterialData materialData;
+  private final boolean events;
+
+  public FillAction(Region region, MaterialData materialData, boolean events) {
+    super(Match.class);
+    this.region = region;
+    this.materialData = materialData;
+    this.events = events;
+  }
+
+  @Override
+  public void trigger(Match match) {
+    for (Block block : region.getBlocks(match.getWorld())) {
+      BlockState newState = block.getState();
+      newState.setMaterialData(materialData);
+
+      if (events) {
+        BlockFormEvent event = new BlockFormEvent(block, newState);
+        match.callEvent(event);
+        if (event.isCancelled()) continue;
+      }
+
+      newState.update(true, true);
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/action/actions/FillAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/FillAction.java
@@ -4,25 +4,33 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.material.MaterialData;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.filters.query.BlockQuery;
 
 public class FillAction extends AbstractAction<Match> {
 
   private final Region region;
   private final MaterialData materialData;
+  private final @Nullable Filter filter;
   private final boolean events;
 
-  public FillAction(Region region, MaterialData materialData, boolean events) {
+  public FillAction(
+      Region region, MaterialData materialData, @Nullable Filter filter, boolean events) {
     super(Match.class);
     this.region = region;
     this.materialData = materialData;
+    this.filter = filter;
     this.events = events;
   }
 
   @Override
   public void trigger(Match match) {
     for (Block block : region.getBlocks(match.getWorld())) {
+      if (filter != null && filter.query(new BlockQuery(block)).isDenied()) continue;
+
       BlockState newState = block.getState();
       newState.setMaterialData(materialData);
 


### PR DESCRIPTION
Adds a `<fill>` action that will place blocks in a block-bounded region.

 - `region` (required) as property (either attribute, or children). If there's multiple children, they're considered a union.
 - `material` (required) as attribute. Can be a material pattern like `wool:15`.
 - `filter` (optional) as attribute. Filter what blocks get affected. :warning: may impact performance for large fills.
 - `events="true"` (optional) as attribute, defaults to false. :warning: May impact performance for large fills.
   - If set to true, events will be called for block placements & block removals, meaning they will be affected by <apply> filters and can affect other pgm features (eg: they can cause damage to a destroyable).
 
The fill action works on the match scope.

Simple example:
```xml
<actions>
  <fill id="fill-with-air" region="some-region" material="air"/>
</actions>
```

Actual example, fills-in the region with water when any player is inside, and sets air when no one remains:
```xml
<actions>
  <fill id="fill-air" region="watery-region" material="air"/>
  <fill id="fill-water" region="watery-region" material="water"/>
  
  <trigger filter="has-players" action="fill-water" scope="match"/>	
  <trigger filter="no-players" action="fill-air" scope="match"/>
</actions>

<filters>
  <not id="no-players">
    <players id="has-players" filter="watery-region"/>
  </not>
</filters>
```
