### PR TITLE
Allow fireballs to be precise when shot

### DIFF
--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
@@ -18,6 +18,7 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
   protected Filter destroyFilter;
   protected Duration coolDown;
   protected boolean throwable;
+  protected boolean precise;
 
   public ProjectileDefinition(
       @Nullable String id,
@@ -29,7 +30,8 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
       List<PotionEffect> potion,
       Filter destroyFilter,
       Duration coolDown,
-      boolean throwable) {
+      boolean throwable,
+      boolean precise) {
     super(id);
     this.name = name;
     this.damage = damage;
@@ -40,6 +42,7 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
     this.destroyFilter = destroyFilter;
     this.coolDown = coolDown;
     this.throwable = throwable;
+    this.precise = precise;
   }
 
   public @Nullable String getName() {

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Fireball;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -40,6 +41,7 @@ import tc.oc.pgm.filters.query.BlockQuery;
 import tc.oc.pgm.filters.query.PlayerBlockQuery;
 import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
 public class ProjectileMatchModule implements MatchModule, Listener {
@@ -92,6 +94,9 @@ public class ProjectileMatchModule implements MatchModule, Listener {
           projectile =
               player.launchProjectile(
                   projectileDefinition.projectile.asSubclass(Projectile.class), velocity);
+          if (projectile instanceof Fireball && projectileDefinition.precise) {
+            NMSHacks.setFireballDirection((Fireball) projectile, velocity);
+          }
         } else {
           projectile =
               player.getWorld().spawn(player.getEyeLocation(), projectileDefinition.projectile);

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
@@ -69,6 +69,7 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
         Duration coolDown = XMLUtils.parseDuration(projectileElement.getAttribute("cooldown"));
         boolean throwable =
             XMLUtils.parseBoolean(projectileElement.getAttribute("throwable"), true);
+        boolean precise = XMLUtils.parseBoolean(projectileElement.getAttribute("precise"), true);
 
         ProjectileDefinition projectileDefinition =
             new ProjectileDefinition(
@@ -81,7 +82,8 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
                 potionKit,
                 destroyFilter,
                 coolDown,
-                throwable);
+                throwable,
+                precise);
 
         factory.getFeatures().addFeature(projectileElement, projectileDefinition);
         projectileModule.projectileDefinitions.add(projectileDefinition);

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -1379,4 +1379,11 @@ public interface NMSHacks {
     tag.setBoolean("NoGravity", true);
     nmsEntity.f(tag); // load from tag
   }
+
+  static void setFireballDirection(Fireball entity, Vector direction) {
+    EntityFireball fireball = ((CraftFireball) entity).getHandle();
+    fireball.dirX = direction.getX() * 0.1D;
+    fireball.dirY = direction.getY() * 0.1D;
+    fireball.dirZ = direction.getZ() * 0.1D;
+  }
 }


### PR DESCRIPTION
Currently, fireballs have randomness when shot. Setting `precise` to true on the projectile fixes this.

`NMSHacks` needed as setting direction via API method call always has the random applied to it.

Signed-off-by: Pugzy <pugzy@mail.com>