### PR TITLE
Fix exception with monostable filter bossbars

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
@@ -181,9 +181,9 @@ public class MonostableFilter extends SingleFilterFunction
               long oldSeconds = lastTick.until(end, ChronoUnit.SECONDS);
               long newSeconds = now.until(end, ChronoUnit.SECONDS);
 
-              // Intentionally use old, as transitioning from 4s to 3.95s should show 4s
+              // Round up as going from 4s to 3.95s should show 4s
               if (oldSeconds != newSeconds)
-                updateBossBar(filterable, Duration.ofSeconds(oldSeconds));
+                updateBossBar(filterable, Duration.ofSeconds(newSeconds + 1));
             }
           });
 
@@ -241,7 +241,7 @@ public class MonostableFilter extends SingleFilterFunction
     }
 
     private float progress(Duration remaining) {
-      return Math.min(1f, (float) remaining.toMillis() / duration.toMillis());
+      return Math.min(1f, (float) remaining.getSeconds() / duration.getSeconds());
     }
   }
 }


### PR DESCRIPTION
"oldSeconds" could be a very, very large number before, as the initial is started at min time. This addresses the issue in not just 1 but 2 ways, ensuring the overflow neither happens, nor would be an issue if it still happened.

exception (provided by an user): 
![image](https://user-images.githubusercontent.com/11789291/215205696-c850e426-c683-42a2-845c-e4d0f32ef227.png)
