### PR TITLE
Fix removal of spaces from name in team parser

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/parsers/TeamParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/TeamParser.java
@@ -23,7 +23,7 @@ public final class TeamParser extends MatchObjectParser<Team, TeamMatchModule> {
 
   @Override
   protected String getName(Team obj) {
-    return obj.getNameLegacy().replace(" ", "");
+    return obj.getNameLegacy();
   }
 
   @Override


### PR DESCRIPTION
Team name suggestions are getting compacted with spaces removed.

In an instance where the team name is "Purple Pirates" trying to join using the below command does not currently work.

`/join Purple Pirates` doesn't match a team and trying to tab the name will return it as `join PurplePirates`.

This fixes the above and means that tabbed names will display like "Purple–Pirates" the same as with map names.

Signed-off-by: Pugzy <pugzy@mail.com>