### PR TITLE
Tablist rendering performance & responsiveness improvements

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
@@ -77,10 +77,10 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
 
       // Only wait if the next stage is not done, or
       // the entire factory is not timed out.
-      final long delay = stage.delay().toMillis();
-      while (!next.isDone() && !timedOut.get()) {
+      final long delay = stage.delay(timedOut.get()).toMillis();
+      while (!next.isDone() && delay > 0) {
         try {
-          Thread.sleep(Math.max(100, delay));
+          Thread.sleep(delay);
         } catch (InterruptedException e) {
           return revert(e);
         }
@@ -166,10 +166,11 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
     /**
      * Get the duration to wait before the next {@link Stage}.
      *
+     * @param timedOut If the factory has timed out, meaning it needs to move quickly.
      * @return Duration to wait.
      */
-    default Duration delay() {
-      return Duration.ZERO;
+    default Duration delay(boolean timedOut) {
+      return timedOut ? Duration.ZERO : Duration.ofMillis(100);
     }
   }
 
@@ -298,8 +299,8 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
     }
 
     @Override
-    public Duration delay() {
-      return Duration.ofSeconds(3);
+    public Duration delay(boolean timedOut) {
+      return timedOut ? Duration.ZERO : Duration.ofSeconds(3);
     }
   }
 
@@ -315,7 +316,12 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
     private MoveMatchStage advanceSync() {
       final boolean move = PGM.get().getMatchManager().getMatches().hasNext();
       match.load();
-      return move ? new MoveMatchStage(match) : null;
+      if (move) {
+        return new MoveMatchStage(match);
+      } else {
+        match.callEvent(new MatchAfterLoadEvent(match));
+        return null;
+      }
     }
 
     @Override
@@ -343,7 +349,7 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
   /** Stage #5: teleport {@link Player}s to the {@link Match}, with time delays. */
   private static class MoveMatchStage implements Stage, Commitable {
     private final Match match;
-    private final Duration delay;
+    private final int teleportsPerSecond;
 
     private MoveMatchStage(Match match) {
       this.match = assertNotNull(match);
@@ -360,23 +366,20 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
                 "dummy", "dummy", ChatColor.AQUA.toString(), "", false, false, players));
       }
 
-      Duration delay = Duration.ZERO;
+      int tpPerSecond = Integer.MAX_VALUE;
       try {
-        delay =
-            Duration.ofMillis(
-                (long)
-                    (1000f
-                        / TextParser.parseFloat(
-                            PGM.get()
-                                .getConfiguration()
-                                .getExperiments()
-                                .getOrDefault("match-teleports-per-second", "")
-                                .toString(),
-                            Range.atLeast(1f))));
+        tpPerSecond =
+            TextParser.parseInteger(
+                PGM.get()
+                    .getConfiguration()
+                    .getExperiments()
+                    .getOrDefault("match-teleports-per-second", "")
+                    .toString(),
+                Range.atLeast(1));
       } catch (TextException e) {
         // No-op, since an experimental feature
       }
-      this.delay = delay;
+      this.teleportsPerSecond = tpPerSecond;
     }
 
     private Stage advanceSync() {
@@ -384,13 +387,14 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
       for (Match otherMatch : Lists.newArrayList(PGM.get().getMatchManager().getMatches())) {
         if (match.equals(otherMatch)) continue;
 
+        int teleported = 0;
         for (MatchPlayer player : otherMatch.getPlayers()) {
+          if (teleported++ >= teleportsPerSecond) return this;
+
           final Player bukkit = player.getBukkit();
 
           otherMatch.removePlayer(bukkit);
           match.addPlayer(bukkit);
-
-          return this;
         }
         otherMatch.unload();
       }
@@ -409,8 +413,8 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
     }
 
     @Override
