### PR TITLE
Allow usage of killrewards for consistency

### DIFF
--- a/core/src/main/java/tc/oc/pgm/killreward/KillRewardModule.java
+++ b/core/src/main/java/tc/oc/pgm/killreward/KillRewardModule.java
@@ -59,7 +59,7 @@ public class KillRewardModule implements MapModule<KillRewardMatchModule> {
       for (Element elKillReward :
           XMLUtils.flattenElements(
               doc.getRootElement(),
-              ImmutableSet.of("kill-rewards"),
+              ImmutableSet.of("kill-rewards", "killrewards"),
               ImmutableSet.of("kill-reward", "killreward"),
               0)) {
         ImmutableList.Builder<ItemStack> items = ImmutableList.builder();


### PR DESCRIPTION
Currently only \<kill-rewards> is valid syntax whereas both \<kill-reward> and \<killreward> are supported. This change should allow \<killrewards> to also be used to maintain consistency, and also has the benefit of making some maps that have accidentally used \<killrewards> function properly. Mainly making this PR as Pugzy never got around to doing so when it came up a few months ago.