### PR TITLE
Fix interaction NPE when player not in match

### DIFF
--- a/core/src/main/java/tc/oc/pgm/regions/RegionMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionMatchModule.java
@@ -260,13 +260,10 @@ public class RegionMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
   public void checkUse(final PlayerInteractEvent event) {
     if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-      MatchPlayer player = this.match.getParticipant(event.getPlayer());
-      if (player == null) return;
-
       Block block = event.getClickedBlock();
       if (block == null) return;
 
-      this.handleUse(event, block.getState(), player);
+      this.handleUse(event, block.getState(), this.match.getParticipant(event.getPlayer()));
     }
   }
 
@@ -310,8 +307,8 @@ public class RegionMatchModule implements MatchModule, Listener {
     }
   }
 
-  private void handleUse(Event event, BlockState blockState, MatchPlayer player) {
-    if (!player.canInteract()) return;
+  private void handleUse(Event event, BlockState blockState, @Nullable MatchPlayer player) {
+    if (!MatchPlayers.canInteract(player)) return;
 
     PlayerBlockQuery query = new PlayerBlockQuery(event, player, blockState);
 


### PR DESCRIPTION
Fixes the following NPE:
```
[Server thread/ERROR]: Could not pass event PlayerInteractEntityEvent to PGM v0.16-SNAPSHOT (git-b81953e)
[...]
Caused by: java.lang.NullPointerException
	at tc.oc.pgm.regions.RegionMatchModule.handleUse(RegionMatchModule.java:314) ~[?:?]
	at tc.oc.pgm.regions.RegionMatchModule.checkItemFrameRotate(RegionMatchModule.java:299) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_352]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_352]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_352]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_352]
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:300) ~[server.jar:git-SportPaper-35e7abc-P.6a9db19-SP.8e61fea-CB.e1ebe52]
	... 81 more
```
Caused by an item-frame click when the player is not in the match 