### PR TITLE
Implement bossbars for cooldown filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -165,6 +165,10 @@ public class BlitzMatchModule implements MatchModule, Listener {
 
   private void checkEnd() {
     // Process eliminations within the same tick simultaneously, so that ties are properly detected
+
+    // Player leaving may have ended the match, causing a rejected execution.
+    if (!match.isRunning()) return;
+
     match
         .getExecutor(MatchScope.RUNNING)
         .execute(

--- a/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/countdowns/MatchCountdown.java
@@ -153,10 +153,10 @@ public abstract class MatchCountdown extends Countdown {
   }
 
   protected Component secondsRemaining(TextColor color) {
-    return seconds(remaining.getSeconds(), color).build();
+    return seconds(remaining.getSeconds(), color);
   }
 
-  protected TextComponent.Builder colonTime() {
+  protected TextComponent colonTime() {
     return clock(remaining).color(urgencyColor());
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/Filterable.java
+++ b/core/src/main/java/tc/oc/pgm/filters/Filterable.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.MatchQuery;
 import tc.oc.pgm.api.filter.query.Query;
+import tc.oc.pgm.util.Audience;
 
 /**
  * An object that {@link Filter}s can be applied to.
@@ -20,7 +21,7 @@ import tc.oc.pgm.api.filter.query.Query;
  * Filterable<A>. Aside from this, the types of the Filterables may not have any particular
  * relationship.
  */
-public interface Filterable<Q extends MatchQuery> extends MatchQuery {
+public interface Filterable<Q extends MatchQuery> extends MatchQuery, Audience {
 
   /** The (single) Filterable that contains this one, or empty if this is a top-level object. */
   @Nullable

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
@@ -1,9 +1,19 @@
 package tc.oc.pgm.filters.matcher.match;
 
+import static tc.oc.pgm.util.Assert.assertNotNull;
+import static tc.oc.pgm.util.text.TemporalComponent.clock;
+import static tc.oc.pgm.util.text.TemporalComponent.seconds;
+
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextReplacementConfig;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.Filterables;
 import tc.oc.pgm.api.filter.ReactorFactory;
@@ -11,6 +21,7 @@ import tc.oc.pgm.api.filter.query.MatchQuery;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.match.Tickable;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.time.Tick;
 import tc.oc.pgm.filters.FilterMatchModule;
 import tc.oc.pgm.filters.Filterable;
@@ -23,9 +34,11 @@ public class MonostableFilter extends SingleFilterFunction
     implements TypedFilter<MatchQuery>, ReactorFactory<MonostableFilter.Reactor<?>> {
 
   private final Duration duration;
+  private final @Nullable Component message;
+  private final boolean colons;
 
   public static Filter afterMatchStart(Duration duration) {
-    return after(MatchPhaseFilter.RUNNING, duration);
+    return after(MatchPhaseFilter.RUNNING, duration, null);
   }
 
   /**
@@ -34,13 +47,15 @@ public class MonostableFilter extends SingleFilterFunction
    * @param filter the filter to listen for changes to
    * @param duration the duration to delay this filters rise
    */
-  public static Filter after(Filter filter, Duration duration) {
-    return AllFilter.of(filter, new InverseFilter(new MonostableFilter(filter, duration)));
+  public static Filter after(Filter filter, Duration duration, @Nullable Component message) {
+    return AllFilter.of(filter, new InverseFilter(new MonostableFilter(filter, duration, message)));
   }
 
-  public MonostableFilter(Filter filter, Duration duration) {
+  public MonostableFilter(Filter filter, Duration duration, @Nullable Component message) {
     super(filter);
     this.duration = duration;
+    this.message = message == null ? null : message.colorIfAbsent(NamedTextColor.YELLOW);
+    this.colons = duration.getSeconds() >= 90;
   }
 
   @Override
@@ -55,17 +70,19 @@ public class MonostableFilter extends SingleFilterFunction
 
   @Override
   public Reactor<?> createReactor(Match match, FilterMatchModule fmm) {
-    return new Reactor<>(match, fmm, Filterables.scope(filter));
+    return message == null
+        ? new Reactor<>(match, fmm, Filterables.scope(filter))
+        : new BossbarReactor<>(match, fmm, Filterables.scope(filter));
   }
 
-  protected final class Reactor<F extends Filterable<?>> extends ReactorFactory.Reactor
+  protected class Reactor<F extends Filterable<?>> extends ReactorFactory.Reactor
       implements Tickable {
 
-    private final Class<F> scope;
+    protected final Class<F> scope;
 
     // Filterables that currently pass the inner filter, mapped to the instants that they expire.
     // They are not actually removed until the inner filter goes false.
-    final Map<Filterable<?>, Instant> endTimes = new HashMap<>();
+    protected final Map<Filterable<?>, Instant> endTimes = new HashMap<>();
 
     public Reactor(Match match, FilterMatchModule fmm, Class<F> scope) {
       super(match, fmm);
@@ -84,13 +101,13 @@ public class MonostableFilter extends SingleFilterFunction
     boolean matches(Filterable<?> filterable, boolean response) {
       if (response) { // If inner filter still matches, check if the time has expired
         final Instant now = this.match.getTick().instant;
-        final Instant end =
-            endTimes.computeIfAbsent(
-                filterable,
-                f -> {
-                  this.invalidate(filterable);
-                  return now.plus(duration);
-                });
+
+        Instant end = endTimes.get(filterable);
+        if (end == null) {
+          // Cannot use computeIfAbsent, as we want invalidation after put
+          endTimes.put(filterable, end = now.plus(duration));
+          this.invalidate(filterable);
+        }
         return now.isBefore(end);
       } else {
         if (endTimes.remove(filterable) != null) {
@@ -110,6 +127,121 @@ public class MonostableFilter extends SingleFilterFunction
               this.invalidate(filterable);
             }
           });
+    }
+  }
+
+  protected class BossbarReactor<F extends Filterable<?>> extends Reactor<F> {
+
+    final Component message;
+    final Map<Filterable<?>, BossBar> bars;
+
+    Instant lastTick = Instant.MIN;
+    // Used to specify that a bulk invalidation update is ongoing, so player-specific invalidations
+    // can be ignored
+    boolean bulkUpdate;
+
+    public BossbarReactor(Match match, FilterMatchModule fmm, Class<F> scope) {
+      super(match, fmm, scope);
+
+      this.message = assertNotNull(MonostableFilter.this.message);
+      this.bars = new HashMap<>();
+
+      // When the scope isn't a player, a player may stop passing while the scope itself still does.
+      // Eg: the scope is team, and it passes, but a player switches team.
+      // In that case, the player that stops passing the filter should get the bossbar added, or
+      // removed.
+      if (scope != MatchPlayer.class)
+        fmm.onChange(MatchPlayer.class, MonostableFilter.this, this::updatePlayerBar);
+    }
+
+    @Override
+    protected void invalidate(Filterable<?> filterable) {
+      bulkUpdate = true;
+      super.invalidate(filterable);
+      bulkUpdate = false;
+
+      Instant end = endTimes.get(filterable);
+
+      // Create or remove boss bar
+      if (end != null && match.getTick().instant.isBefore(end)) createBossBar(filterable);
+      else removeBossBar(filterable);
+    }
+
+    @Override
+    public void tick(Match match, Tick tick) {
+      super.tick(match, tick);
+
+      final Instant now = tick.instant;
+
+      endTimes.forEach(
+          (filterable, end) -> {
+            if (now.isBefore(end)) {
+              // If the entry is still valid, check if its elapsed time crossed a second
+              // boundary over the last tick, and update the boss bar if it did.
+              long oldSeconds = lastTick.until(end, ChronoUnit.SECONDS);
+              long newSeconds = now.until(end, ChronoUnit.SECONDS);
+
+              // Intentionally use old, as transitioning from 4s to 3.95s should show 4s
+              if (oldSeconds != newSeconds)
+                updateBossBar(filterable, Duration.ofSeconds(oldSeconds));
+            }
+          });
+
+      lastTick = now;
+    }
+
+    private void createBossBar(Filterable<?> filterable) {
+      Component message = getMessage(duration);
+
+      BossBar bar =
+          bars.computeIfAbsent(
+              filterable,
+              f -> BossBar.bossBar(message, 1f, BossBar.Color.YELLOW, BossBar.Overlay.PROGRESS));
+
+      bar.name(message).progress(1f);
+      filterable.showBossBar(bar);
+    }
+
+    private void updateBossBar(Filterable<?> filterable, Duration remaining) {
+      Component msg = getMessage(remaining);
+      float progress = progress(remaining);
+
+      bars.computeIfPresent(filterable, (f, b) -> b.name(msg).progress(progress));
+    }
+
+    private void removeBossBar(Filterable<?> filterable) {
+      BossBar bar = bars.remove(filterable);
+      if (bar != null) filterable.hideBossBar(bar);
+    }
+
+    private void updatePlayerBar(MatchPlayer player, boolean response) {
+      // Ignore player-specific updates during a bulk update
+      if (bulkUpdate) return;
+
+      BossBar bar = response ? bars.get(player.getFilterableAncestor(scope)) : null;
+
+      // We need to hide all other scope's bars from the player, otherwise the player may keep a bar
+      // from a different scope (eg: team) it no longer is part of.
+
+      for (BossBar otherBar : bars.values()) {
+        if (bar != otherBar) player.hideBossBar(otherBar);
+      }
+      // And finally ensure the player is added to the bar of their current scope, if any.
+      if (bar != null) player.showBossBar(bar);
+    }
+
+    private Component getMessage(Duration remaining) {
+      Component duration =
+          colons
+              ? clock(remaining).color(NamedTextColor.AQUA)
+              : seconds(remaining.getSeconds(), NamedTextColor.AQUA);
+
+      return message.replaceText(
+          TextReplacementConfig.builder().once().matchLiteral("{0}").replacement(duration).build());
+    }
+
+    private float progress(Duration remaining) {
+      return Math.min(1f, (float) remaining.toMillis() / duration.toMillis());
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
@@ -521,16 +522,18 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
     if (duration.isNegative() || duration.isZero()) return StaticFilter.DENY;
 
     Filter child = parseProperty(Node.fromAttrOrSelf(el, "filter"), DynamicFilterValidation.ANY);
-    return new MonostableFilter(child, duration);
+    Component message = XMLUtils.parseFormattedText(el, "message", null);
+    return new MonostableFilter(child, duration, message);
   }
 
   @MethodParser("after")
   public Filter parseAfterFilter(Element el) throws InvalidXMLException {
     Duration duration = XMLUtils.parseDuration(Node.fromRequiredAttr(el, "duration"));
     Filter child = parseProperty(Node.fromAttrOrSelf(el, "filter"), DynamicFilterValidation.ANY);
-
     if (duration.isNegative() || duration.isZero()) return child;
-    return MonostableFilter.after(child, duration);
+
+    Component message = XMLUtils.parseFormattedText(el, "message", null);
+    return MonostableFilter.after(child, duration, message);
   }
 
   @MethodParser("rank")

--- a/core/src/main/java/tc/oc/pgm/flag/state/Respawning.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Respawning.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.flag.state;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.util.text.TemporalComponent.duration;
 
 import java.time.Duration;
 import net.kyori.adventure.text.Component;
@@ -14,7 +15,6 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.flag.Post;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
-import tc.oc.pgm.util.text.TemporalComponent;
 
 /**
  * State of a flag while it is waiting to respawn at a {@link Post} after being {@link Captured}.
@@ -57,8 +57,7 @@ public class Respawning extends Spawned implements Returning {
     // Respawn is delayed
     String postName = this.post.getPostName();
 
-    TranslatableComponent.Builder timeComponent =
-        TemporalComponent.duration(respawnTime, NamedTextColor.AQUA);
+    TranslatableComponent timeComponent = duration(respawnTime, NamedTextColor.AQUA);
     Component message =
         postName != null
             ? translatable(

--- a/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModesPaginatedResult.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.modes;
 
+import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
@@ -73,14 +74,14 @@ public class ModesPaginatedResult extends PrettyPaginatedComponentResults<ModeCh
    * @param countdown to format
    * @return Formatted text
    */
-  public TextComponent.Builder formatSingleCountdown(ModeChangeCountdown countdown) {
+  public TextComponent formatSingleCountdown(ModeChangeCountdown countdown) {
     Duration currentTimeLeft = modes.getCountdown().getTimeLeft(countdown);
 
     if (countdown.getMatch().isRunning() && currentTimeLeft != null) {
       return clock(currentTimeLeft).append(space().append(translatable("command.timeLeft")));
     }
 
-    return text();
+    return empty();
   }
 
   private boolean isRunning(ModeChangeCountdown countdown) {

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileCooldown.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileCooldown.java
@@ -39,7 +39,7 @@ public class ProjectileCooldown {
   }
 
   public String getTimeLeftString() {
-    return TextTranslations.translateLegacy(ticker(getTimeLeft()).build(), matchPlayer.getBukkit());
+    return TextTranslations.translateLegacy(ticker(getTimeLeft()), matchPlayer.getBukkit());
   }
 
   public boolean isActive() {

--- a/util/src/main/java/tc/oc/pgm/util/text/TemporalComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TemporalComponent.java
@@ -33,7 +33,7 @@ public final class TemporalComponent {
    * @param color a unit color
    * @return a component builder
    */
-  public static TranslatableComponent.Builder duration(
+  public static TranslatableComponent duration(
       final @Nullable Duration duration, final @Nullable TextColor color) {
     if (duration == null) {
       return duration(A_LONG_TIME, color);
@@ -47,7 +47,7 @@ public final class TemporalComponent {
    * @param duration a duration
    * @return a component builder
    */
-  public static TranslatableComponent.Builder duration(final @Nullable Duration duration) {
+  public static TranslatableComponent duration(final @Nullable Duration duration) {
     return duration(duration, null);
   }
 
@@ -58,7 +58,7 @@ public final class TemporalComponent {
    * @param color a unit color
    * @return a component builder
    */
-  public static TranslatableComponent.Builder duration(
+  public static TranslatableComponent duration(
       final long seconds, final @Nullable TextColor color) {
     final String key;
     long quantity = 1;
@@ -92,7 +92,7 @@ public final class TemporalComponent {
       key = "misc.eon";
     }
 
-    return translatable().key(key).args(color == null ? text(quantity) : text(quantity, color));
+    return translatable(key, text(quantity, color));
   }
 
   /**
@@ -101,13 +101,13 @@ public final class TemporalComponent {
    * @param seconds a number of seconds
    * @return a component builder
    */
-  public static TextComponent.Builder ticker(final long seconds) {
+  public static TextComponent ticker(final long seconds) {
     if (seconds >= MINUTE) {
-      return text().content((seconds % HOUR) / MINUTE + "m");
+      return text((seconds % HOUR) / MINUTE + "m");
     } else if (seconds >= SECOND) {
-      return text().content(seconds + "s");
+      return text(seconds + "s");
     } else {
-      return text().content("<1s");
+      return text("<1s");
     }
   }
 
@@ -117,7 +117,7 @@ public final class TemporalComponent {
    * @param duration a duration
    * @return a component builder
    */
-  public static TextComponent.Builder ticker(final Duration duration) {
+  public static TextComponent ticker(final Duration duration) {
     return ticker(duration.getSeconds());
   }
 
@@ -127,18 +127,13 @@ public final class TemporalComponent {
    * @param seconds a number of seconds
    * @return a component builder
    */
-  public static TextComponent.Builder clock(final long seconds) {
+  public static TextComponent clock(final long seconds) {
     if (seconds >= HOUR) {
-      return text()
-          .content(
-              String.format(
-                  CLOCK_FORMAT_LONG,
-                  seconds / HOUR,
-                  (seconds % HOUR) / MINUTE,
-                  (seconds % MINUTE)));
+      return text(
+          String.format(
+              CLOCK_FORMAT_LONG, seconds / HOUR, (seconds % HOUR) / MINUTE, (seconds % MINUTE)));
     } else {
-      return text()
-          .content(String.format(CLOCK_FORMAT, (seconds % HOUR) / MINUTE, (seconds % MINUTE)));
+      return text(String.format(CLOCK_FORMAT, (seconds % HOUR) / MINUTE, (seconds % MINUTE)));
     }
   }
 
@@ -148,7 +143,7 @@ public final class TemporalComponent {
    * @param duration a duration
    * @return a component builder
    */
-  public static TextComponent.Builder clock(final Duration duration) {
+  public static TextComponent clock(final Duration duration) {
     if (duration.isNegative()) {
       return clock(0);
     }
@@ -162,18 +157,15 @@ public final class TemporalComponent {
    * @param color a unit color
    * @return a component builder
    */
-  public static TranslatableComponent.Builder seconds(
-      final long seconds, final @Nullable TextColor color) {
-    return translatable()
-        .key((seconds == 1) ? "misc.second" : "misc.seconds")
-        .args(color == null ? text(seconds) : text(seconds, color));
+  public static TranslatableComponent seconds(final long seconds, final @Nullable TextColor color) {
+    return translatable((seconds == 1) ? "misc.second" : "misc.seconds", text(seconds, color));
   }
 
   // TODO: Change these signature after the Community refactor
 
   @Deprecated
   public static Component briefNaturalApproximate(final Duration duration) {
-    return duration(duration).build();
+    return duration(duration);
   }
 
   @Deprecated

--- a/util/src/test/java/tc/oc/pgm/util/text/TemporalComponentTest.java
+++ b/util/src/test/java/tc/oc/pgm/util/text/TemporalComponentTest.java
@@ -37,7 +37,7 @@ public final class TemporalComponentTest {
   })
   void testDurationSeconds(String key, long units, long seconds) {
     final TextColor color = NamedTextColor.GOLD;
-    assertEquals(translatable(key, text(units, color)), duration(seconds, color).build());
+    assertEquals(translatable(key, text(units, color)), duration(seconds, color));
   }
 
   @ParameterizedTest
@@ -48,7 +48,7 @@ public final class TemporalComponentTest {
     "misc.minute,  1,  60001"
   })
   void testDuration(String key, long units, long milliseconds) {
-    assertEquals(translatable(key, text(units)), duration(Duration.ofMillis(milliseconds)).build());
+    assertEquals(translatable(key, text(units)), duration(Duration.ofMillis(milliseconds)));
   }
 
   @ParameterizedTest
@@ -60,7 +60,7 @@ public final class TemporalComponentTest {
     "9m,  540",
   })
   void testTicker(String expected, long seconds) {
-    assertEquals(text(expected), ticker(seconds).build());
+    assertEquals(text(expected), ticker(seconds));
   }
 
   @ParameterizedTest
@@ -75,6 +75,6 @@ public final class TemporalComponentTest {
     "10:00:00, 36000",
   })
   void testClock(String expected, long seconds) {
-    assertEquals(text(expected), clock(seconds).build());
+    assertEquals(text(expected), clock(seconds));
   }
 }


### PR DESCRIPTION
Reimplements the feature from 1.11+ PGM where `<countdown>` filters could include a `message` attribute, and show as a bossbar. Additionally, the new `<after>` filter also has the same functionality.

Example (assumes a previous filter other-filter exists):
`<after message="Something will happen in {0}" duration="30s" filter="other-filter" />`

The literal `{0}` will be replaced by the remaining time.

Additionally, it does a bit of a cleanup pass on time components, changing the return types from builders to components.