### PR TITLE
Make icon on class module required

### DIFF
--- a/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
+++ b/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
@@ -177,7 +177,7 @@ public class ClassModule implements MapModule<ClassMatchModule> {
         kits.add(kit);
       }
 
-      MaterialData icon = XMLUtils.parseMaterialData(Node.fromAttr(classEl, "icon"));
+      MaterialData icon = XMLUtils.parseMaterialData(Node.fromRequiredAttr(classEl, "icon"));
 
       boolean restrict = XMLUtils.parseBoolean(classEl.getAttribute("restrict"), false);
 


### PR DESCRIPTION
The docs don't specify that this attribute is required but it is otherwise exceptions are thrown.
This has always been the case even from old OCN PGM and its lifetime.

There's no fallback provided and PGM attempts to make an item using the value of null. 👍 