### PR TITLE
Fix index out of bounds exception on velocity attribute parsing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/regions/RegionFilterApplicationParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionFilterApplicationParser.java
@@ -127,7 +127,7 @@ public class RegionFilterApplicationParser {
     if (attrVelocity != null) {
       // Legacy support
       String velocityText = attrVelocity.getValue();
-      if (velocityText.charAt(0) == '@') velocityText = velocityText.substring(1);
+      if (velocityText.startsWith("@")) velocityText = velocityText.substring(1);
       Vector velocity = XMLUtils.parseVector(attrVelocity, velocityText);
       add(el, new RegionFilterApplication(RFAScope.EFFECT, region, effectFilter, velocity));
     }


### PR DESCRIPTION
Fixes:
```
java.lang.StringIndexOutOfBoundsException: String index out of range: 0
	at java.lang.String.charAt(String.java:658) ~[?:1.8.0_352]
	at tc.oc.pgm.regions.RegionFilterApplicationParser.parse(RegionFilterApplicationParser.java:130) ~[?:?]
	at tc.oc.pgm.regions.RegionModule$Factory.parse(RegionModule.java:60) ~[?:?]
	at tc.oc.pgm.regions.RegionModule$Factory.parse(RegionModule.java:34) ~[?:?]
	at tc.oc.pgm.map.MapFactoryImpl.createModule(MapFactoryImpl.java:74) ~[?:?]
	at tc.oc.pgm.map.MapFactoryImpl.createModule(MapFactoryImpl.java:42) ~[?:?]
	at tc.oc.pgm.api.module.ModuleGraph.load(ModuleGraph.java:159) ~[?:?]
	at tc.oc.pgm.api.module.ModuleGraph.loadAll(ModuleGraph.java:47) ~[?:?]
	at tc.oc.pgm.map.MapFactoryImpl.load(MapFactoryImpl.java:112) ~[?:?]
	at tc.oc.pgm.map.MapLibraryImpl.loadMap(MapLibraryImpl.java:213) ~[?:?]
	at tc.oc.pgm.map.MapLibraryImpl.loadMapSafe(MapLibraryImpl.java:240) ~[?:?]
	at tc.oc.pgm.map.MapLibraryImpl.lambda$null$3(MapLibraryImpl.java:179) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) [?:1.8.0_352]
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948) [?:1.8.0_352]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) [?:1.8.0_352]
	at java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290) [?:1.8.0_352]
	at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731) [?:1.8.0_352]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289) [?:1.8.0_352]
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056) [?:1.8.0_352]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692) [?:1.8.0_352]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175) [?:1.8.0_352]
```
Which occurs when someone has an empty velocity argument in a region, ie: `velocity=""`