### PR TITLE
Fix friend only settings for observers and messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -206,10 +206,13 @@ public class ChatDispatcher implements Listener {
 
     if (!sender.getBukkit().hasPermission(Permissions.STAFF)) {
       if (option.equals(SettingValue.MESSAGE_OFF))
-        throw exception("command.message.blocked", receiver.getName(NameStyle.FANCY));
+        throw exception("command.message.blocked", receiver.getName());
 
-      if (isMuted(receiver))
-        throw exception("moderation.mute.target", receiver.getName(NameStyle.FANCY));
+      if (option.equals(SettingValue.MESSAGE_FRIEND)
+          && !Integration.isFriend(receiver.getBukkit(), sender.getBukkit()))
+        throw exception("command.message.friendsOnly", receiver.getName());
+
+      if (isMuted(receiver)) throw exception("moderation.mute.target", receiver.getName());
     }
 
     trackMessage(receiver.getBukkit(), sender.getBukkit());

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
+import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.party.Competitor;
@@ -209,8 +210,11 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     if (!other.isVisible() && !isSpectatorTarget) return false;
     if (other.isParticipating()) return true;
     if (other.isVanished() && !getBukkit().hasPermission(Permissions.VANISH)) return false;
-    return isObserving()
-        && getSettings().getValue(SettingKey.OBSERVERS) == SettingValue.OBSERVERS_ON;
+    SettingValue setting = getSettings().getValue(SettingKey.OBSERVERS);
+    boolean friendsOnly =
+        Integration.isFriend(getBukkit(), other.getBukkit())
+            && setting == SettingValue.OBSERVERS_FRIEND;
+    return isObserving() && (setting == SettingValue.OBSERVERS_ON || friendsOnly);
   }
 
   @Override


### PR DESCRIPTION
Another day, another bug fix! This time related to the friends option not being properly applied to observers and private messages. Changes are pretty straightforward and should work as intended. Let me know if there's any additional suggestions 👍 



Signed-off-by: applenick <applenick@users.noreply.github.com>