### PR TITLE
Make module graph load order consistent

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -27,7 +27,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.Datastore;
-import tc.oc.pgm.api.Modules;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.Contributor;
@@ -116,7 +115,6 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
       return; // Indicates the plugin failed to load, so exit early
     }
 
-    Modules.registerAll();
     Permissions.registerAll();
 
     final CommandSender console = getServer().getConsoleSender();

--- a/core/src/main/java/tc/oc/pgm/action/ActionModule.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionModule.java
@@ -47,7 +47,7 @@ public class ActionModule implements MapModule<ActionMatchModule> {
   public static class Factory implements MapModuleFactory<ActionModule> {
 
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(VariablesModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -2,8 +2,9 @@ package tc.oc.pgm.api;
 
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.action.ActionMatchModule;
 import tc.oc.pgm.action.ActionModule;
@@ -131,43 +132,71 @@ import tc.oc.pgm.wool.WoolModule;
 import tc.oc.pgm.worldborder.WorldBorderMatchModule;
 import tc.oc.pgm.worldborder.WorldBorderModule;
 
-public interface Modules {
+public final class Modules {
 
-  Map<Class<? extends MapModule>, MapModuleFactory<? extends MapModule>> MAP =
-      new ConcurrentHashMap<>();
+  public static final Map<Class<? extends MapModule<?>>, MapModuleFactory<?>> MAP;
+  public static final Map<Class<? extends MapModule<?>>, MapModuleFactory<?>> MAP_DEPENDENCY_ONLY;
 
-  Map<Class<? extends MapModule>, MapModuleFactory<? extends MapModule>> MAP_DEPENDENCY_ONLY =
-      new ConcurrentHashMap<>(); // No modules fit this yet, exists for consistency.
-  Map<Class<? extends MatchModule>, MatchModuleFactory<? extends MatchModule>> MATCH =
-      new ConcurrentHashMap<>();
+  public static final Map<Class<? extends MatchModule>, MatchModuleFactory<?>> MATCH;
+  public static final Map<Class<? extends MatchModule>, MatchModuleFactory<?>>
+      MATCH_DEPENDENCY_ONLY;
 
-  Map<Class<? extends MatchModule>, MatchModuleFactory<? extends MatchModule>>
-      MATCH_DEPENDENCY_ONLY = new ConcurrentHashMap<>();
-  Map<Class<? extends MapModule>, Class<? extends MatchModule>> MAP_TO_MATCH =
-      new ConcurrentHashMap<>();
+  public static final Map<Class<? extends MapModule<?>>, Class<? extends MatchModule>> MAP_TO_MATCH;
 
-  static <M extends MatchModule> void register(Class<M> match, MatchModuleFactory<M> factory) {
-    if (MATCH.containsKey(assertNotNull(match)))
-      throw new IllegalArgumentException(match.getSimpleName() + " was registered twice");
-    MATCH.put(match, assertNotNull(factory));
+  static {
+    Modules modules = new Modules();
+
+    // Immutable maps maintain ordering
+    MAP = ImmutableMap.copyOf(modules.map);
+    MAP_DEPENDENCY_ONLY = ImmutableMap.copyOf(modules.mapDependencyOnly);
+    MATCH = ImmutableMap.copyOf(modules.match);
+    MATCH_DEPENDENCY_ONLY = ImmutableMap.copyOf(modules.matchDependencyOnly);
+    MAP_TO_MATCH = ImmutableMap.copyOf(modules.mapToMatch);
   }
 
-  static <M extends MatchModule, N extends MapModule<M>> void register(
-      Class<N> map, @Nullable Class<M> match, MapModuleFactory<N> factory) {
-    if (MAP.containsKey(assertNotNull(map)) || MAP_TO_MATCH.containsKey(map))
-      throw new IllegalArgumentException(map.getSimpleName() + " was registered twice");
-    MAP.put(map, assertNotNull(factory));
-    if (match != null) MAP_TO_MATCH.put(map, match);
+  Map<Class<? extends MapModule<?>>, MapModuleFactory<? extends MapModule<?>>> map;
+  // No modules fit this yet, exists for consistency.
+  Map<Class<? extends MapModule<?>>, MapModuleFactory<? extends MapModule<?>>> mapDependencyOnly;
+  Map<Class<? extends MatchModule>, MatchModuleFactory<? extends MatchModule>> match;
+  Map<Class<? extends MatchModule>, MatchModuleFactory<? extends MatchModule>> matchDependencyOnly;
+
+  Map<Class<? extends MapModule<?>>, Class<? extends MatchModule>> mapToMatch;
+
+  private Modules() {
+    // Linked hash maps to have consistent ordering based on registration
+    this.map = new LinkedHashMap<>();
+    this.mapDependencyOnly = new LinkedHashMap<>();
+
+    this.match = new LinkedHashMap<>();
+    this.matchDependencyOnly = new LinkedHashMap<>();
+
+    this.mapToMatch = new LinkedHashMap<>();
+
+    registerAll();
   }
 
-  static <M extends MatchModule> void registerDependencyOnly(
-      Class<M> match, MatchModuleFactory<M> factory) {
-    if (MATCH_DEPENDENCY_ONLY.containsKey(assertNotNull(match)))
-      throw new IllegalArgumentException(match.getSimpleName() + " was registered twice");
-    MATCH_DEPENDENCY_ONLY.put(match, assertNotNull(factory));
+  <M extends MatchModule> void register(Class<M> matchModule, MatchModuleFactory<M> factory) {
+    if (match.containsKey(assertNotNull(matchModule)))
+      throw new IllegalArgumentException(matchModule.getSimpleName() + " was registered twice");
+    match.put(matchModule, assertNotNull(factory));
   }
 
-  static void registerAll() {
+  <M extends MatchModule, N extends MapModule<M>> void register(
+      Class<N> mapModule, @Nullable Class<M> matchModule, MapModuleFactory<N> factory) {
+    if (map.containsKey(assertNotNull(mapModule)) || mapToMatch.containsKey(mapModule))
+      throw new IllegalArgumentException(mapModule.getSimpleName() + " was registered twice");
+    map.put(mapModule, assertNotNull(factory));
+    if (matchModule != null) mapToMatch.put(mapModule, matchModule);
+  }
+
+  <M extends MatchModule> void registerDependencyOnly(
+      Class<M> matchModule, MatchModuleFactory<M> factory) {
+    if (matchDependencyOnly.containsKey(assertNotNull(matchModule)))
+      throw new IllegalArgumentException(matchModule.getSimpleName() + " was registered twice");
+    matchDependencyOnly.put(matchModule, assertNotNull(factory));
+  }
+
+  void registerAll() {
     // MatchModules that are always created
     register(EventFilterMatchModule.class, EventFilterMatchModule::new);
     register(MultiTradeMatchModule.class, MultiTradeMatchModule::new);

--- a/core/src/main/java/tc/oc/pgm/api/map/factory/MapFactory.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/factory/MapFactory.java
@@ -12,7 +12,7 @@ import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.Version;
 
 /** A factory for creating {@link MapInfo}s and {@link MapContext}s. */
-public interface MapFactory extends ModuleContext<MapModule>, AutoCloseable {
+public interface MapFactory extends ModuleContext<MapModule<?>>, AutoCloseable {
 
   /**
    * Get the {@link RegionParser} for parsing region references.

--- a/core/src/main/java/tc/oc/pgm/api/map/factory/MapModuleFactory.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/factory/MapModuleFactory.java
@@ -8,7 +8,7 @@ import tc.oc.pgm.api.module.ModuleFactory;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
 /** A factory for creating {@link MapModule}s from a {@link Document}. */
-public interface MapModuleFactory<T extends MapModule> extends ModuleFactory<MapModule> {
+public interface MapModuleFactory<T extends MapModule<?>> extends ModuleFactory<MapModule<?>> {
 
   /**
    * Parses a {@link Document} to create a {@link MapModule}.

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzModule.java
@@ -22,7 +22,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class BlitzModule implements MapModule {
+public class BlitzModule implements MapModule<BlitzMatchModule> {
 
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("blitz", "Blitz", true, true));
@@ -45,7 +45,7 @@ public class BlitzModule implements MapModule {
   public static class Factory implements MapModuleFactory<BlitzModule> {
 
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsModule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsModule.java
@@ -18,7 +18,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.parse.FilterParser;
@@ -32,7 +31,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class BlockDropsModule implements MapModule {
+public class BlockDropsModule implements MapModule<BlockDropsMatchModule> {
   private final BlockDropsRuleSet ruleSet;
 
   public BlockDropsModule(BlockDropsRuleSet ruleSet) {
@@ -40,13 +39,13 @@ public class BlockDropsModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public BlockDropsMatchModule createMatchModule(Match match) {
     return new BlockDropsMatchModule(match, this.ruleSet);
   }
 
   public static class Factory implements MapModuleFactory<BlockDropsModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(
           KitModule.class, RegionModule.class, FilterModule.class, ItemModifyModule.class);
     }

--- a/core/src/main/java/tc/oc/pgm/broadcast/BroadcastModule.java
+++ b/core/src/main/java/tc/oc/pgm/broadcast/BroadcastModule.java
@@ -13,7 +13,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.countdowns.CountdownRunner;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.util.TimeUtils;
@@ -21,7 +20,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class BroadcastModule implements MapModule {
+public class BroadcastModule implements MapModule<BroadcastMatchModule> {
   private final Multimap<Duration, Broadcast> broadcasts;
 
   public BroadcastModule(Multimap<Duration, Broadcast> broadcasts) {
@@ -29,7 +28,7 @@ public class BroadcastModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public BroadcastMatchModule createMatchModule(Match match) {
     return new BroadcastMatchModule(match, this.broadcasts);
   }
 

--- a/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
+++ b/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
@@ -22,7 +22,6 @@ import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.kits.KitModule;
 import tc.oc.pgm.kits.KitParser;
@@ -31,7 +30,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ClassModule implements MapModule {
+public class ClassModule implements MapModule<ClassMatchModule> {
 
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("classes", "Classes", false, true));
@@ -51,7 +50,7 @@ public class ClassModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ClassMatchModule createMatchModule(Match match) {
     return new ClassMatchModule(match, this.family, this.classes, this.defaultClass);
   }
 
@@ -69,7 +68,7 @@ public class ClassModule implements MapModule {
 
   public static class Factory implements MapModuleFactory<ClassModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return Collections.singleton(KitModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointModule.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointModule.java
@@ -67,12 +67,12 @@ public class ControlPointModule implements MapModule<ControlPointMatchModule> {
 
   public static class Factory implements MapModuleFactory<ControlPointModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(TeamModule.class);
     }
 
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class, FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -35,7 +35,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class CoreModule implements MapModule {
+public class CoreModule implements MapModule<CoreMatchModule> {
 
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("dtc", "core", "Destroy the Core", true, false));
@@ -47,12 +47,12 @@ public class CoreModule implements MapModule {
   }
 
   @Override
-  public Collection<Class> getSoftDependencies() {
+  public Collection<Class<? extends MatchModule>> getSoftDependencies() {
     return ImmutableList.of(GoalMatchModule.class);
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public CoreMatchModule createMatchModule(Match match) {
     ImmutableList.Builder<Core> cores = new ImmutableList.Builder<>();
     for (CoreFactory factory : this.coreFactories) {
       Core core = new Core(factory, match);
@@ -72,12 +72,12 @@ public class CoreModule implements MapModule {
   public static class Factory implements MapModuleFactory<CoreModule> {
 
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(ObjectiveModesModule.class);
     }
 
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class, TeamModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/crafting/CraftingModule.java
+++ b/core/src/main/java/tc/oc/pgm/crafting/CraftingModule.java
@@ -19,12 +19,11 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.material.matcher.SingleMaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class CraftingModule implements MapModule {
+public class CraftingModule implements MapModule<CraftingMatchModule> {
 
   private final Set<Recipe> customRecipes;
   private final Set<SingleMaterialMatcher> disabledRecipes;
@@ -35,7 +34,7 @@ public class CraftingModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public CraftingMatchModule createMatchModule(Match match) {
     return new CraftingMatchModule(match, customRecipes, disabledRecipes);
   }
 

--- a/core/src/main/java/tc/oc/pgm/damage/DamageModule.java
+++ b/core/src/main/java/tc/oc/pgm/damage/DamageModule.java
@@ -11,10 +11,9 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
-public class DamageModule implements MapModule {
+public class DamageModule implements MapModule<DamageMatchModule> {
 
   private final List<Filter> filters;
 
@@ -23,7 +22,7 @@ public class DamageModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public DamageMatchModule createMatchModule(Match match) {
     return new DamageMatchModule(match, filters);
   }
 

--- a/core/src/main/java/tc/oc/pgm/damage/DisableDamageModule.java
+++ b/core/src/main/java/tc/oc/pgm/damage/DisableDamageModule.java
@@ -10,13 +10,12 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.player.PlayerRelation;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class DisableDamageModule implements MapModule {
+public class DisableDamageModule implements MapModule<DisableDamageMatchModule> {
   protected final SetMultimap<DamageCause, PlayerRelation> causes;
 
   public DisableDamageModule(SetMultimap<DamageCause, PlayerRelation> causes) {
@@ -24,7 +23,7 @@ public class DisableDamageModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public DisableDamageMatchModule createMatchModule(Match match) {
     return new DisableDamageMatchModule(match, this.causes);
   }
 

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -34,7 +34,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class DestroyableModule implements MapModule {
+public class DestroyableModule implements MapModule<DestroyableMatchModule> {
 
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("dtm", "monument", "Destroy the Monument", true, false));
@@ -50,7 +50,7 @@ public class DestroyableModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public DestroyableMatchModule createMatchModule(Match match) {
     ImmutableList.Builder<Destroyable> destroyables = new ImmutableList.Builder<>();
     for (DestroyableFactory factory : this.destroyableFactories) {
       Destroyable destroyable = new Destroyable(factory, match);
@@ -69,12 +69,12 @@ public class DestroyableModule implements MapModule {
   public static class Factory implements MapModuleFactory<DestroyableModule> {
 
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(BlockDropsModule.class, ObjectiveModesModule.class);
     }
 
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(TeamModule.class, RegionModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/enderchest/EnderChestModule.java
+++ b/core/src/main/java/tc/oc/pgm/enderchest/EnderChestModule.java
@@ -10,7 +10,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.regions.RandomPointsValidation;
@@ -19,7 +18,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class EnderChestModule implements MapModule {
+public class EnderChestModule implements MapModule<EnderChestMatchModule> {
 
   private final boolean enabled;
   private final List<Dropoff> dropoffs;
@@ -32,7 +31,7 @@ public class EnderChestModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public EnderChestMatchModule createMatchModule(Match match) {
     return new EnderChestMatchModule(match, enabled, dropoffs, fallback);
   }
 

--- a/core/src/main/java/tc/oc/pgm/fallingblocks/FallingBlocksModule.java
+++ b/core/src/main/java/tc/oc/pgm/fallingblocks/FallingBlocksModule.java
@@ -12,7 +12,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.parse.FilterParser;
@@ -21,7 +20,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class FallingBlocksModule implements MapModule {
+public class FallingBlocksModule implements MapModule<FallingBlocksMatchModule> {
   private final List<FallingBlocksRule> rules;
 
   public FallingBlocksModule(List<FallingBlocksRule> rules) {
@@ -29,13 +28,13 @@ public class FallingBlocksModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public FallingBlocksMatchModule createMatchModule(Match match) {
     return new FallingBlocksMatchModule(match, this.rules);
   }
 
   public static class Factory implements MapModuleFactory<FallingBlocksModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(FilterModule.class, RegionModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/ffa/FreeForAllModule.java
+++ b/core/src/main/java/tc/oc/pgm/ffa/FreeForAllModule.java
@@ -21,7 +21,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class FreeForAllModule implements MapModule {
+public class FreeForAllModule implements MapModule<FreeForAllMatchModule> {
 
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("ffa", "Free for All", false, false));
@@ -46,13 +46,13 @@ public class FreeForAllModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public FreeForAllMatchModule createMatchModule(Match match) {
     return new FreeForAllMatchModule(match, options);
   }
 
   public static class Factory implements MapModuleFactory<FreeForAllModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(TeamModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/filters/FilterModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterModule.java
@@ -43,7 +43,7 @@ public class FilterModule implements MapModule<FilterMatchModule> {
 
   public static class Factory implements MapModuleFactory<FilterModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(VariablesModule.class, TeamModule.class, ClassModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/flag/FlagModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagModule.java
@@ -19,7 +19,7 @@ import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.teams.TeamModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
-public class FlagModule implements MapModule {
+public class FlagModule implements MapModule<FlagMatchModule> {
 
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("ctf", "flag", "Capture the Flag", true, false));
@@ -40,7 +40,7 @@ public class FlagModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) throws ModuleLoadException {
+  public FlagMatchModule createMatchModule(Match match) throws ModuleLoadException {
     return new FlagMatchModule(match, this.posts, this.nets, this.flags);
   }
 
@@ -51,7 +51,7 @@ public class FlagModule implements MapModule {
 
   public static class Factory implements MapModuleFactory<FlagModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(TeamModule.class, RegionModule.class, FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/gamerules/GameRulesModule.java
+++ b/core/src/main/java/tc/oc/pgm/gamerules/GameRulesModule.java
@@ -12,11 +12,10 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.modules.WorldTimeModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
-public class GameRulesModule implements MapModule {
+public class GameRulesModule implements MapModule<GameRulesMatchModule> {
 
   private Map<String, String> gameRules;
 
@@ -24,13 +23,13 @@ public class GameRulesModule implements MapModule {
     this.gameRules = gamerules;
   }
 
-  public MatchModule createMatchModule(Match match) {
+  public GameRulesMatchModule createMatchModule(Match match) {
     return new GameRulesMatchModule(match, this.gameRules);
   }
 
   public static class Factory implements MapModuleFactory<GameRulesModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(WorldTimeModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/hunger/HungerModule.java
+++ b/core/src/main/java/tc/oc/pgm/hunger/HungerModule.java
@@ -7,13 +7,12 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
-public class HungerModule implements MapModule {
+public class HungerModule implements MapModule<HungerMatchModule> {
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public HungerMatchModule createMatchModule(Match match) {
     return new HungerMatchModule(match);
   }
 

--- a/core/src/main/java/tc/oc/pgm/killreward/KillRewardModule.java
+++ b/core/src/main/java/tc/oc/pgm/killreward/KillRewardModule.java
@@ -14,7 +14,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.matcher.player.KillStreakFilter;
@@ -26,7 +25,7 @@ import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class KillRewardModule implements MapModule {
+public class KillRewardModule implements MapModule<KillRewardMatchModule> {
   protected final ImmutableList<KillReward> rewards;
 
   public KillRewardModule(List<KillReward> rewards) {
@@ -34,18 +33,18 @@ public class KillRewardModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public KillRewardMatchModule createMatchModule(Match match) {
     return new KillRewardMatchModule(match, this.rewards);
   }
 
   public static class Factory implements MapModuleFactory<KillRewardModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(RegionModule.class, FilterModule.class, ItemModifyModule.class);
     }
 
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(KitModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitModule.java
@@ -27,7 +27,7 @@ import tc.oc.pgm.util.text.TextParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class KitModule implements MapModule {
+public class KitModule implements MapModule<KitMatchModule> {
 
   protected final Set<KitRule> kitRules;
 
@@ -42,7 +42,7 @@ public class KitModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public KitMatchModule createMatchModule(Match match) {
     return new KitMatchModule(match, kitRules);
   }
 
@@ -54,7 +54,7 @@ public class KitModule implements MapModule {
   public static class Factory implements MapModuleFactory<KitModule> {
 
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(ActionModule.class, TeamModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/map/MapContextImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapContextImpl.java
@@ -21,7 +21,7 @@ public class MapContextImpl extends MapInfoImpl implements MapContext {
   private final MapSource source;
   private final List<MapModule> modules;
 
-  public MapContextImpl(MapInfo info, MapSource source, Collection<MapModule> modules) {
+  public MapContextImpl(MapInfo info, MapSource source, Collection<MapModule<?>> modules) {
     super(info);
     this.source = assertNotNull(source);
     this.modules = ImmutableList.copyOf(assertNotNull(modules));

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -39,7 +39,8 @@ import tc.oc.pgm.util.Version;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.SAXHandler;
 
-public class MapFactoryImpl extends ModuleGraph<MapModule, MapModuleFactory<? extends MapModule>>
+public class MapFactoryImpl
+    extends ModuleGraph<MapModule<?>, MapModuleFactory<? extends MapModule<?>>>
     implements MapFactory {
 
   private static final ThreadLocal<SAXBuilder> DOCUMENT_FACTORY =
@@ -68,7 +69,7 @@ public class MapFactoryImpl extends ModuleGraph<MapModule, MapModuleFactory<? ex
   }
 
   @Override
-  protected MapModule createModule(MapModuleFactory factory) throws ModuleLoadException {
+  protected MapModule<?> createModule(MapModuleFactory<?> factory) throws ModuleLoadException {
     try {
       return factory.parse(this, logger, document);
     } catch (InvalidXMLException e) {
@@ -139,7 +140,7 @@ public class MapFactoryImpl extends ModuleGraph<MapModule, MapModuleFactory<? ex
       throw e;
     }
 
-    for (MapModule module : getModules()) {
+    for (MapModule<?> module : getModules()) {
       module.postParse(this, logger, document);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesModule.java
@@ -26,7 +26,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ObjectiveModesModule implements MapModule {
+public class ObjectiveModesModule implements MapModule<ObjectiveModesMatchModule> {
 
   private final ImmutableList<Mode> modes;
   public static final Duration DEFAULT_SHOW_BEFORE = Duration.ofSeconds(60L);
@@ -47,7 +47,7 @@ public class ObjectiveModesModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ObjectiveModesMatchModule createMatchModule(Match match) {
     return new ObjectiveModesMatchModule(match, this.modes);
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/DiscardPotionBottlesModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/DiscardPotionBottlesModule.java
@@ -7,13 +7,12 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
-public class DiscardPotionBottlesModule implements MapModule {
+public class DiscardPotionBottlesModule implements MapModule<DiscardPotionBottlesMatchModule> {
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public DiscardPotionBottlesMatchModule createMatchModule(Match match) {
     return new DiscardPotionBottlesMatchModule(match);
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/FriendlyFireRefundModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/FriendlyFireRefundModule.java
@@ -6,14 +6,13 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class FriendlyFireRefundModule implements MapModule {
+public class FriendlyFireRefundModule implements MapModule<FriendlyFireRefundMatchModule> {
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public FriendlyFireRefundMatchModule createMatchModule(Match match) {
     return new FriendlyFireRefundMatchModule(match);
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/InternalModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/InternalModule.java
@@ -6,7 +6,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
@@ -15,10 +14,10 @@ import tc.oc.pgm.util.xml.XMLUtils;
  * Assorted features used by internal maps i.e. maps that have no outer surface. We assume that such
  * maps have a bedrock outfill spanning the full world height.
  */
-public class InternalModule implements MapModule {
+public class InternalModule implements MapModule<InternalMatchModule> {
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public InternalMatchModule createMatchModule(Match match) {
     return new InternalMatchModule(match);
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/ItemDestroyModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ItemDestroyModule.java
@@ -8,13 +8,12 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.matcher.block.BlockFilter;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ItemDestroyModule implements MapModule {
+public class ItemDestroyModule implements MapModule<ItemDestroyMatchModule> {
   protected final Set<BlockFilter> itemsToRemove;
 
   public ItemDestroyModule(Set<BlockFilter> itemsToRemove) {
@@ -22,7 +21,7 @@ public class ItemDestroyModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ItemDestroyMatchModule createMatchModule(Match match) {
     return new ItemDestroyMatchModule(match, this.itemsToRemove);
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/ItemKeepModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ItemKeepModule.java
@@ -8,13 +8,12 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.matcher.block.BlockFilter;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ItemKeepModule implements MapModule {
+public class ItemKeepModule implements MapModule<ItemKeepMatchModule> {
   protected final Set<BlockFilter> itemsToKeep;
   protected final Set<BlockFilter> armorToKeep;
 
@@ -24,7 +23,7 @@ public class ItemKeepModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ItemKeepMatchModule createMatchModule(Match match) {
     return new ItemKeepMatchModule(match, this.itemsToKeep, this.armorToKeep);
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/MobsModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/MobsModule.java
@@ -11,13 +11,12 @@ import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class MobsModule implements MapModule {
+public class MobsModule implements MapModule<MobsMatchModule> {
 
   private final Filter mobsFilter;
 
@@ -26,13 +25,13 @@ public class MobsModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public MobsMatchModule createMatchModule(Match match) {
     return new MobsMatchModule(match, this.mobsFilter);
   }
 
   public static class Factory implements MapModuleFactory<MobsModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
@@ -12,11 +12,10 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ModifyBowProjectileModule implements MapModule {
+public class ModifyBowProjectileModule implements MapModule<ModifyBowProjectileMatchModule> {
   protected final Class<? extends Entity> cls;
   protected final float velocityMod;
   protected final Set<PotionEffect> potionEffects;
@@ -29,7 +28,7 @@ public class ModifyBowProjectileModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ModifyBowProjectileMatchModule createMatchModule(Match match) {
     return new ModifyBowProjectileMatchModule(
         match, this.cls, this.velocityMod, this.potionEffects);
   }

--- a/core/src/main/java/tc/oc/pgm/modules/ToolRepairModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ToolRepairModule.java
@@ -10,12 +10,11 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ToolRepairModule implements MapModule {
+public class ToolRepairModule implements MapModule<ToolRepairMatchModule> {
   protected final Set<Material> toRepair;
 
   public ToolRepairModule(Set<Material> toRepair) {
@@ -23,7 +22,7 @@ public class ToolRepairModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ToolRepairMatchModule createMatchModule(Match match) {
     return new ToolRepairMatchModule(match, this.toRepair);
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/WorldTimeModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/WorldTimeModule.java
@@ -12,7 +12,7 @@ import tc.oc.pgm.api.module.exception.ModuleLoadException;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class WorldTimeModule implements MapModule, MatchModule {
+public class WorldTimeModule implements MapModule<WorldTimeModule>, MatchModule {
   private final boolean lock;
   private final Long time;
   private final boolean random;
@@ -70,15 +70,11 @@ public class WorldTimeModule implements MapModule, MatchModule {
   }
 
   public static boolean parseTimeLock(Element timelockEl) {
-    boolean lock = true;
-    if (timelockEl.getTextNormalize().equalsIgnoreCase("off")) {
-      lock = false;
-    }
-    return lock;
+    return !timelockEl.getTextNormalize().equalsIgnoreCase("off");
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) throws ModuleLoadException {
+  public WorldTimeModule createMatchModule(Match match) throws ModuleLoadException {
     return this;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/portals/PortalModule.java
+++ b/core/src/main/java/tc/oc/pgm/portals/PortalModule.java
@@ -41,7 +41,7 @@ import tc.oc.pgm.regions.Union;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class PortalModule implements MapModule {
+public class PortalModule implements MapModule<PortalMatchModule> {
   private static final Component PROTECT_MESSAGE = translatable("map.protectPortal");
 
   protected final Set<Portal> portals;
@@ -63,7 +63,7 @@ public class PortalModule implements MapModule {
 
   public static class Factory implements MapModuleFactory<PortalModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class, FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
@@ -17,7 +17,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.kits.KitParser;
@@ -25,17 +24,17 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ProjectileModule implements MapModule {
+public class ProjectileModule implements MapModule<ProjectileMatchModule> {
   Set<ProjectileDefinition> projectileDefinitions = new HashSet<>();
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ProjectileMatchModule createMatchModule(Match match) {
     return new ProjectileMatchModule(match, this.projectileDefinitions);
   }
 
   public static class Factory implements MapModuleFactory<ProjectileModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/proximity/ProximityAlarmModule.java
+++ b/core/src/main/java/tc/oc/pgm/proximity/ProximityAlarmModule.java
@@ -13,7 +13,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.operator.InverseFilter;
 import tc.oc.pgm.filters.parse.FilterParser;
@@ -22,7 +21,7 @@ import tc.oc.pgm.teams.TeamModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ProximityAlarmModule implements MapModule {
+public class ProximityAlarmModule implements MapModule<ProximityAlarmMatchModule> {
   private final Set<ProximityAlarmDefinition> definitions;
 
   public ProximityAlarmModule(Set<ProximityAlarmDefinition> definitions) {
@@ -30,13 +29,13 @@ public class ProximityAlarmModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ProximityAlarmMatchModule createMatchModule(Match match) {
     return new ProximityAlarmMatchModule(match, this.definitions);
   }
 
   public static class Factory implements MapModuleFactory<ProximityAlarmModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(TeamModule.class, RegionModule.class, FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/rage/RageModule.java
+++ b/core/src/main/java/tc/oc/pgm/rage/RageModule.java
@@ -9,15 +9,14 @@ import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
-public class RageModule implements MapModule {
+public class RageModule implements MapModule<RageMatchModule> {
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("rage", "Rage", true, true));
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public RageMatchModule createMatchModule(Match match) {
     return new RageMatchModule(match);
   }
 

--- a/core/src/main/java/tc/oc/pgm/regions/RegionModule.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionModule.java
@@ -10,13 +10,12 @@ import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.kits.KitModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class RegionModule implements MapModule {
+public class RegionModule implements MapModule<RegionMatchModule> {
   protected final RFAContext rfaContext;
 
   public RegionModule(RFAContext rfaContext) {
@@ -28,13 +27,13 @@ public class RegionModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public RegionMatchModule createMatchModule(Match match) {
     return new RegionMatchModule(match, this.rfaContext);
   }
 
   public static class Factory implements MapModuleFactory<RegionModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(FilterModule.class, KitModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/renewable/RenewableModule.java
+++ b/core/src/main/java/tc/oc/pgm/renewable/RenewableModule.java
@@ -44,7 +44,7 @@ public class RenewableModule implements MapModule<RenewableMatchModule> {
 
   public static class Factory implements MapModuleFactory<RenewableModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(RegionModule.class, FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/score/ScoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreModule.java
@@ -21,7 +21,6 @@ import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.blitz.BlitzModule;
 import tc.oc.pgm.filters.FilterModule;
@@ -34,7 +33,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class ScoreModule implements MapModule {
+public class ScoreModule implements MapModule<ScoreMatchModule> {
   private static final MapTag SCORE_TAG =
       new MapTag("tdm", "deathmatch", "Deathmatch", true, false);
   private static final MapTag BOX_TAG = new MapTag("scorebox", "Scorebox", false, true);
@@ -56,7 +55,7 @@ public class ScoreModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public ScoreMatchModule createMatchModule(Match match) {
     ImmutableSet.Builder<ScoreBox> scoreBoxes = ImmutableSet.builder();
     for (ScoreBoxFactory factory : this.scoreBoxFactories) {
       scoreBoxes.add(factory.createScoreBox(match));
@@ -75,12 +74,12 @@ public class ScoreModule implements MapModule {
 
   public static class Factory implements MapModuleFactory<ScoreModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class, FilterModule.class);
     }
 
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(BlitzModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/shops/ShopModule.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopModule.java
@@ -76,7 +76,7 @@ public class ShopModule implements MapModule<ShopMatchModule> {
   public static class Factory implements MapModuleFactory<ShopModule> {
 
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(ActionModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -18,7 +18,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.matcher.StaticFilter;
@@ -32,18 +31,18 @@ import tc.oc.pgm.util.xml.InheritingElement;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class SpawnerModule implements MapModule {
+public class SpawnerModule implements MapModule<SpawnerMatchModule> {
 
   private final List<SpawnerDefinition> spawnerDefinitions = new ArrayList<>();
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public SpawnerMatchModule createMatchModule(Match match) {
     return new SpawnerMatchModule(match, spawnerDefinitions);
   }
 
   public static class Factory implements MapModuleFactory<SpawnerModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(RegionModule.class, FilterModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
@@ -15,7 +15,6 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.kits.KitModule;
@@ -26,7 +25,7 @@ import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class SpawnModule implements MapModule {
+public class SpawnModule implements MapModule<SpawnMatchModule> {
 
   public static final Duration DEFAULT_RESPAWN_DELAY = Duration.ofMillis(2000);
   public static final Duration MINIMUM_RESPAWN_DELAY = Duration.ofMillis(1500);
@@ -44,7 +43,7 @@ public class SpawnModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public SpawnMatchModule createMatchModule(Match match) {
     return new SpawnMatchModule(match, this);
   }
 
@@ -53,12 +52,12 @@ public class SpawnModule implements MapModule {
     private FilterParser filterParser;
 
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class, KitModule.class);
     }
 
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(TeamModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimitModule.java
@@ -45,7 +45,7 @@ public class TimeLimitModule implements MapModule<TimeLimitMatchModule> {
 
     @Nullable
     @Override
-    public Collection<Class<? extends MapModule>> getWeakDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
       return ImmutableList.of(TeamModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTModule.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTModule.java
@@ -13,7 +13,6 @@ import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.matcher.CauseFilter;
 import tc.oc.pgm.filters.operator.DenyFilter;
 import tc.oc.pgm.regions.EverywhereRegion;
@@ -24,7 +23,7 @@ import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class TNTModule implements MapModule {
+public class TNTModule implements MapModule<TNTMatchModule> {
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("autotnt", "Instant TNT", false, true));
   public static final int DEFAULT_DISPENSER_NUKE_LIMIT = 16;
@@ -42,13 +41,13 @@ public class TNTModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public TNTMatchModule createMatchModule(Match match) {
     return new TNTMatchModule(match, this.properties);
   }
 
   public static class Factory implements MapModuleFactory<TNTModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
+++ b/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
@@ -32,7 +32,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class WoolModule implements MapModule {
+public class WoolModule implements MapModule<WoolMatchModule> {
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("ctw", "wool", "Capture the Wool", true, false));
 
@@ -49,7 +49,7 @@ public class WoolModule implements MapModule {
   }
 
   @Override
-  public Collection<Class> getSoftDependencies() {
+  public Collection<Class<? extends MatchModule>> getSoftDependencies() {
     return ImmutableList.of(GoalMatchModule.class);
   }
 
@@ -58,7 +58,7 @@ public class WoolModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public WoolMatchModule createMatchModule(Match match) {
     Multimap<Team, MonumentWool> wools = ArrayListMultimap.create();
     for (Entry<TeamFactory, MonumentWoolFactory> woolEntry : this.woolFactories.entries()) {
       Team team = match.needModule(TeamMatchModule.class).getTeam(woolEntry.getKey());
@@ -72,7 +72,7 @@ public class WoolModule implements MapModule {
 
   public static class Factory implements MapModuleFactory<WoolModule> {
     @Override
-    public Collection<Class<? extends MapModule>> getSoftDependencies() {
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class, TeamModule.class);
     }
 

--- a/core/src/main/java/tc/oc/pgm/worldborder/WorldBorderModule.java
+++ b/core/src/main/java/tc/oc/pgm/worldborder/WorldBorderModule.java
@@ -14,14 +14,13 @@ import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.matcher.match.MonostableFilter;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
-public class WorldBorderModule implements MapModule {
+public class WorldBorderModule implements MapModule<WorldBorderMatchModule> {
   private final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("border", "World Border", false, true));
   private final List<WorldBorder> borders;
@@ -36,7 +35,7 @@ public class WorldBorderModule implements MapModule {
   }
 
   @Override
-  public MatchModule createMatchModule(Match match) {
+  public WorldBorderMatchModule createMatchModule(Match match) {
     return new WorldBorderMatchModule(match, borders);
   }
 


### PR DESCRIPTION
Currently PGM has a ModuleGraph to resolve dependencies, however, every so often a required dependency is forgotten by a developer, and then what? What happens is because module load order is arbitrary (hash maps), it may work or not work at random, based on server restarts. What makes it worse, is that because "most" dependencies are right, they will force the "right" module to load first **most** of the times, making it extremely difficult to debug or find the *one* missing link in the chain.

Example: modules B, C, D, E, F, G all rely on module A being loaded first. However, module F has forgotten to declare that dependency (the developer making the module forgot to declare it). If, arbitrarily, any of the modules A, B, C, D, E, or G are loaded *before* F, then the error will be completely hidden away, as any of them will force A to load first, and so, by the time F loads, A will already be present. However, in the one-in-a-thousand time, that F loads before them all, all pgm maps using F will fail to load.

This is extremely frustrating behavior to debug, so what this change does is make it so the order is no longer arbitrary, but instead, is consistent with the order modules are defined/registered in pgm. This means if a bug occurs, it will occur **every** time, and if it doesn't occur, it won't **ever** occur.

Additionally, i've cleaned-up the raw usages of MapModule without generics, and made the module factories immutable.