### PR TITLE
Only check .xml files in the map includes directory

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeProcessorImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeProcessorImpl.java
@@ -95,6 +95,7 @@ public class MapIncludeProcessorImpl implements MapIncludeProcessor {
     }
     File[] files = includeFiles.listFiles();
     for (File file : files) {
+      if (!file.getName().endsWith(".xml")) continue;
       try {
         MapIncludeImpl include = new MapIncludeImpl(file);
         this.includes.put(include.getId(), include);


### PR DESCRIPTION
Adds a safety check so only `.xml` files are parsed when loading map includes. At the moment this is not a breaking issue, as PGM does properly handle if a file within the directory can't be parsed (throws an error then continues loading). However it's probably safer to have this extra check in there to prevent user confusion. 


Signed-off-by: applenick <applenick@users.noreply.github.com>