### PR TITLE
Prevent /reply revealing vanished players

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -448,10 +448,10 @@ public class ChatDispatcher implements Listener {
     String lastKnownName = targetIdent.getName();
     String currentName = Players.getVisibleName(sender, target.getBukkit());
 
-    boolean reveal = Players.shouldReveal(sender, target.getBukkit());
+    // Ensure the target is visible to the viewing sender
     boolean visible = Players.isVisible(sender, target.getBukkit());
 
-    if ((currentName.equalsIgnoreCase(lastKnownName) && visible) || reveal) {
+    if (currentName.equalsIgnoreCase(lastKnownName) && visible) {
       return target.getId();
     }
 

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -261,10 +261,22 @@ public class ChatDispatcher implements Listener {
   @CommandDescription("Reply to a direct message")
   public void sendReply(
       Match match, @NotNull MatchPlayer sender, @Argument("message") @Greedy String message) {
-    final MatchPlayer receiver = manager.getPlayer(lastMessagedBy.get(sender.getBukkit()));
+    MatchPlayer receiver = manager.getPlayer(getLastMessagedUser(sender.getBukkit()));
     if (receiver == null) throw exception("command.message.noReply", text("/msg"));
 
     sendDirect(match, sender, receiver, message);
+  }
+
+  private UUID getLastMessagedUser(Player sender) {
+    UUID targetId = lastMessagedBy.get(sender);
+    MatchPlayer target = manager.getPlayer(targetId);
+
+    // Prevent replying to vanished players
+    if (target == null || Integration.isVanished(target.getBukkit())) {
+      return null;
+    }
+
+    return targetId;
   }
 
   @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -108,6 +108,8 @@ command.message.noReply = Did not find a message to reply to, use {0}
 # {0} = player name
 command.message.blocked = {0} is not accepting messages at this time.
 
+command.message.self = You may not message yourself!
+
 # {0} = map name
 command.maps.hover = Click to view {0}
 


### PR DESCRIPTION
Another fix! This PR prevents `/reply` revealing vanished players 👻 Was discovered due to the new ability to be vanished and nicked at the same time. 


Signed-off-by: applenick <applenick@users.noreply.github.com>