-    public Duration delay() {
-      return delay;
+    public Duration delay(boolean timedOut) {
+      return Duration.ofSeconds(1);
     }
 
     @Override

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
@@ -75,6 +75,7 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
   public void onNameDecorationChange(NameDecorationChangeEvent event) {
     if (event.getUUID() == null) return;
     decorationCache.invalidate(event.getUUID());
+    PlayerComponent.RENDERER.decorationChanged(event.getUUID());
 
     final Player player = Bukkit.getPlayer(event.getUUID());
     final MatchPlayer matchPlayer = PGM.get().getMatchManager().getPlayer(player);

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -76,7 +76,7 @@ public class SidebarMatchModule implements MatchModule, Listener {
   protected final Map<Goal<?>, BlinkTask> blinkingGoals = new HashMap<>();
 
   protected @Nullable Future<?> renderTask;
-  private final RateLimiter rateLimit = new RateLimiter(50, 1000, 40, 1000);
+  private final RateLimiter rateLimit = new RateLimiter(50, 1000, 5_000, 40, 1000);
 
   private final Match match;
   private final SidebarRenderer renderer;

--- a/core/src/main/java/tc/oc/pgm/util/player/PlayerComponent.java
+++ b/core/src/main/java/tc/oc/pgm/util/player/PlayerComponent.java
@@ -30,7 +30,7 @@ public final class PlayerComponent implements RenderableComponent {
   public static final PlayerComponent UNKNOWN_PLAYER =
       new PlayerComponent(null, new PlayerData(null, null, NameStyle.PLAIN));
 
-  private static final PlayerRenderer RENDERER = new PlayerRenderer();
+  public static final PlayerRenderer RENDERER = new PlayerRenderer();
 
   // The data for player being rendered.
   private final @Nullable Player player;

--- a/core/src/main/java/tc/oc/pgm/util/player/PlayerRenderer.java
+++ b/core/src/main/java/tc/oc/pgm/util/player/PlayerRenderer.java
@@ -24,7 +24,7 @@ import tc.oc.pgm.util.named.NameDecorationProvider;
 import tc.oc.pgm.util.named.NameStyle;
 
 @SuppressWarnings("UnstableApiUsage")
-class PlayerRenderer {
+public class PlayerRenderer {
   private static final TextColor DEAD_COLOR = NamedTextColor.DARK_GRAY;
   private static final Style NICK_STYLE =
       Style.style(TextDecoration.ITALIC).decoration(TextDecoration.STRIKETHROUGH, false);
@@ -46,6 +46,19 @@ class PlayerRenderer {
 
   public Component render(PlayerData data, PlayerRelationship relation) {
     return nameCache.getUnchecked(new PlayerCacheKey(data, relation));
+  }
+
+  public void decorationChanged(UUID uuid) {
+    nameCache
+        .asMap()
+        .entrySet()
+        .removeIf(
+            entry -> {
+              PlayerCacheKey key = entry.getKey();
+              return key.relationship.reveal
+                  && key.data.style.has(NameStyle.Flag.FLAIR)
+                  && uuid.equals(key.data.uuid);
+            });
   }
 
   private Component render(PlayerCacheKey key) {

--- a/core/src/main/java/tc/oc/pgm/worldborder/WorldBorderMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/worldborder/WorldBorderMatchModule.java
@@ -7,24 +7,19 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.bukkit.Location;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
-import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.filters.query.MatchQuery;
 import tc.oc.pgm.goals.events.GoalEvent;
-import tc.oc.pgm.util.bukkit.WorldBorders;
 import tc.oc.pgm.util.collection.DefaultMapAdapter;
-import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
 
 @ListenerScope(MatchScope.LOADED)
 public class WorldBorderMatchModule implements MatchModule, Listener {
@@ -152,27 +147,5 @@ public class WorldBorderMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onGoalComplete(GoalEvent event) {
     update(event);
-  }
-
-  /** Prevent teleporting outside the border */
-  @EventHandler(priority = EventPriority.HIGH)
-  public void onPlayerTeleport(final PlayerTeleportEvent event) {
-    if (event.getCause() == PlayerTeleportEvent.TeleportCause.PLUGIN) {
-      if (WorldBorders.isInsideBorder(event.getFrom())
-          && !WorldBorders.isInsideBorder(event.getTo())) {
-        event.setCancelled(true);
-      }
-    }
-  }
-
-  @EventHandler(priority = EventPriority.HIGH)
-  public void onPlayerMove(final PlayerCoarseMoveEvent event) {
-    MatchPlayer player = match.getPlayer(event.getPlayer());
-    if (player != null && player.isObserving()) {
-      Location location = event.getTo();
-      if (WorldBorders.clampToBorder(location)) {
-        event.setTo(location);
-      }
-    }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/concurrent/RateLimiter.java
+++ b/util/src/main/java/tc/oc/pgm/util/concurrent/RateLimiter.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 
 public class RateLimiter {
   private final int minDelay, maxDelay;
+  private final int timedOutDelay;
   private final int timeRatio;
   private final int tpsRatio;
 
@@ -11,9 +12,10 @@ public class RateLimiter {
   private long endedAt = 0;
   private long timedOutUntil = 0;
 
-  public RateLimiter(int minDelay, int maxDelay, int timeRatio, int tpsRatio) {
+  public RateLimiter(int minDelay, int maxDelay, int timedOutDelay, int timeRatio, int tpsRatio) {
     this.minDelay = minDelay;
     this.maxDelay = maxDelay;
+    this.timedOutDelay = timedOutDelay;
     this.timeRatio = timeRatio;
     this.tpsRatio = tpsRatio;
   }
@@ -34,11 +36,12 @@ public class RateLimiter {
   public long getDelay() {
     long now = System.currentTimeMillis();
 
+    boolean timedOut = timedOutUntil > now;
     long nextUpdate =
         (endedAt - now)
             + ((endedAt - startedAt) * timeRatio)
             + (long) Math.max(0, (20 - Bukkit.getServer().spigot().getTPS()[0]) * tpsRatio)
-            + (timedOutUntil > now ? maxDelay : 0);
-    return Math.min(Math.max(minDelay, nextUpdate), maxDelay);
+            + (timedOut ? timedOutDelay : 0);
+    return Math.min(Math.max(minDelay, nextUpdate), timedOut ? timedOutDelay : maxDelay);
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabManagerDirtyTracker.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabManagerDirtyTracker.java
@@ -1,0 +1,56 @@
+package tc.oc.pgm.util.tablist;
+
+public class TabManagerDirtyTracker {
+  private boolean layoutOrContent;
+  private boolean headerOrFooter;
+
+  // Is any child view prioritized?
+  private boolean priority;
+
+  private final Runnable callback;
+
+  public TabManagerDirtyTracker(Runnable callback) {
+    this.callback = callback;
+  }
+
+  protected void update(TabViewDirtyTracker tab) {
+    // If anything can be propagated upwards, do so
+    if ((tab.isLayoutOrContent() && !layoutOrContent)
+        || (tab.isHeaderOrFooter() && !headerOrFooter)
+        || (tab.isPriority() && !priority)) {
+
+      layoutOrContent |= tab.isLayoutOrContent();
+      headerOrFooter |= tab.isHeaderOrFooter();
+      priority |= tab.isPriority();
+      callback.run();
+    }
+  }
+
+  public boolean isLayoutOrContent() {
+    return layoutOrContent;
+  }
+
+  public boolean isHeaderOrFooter() {
+    return headerOrFooter;
+  }
+
+  public boolean isDirty() {
+    return layoutOrContent || headerOrFooter;
+  }
+
+  public boolean isPriority() {
+    return priority;
+  }
+
+  public void validateHeaderAndFooter() {
+    this.headerOrFooter = false;
+  }
+
+  public void validatePriority() {
+    this.priority = false;
+  }
+
+  public void validate() {
+    layoutOrContent = headerOrFooter = priority = false;
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabViewDirtyTracker.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabViewDirtyTracker.java
@@ -1,0 +1,121 @@
+package tc.oc.pgm.util.tablist;
+
+public class TabViewDirtyTracker {
+  private boolean layout;
+  private boolean content;
+  private boolean header;
+  private boolean footer;
+
+  // Should this view be prioritized?
+  private boolean priority;
+
+  private TabManagerDirtyTracker parent;
+
+  private void propagate() {
+    if (parent != null) parent.update(this);
+  }
+
+  public void enable(TabManagerDirtyTracker parent) {
+    this.parent = parent;
+    // Invalidate everything
+    layout = content = header = footer = true;
+    this.priority = true;
+    this.propagate();
+  }
+
+  public boolean isDirty() {
+    return layout || content || header || footer;
+  }
+
+  public boolean isPriority() {
+    return priority;
+  }
+
+  public boolean isLayout() {
+    return layout;
+  }
+
+  public boolean isContent() {
+    return content;
+  }
+
+  public boolean isLayoutOrContent() {
+    return layout || content;
+  }
+
+  public boolean isHeader() {
+    return header;
+  }
+
+  public boolean isFooter() {
+    return footer;
+  }
+
+  public boolean isHeaderOrFooter() {
+    return header || footer;
+  }
+
+  public void invalidateLayout() {
+    if (!this.layout) {
+      this.layout = true;
+      this.propagate();
+    }
+  }
+
+  public void invalidateContent() {
+    if (!this.content) {
+      this.content = true;
+      this.propagate();
+    }
+  }
+
+  public void invalidateLayoutAndContent() {
+    if (!layout || !content) {
+      layout = content = true;
+      this.propagate();
+    }
+  }
+
+  public void invalidateHeader() {
+    if (!this.header) {
+      this.header = true;
+      this.propagate();
+    }
+  }
+
+  public void invalidateFooter() {
+    if (!this.footer) {
+      this.footer = true;
+      this.propagate();
+    }
+  }
+
+  public void prioritize() {
+    if (!priority) {
+      this.priority = true;
+      // Avoid propagating if nothing is dirty
+      // Will propagate once anything else makes it becomes dirty
+      if (isDirty()) this.propagate();
+    }
+  }
+
+  public void validateLayout() {
+    this.layout = false;
+  }
+
+  public void validateContent() {
+    this.content = false;
+  }
+
+  public void validateHeader() {
+    this.header = false;
+  }
+
+  public void validateFooter() {
+    this.footer = false;
+  }
+
+  public void validatePriority() {
+    priority = false;
+  }
+}


### PR DESCRIPTION
Brings many fixes & improvements around tablist, and cycling performance:
  - Fixed vanishing not updating the tablist layout to hide the player
  - Fixed match teleports per second not being respected after cycle gets to 0 (timed out factory)
  - Changed teleports per second to batch N players per second, instead of one every 1000/N millis
  - Fixed default world border (set to 10.000 blocks) not being enforced, causing performance issues if bypassed.
  - Fixed mapmaker flairs being taken away after cycling to a map of the same author
  - Fixed player rendering caching name flairs even after a decoration change event, fixes mapmaker flairs updating on tablist
 - Tablist will now fully pause updating during cycle (up to 30s), and will issue one full re-render after everyone is teleported, then resume normal operation
 - Tablist now has a priority re-render system, if you switch team your own tablist will be prioritized, others can update later. This increases the perceived responsiveness of tablist.
 - Tablist can now be configured to render in batches of N players, so first priority views are updated, then views are updated picking N from the dirty views and re-scheduling the other ones until eventually no views are left to update.
 - Tablist header & footer can now be rendered without doing layout, meaning the scheduled 1s timer (for current match time) will update in a timely manner regardless of how delayed everything else is, and won't force everything else to be triggered on a 1s cooldown.
 
