### PR TITLE
Add consumables

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -20,6 +20,8 @@ import tc.oc.pgm.broadcast.BroadcastMatchModule;
 import tc.oc.pgm.broadcast.BroadcastModule;
 import tc.oc.pgm.classes.ClassMatchModule;
 import tc.oc.pgm.classes.ClassModule;
+import tc.oc.pgm.consumable.ConsumableMatchModule;
+import tc.oc.pgm.consumable.ConsumableModule;
 import tc.oc.pgm.controlpoint.ControlPointMatchModule;
 import tc.oc.pgm.controlpoint.ControlPointModule;
 import tc.oc.pgm.core.CoreMatchModule;
@@ -291,6 +293,7 @@ public final class Modules {
         new FallingBlocksModule.Factory());
     register(FlagModule.class, FlagMatchModule.class, new FlagModule.Factory());
     register(ProjectileModule.class, ProjectileMatchModule.class, new ProjectileModule.Factory());
+    register(ConsumableModule.class, ConsumableMatchModule.class, new ConsumableModule.Factory());
     register(
         DiscardPotionBottlesModule.class,
         DiscardPotionBottlesMatchModule.class,

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableDefinition.java
@@ -1,0 +1,37 @@
+package tc.oc.pgm.consumable;
+
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.action.Action;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+
+public class ConsumableDefinition extends SelfIdentifyingFeatureDefinition {
+
+  private final Action<? super MatchPlayer> action;
+  private final ConsumeCause cause;
+  /** If true, replaces vanilla behaviour, otherwise keeps vanilla behaviour */
+  private final boolean preventDefault;
+
+  public ConsumableDefinition(
+      @Nullable String id,
+      Action<? super MatchPlayer> action,
+      ConsumeCause cause,
+      boolean preventDefault) {
+    super(id);
+    this.action = action;
+    this.cause = cause;
+    this.preventDefault = preventDefault;
+  }
+
+  public Action<? super MatchPlayer> getAction() {
+    return action;
+  }
+
+  public ConsumeCause getCause() {
+    return cause;
+  }
+
+  public boolean getPreventDefault() {
+    return preventDefault;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableDefinition.java
@@ -10,17 +10,17 @@ public class ConsumableDefinition extends SelfIdentifyingFeatureDefinition {
   private final Action<? super MatchPlayer> action;
   private final ConsumeCause cause;
   /** If true, replaces vanilla behaviour, otherwise keeps vanilla behaviour */
-  private final boolean preventDefault;
+  private final boolean override;
 
   public ConsumableDefinition(
       @Nullable String id,
       Action<? super MatchPlayer> action,
       ConsumeCause cause,
-      boolean preventDefault) {
+      boolean override) {
     super(id);
     this.action = action;
     this.cause = cause;
-    this.preventDefault = preventDefault;
+    this.override = override;
   }
 
   public Action<? super MatchPlayer> getAction() {
@@ -31,7 +31,7 @@ public class ConsumableDefinition extends SelfIdentifyingFeatureDefinition {
     return cause;
   }
 
-  public boolean getPreventDefault() {
-    return preventDefault;
+  public boolean getOverride() {
+    return override;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
@@ -10,8 +10,9 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.kits.tag.ItemTags;
+import tc.oc.pgm.util.MatchPlayers;
+import tc.oc.pgm.util.inventory.InventoryUtils;
 
 public class ConsumableMatchModule implements MatchModule, Listener {
 
@@ -32,16 +33,10 @@ public class ConsumableMatchModule implements MatchModule, Listener {
 
     Player player = event.getPlayer();
     MatchPlayer matchPlayer = match.getPlayer(player);
-    ParticipantState playerState = match.getParticipantState(player);
-    if (matchPlayer == null || playerState == null) return;
+    if (!MatchPlayers.canInteract(matchPlayer)) return;
 
-    if (consumableDefinition.getPreventDefault()) {
-      ItemStack itemInHand = player.getItemInHand();
-      if (itemInHand.getAmount() > 1) {
-        itemInHand.setAmount(itemInHand.getAmount() - 1);
-      } else {
-        player.setItemInHand(null);
-      }
+    if (consumableDefinition.getOverride()) {
+      InventoryUtils.consumeItem(player);
       event.setCancelled(true);
     }
 

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
@@ -1,0 +1,63 @@
+package tc.oc.pgm.consumable;
+
+import com.google.common.collect.ImmutableSet;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.player.ParticipantState;
+import tc.oc.pgm.kits.tag.ItemTags;
+
+public class ConsumableMatchModule implements MatchModule, Listener {
+
+  private final Match match;
+  private final ImmutableSet<ConsumableDefinition> consumableDefinitions;
+
+  public ConsumableMatchModule(
+      Match match, ImmutableSet<ConsumableDefinition> consumableDefinitions) {
+    this.match = match;
+    this.consumableDefinitions = consumableDefinitions;
+  }
+
+  @EventHandler
+  private void onItemConsume(PlayerItemConsumeEvent event) {
+    ConsumableDefinition consumableDefinition = getConsumableDefinition(event.getItem());
+    if (consumableDefinition == null) return;
+    if (consumableDefinition.getCause() != ConsumeCause.EAT) return;
+
+    Player player = event.getPlayer();
+    MatchPlayer matchPlayer = match.getPlayer(player);
+    ParticipantState playerState = match.getParticipantState(player);
+    if (playerState == null) return;
+
+    if (consumableDefinition.getPreventDefault()) {
+      ItemStack itemInHand = player.getItemInHand();
+      if (itemInHand.getAmount() > 1) {
+        itemInHand.setAmount(itemInHand.getAmount() - 1);
+      } else {
+        player.setItemInHand(null);
+      }
+      event.setCancelled(true);
+    }
+
+    consumableDefinition.getAction().trigger(matchPlayer);
+  }
+
+  private @Nullable ConsumableDefinition getConsumableDefinition(ItemStack item) {
+    String consumableId = ItemTags.CONSUMABLE.get(item);
+    if (consumableId != null) {
+      for (ConsumableDefinition consumableDefinition : consumableDefinitions) {
+        if (consumableDefinition.getId().equals(consumableId)) {
+          return consumableDefinition;
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
@@ -33,7 +33,7 @@ public class ConsumableMatchModule implements MatchModule, Listener {
     Player player = event.getPlayer();
     MatchPlayer matchPlayer = match.getPlayer(player);
     ParticipantState playerState = match.getParticipantState(player);
-    if (playerState == null) return;
+    if (matchPlayer == null || playerState == null) return;
 
     if (consumableDefinition.getPreventDefault()) {
       ItemStack itemInHand = player.getItemInHand();

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
@@ -51,22 +51,13 @@ public class ConsumableModule implements MapModule<ConsumableMatchModule> {
 
       Set<ConsumableDefinition> consumableDefinitions = new HashSet<>();
 
-      List<Element> consumableElements =
-          XMLUtils.flattenElements(doc.getRootElement(), "consumables", "consumable");
-      if (consumableElements.size() == 0) return null;
-
-      for (Element consumableElement : consumableElements) {
+      for (Element consumableElement : XMLUtils.flattenElements(doc.getRootElement(), "consumables", "consumable")) {
         String id = XMLUtils.getRequiredAttribute(consumableElement, "id").getValue();
         boolean preventDefault =
             XMLUtils.parseBoolean(consumableElement.getAttribute("prevent-default"), true);
 
-        Action<? super MatchPlayer> action;
-        Node actionNode = Node.fromAttr(consumableElement, "action", "kit");
-        if (actionNode != null) {
-          action = actionParser.parseReference(actionNode, null, MatchPlayer.class);
-        } else {
-          action = KitNode.EMPTY;
-        }
+        Node actionNode = Node.fromRequiredAttr(consumableElement, "action", "kit");
+        Action<? super MatchPlayer> action = actionParser.parseReference(actionNode, MatchPlayer.class);
 
         ConsumeCause cause =
             XMLUtils.parseEnum(
@@ -82,6 +73,7 @@ public class ConsumableModule implements MapModule<ConsumableMatchModule> {
         consumableDefinitions.add(consumableDefinition);
       }
 
+      if (consumableDefinitions.isEmpty()) return null;
       return new ConsumableModule(ImmutableSet.copyOf(consumableDefinitions));
     }
   }

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 import org.jdom2.Document;
@@ -50,8 +51,11 @@ public class ConsumableModule implements MapModule<ConsumableMatchModule> {
 
       Set<ConsumableDefinition> consumableDefinitions = new HashSet<>();
 
-      for (Element consumableElement :
-          XMLUtils.flattenElements(doc.getRootElement(), "consumables", "consumable")) {
+      List<Element> consumableElements =
+          XMLUtils.flattenElements(doc.getRootElement(), "consumables", "consumable");
+      if (consumableElements.size() == 0) return null;
+
+      for (Element consumableElement : consumableElements) {
         String id = XMLUtils.getRequiredAttribute(consumableElement, "id").getValue();
         boolean preventDefault =
             XMLUtils.parseBoolean(consumableElement.getAttribute("prevent-default"), true);

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
@@ -1,0 +1,84 @@
+package tc.oc.pgm.consumable;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.action.Action;
+import tc.oc.pgm.action.ActionModule;
+import tc.oc.pgm.action.ActionParser;
+import tc.oc.pgm.api.map.MapModule;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.map.factory.MapModuleFactory;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.kits.KitNode;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLUtils;
+
+public class ConsumableModule implements MapModule<ConsumableMatchModule> {
+
+  private final ImmutableSet<ConsumableDefinition> consumableDefinitions;
+
+  private ConsumableModule(ImmutableSet<ConsumableDefinition> consumableDefinitions) {
+    this.consumableDefinitions = consumableDefinitions;
+  }
+
+  @Override
+  public @Nullable ConsumableMatchModule createMatchModule(Match match) throws ModuleLoadException {
+    return new ConsumableMatchModule(match, consumableDefinitions);
+  }
+
+  public static class Factory implements MapModuleFactory<ConsumableModule> {
+
+    @Override
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
+      return ImmutableList.of(ActionModule.class);
+    }
+
+    @Override
+    public @Nullable ConsumableModule parse(MapFactory factory, Logger logger, Document doc)
+        throws InvalidXMLException {
+      ActionParser actionParser = new ActionParser(factory);
+
+      Set<ConsumableDefinition> consumableDefinitions = new HashSet<>();
+
+      for (Element consumableElement :
+          XMLUtils.flattenElements(doc.getRootElement(), "consumables", "consumable")) {
+        String id = XMLUtils.getRequiredAttribute(consumableElement, "id").getValue();
+        boolean preventDefault =
+            XMLUtils.parseBoolean(consumableElement.getAttribute("prevent-default"), true);
+
+        Action<? super MatchPlayer> action;
+        Node actionNode = Node.fromAttr(consumableElement, "action", "kit");
+        if (actionNode != null) {
+          action = actionParser.parseReference(actionNode, null, MatchPlayer.class);
+        } else {
+          action = KitNode.EMPTY;
+        }
+
+        ConsumeCause cause =
+            XMLUtils.parseEnum(
+                Node.fromAttr(consumableElement, "on"),
+                ConsumeCause.class,
+                "consume cause",
+                ConsumeCause.EAT);
+
+        ConsumableDefinition consumableDefinition =
+            new ConsumableDefinition(id, action, cause, preventDefault);
+
+        factory.getFeatures().addFeature(consumableElement, consumableDefinition);
+        consumableDefinitions.add(consumableDefinition);
+      }
+
+      return new ConsumableModule(ImmutableSet.copyOf(consumableDefinitions));
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
@@ -60,10 +60,9 @@ public class ConsumableModule implements MapModule<ConsumableMatchModule> {
 
         ConsumeCause cause =
             XMLUtils.parseEnum(
-                Node.fromAttr(consumableElement, "on"),
+                Node.fromRequiredAttr(consumableElement, "on"),
                 ConsumeCause.class,
-                "consume cause",
-                ConsumeCause.EAT);
+                "consume cause");
 
         ConsumableDefinition consumableDefinition =
             new ConsumableDefinition(id, action, cause, override);

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableModule.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 import org.jdom2.Document;
@@ -19,7 +18,6 @@ import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.kits.KitNode;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
@@ -51,13 +49,14 @@ public class ConsumableModule implements MapModule<ConsumableMatchModule> {
 
       Set<ConsumableDefinition> consumableDefinitions = new HashSet<>();
 
-      for (Element consumableElement : XMLUtils.flattenElements(doc.getRootElement(), "consumables", "consumable")) {
+      for (Element consumableElement :
+          XMLUtils.flattenElements(doc.getRootElement(), "consumables", "consumable")) {
         String id = XMLUtils.getRequiredAttribute(consumableElement, "id").getValue();
-        boolean preventDefault =
-            XMLUtils.parseBoolean(consumableElement.getAttribute("prevent-default"), true);
+        boolean override = XMLUtils.parseBoolean(consumableElement.getAttribute("override"), true);
 
         Node actionNode = Node.fromRequiredAttr(consumableElement, "action", "kit");
-        Action<? super MatchPlayer> action = actionParser.parseReference(actionNode, MatchPlayer.class);
+        Action<? super MatchPlayer> action =
+            actionParser.parseReference(actionNode, MatchPlayer.class);
 
         ConsumeCause cause =
             XMLUtils.parseEnum(
@@ -67,7 +66,7 @@ public class ConsumableModule implements MapModule<ConsumableMatchModule> {
                 ConsumeCause.EAT);
 
         ConsumableDefinition consumableDefinition =
-            new ConsumableDefinition(id, action, cause, preventDefault);
+            new ConsumableDefinition(id, action, cause, override);
 
         factory.getFeatures().addFeature(consumableElement, consumableDefinition);
         consumableDefinitions.add(consumableDefinition);

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumeCause.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumeCause.java
@@ -1,0 +1,5 @@
+package tc.oc.pgm.consumable;
+
+public enum ConsumeCause {
+  EAT
+}

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -40,6 +40,7 @@ import tc.oc.pgm.action.ActionParser;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.consumable.ConsumableDefinition;
 import tc.oc.pgm.doublejump.DoubleJumpKit;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.kits.tag.Grenade;
@@ -599,6 +600,16 @@ public abstract class KitParser {
               .getId());
       String name = itemStack.getItemMeta().getDisplayName();
       ItemTags.ORIGINAL_NAME.set(itemStack, name != null ? name : "");
+    }
+
+    Node consumableNode = Node.fromAttr(el, "consumable");
+    if (consumableNode != null) {
+      ItemTags.CONSUMABLE.set(
+          itemStack,
+          factory
+              .getFeatures()
+              .createReference(consumableNode, ConsumableDefinition.class)
+              .getId());
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/kits/tag/ItemTags.java
+++ b/core/src/main/java/tc/oc/pgm/kits/tag/ItemTags.java
@@ -6,6 +6,7 @@ public class ItemTags {
 
   public static final ItemTag<Boolean> PREVENT_SHARING = ItemTag.newBoolean("prevent-sharing");
   public static final ItemTag<String> PROJECTILE = ItemTag.newString("projectile");
+  public static final ItemTag<String> CONSUMABLE = ItemTag.newString("consumable");
   public static final ItemTag<String> ORIGINAL_NAME = ItemTag.newString("original-name");
   public static final ItemTag<Boolean> INFINITE = ItemTag.newBoolean("infinite");
 

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -41,6 +41,7 @@ import tc.oc.pgm.filters.query.BlockQuery;
 import tc.oc.pgm.filters.query.PlayerBlockQuery;
 import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
+import tc.oc.pgm.util.inventory.InventoryUtils;
 import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
@@ -121,12 +122,7 @@ public class ProjectileMatchModule implements MatchModule, Listener {
       }
 
       if (projectileDefinition.throwable) {
-        ItemStack itemInHand = player.getItemInHand();
-        if (itemInHand.getAmount() > 1) {
-          itemInHand.setAmount(itemInHand.getAmount() - 1);
-        } else {
-          player.setItemInHand(null);
-        }
+        InventoryUtils.consumeItem(player);
       }
 
       if (projectileDefinition.coolDown != null) {

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -150,4 +150,13 @@ public final class InventoryUtils {
     // TODO: Newer versions of Bukkit can use HumanEntity#openMerchant(Merchant, boolean)
     viewer.openMerchantCopy(villager);
   }
+
+  public static void consumeItem(Player player) {
+    ItemStack itemInHand = player.getItemInHand();
+    if (itemInHand.getAmount() > 1) {
+      itemInHand.setAmount(itemInHand.getAmount() - 1);
+    } else {
+      player.setItemInHand(null);
+    }
+  }
 }


### PR DESCRIPTION
This allows kits to be applied when eating some food item. Currently it's fairly limited but should be easy to expand in the future, if we want. Some example XML:

```xml
<kits>
    <kit id="spawn">
        <item slot="1" amount="1" damage="1" consumable="fast-apple">golden apple</item>
    </kit>
    <kit id="fast-apple-kit">
        <potion duration="4" amplifier="10">speed</potion>
    </kit>
</kits>
<consumables>
    <consumable id="fast-apple" action="fast-apple-kit"/>
</consumables>
```
or with defaults explicitly specified:
```xml
<consumable id="fast-apple" action="fast-apple-kit" on="eat" override="true"/>
```

`action` specifies the player-scoped action to apply on consumption. You can also use `kit` instead, but the result is the exact same.

`on` specifies how you use the consumable. `eat` is currently the only option, but later we could add click-to-eat consumables.

`override` specifies if it should override vanilla behaviour. For example, if `override` is `false`, this will also give you the vanilla golden apple effects and hunger restoration, but if it is `true` it will override vanilla behavior meaning the only result will be what's specified in the action/kit.

Much of this code is based on the similar `projectiles` module.