### PR TITLE
Add permission for observers to view players' inventories

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/core/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -38,6 +38,8 @@ public interface Permissions {
   String BAN = ROOT + ".ban"; // Access to the /ban command
   String FREEZE = ROOT + ".freeze"; // Access to the /freeze command
   String VANISH = ROOT + ".vanish"; // Access to /vanish command
+  String VIEW_INVENTORY =
+      ROOT + ".inventory"; // Access to /inventory and can click on players to see their inventory
 
   String MAPMAKER = GROUP + ".mapmaker"; // Permission group for mapmakers, defined in config.yml
 
@@ -46,7 +48,11 @@ public interface Permissions {
       new Permission(
           "pgm.default",
           PermissionDefault.TRUE,
-          new ImmutableMap.Builder<String, Boolean>().put(JOIN, true).put(LEAVE, true).build());
+          new ImmutableMap.Builder<String, Boolean>()
+              .put(JOIN, true)
+              .put(LEAVE, true)
+              .put(VIEW_INVENTORY, true)
+              .build());
 
   Permission PREMIUM =
       new Permission(

--- a/core/src/main/java/tc/oc/pgm/command/InventoryCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/InventoryCommand.java
@@ -5,12 +5,15 @@ import static tc.oc.pgm.util.text.TextException.exception;
 import cloud.commandframework.annotations.Argument;
 import cloud.commandframework.annotations.CommandDescription;
 import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.CommandPermission;
+import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.inventory.ViewInventoryMatchModule;
 
 public final class InventoryCommand {
   @CommandMethod("inventory|inv|vi <player>")
   @CommandDescription("View a player's inventory")
+  @CommandPermission(Permissions.VIEW_INVENTORY)
   public void inventory(
       ViewInventoryMatchModule inventories,
       MatchPlayer viewer,

--- a/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
@@ -38,6 +38,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
+import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
@@ -261,7 +262,11 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
   }
 
   public boolean canPreviewInventory(MatchPlayer viewer, MatchPlayer holder) {
-    return viewer != null && holder != null && viewer.isObserving() && holder.isAlive();
+    return viewer != null
+        && holder != null
+        && viewer.isObserving()
+        && holder.isAlive()
+        && viewer.getBukkit().hasPermission(Permissions.VIEW_INVENTORY);
   }
 
   protected void scheduleCheck(Player updater) {


### PR DESCRIPTION
This adds a required permission for viewing players' inventories, and gives it to everyone by default. This way, servers can prevent inventory viewing.

Note this is currently not tested, and should be before it's merged. It's straightforward enough I thought I'd make a PR for it anyway.