### PR TITLE
Add contribution getter to score module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
@@ -334,4 +334,8 @@ public class ScoreMatchModule implements MatchModule, Listener {
 
     this.match.calculateVictory();
   }
+
+  public double getContribution(UUID player) {
+    return contributions.get(player);
+  }
 }


### PR DESCRIPTION
This getter existed in the community branch, but never made it into community-two, it allows for 3rd parties to get how much score a player contributed