### PR TITLE
Cleanup score & projectile module parsing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.projectile;
 
 import static tc.oc.pgm.util.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.Set;
 import org.bukkit.Material;
@@ -54,12 +55,13 @@ public class ProjectileMatchModule implements MatchModule, Listener {
   private static final ThreadLocal<ProjectileDefinition> launchingDefinition = new ThreadLocal<>();
 
   private final Match match;
-  private final Set<ProjectileDefinition> projectileDefinitions;
-  private Set<ProjectileCooldown> projectileCooldowns = new HashSet<>();
+  private final ImmutableSet<ProjectileDefinition> projectileDefinitions;
+  private final Set<ProjectileCooldown> projectileCooldowns = new HashSet<>();
 
   private static final String DEFINITION_KEY = "projectileDefinition";
 
-  public ProjectileMatchModule(Match match, Set<ProjectileDefinition> projectileDefinitions) {
+  public ProjectileMatchModule(
+      Match match, ImmutableSet<ProjectileDefinition> projectileDefinitions) {
     this.match = match;
     this.projectileDefinitions = projectileDefinitions;
   }

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.projectile;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
@@ -25,7 +26,11 @@ import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class ProjectileModule implements MapModule<ProjectileMatchModule> {
-  Set<ProjectileDefinition> projectileDefinitions = new HashSet<>();
+  private final ImmutableSet<ProjectileDefinition> projectileDefinitions;
+
+  public ProjectileModule(ImmutableSet<ProjectileDefinition> projectileDefinitions) {
+    this.projectileDefinitions = projectileDefinitions;
+  }
 
   @Override
   public ProjectileMatchModule createMatchModule(Match match) {
@@ -41,7 +46,7 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
     @Override
     public ProjectileModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
-      ProjectileModule projectileModule = new ProjectileModule();
+      Set<ProjectileDefinition> projectiles = new HashSet<>();
       KitParser kitParser = factory.getKits();
       FilterParser filterParser = factory.getFilters();
 
@@ -86,10 +91,10 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
                 precise);
 
         factory.getFeatures().addFeature(projectileElement, projectileDefinition);
-        projectileModule.projectileDefinitions.add(projectileDefinition);
+        projectiles.add(projectileDefinition);
       }
 
-      return projectileModule;
+      return projectiles.isEmpty() ? null : new ProjectileModule(ImmutableSet.copyOf(projectiles));
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/score/ScoreConfig.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreConfig.java
@@ -3,10 +3,25 @@ package tc.oc.pgm.score;
 import tc.oc.pgm.api.filter.Filter;
 
 public class ScoreConfig {
-  public int scoreLimit = -1;
-  public int deathScore;
-  public int killScore;
-  public int mercyLimit;
-  public int mercyLimitMin;
-  public Filter scoreboardFilter;
+  public final int scoreLimit;
+  public final int deathScore;
+  public final int killScore;
+  public final int mercyLimit;
+  public final int mercyLimitMin;
+  public final Filter scoreboardFilter;
+
+  public ScoreConfig(
+      int scoreLimit,
+      int deathScore,
+      int killScore,
+      int mercyLimit,
+      int mercyLimitMin,
+      Filter scoreboardFilter) {
+    this.scoreLimit = scoreLimit;
+    this.deathScore = deathScore;
+    this.killScore = killScore;
+    this.mercyLimit = mercyLimit;
+    this.mercyLimitMin = mercyLimitMin;
+    this.scoreboardFilter = scoreboardFilter;
+  }
 }


### PR DESCRIPTION
Fixes them parsing to mutable objects which can lead to bugs if they're ever later edited at match-time. They now follow the convention of the rest of pgm, which parses to immutable objects.