### PR TITLE
Re-add methods to avoid 3rd party plugin breakage

### DIFF
--- a/core/src/main/java/tc/oc/pgm/teams/Team.java
+++ b/core/src/main/java/tc/oc/pgm/teams/Team.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.Feature;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.join.JoinMatchModule;
 import tc.oc.pgm.join.JoinRequest;
 import tc.oc.pgm.join.JoinResultOption;
@@ -150,14 +151,33 @@ public class Team extends PartyImpl implements Competitor, Feature<TeamFactory> 
     return getPlayers().size() >= getMinPlayers();
   }
 
+  public int getSize() {
+    return this.getPlayers().size();
+  }
+
+  @Deprecated // Kept to avoid other plugins breaking
+  public int getSize(boolean priority) {
+    return this.getPlayers().size();
+  }
+
+  @Deprecated // Kept to avoid other plugins breaking
+  public float getFullness(boolean priority) {
+    return getFullness();
+  }
+
+  @Deprecated // Kept to avoid other plugins breaking
+  public int getSizeAfterJoin(MatchPlayer joining, Team newTeam, boolean priority) {
+    return this.getSize() + (newTeam == this ? 1 : 0);
+  }
+
   /** Return a normalized "fullness" ratio for this team. */
   public float getFullness() {
-    return (float) this.getPlayers().size() / this.getMaxOverfill();
+    return (float) this.getSize() / this.getMaxOverfill();
   }
 
   /** Return a normalized "fullness" ratio for this team. */
   public float getFullnessAfterJoin(int players) {
-    return (float) (this.getPlayers().size() + players) / this.getMaxOverfill();
+    return (float) (this.getSize() + players) / this.getMaxOverfill();
   }
 
   /**


### PR DESCRIPTION
Re-adds methods that were removed previously due to PGM no longer using them, but that other 3rd party plugins (mainly, Events) may be using. They're re-added as deprecated and should be removed in the future, being kept just as a transition period until next release.