### PR TITLE
Cleanup cloud command graph & add player parser

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -41,7 +41,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.module.Module;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
-import tc.oc.pgm.command.util.CommandGraph;
+import tc.oc.pgm.command.util.PGMCommandGraph;
 import tc.oc.pgm.db.CacheDatastore;
 import tc.oc.pgm.db.SQLDatastore;
 import tc.oc.pgm.integrations.SimpleVanishIntegration;
@@ -324,7 +324,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
 
   private void registerCommands() {
     try {
-      new CommandGraph(this);
+      new PGMCommandGraph(this);
     } catch (Exception e) {
       getLogger().log(Level.SEVERE, "Exception registering commands", e);
     }

--- a/core/src/main/java/tc/oc/pgm/command/injectors/PlayerProvider.java
+++ b/core/src/main/java/tc/oc/pgm/command/injectors/PlayerProvider.java
@@ -1,0 +1,23 @@
+package tc.oc.pgm.command.injectors;
+
+import static tc.oc.pgm.util.text.TextException.playerOnly;
+
+import cloud.commandframework.annotations.AnnotationAccessor;
+import cloud.commandframework.annotations.injection.ParameterInjector;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.CommandExecutionException;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public final class PlayerProvider implements ParameterInjector<CommandSender, Player> {
+
+  @Override
+  public Player create(
+      CommandContext<CommandSender> context, @NotNull AnnotationAccessor annotations) {
+    CommandSender sender = context.getSender();
+    if (sender instanceof Player) return (Player) sender;
+
+    throw new CommandExecutionException(playerOnly());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/parsers/MatchPlayerParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/MatchPlayerParser.java
@@ -1,55 +1,29 @@
 package tc.oc.pgm.command.parsers;
 
-import static cloud.commandframework.arguments.parser.ArgumentParseResult.failure;
-import static cloud.commandframework.arguments.parser.ArgumentParseResult.success;
-import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
-import static tc.oc.pgm.util.text.TextException.exception;
-import static tc.oc.pgm.util.text.TextException.playerOnly;
-
 import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.context.CommandContext;
-import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
 import java.util.List;
 import java.util.Queue;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.util.Players;
 
 public final class MatchPlayerParser implements ArgumentParser<CommandSender, MatchPlayer> {
+
+  private final PlayerParser parser = new PlayerParser();
 
   @Override
   public @NotNull ArgumentParseResult<@NotNull MatchPlayer> parse(
       @NotNull CommandContext<@NotNull CommandSender> context,
       @NotNull Queue<@NotNull String> inputQueue) {
-    final String input = inputQueue.poll();
-
-    if (input == null) {
-      return failure(new NoInputProvidedException(MatchPlayerParser.class, context));
-    }
-
-    CommandSender sender = context.getSender();
-    MatchPlayer mp;
-
-    if (input.equals(CURRENT)) {
-      if (!(context.getSender() instanceof Player)) return failure(playerOnly());
-
-      mp = PGM.get().getMatchManager().getPlayer((Player) context.getSender());
-    } else {
-      mp = Players.getMatchPlayer(sender, input);
-    }
-
-    return mp != null ? success(mp) : failure(exception("command.playerNotFound"));
+    return parser.parse(context, inputQueue).mapParsedValue(PGM.get().getMatchManager()::getPlayer);
   }
 
   @Override
   public @NotNull List<@NotNull String> suggestions(
       @NotNull CommandContext<CommandSender> context, @NotNull String input) {
-    CommandSender sender = context.getSender();
-
-    return Players.getPlayerNames(sender, input);
+    return parser.suggestions(context, input);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/parsers/PlayerParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/PlayerParser.java
@@ -1,0 +1,52 @@
+package tc.oc.pgm.command.parsers;
+
+import static cloud.commandframework.arguments.parser.ArgumentParseResult.failure;
+import static cloud.commandframework.arguments.parser.ArgumentParseResult.success;
+import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
+import static tc.oc.pgm.util.text.TextException.exception;
+import static tc.oc.pgm.util.text.TextException.playerOnly;
+
+import cloud.commandframework.arguments.parser.ArgumentParseResult;
+import cloud.commandframework.arguments.parser.ArgumentParser;
+import cloud.commandframework.context.CommandContext;
+import cloud.commandframework.exceptions.parsing.NoInputProvidedException;
+import java.util.List;
+import java.util.Queue;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import tc.oc.pgm.util.Players;
+
+public final class PlayerParser implements ArgumentParser<CommandSender, Player> {
+
+  @Override
+  public @NotNull ArgumentParseResult<@NotNull Player> parse(
+      @NotNull CommandContext<@NotNull CommandSender> context,
+      @NotNull Queue<@NotNull String> inputQueue) {
+    final String input = inputQueue.poll();
+
+    if (input == null) {
+      return failure(new NoInputProvidedException(PlayerParser.class, context));
+    }
+
+    CommandSender sender = context.getSender();
+    Player player;
+
+    if (input.equals(CURRENT)) {
+      if (!(context.getSender() instanceof Player)) return failure(playerOnly());
+      player = (Player) context.getSender();
+    } else {
+      player = Players.getPlayer(sender, input);
+    }
+
+    return player != null ? success(player) : failure(exception("command.playerNotFound"));
+  }
+
+  @Override
+  public @NotNull List<@NotNull String> suggestions(
+      @NotNull CommandContext<CommandSender> context, @NotNull String input) {
+    CommandSender sender = context.getSender();
+
+    return Players.getPlayerNames(sender, input);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
@@ -14,7 +14,6 @@ import cloud.commandframework.arguments.parser.ArgumentParser;
 import cloud.commandframework.arguments.parser.ParserParameters;
 import cloud.commandframework.arguments.parser.ParserRegistry;
 import cloud.commandframework.arguments.parser.StandardParameters;
-import cloud.commandframework.arguments.standard.StringArgument;
 import cloud.commandframework.bukkit.CloudBukkitCapabilities;
 import cloud.commandframework.exceptions.ArgumentParseException;
 import cloud.commandframework.exceptions.CommandExecutionException;
@@ -27,151 +26,36 @@ import cloud.commandframework.extra.confirmation.CommandConfirmationManager;
 import cloud.commandframework.meta.CommandMeta;
 import cloud.commandframework.minecraft.extras.MinecraftHelp;
 import cloud.commandframework.paper.PaperCommandManager;
-import io.leangen.geantyref.TypeFactory;
 import io.leangen.geantyref.TypeToken;
 import java.lang.reflect.Type;
-import java.time.Duration;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.util.ComponentMessageThrowable;
 import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
-import tc.oc.pgm.action.actions.ExposedAction;
-import tc.oc.pgm.api.Config;
-import tc.oc.pgm.api.PGM;
-import tc.oc.pgm.api.map.MapInfo;
-import tc.oc.pgm.api.map.MapLibrary;
-import tc.oc.pgm.api.map.MapOrder;
-import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.match.MatchManager;
-import tc.oc.pgm.api.party.Party;
-import tc.oc.pgm.api.party.VictoryCondition;
-import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.api.setting.SettingKey;
-import tc.oc.pgm.api.setting.SettingValue;
-import tc.oc.pgm.classes.PlayerClass;
-import tc.oc.pgm.command.ActionCommand;
-import tc.oc.pgm.command.AdminCommand;
-import tc.oc.pgm.command.CancelCommand;
-import tc.oc.pgm.command.ClassCommand;
-import tc.oc.pgm.command.CycleCommand;
-import tc.oc.pgm.command.FinishCommand;
-import tc.oc.pgm.command.FreeForAllCommand;
-import tc.oc.pgm.command.InventoryCommand;
-import tc.oc.pgm.command.JoinCommand;
-import tc.oc.pgm.command.ListCommand;
-import tc.oc.pgm.command.MapCommand;
-import tc.oc.pgm.command.MapDevCommand;
-import tc.oc.pgm.command.MapOrderCommand;
-import tc.oc.pgm.command.MapPoolCommand;
-import tc.oc.pgm.command.MatchCommand;
-import tc.oc.pgm.command.ModeCommand;
-import tc.oc.pgm.command.ProximityCommand;
-import tc.oc.pgm.command.RestartCommand;
-import tc.oc.pgm.command.SettingCommand;
-import tc.oc.pgm.command.StartCommand;
-import tc.oc.pgm.command.StatsCommand;
-import tc.oc.pgm.command.TeamCommand;
-import tc.oc.pgm.command.TimeLimitCommand;
-import tc.oc.pgm.command.VanishCommand;
-import tc.oc.pgm.command.VotingCommand;
-import tc.oc.pgm.command.injectors.MapPollProvider;
-import tc.oc.pgm.command.injectors.MapPoolManagerProvider;
-import tc.oc.pgm.command.injectors.MatchModuleInjectionService;
-import tc.oc.pgm.command.injectors.MatchPlayerProvider;
-import tc.oc.pgm.command.injectors.MatchProvider;
-import tc.oc.pgm.command.injectors.TeamMatchModuleProvider;
-import tc.oc.pgm.command.parsers.DurationParser;
-import tc.oc.pgm.command.parsers.EnumParser;
-import tc.oc.pgm.command.parsers.ExposedActionParser;
-import tc.oc.pgm.command.parsers.MapInfoParser;
-import tc.oc.pgm.command.parsers.MapPoolParser;
-import tc.oc.pgm.command.parsers.MatchPlayerParser;
-import tc.oc.pgm.command.parsers.ModeParser;
-import tc.oc.pgm.command.parsers.PartyParser;
-import tc.oc.pgm.command.parsers.PlayerClassParser;
-import tc.oc.pgm.command.parsers.RotationParser;
-import tc.oc.pgm.command.parsers.SettingValueParser;
-import tc.oc.pgm.command.parsers.TeamParser;
-import tc.oc.pgm.command.parsers.TeamsParser;
-import tc.oc.pgm.command.parsers.VictoryConditionParser;
-import tc.oc.pgm.listeners.ChatDispatcher;
-import tc.oc.pgm.modes.Mode;
-import tc.oc.pgm.rotation.MapPoolManager;
-import tc.oc.pgm.rotation.pools.MapPool;
-import tc.oc.pgm.rotation.pools.MapPoolType;
-import tc.oc.pgm.rotation.pools.Rotation;
-import tc.oc.pgm.rotation.vote.MapPoll;
-import tc.oc.pgm.teams.Team;
-import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.Audience;
 
-public class CommandGraph {
+public abstract class CommandGraph<P extends Plugin> {
 
-  private final PGM pgm;
-  private final PaperCommandManager<CommandSender> manager;
-  private final MinecraftHelp<CommandSender> minecraftHelp;
-  private final CommandConfirmationManager<CommandSender> confirmationManager;
-  private final AnnotationParser<CommandSender> annotationParser;
+  protected P plugin;
+  protected PaperCommandManager<CommandSender> manager;
+  protected MinecraftHelp<CommandSender> minecraftHelp;
+  protected CommandConfirmationManager<CommandSender> confirmationManager;
+  protected AnnotationParser<CommandSender> annotationParser;
 
-  private final ParameterInjectorRegistry<CommandSender> injectors;
-  private final ParserRegistry<CommandSender> parsers;
+  protected ParameterInjectorRegistry<CommandSender> injectors;
+  protected ParserRegistry<CommandSender> parsers;
 
-  public CommandGraph(PGM pgm) throws Exception {
-    this.pgm = pgm;
-    this.manager =
-        PaperCommandManager.createNative(pgm, CommandExecutionCoordinator.simpleCoordinator());
-
-    this.manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
-
-    // Create the Minecraft help menu system
-    this.minecraftHelp = new MinecraftHelp<>("/pgm help", Audience::get, manager);
-
-    // Register Brigadier mappings
-    if (this.manager.hasCapability(CloudBukkitCapabilities.BRIGADIER))
-      this.manager.registerBrigadier();
-
-    // Register asynchronous completions
-    if (this.manager.hasCapability(CloudBukkitCapabilities.ASYNCHRONOUS_COMPLETION))
-      this.manager.registerAsynchronousCompletions();
-
-    // Add the input queue to the context, this allows greedy suggestions to work on it
-    this.manager.registerCommandPreProcessor(
-        context ->
-            context.getCommandContext().store(CommandKeys.INPUT_QUEUE, context.getInputQueue()));
-
-    // By default, suggestions run by a filtered processor.
-    // By default, it prevents suggestions like "s" -> "Something" or "someh" -> "Something"
-    this.manager.commandSuggestionProcessor((cpc, strings) -> strings);
-
-    // Create the confirmation this.manager. This allows us to require certain commands to be
-    // confirmed before they can be executed
-    this.confirmationManager =
-        new CommandConfirmationManager<>(
-            30L,
-            TimeUnit.SECONDS,
-            // TODO: clickable & translatable
-            context ->
-                Audience.get(context.getCommandContext().getSender())
-                    .sendWarning(text("Confirmation required. Confirm using /pgm confirm.")),
-            sender ->
-                Audience.get(sender).sendWarning(text("You don't have any pending commands.")));
-    this.confirmationManager.registerConfirmationProcessor(this.manager);
-
-    final Function<ParserParameters, CommandMeta> commandMetaFunction =
-        p ->
-            CommandMeta.simple()
-                .with(
-                    CommandMeta.DESCRIPTION,
-                    p.get(StandardParameters.DESCRIPTION, "No description"))
-                .build();
-
-    this.annotationParser =
-        new AnnotationParser<>(manager, CommandSender.class, commandMetaFunction);
+  public CommandGraph(P plugin) throws Exception {
+    this.plugin = plugin;
+    this.manager = createCommandManager();
+    this.minecraftHelp = createHelp();
+    // Allows us to require certain commands to be confirmed before they can be executed
+    this.confirmationManager = createConfirmationManager();
+    this.annotationParser = createAnnotationParser();
 
     // Utility
     this.injectors = manager.parameterInjectorRegistry();
@@ -181,116 +65,73 @@ public class CommandGraph {
     setupInjectors();
     setupParsers();
     registerCommands();
-
-    manager.command(
-        manager
-            .commandBuilder("pgm")
-            .literal("confirm")
-            .meta(CommandMeta.DESCRIPTION, "Confirm a pending command")
-            .handler(this.confirmationManager.createConfirmationExecutionHandler()));
-
-    manager.command(
-        manager
-            .commandBuilder("pgm")
-            .literal("help")
-            .argument(StringArgument.optional("query", StringArgument.StringMode.GREEDY))
-            .handler(
-                context ->
-                    minecraftHelp.queryCommands(
-                        context.<String>getOptional("query").orElse(""), context.getSender())));
   }
+
+  protected PaperCommandManager<CommandSender> createCommandManager() throws Exception {
+    PaperCommandManager<CommandSender> manager =
+        PaperCommandManager.createNative(plugin, CommandExecutionCoordinator.simpleCoordinator());
+
+    manager.setSetting(CommandManager.ManagerSettings.LIBERAL_FLAG_PARSING, true);
+
+    // Register Brigadier mappings
+    if (manager.hasCapability(CloudBukkitCapabilities.BRIGADIER)) manager.registerBrigadier();
+
+    // Register asynchronous completions
+    if (manager.hasCapability(CloudBukkitCapabilities.ASYNCHRONOUS_COMPLETION))
+      manager.registerAsynchronousCompletions();
+
+    // Add the input queue to the context, this allows greedy suggestions to work on it
+    manager.registerCommandPreProcessor(
+        context ->
+            context.getCommandContext().store(CommandKeys.INPUT_QUEUE, context.getInputQueue()));
+
+    // By default, suggestions run by a filtered processor.
+    // By default, it prevents suggestions like "s" -> "Something" or "someh" -> "Something"
+    manager.commandSuggestionProcessor((cpc, strings) -> strings);
+
+    return manager;
+  }
+
+  protected AnnotationParser<CommandSender> createAnnotationParser() {
+    final Function<ParserParameters, CommandMeta> commandMetaFunction =
+        p ->
+            CommandMeta.simple()
+                .with(
+                    CommandMeta.DESCRIPTION,
+                    p.get(StandardParameters.DESCRIPTION, "No description"))
+                .build();
+    return new AnnotationParser<>(manager, CommandSender.class, commandMetaFunction);
+  }
+
+  protected abstract MinecraftHelp<CommandSender> createHelp();
+
+  protected abstract CommandConfirmationManager<CommandSender> createConfirmationManager();
+
+  protected abstract void setupInjectors();
+
+  protected abstract void setupParsers();
+
+  protected abstract void registerCommands();
 
   // Commands
-  public void registerCommands() {
-    register(new ActionCommand());
-    register(new AdminCommand());
-    register(new CancelCommand());
-    register(new ClassCommand());
-    register(new CycleCommand());
-    register(new FinishCommand());
-    register(new FreeForAllCommand());
-    register(new InventoryCommand());
-    register(new JoinCommand());
-    register(new ListCommand());
-    register(new MapCommand());
-    register(new MapDevCommand());
-    register(new MapOrderCommand());
-    register(new MapPoolCommand());
-    register(new MatchCommand());
-    register(new ModeCommand());
-    register(new ProximityCommand());
-    register(new RestartCommand());
-    register(SettingCommand.getInstance());
-    register(new StartCommand());
-    register(new StatsCommand());
-    register(new TeamCommand());
-    register(new TimeLimitCommand());
-    register(new VotingCommand());
-
-    if (PGM.get().getConfiguration().isVanishEnabled()) register(new VanishCommand());
-
-    register(ChatDispatcher.get());
-  }
-
   protected void register(Object command) {
     annotationParser.parse(command);
   }
 
   // Injectors
-  protected void setupInjectors() {
-    registerInjector(PGM.class, Function.identity());
-    registerInjector(Config.class, PGM::getConfiguration);
-    registerInjector(MatchManager.class, PGM::getMatchManager);
-    registerInjector(MapLibrary.class, PGM::getMapLibrary);
-    registerInjector(MapOrder.class, PGM::getMapOrder);
-
-    // NOTE: order is important. Audience must be first, otherwise a Match or MatchPlayer (which
-    // implement Audience) would be used, causing everyone to get all command feedback (Match), or
-    // console being unable to use commands (MatchPlayer).
-    registerInjector(Audience.class, (c, s) -> Audience.get(c.getSender()));
-    registerInjector(Match.class, new MatchProvider());
-    registerInjector(MatchPlayer.class, new MatchPlayerProvider());
-    registerInjector(TeamMatchModule.class, new TeamMatchModuleProvider());
-    registerInjector(MapPoolManager.class, new MapPoolManagerProvider());
-    registerInjector(MapPoll.class, new MapPollProvider());
-
-    // Able to inject any match module
-    injectors.registerInjectionService(new MatchModuleInjectionService());
-  }
-
   protected <T> void registerInjector(Class<T> type, ParameterInjector<CommandSender, T> provider) {
     injectors.registerInjector(type, provider);
   }
 
-  protected <T> void registerInjector(Class<T> type, Function<PGM, T> function) {
-    registerInjector(type, (a, b) -> function.apply(PGM.get()));
+  protected <T> void registerInjector(Class<T> type, Supplier<T> supplier) {
+    registerInjector(type, (a, b) -> supplier.get());
   }
 
-  //
+  protected <T> void registerInjector(Class<T> type, Function<P, T> function) {
+    registerInjector(type, (a, b) -> function.apply(plugin));
+  }
+
   // Parsers
-  //
-  protected void setupParsers() {
-    // Cloud has a default duration parser, but time type is not optional
-    registerParser(Duration.class, new DurationParser());
-    registerParser(MatchPlayer.class, new MatchPlayerParser());
-    registerParser(MapPool.class, new MapPoolParser());
-    registerParser(Rotation.class, new RotationParser());
-    registerParser(MapPoolType.class, new EnumParser<>(MapPoolType.class, CommandKeys.POOL_TYPE));
-
-    registerParser(MapInfo.class, MapInfoParser::new);
-    registerParser(Party.class, PartyParser::new);
-    registerParser(Team.class, TeamParser::new);
-    registerParser(TypeFactory.parameterizedClass(Collection.class, Team.class), TeamsParser::new);
-    registerParser(PlayerClass.class, PlayerClassParser::new);
-    registerParser(Mode.class, ModeParser::new);
-    registerParser(ExposedAction.class, ExposedActionParser::new);
-    registerParser(
-        TypeFactory.parameterizedClass(Optional.class, VictoryCondition.class),
-        new VictoryConditionParser());
-    registerParser(SettingKey.class, new EnumParser<>(SettingKey.class, CommandKeys.SETTING_KEY));
-    registerParser(SettingValue.class, new SettingValueParser());
-  }
-
   protected <T> void registerParser(Class<T> type, ArgumentParser<CommandSender, T> parser) {
     parsers.registerParserSupplier(TypeToken.get(type), op -> parser);
   }
@@ -323,13 +164,13 @@ public class CommandGraph {
         ex, (cs, e) -> Audience.get(cs).sendWarning(toComponent.apply(e)));
   }
 
-  private <E extends Exception> void handleException(CommandSender cs, E e) {
+  protected <E extends Exception> void handleException(CommandSender cs, E e) {
     Audience audience = Audience.get(cs);
     Component message = getMessage(e);
     if (message != null) audience.sendWarning(message);
   }
 
-  private @Nullable Component getMessage(Throwable t) {
+  protected @Nullable Component getMessage(Throwable t) {
     ComponentMessageThrowable messageThrowable = getParentCause(t, ComponentMessageThrowable.class);
     if (messageThrowable != null) return messageThrowable.componentMessage();
 

--- a/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
@@ -1,0 +1,213 @@
+package tc.oc.pgm.command.util;
+
+import static net.kyori.adventure.text.Component.text;
+
+import cloud.commandframework.arguments.standard.StringArgument;
+import cloud.commandframework.extra.confirmation.CommandConfirmationManager;
+import cloud.commandframework.meta.CommandMeta;
+import cloud.commandframework.minecraft.extras.MinecraftHelp;
+import io.leangen.geantyref.TypeFactory;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import tc.oc.pgm.action.actions.ExposedAction;
+import tc.oc.pgm.api.Config;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.api.map.MapLibrary;
+import tc.oc.pgm.api.map.MapOrder;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchManager;
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.api.party.VictoryCondition;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.setting.SettingKey;
+import tc.oc.pgm.api.setting.SettingValue;
+import tc.oc.pgm.classes.PlayerClass;
+import tc.oc.pgm.command.ActionCommand;
+import tc.oc.pgm.command.AdminCommand;
+import tc.oc.pgm.command.CancelCommand;
+import tc.oc.pgm.command.ClassCommand;
+import tc.oc.pgm.command.CycleCommand;
+import tc.oc.pgm.command.FinishCommand;
+import tc.oc.pgm.command.FreeForAllCommand;
+import tc.oc.pgm.command.InventoryCommand;
+import tc.oc.pgm.command.JoinCommand;
+import tc.oc.pgm.command.ListCommand;
+import tc.oc.pgm.command.MapCommand;
+import tc.oc.pgm.command.MapDevCommand;
+import tc.oc.pgm.command.MapOrderCommand;
+import tc.oc.pgm.command.MapPoolCommand;
+import tc.oc.pgm.command.MatchCommand;
+import tc.oc.pgm.command.ModeCommand;
+import tc.oc.pgm.command.ProximityCommand;
+import tc.oc.pgm.command.RestartCommand;
+import tc.oc.pgm.command.SettingCommand;
+import tc.oc.pgm.command.StartCommand;
+import tc.oc.pgm.command.StatsCommand;
+import tc.oc.pgm.command.TeamCommand;
+import tc.oc.pgm.command.TimeLimitCommand;
+import tc.oc.pgm.command.VanishCommand;
+import tc.oc.pgm.command.VotingCommand;
+import tc.oc.pgm.command.injectors.MapPollProvider;
+import tc.oc.pgm.command.injectors.MapPoolManagerProvider;
+import tc.oc.pgm.command.injectors.MatchModuleInjectionService;
+import tc.oc.pgm.command.injectors.MatchPlayerProvider;
+import tc.oc.pgm.command.injectors.MatchProvider;
+import tc.oc.pgm.command.injectors.PlayerProvider;
+import tc.oc.pgm.command.injectors.TeamMatchModuleProvider;
+import tc.oc.pgm.command.parsers.DurationParser;
+import tc.oc.pgm.command.parsers.EnumParser;
+import tc.oc.pgm.command.parsers.ExposedActionParser;
+import tc.oc.pgm.command.parsers.MapInfoParser;
+import tc.oc.pgm.command.parsers.MapPoolParser;
+import tc.oc.pgm.command.parsers.MatchPlayerParser;
+import tc.oc.pgm.command.parsers.ModeParser;
+import tc.oc.pgm.command.parsers.PartyParser;
+import tc.oc.pgm.command.parsers.PlayerClassParser;
+import tc.oc.pgm.command.parsers.PlayerParser;
+import tc.oc.pgm.command.parsers.RotationParser;
+import tc.oc.pgm.command.parsers.SettingValueParser;
+import tc.oc.pgm.command.parsers.TeamParser;
+import tc.oc.pgm.command.parsers.TeamsParser;
+import tc.oc.pgm.command.parsers.VictoryConditionParser;
+import tc.oc.pgm.listeners.ChatDispatcher;
+import tc.oc.pgm.modes.Mode;
+import tc.oc.pgm.rotation.MapPoolManager;
+import tc.oc.pgm.rotation.pools.MapPool;
+import tc.oc.pgm.rotation.pools.MapPoolType;
+import tc.oc.pgm.rotation.pools.Rotation;
+import tc.oc.pgm.rotation.vote.MapPoll;
+import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.teams.TeamMatchModule;
+import tc.oc.pgm.util.Audience;
+
+public class PGMCommandGraph extends CommandGraph<PGM> {
+
+  public PGMCommandGraph(PGM pgm) throws Exception {
+    super(pgm);
+  }
+
+  protected MinecraftHelp<CommandSender> createHelp() {
+    // Create the Minecraft help menu system
+    return new MinecraftHelp<>("/pgm help", Audience::get, manager);
+  }
+
+  protected CommandConfirmationManager<CommandSender> createConfirmationManager() {
+    CommandConfirmationManager<CommandSender> ccm =
+        new CommandConfirmationManager<>(
+            30L,
+            TimeUnit.SECONDS,
+            // TODO: clickable & translatable
+            context ->
+                Audience.get(context.getCommandContext().getSender())
+                    .sendWarning(text("Confirmation required. Confirm using /pgm confirm.")),
+            sender ->
+                Audience.get(sender).sendWarning(text("You don't have any pending commands.")));
+    ccm.registerConfirmationProcessor(this.manager);
+    return ccm;
+  }
+
+  // Commands
+  protected void registerCommands() {
+    register(new ActionCommand());
+    register(new AdminCommand());
+    register(new CancelCommand());
+    register(new ClassCommand());
+    register(new CycleCommand());
+    register(new FinishCommand());
+    register(new FreeForAllCommand());
+    register(new InventoryCommand());
+    register(new JoinCommand());
+    register(new ListCommand());
+    register(new MapCommand());
+    register(new MapDevCommand());
+    register(new MapOrderCommand());
+    register(new MapPoolCommand());
+    register(new MatchCommand());
+    register(new ModeCommand());
+    register(new ProximityCommand());
+    register(new RestartCommand());
+    register(SettingCommand.getInstance());
+    register(new StartCommand());
+    register(new StatsCommand());
+    register(new TeamCommand());
+    register(new TimeLimitCommand());
+    register(new VotingCommand());
+
+    if (PGM.get().getConfiguration().isVanishEnabled()) register(new VanishCommand());
+
+    register(ChatDispatcher.get());
+
+    manager.command(
+        manager
+            .commandBuilder("pgm")
+            .literal("confirm")
+            .meta(CommandMeta.DESCRIPTION, "Confirm a pending command")
+            .handler(this.confirmationManager.createConfirmationExecutionHandler()));
+
+    manager.command(
+        manager
+            .commandBuilder("pgm")
+            .literal("help")
+            .argument(StringArgument.optional("query", StringArgument.StringMode.GREEDY))
+            .handler(
+                context ->
+                    minecraftHelp.queryCommands(
+                        context.<String>getOptional("query").orElse(""), context.getSender())));
+  }
+
+  // Injectors
+  protected void setupInjectors() {
+    registerInjector(PGM.class, Function.identity());
+    registerInjector(Config.class, PGM::getConfiguration);
+    registerInjector(MatchManager.class, PGM::getMatchManager);
+    registerInjector(MapLibrary.class, PGM::getMapLibrary);
+    registerInjector(MapOrder.class, PGM::getMapOrder);
+
+    // NOTE: order is important. Audience must be first, otherwise a Match or MatchPlayer (which
+    // implement Audience) would be used, causing everyone to get all command feedback (Match), or
+    // console being unable to use commands (MatchPlayer).
+    registerInjector(Audience.class, (c, s) -> Audience.get(c.getSender()));
+    registerInjector(Match.class, new MatchProvider());
+    registerInjector(MatchPlayer.class, new MatchPlayerProvider());
+    registerInjector(TeamMatchModule.class, new TeamMatchModuleProvider());
+    registerInjector(MapPoolManager.class, new MapPoolManagerProvider());
+    registerInjector(MapPoll.class, new MapPollProvider());
+
+    registerInjector(Player.class, new PlayerProvider());
+
+    // Able to inject any match module
+    injectors.registerInjectionService(new MatchModuleInjectionService());
+  }
+
+  //
+  // Parsers
+  //
+  protected void setupParsers() {
+    // Cloud has a default duration parser, but time type is not optional
+    registerParser(Duration.class, new DurationParser());
+    registerParser(Player.class, new PlayerParser());
+    registerParser(MatchPlayer.class, new MatchPlayerParser());
+    registerParser(MapPool.class, new MapPoolParser());
+    registerParser(Rotation.class, new RotationParser());
+    registerParser(MapPoolType.class, new EnumParser<>(MapPoolType.class, CommandKeys.POOL_TYPE));
+
+    registerParser(MapInfo.class, MapInfoParser::new);
+    registerParser(Party.class, PartyParser::new);
+    registerParser(Team.class, TeamParser::new);
+    registerParser(TypeFactory.parameterizedClass(Collection.class, Team.class), TeamsParser::new);
+    registerParser(PlayerClass.class, PlayerClassParser::new);
+    registerParser(Mode.class, ModeParser::new);
+    registerParser(ExposedAction.class, ExposedActionParser::new);
+    registerParser(
+        TypeFactory.parameterizedClass(Optional.class, VictoryCondition.class),
+        new VictoryConditionParser());
+    registerParser(SettingKey.class, new EnumParser<>(SettingKey.class, CommandKeys.SETTING_KEY));
+    registerParser(SettingValue.class, new SettingValueParser());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -134,31 +134,28 @@
         </dependency>
 
         <!-- Framework for defining and parsing commands -->
-        <!-- Version 1.8.0-pgm includes fixes/features not yet in upstream. To be changed when merged. -->
-        <!-- Source: https://github.com/Pablete1234/cloud/commits/1.8.0-pgm -->
-        <!-- Repo: https://repo.pgm.fyi/#/snapshots/cloud/commandframework -->
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-core</artifactId>
-            <version>1.8.0-pgm-SNAPSHOT</version>
+            <version>1.8.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-annotations</artifactId>
-            <version>1.8.0-pgm-SNAPSHOT</version>
+            <version>1.8.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-paper</artifactId>
-            <version>1.8.0-pgm-SNAPSHOT</version>
+            <version>1.8.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-minecraft-extras</artifactId>
-            <version>1.8.0-pgm-SNAPSHOT</version>
+            <version>1.8.1</version>
             <scope>compile</scope>
         </dependency>
         <!-- Allows registering brigadier mappings -->


### PR DESCRIPTION
Extracts pgm-specific logic from CommandGraph into PGMCommandGraph, so that the class can be re-used easier by other plugins, and also adds a Player parser for any command that is leftover using player and not match player