### PR TITLE
Trigger carrying item dynamic filter on bowing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
@@ -3,10 +3,12 @@ package tc.oc.pgm.filters.matcher.player;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
+import tc.oc.pgm.projectile.EntityLaunchEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.inventory.ItemMatcher;
 
@@ -18,7 +20,11 @@ public class CarryingItemFilter extends ParticipantItemFilter {
   @Override
   public Collection<Class<? extends Event>> getRelevantEvents() {
     return ImmutableList.of(
-        PlayerItemTransferEvent.class, ApplyKitEvent.class, PlayerItemBreakEvent.class);
+        PlayerItemTransferEvent.class,
+        ApplyKitEvent.class,
+        PlayerItemBreakEvent.class,
+        EntityShootBowEvent.class,
+        EntityLaunchEvent.class);
   }
 
   @Override


### PR DESCRIPTION
@lefckntea was trying to trigger an action when you shoot your last arrow, via a dynamic filter.
```xml
<carrying><item material="arrow"/></carrying>
```
However, this dynamic filter wasn't updated until the player moved, or modified their inventory in some way.

This PR makes it so it detects when arrows are shot and correctly updates this dynamic filter.