### PR TITLE
Fix vanish state and tablist

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -136,14 +136,6 @@ public interface MatchPlayer
   boolean isFrozen();
 
   /**
-   * Get whether the {@link MatchPlayer} is currently vanished. Determines whether to display to
-   * non-staff or not.
-   *
-   * @return Whether the {@link MatchPlayer} is vanished.
-   */
-  boolean isVanished();
-
-  /**
    * Get whether the {@link MatchPlayer} is using a legacy version (1.7.X)
    *
    * @return Whether the {@link MatchPlayer} is using a legacy version
@@ -215,13 +207,6 @@ public interface MatchPlayer
    * @param gameMode - The gamemode to set
    */
   void setGameMode(GameMode gameMode);
-
-  /**
-   * Mark the {@link MatchPlayer} as vanished or not.
-   *
-   * @param vanished - Whether the player is vanished
-   */
-  void setVanished(boolean vanished);
 
   /**
    * Get the protocol version of the {@link MatchPlayer}'s client

--- a/core/src/main/java/tc/oc/pgm/api/player/event/PlayerVanishEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/event/PlayerVanishEvent.java
@@ -7,14 +7,16 @@ import tc.oc.pgm.api.player.MatchPlayer;
 public class PlayerVanishEvent extends MatchPlayerEvent {
 
   private final boolean quiet;
+  private final boolean vanished;
 
   public PlayerVanishEvent(MatchPlayer vanisher, boolean vanished, boolean quiet) {
     super(vanisher);
     this.quiet = quiet;
+    this.vanished = vanished;
   }
 
   public boolean isVanished() {
-    return getPlayer().isVanished();
+    return vanished;
   }
 
   public boolean isQuiet() {

--- a/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
@@ -167,11 +167,11 @@ public final class MatchCommand {
     }
   }
 
-  private int getNonVanishedCount(Collection<MatchPlayer> players) {
+  private long getNonVanishedCount(Collection<MatchPlayer> players) {
     return players.stream()
         .map(MatchPlayer::getBukkit)
-        .mapToInt(p -> Integration.isVanished(p) ? 0 : 1)
-        .sum();
+        .filter(p -> !Integration.isVanished(p))
+        .count();
   }
 
   private MatchPlayer getMatchPlayer(CommandSender sender, Match match) {

--- a/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
@@ -24,6 +24,7 @@ import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchPhase;
 import tc.oc.pgm.api.party.Competitor;
@@ -81,10 +82,7 @@ public final class MatchCommand {
         msg.append(text(teamName, TextFormatter.convert(team.getColor())))
             .append(
                 text(": ", NamedTextColor.GRAY)
-                    .append(
-                        text(
-                            team.getPlayers().stream().filter(mp -> !mp.isVanished()).count(),
-                            NamedTextColor.WHITE)));
+                    .append(text(getNonVanishedCount(team.getPlayers()), NamedTextColor.WHITE)));
 
         if (team.getMaxPlayers() != Integer.MAX_VALUE) {
           msg.append(text("/" + team.getMaxPlayers(), NamedTextColor.GRAY));
@@ -110,10 +108,7 @@ public final class MatchCommand {
                     TextTranslations.translate("match.info.observers", sender),
                     NamedTextColor.AQUA))
             .append(text(": ", NamedTextColor.GRAY))
-            .append(
-                text(
-                    match.getObservers().stream().filter(mp -> !mp.isVanished()).count(),
-                    NamedTextColor.WHITE))
+            .append(text(getNonVanishedCount(match.getObservers()), NamedTextColor.WHITE))
             .build());
 
     viewer.sendMessage(
@@ -170,6 +165,13 @@ public final class MatchCommand {
     if (smm != null) {
       viewer.sendMessage(smm.getStatusMessage(getMatchPlayer(sender, match)));
     }
+  }
+
+  private int getNonVanishedCount(Collection<MatchPlayer> players) {
+    return players.stream()
+        .map(MatchPlayer::getBukkit)
+        .mapToInt(p -> Integration.isVanished(p) ? 0 : 1)
+        .sum();
   }
 
   private MatchPlayer getMatchPlayer(CommandSender sender, Match match) {

--- a/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
+++ b/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
@@ -84,7 +84,10 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
   public boolean setVanished(MatchPlayer player, boolean vanish, boolean quiet) {
     final Match match = player.getMatch();
 
-    // Call vanish event first so name renders existing state properly for leave msg
+    // Set vanish status in match player
+    player.setVanished(vanish);
+
+    // Call vanish event next so name renders existing state properly for leave msg
     if (vanish) match.callEvent(new PlayerVanishEvent(player, vanish, quiet));
 
     // Keep track of the UUID and apply/remove META data, so we can detect vanish status from other
@@ -99,9 +102,6 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
     if (vanish && player.getParty() instanceof Competitor) {
       match.setParty(player, match.getDefaultParty());
     }
-
-    // Set vanish status in match player
-    player.setVanished(vanish);
 
     // Reset visibility to hide/show player
     player.resetVisibility();

--- a/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
+++ b/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
@@ -84,9 +84,6 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
   public boolean setVanished(MatchPlayer player, boolean vanish, boolean quiet) {
     final Match match = player.getMatch();
 
-    // Set vanish status in match player
-    player.setVanished(vanish);
-
     // Call vanish event next so name renders existing state properly for leave msg
     if (vanish) match.callEvent(new PlayerVanishEvent(player, vanish, quiet));
 
@@ -149,11 +146,6 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
     if (!player.getBukkit().hasPermission(Permissions.VANISH))
       return; // Do not vanish players with no perms
 
-    if (isVanished(player.getId())) {
-      player.setVanished(true);
-      return;
-    }
-
     // Automatic vanish if player logs in via a "vanish" subdomain
     String domain = loginSubdomains.getIfPresent(player.getId());
     if (domain != null) {
@@ -188,8 +180,6 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
     if (event.getInitialParty() instanceof Competitor) {
       setVanished(player, false, false);
     }
-
-    player.setVanished(isVanished(player.getId()));
   }
 
   private boolean isVanishSubdomain(String address) {

--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
@@ -101,7 +102,7 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
     }
 
     // Don't allow vanished players to join
-    if (joining.isVanished()) {
+    if (Integration.isVanished(joining.getBukkit())) {
       return GenericJoinResult.Status.VANISHED.toResult();
     }
 
@@ -160,7 +161,7 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
 
   @Override
   public boolean forceJoin(MatchPlayer joining, @Nullable Competitor forcedParty) {
-    if (joining.isVanished()) return join(joining, forcedParty);
+    if (Integration.isVanished(joining.getBukkit())) return join(joining, forcedParty);
 
     for (JoinHandler handler : handlers) {
       if (handler.forceJoin(joining, forcedParty)) return true;

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -106,7 +106,7 @@ public class ChatDispatcher implements Listener {
   @CommandDescription("Send a message to everyone")
   public void sendGlobal(
       Match match, @NotNull MatchPlayer sender, @Argument("message") @Greedy String message) {
-    if (sender.isVanished()) {
+    if (Integration.isVanished(sender.getBukkit())) {
       sendAdmin(match, sender, message);
       return;
     }
@@ -128,7 +128,7 @@ public class ChatDispatcher implements Listener {
   @CommandDescription("Send a message to your team")
   public void sendTeam(
       Match match, @NotNull MatchPlayer sender, @Argument("message") @Greedy String message) {
-    if (sender.isVanished()) {
+    if (Integration.isVanished(sender.getBukkit())) {
       sendAdmin(match, sender, message);
       return;
     }

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -202,7 +202,8 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
         spectatorTarget != null && spectatorTarget.getId().equals(other.getId());
     if (!other.isVisible() && !isSpectatorTarget) return false;
     if (other.isParticipating()) return true;
-    if (Integration.isVanished(other.getBukkit()) && !getBukkit().hasPermission(Permissions.VANISH)) return false;
+    if (Integration.isVanished(other.getBukkit()) && !getBukkit().hasPermission(Permissions.VANISH))
+      return false;
     SettingValue setting = getSettings().getValue(SettingKey.OBSERVERS);
     boolean friendsOnly =
         Integration.isFriend(getBukkit(), other.getBukkit())

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -78,7 +78,6 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
   private final AtomicBoolean visible;
   private final AtomicBoolean protocolReady;
   private final AtomicInteger protocolVersion;
-  private final AtomicBoolean vanished;
   private final AttributeMap attributeMap;
 
   public MatchPlayerImpl(Match match, Player player) {
@@ -93,7 +92,6 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     this.frozen = new AtomicBoolean(false);
     this.dead = new AtomicBoolean(false);
     this.visible = new AtomicBoolean(false);
-    this.vanished = new AtomicBoolean(false);
     this.protocolReady = new AtomicBoolean(ViaUtils.isReady(player));
     this.protocolVersion = new AtomicInteger(ViaUtils.getProtocolVersion(player));
     this.attributeMap = new AttributeMapImpl(player);
@@ -193,11 +191,6 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
   }
 
   @Override
-  public boolean isVanished() {
-    return vanished.get();
-  }
-
-  @Override
   public boolean canInteract() {
     return isAlive() && !isFrozen();
   }
@@ -209,7 +202,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
         spectatorTarget != null && spectatorTarget.getId().equals(other.getId());
     if (!other.isVisible() && !isSpectatorTarget) return false;
     if (other.isParticipating()) return true;
-    if (other.isVanished() && !getBukkit().hasPermission(Permissions.VANISH)) return false;
+    if (Integration.isVanished(other.getBukkit()) && !getBukkit().hasPermission(Permissions.VANISH)) return false;
     SettingValue setting = getSettings().getValue(SettingKey.OBSERVERS);
     boolean friendsOnly =
         Integration.isFriend(getBukkit(), other.getBukkit())
@@ -342,11 +335,6 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
   @Override
   public void setGameMode(GameMode gameMode) {
     getBukkit().setGameMode(gameMode);
-  }
-
-  @Override
-  public void setVanished(boolean yes) {
-    vanished.set(yes);
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/tablist/MatchTabView.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchTabView.java
@@ -14,6 +14,7 @@ import org.bukkit.event.Listener;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.Party;
@@ -322,8 +323,8 @@ public class MatchTabView extends TabView implements Listener {
 
   private boolean shouldHide(MatchPlayer other) {
     return other != matchPlayer
-        && other.isVanished()
-        && !matchPlayer.getBukkit().hasPermission(Permissions.STAFF);
+        && Integration.isVanished(other.getBukkit())
+        && !matchPlayer.getBukkit().hasPermission(Permissions.VANISH);
   }
 
   private static int divideRoundingUp(int numerator, int denominator) {

--- a/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -29,6 +29,7 @@ import org.bukkit.event.Listener;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
@@ -293,7 +294,7 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
     Party oldTeam = player.getParty();
     if (oldTeam == newTeam) return true;
 
-    if (!player.isVanished() && match.setParty(player, newTeam)) {
+    if (!Integration.isVanished(player.getBukkit()) && match.setParty(player, newTeam)) {
       setAutoJoin(player, autoJoin);
       return true;
     } else {

--- a/core/src/main/java/tc/oc/pgm/util/player/PlayerData.java
+++ b/core/src/main/java/tc/oc/pgm/util/player/PlayerData.java
@@ -72,7 +72,7 @@ class PlayerData {
     MatchPlayer mp = player != null ? PGM.get().getMatchManager().getPlayer(player) : null;
     this.teamColor = mp == null ? PlayerComponent.OFFLINE_COLOR : mp.getParty().getTextColor();
     this.dead = mp != null && mp.isDead();
-    this.vanish = mp != null && mp.isVanished();
+    this.vanish = mp != null && Integration.isVanished(mp.getBukkit());
     this.online = player != null && player.isOnline();
     this.conceal = true;
     this.style = style;

--- a/util/src/main/java/tc/oc/pgm/util/tablist/PlayerTabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/PlayerTabEntry.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.event.player.PlayerSkinPartsChangeEvent;
 import tc.oc.pgm.util.nms.NMSHacks;
 import tc.oc.pgm.util.skin.Skin;
@@ -71,8 +70,18 @@ public class PlayerTabEntry extends DynamicTabEntry {
   }
 
   @Override
-  public @Nullable Skin getSkin(TabView view) {
-    return NMSHacks.getPlayerSkin(this.player);
+  public Skin getSkin(TabView view) {
+    Player viewer = view.getViewer();
+    if (viewer == null) {
+      return null;
+    }
+
+    // TODO: find different solution for non-SportPaper servers
+    return this.player.hasFakeSkin(viewer)
+        ? new Skin(
+            this.player.getFakeSkin(viewer).getData(),
+            this.player.getFakeSkin(viewer).getSignature())
+        : NMSHacks.getPlayerSkin(this.player);
   }
 
   @Override


### PR DESCRIPTION
Another fix! This PR fixes `/vanish` incorrectly setting the MatchPlayer vanish state after the `PlayerVanishEvent` is called. Also provides the proper fake skin to the `PlayerTabEntry` as the logic under the NMSHacks method does not take into account the skin magic SportPaper does. We'll need to further address that at a later date to better accommodate multi-version support.


Update: see comments below for new logic, primary change now is the removal of the `vanished` state from MatchPlayer.

Signed-off-by: applenick <applenick@users.noreply.github.com>