### PR TITLE
Add arrow pickup prevention

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
@@ -171,9 +171,6 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
     if (!NMSHacks.isCraftItemArrowEntity(event.getItem())) {
       return;
     }
-    if (pickupFilter == null) {
-      return;
-    }
     Filter.QueryResponse response =
         pickupFilter.query(new PlayerQuery(event, match.getPlayer(event.getPlayer())));
     if (response.isDenied()) {

--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
@@ -15,18 +15,22 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.filters.query.PlayerQuery;
 import tc.oc.pgm.projectile.EntityLaunchEvent;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
 public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
@@ -35,16 +39,22 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
   private final Class<? extends Entity> cls;
   private final float velocityMod;
   private final Set<PotionEffect> potionEffects;
+  private final Filter pickupFilter;
 
   private static final Sound PROJECTILE_SOUND =
       sound(key("random.successful_hit"), Sound.Source.MASTER, 0.18f, 0.45f);
 
   public ModifyBowProjectileMatchModule(
-      Match match, Class<? extends Entity> cls, float velocityMod, Set<PotionEffect> effects) {
+      Match match,
+      Class<? extends Entity> cls,
+      float velocityMod,
+      Set<PotionEffect> effects,
+      Filter pickupFilter) {
     this.match = match;
     this.cls = cls;
     this.velocityMod = velocityMod;
     potionEffects = effects;
+    this.pickupFilter = pickupFilter;
   }
 
   @EventHandler(ignoreCancelled = true)
@@ -153,6 +163,21 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
           ((LivingEntity) event.getEntity()).addPotionEffect(potionEffect);
         }
       }
+    }
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void preventArrowPickup(PlayerPickupItemEvent event) {
+    if (!NMSHacks.isCraftItemArrowEntity(event.getItem())) {
+      return;
+    }
+    if (pickupFilter == null) {
+      return;
+    }
+    Filter.QueryResponse response =
+        pickupFilter.query(new PlayerQuery(event, match.getPlayer(event.getPlayer())));
+    if (response.isDenied()) {
+      event.setCancelled(true);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
@@ -13,6 +13,7 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
@@ -50,7 +51,7 @@ public class ModifyBowProjectileModule implements MapModule<ModifyBowProjectileM
       Class<? extends Entity> projectile = Arrow.class;
       float velocityMod = 1;
       Set<PotionEffect> potionEffects = new HashSet<>();
-      Filter pickupFilter = null;
+      Filter pickupFilter = StaticFilter.ALLOW;
 
       for (Element parent : doc.getRootElement().getChildren("modifybowprojectile")) {
         Element projectileElement = parent.getChild("projectile");
@@ -70,11 +71,8 @@ public class ModifyBowProjectileModule implements MapModule<ModifyBowProjectileM
           changed = true;
         }
 
-        Element noPickupElement = parent.getChild("pickup");
-        if (noPickupElement != null) {
-          pickupFilter = filters.parseFilterProperty(noPickupElement, "filter");
-          changed = true;
-        }
+        pickupFilter = filters.parseFilterProperty(parent, "pickup-filter", StaticFilter.ALLOW);
+        changed |= pickupFilter != StaticFilter.ALLOW;
       }
 
       return !changed

--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
@@ -8,10 +8,12 @@ import org.bukkit.entity.Entity;
 import org.bukkit.potion.PotionEffect;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
@@ -19,28 +21,36 @@ public class ModifyBowProjectileModule implements MapModule<ModifyBowProjectileM
   protected final Class<? extends Entity> cls;
   protected final float velocityMod;
   protected final Set<PotionEffect> potionEffects;
+  protected final Filter pickupFilter;
 
   public ModifyBowProjectileModule(
-      Class<? extends Entity> cls, float velocityMod, Set<PotionEffect> effects) {
+      Class<? extends Entity> cls,
+      float velocityMod,
+      Set<PotionEffect> effects,
+      Filter pickupFilter) {
     this.cls = cls;
     this.velocityMod = velocityMod;
     potionEffects = effects;
+    this.pickupFilter = pickupFilter;
   }
 
   @Override
   public ModifyBowProjectileMatchModule createMatchModule(Match match) {
     return new ModifyBowProjectileMatchModule(
-        match, this.cls, this.velocityMod, this.potionEffects);
+        match, this.cls, this.velocityMod, this.potionEffects, this.pickupFilter);
   }
 
   public static class Factory implements MapModuleFactory<ModifyBowProjectileModule> {
     @Override
     public ModifyBowProjectileModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
+      FilterParser filters = factory.getFilters();
+
       boolean changed = false;
       Class<? extends Entity> projectile = Arrow.class;
       float velocityMod = 1;
       Set<PotionEffect> potionEffects = new HashSet<>();
+      Filter pickupFilter = null;
 
       for (Element parent : doc.getRootElement().getChildren("modifybowprojectile")) {
         Element projectileElement = parent.getChild("projectile");
@@ -59,11 +69,16 @@ public class ModifyBowProjectileModule implements MapModule<ModifyBowProjectileM
           potionEffects.add(XMLUtils.parsePotionEffect(potionElement));
           changed = true;
         }
+
+        for (Element noPickupElement : parent.getChildren("pickup")) {
+          pickupFilter = filters.parseFilterProperty(noPickupElement, "filter");
+          changed = true;
+        }
       }
 
       return !changed
           ? null
-          : new ModifyBowProjectileModule(projectile, velocityMod, potionEffects);
+          : new ModifyBowProjectileModule(projectile, velocityMod, potionEffects, pickupFilter);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
@@ -70,7 +70,8 @@ public class ModifyBowProjectileModule implements MapModule<ModifyBowProjectileM
           changed = true;
         }
 
-        for (Element noPickupElement : parent.getChildren("pickup")) {
+        Element noPickupElement = parent.getChild("pickup");
+        if (noPickupElement != null) {
           pickupFilter = filters.parseFilterProperty(noPickupElement, "filter");
           changed = true;
         }


### PR DESCRIPTION
This adds a way to filter which players can pick up arrows:
```xml
<modifybowprojectile pickup-filter="some-filter"/>
```

The primary use case that I'm aware of is when `pickup-filter="never"`. 
- We're implementing BuildUHC in PGM, and BuildUHC traditionally doesn't allow arrows to be picked up.
- Many players complain about "too many arrows" — preventing arrow pickups provides another way to control how many arrows are available
- Tea's working on controlling when players have arrows via actions & triggers that give & take arrows. These only work by limiting the player to 1 arrow, which is simpler if they can't pick up arrows.