### PR TITLE
Add health display

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -103,6 +103,7 @@ import tc.oc.pgm.renewable.RenewableModule;
 import tc.oc.pgm.score.ScoreMatchModule;
 import tc.oc.pgm.score.ScoreModule;
 import tc.oc.pgm.scoreboard.ScoreboardMatchModule;
+import tc.oc.pgm.scoreboard.ScoreboardModule;
 import tc.oc.pgm.scoreboard.SidebarMatchModule;
 import tc.oc.pgm.shield.ShieldMatchModule;
 import tc.oc.pgm.shops.ShopMatchModule;
@@ -223,13 +224,13 @@ public final class Modules {
 
     // MatchModules that require other dependencies
     register(GoalMatchModule.class, new GoalMatchModule.Factory());
-    register(ScoreboardMatchModule.class, new ScoreboardMatchModule.Factory());
     register(JoinMatchModule.class, new JoinMatchModule.Factory());
     register(StartMatchModule.class, new StartMatchModule.Factory());
     register(SidebarMatchModule.class, new SidebarMatchModule.Factory());
     register(PickerMatchModule.class, new PickerMatchModule.Factory());
 
     // MapModules that create a MatchModule
+    register(ScoreboardModule.class, ScoreboardMatchModule.class, new ScoreboardModule.Factory());
     register(VariablesModule.class, VariablesMatchModule.class, new VariablesModule.Factory());
     register(TeamModule.class, TeamMatchModule.class, new TeamModule.Factory());
     register(FreeForAllModule.class, FreeForAllMatchModule.class, new FreeForAllModule.Factory());

--- a/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardDisplayItem.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardDisplayItem.java
@@ -1,0 +1,6 @@
+package tc.oc.pgm.scoreboard;
+
+public enum ScoreboardDisplayItem {
+  NONE,
+  HEALTH
+}

--- a/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardModule.java
@@ -1,0 +1,57 @@
+package tc.oc.pgm.scoreboard;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.logging.Logger;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.map.MapModule;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.map.factory.MapModuleFactory;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.ffa.FreeForAllModule;
+import tc.oc.pgm.teams.TeamModule;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.XMLUtils;
+
+public class ScoreboardModule implements MapModule<ScoreboardMatchModule> {
+
+  private final ScoreboardDisplayItem belowName;
+
+  private ScoreboardModule(ScoreboardDisplayItem belowName) {
+    this.belowName = belowName;
+  }
+
+  public static class Factory implements MapModuleFactory<ScoreboardModule> {
+
+    @Override
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
+      return ImmutableList.of(TeamModule.class, FreeForAllModule.class);
+    }
+
+    @Override
+    public @Nullable ScoreboardModule parse(MapFactory factory, Logger logger, Document doc)
+        throws InvalidXMLException {
+      Element elScoreboard = doc.getRootElement().getChild("scoreboard");
+
+      ScoreboardDisplayItem belowName = ScoreboardDisplayItem.NONE;
+
+      if (elScoreboard != null) {
+        belowName =
+            XMLUtils.parseEnum(
+                elScoreboard.getAttribute("below-name"),
+                ScoreboardDisplayItem.class,
+                "scoreboard display item");
+      }
+
+      return new ScoreboardModule(belowName);
+    }
+  }
+
+  @Override
+  public @Nullable ScoreboardMatchModule createMatchModule(Match match) throws ModuleLoadException {
+    return new ScoreboardMatchModule(match, belowName);
+  }
+}


### PR DESCRIPTION
This adds an optional health display below players' names, with the following syntax:

```xml
<scoreboard below-name="health"/>
```

There are a few issues, currently:
- Firstly, observers can see the health of other observers. I'm not sure if this is fixable — as far as I can tell either someone sees _everyone's_ health or _no one's_.
- Until a player takes damage, their health is incorrectly shown as `0`, which is fairly clearly not their actual health. As far as I'm aware, this is an issue with vanilla minecraft. This can be overcome by displaying a dummy value in place of health and manually updating it whenever a player's health changes (or possibly every tick) but that's fairly complicated and possibly has other issues.