### PR TITLE
Switch locked items to use item tags

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -43,7 +43,6 @@ import tc.oc.pgm.flag.event.FlagStateChangeEvent;
 import tc.oc.pgm.goals.events.GoalEvent;
 import tc.oc.pgm.kits.ArmorType;
 import tc.oc.pgm.kits.Kit;
-import tc.oc.pgm.kits.KitMatchModule;
 import tc.oc.pgm.score.ScoreMatchModule;
 import tc.oc.pgm.scoreboard.SidebarMatchModule;
 import tc.oc.pgm.spawns.events.ParticipantDespawnEvent;
@@ -57,7 +56,6 @@ public class Carried extends Spawned implements Missing {
 
   protected final MatchPlayer carrier;
   protected ItemStack helmetItem;
-  protected boolean helmetLocked;
   protected @Nullable NetDefinition deniedByNet;
   protected @Nullable Flag deniedByFlag;
   protected @Nullable Component lastMessage;
@@ -112,13 +110,8 @@ public class Carried extends Spawned implements Missing {
     if (kit != null) carrier.applyKit(kit, false);
 
     this.helmetItem = this.carrier.getBukkit().getInventory().getHelmet();
-    this.helmetLocked =
-        this.flag
-            .getMatch()
-            .getModule(KitMatchModule.class)
-            .lockArmorSlot(this.carrier, ArmorType.HELMET, false);
-
     this.carrier.getBukkit().getInventory().setHelmet(this.flag.getBannerItem().clone());
+
     PGM.get()
         .getExecutor()
         .schedule(
@@ -152,11 +145,6 @@ public class Carried extends Spawned implements Missing {
 
     this.carrier.getInventory().remove(this.flag.getBannerItem());
     this.carrier.getInventory().setHelmet(this.helmetItem);
-
-    this.flag
-        .getMatch()
-        .getModule(KitMatchModule.class)
-        .lockArmorSlot(this.carrier, ArmorType.HELMET, this.helmetLocked);
 
     Kit kit = this.flag.getDefinition().getDropKit();
     if (kit != null) this.carrier.applyKit(kit, false);

--- a/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
@@ -40,11 +40,6 @@ public class ArmorKit extends AbstractKit {
       if (force || wearing[slot] == null || wearing[slot].getType() == Material.AIR) {
         wearing[slot] = entry.getValue().stack.clone();
         ItemModifier.apply(wearing[slot], player);
-
-        KitMatchModule kitMatchModule = player.getMatch().getModule(KitMatchModule.class);
-        if (kitMatchModule != null) {
-          kitMatchModule.lockArmorSlot(player, entry.getKey(), entry.getValue().locked);
-        }
       }
     }
     player.getBukkit().getInventory().setArmorContents(wearing);

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -586,6 +586,10 @@ public abstract class KitParser {
       ItemTags.PREVENT_SHARING.set(itemStack, true);
     }
 
+    if (XMLUtils.parseBoolean(el.getAttribute("locked"), false)) {
+      ItemTags.LOCKED.set(itemStack, true);
+    }
+
     if (itemStack.getAmount() == -1) {
       ItemTags.INFINITE.set(itemStack, true);
     }

--- a/core/src/main/java/tc/oc/pgm/kits/tag/ItemTags.java
+++ b/core/src/main/java/tc/oc/pgm/kits/tag/ItemTags.java
@@ -9,6 +9,7 @@ public class ItemTags {
   public static final ItemTag<String> CONSUMABLE = ItemTag.newString("consumable");
   public static final ItemTag<String> ORIGINAL_NAME = ItemTag.newString("original-name");
   public static final ItemTag<Boolean> INFINITE = ItemTag.newBoolean("infinite");
+  public static final ItemTag<Boolean> LOCKED = ItemTag.newBoolean("locked");
 
   private ItemTags() {}
 }

--- a/core/src/main/java/tc/oc/pgm/modules/ItemKeepMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ItemKeepMatchModule.java
@@ -20,7 +20,6 @@ import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.filters.matcher.block.BlockFilter;
 import tc.oc.pgm.kits.ArmorType;
-import tc.oc.pgm.kits.KitMatchModule;
 
 @ListenerScope(MatchScope.RUNNING)
 public class ItemKeepMatchModule implements MatchModule, Listener {
@@ -81,7 +80,6 @@ public class ItemKeepMatchModule implements MatchModule, Listener {
       this.keptInv.put(player, keptItems);
     }
 
-    KitMatchModule kitMatchModule = this.match.getModule(KitMatchModule.class);
     ItemStack[] wearing = event.getEntity().getInventory().getArmorContents();
     Map<ArmorType, ItemStack> keptArmor = new HashMap<>();
     for (int slot = 0; slot < wearing.length; slot++) {
@@ -90,12 +88,6 @@ public class ItemKeepMatchModule implements MatchModule, Listener {
         if (this.canKeepArmor(stack)) {
           event.getDrops().remove(stack);
           keptArmor.put(ArmorType.byArmorSlot(slot), stack);
-        } else if (kitMatchModule != null
-            && !"true".equalsIgnoreCase(this.match.getWorld().getGameRuleValue("keepInventory"))) {
-          // TODO: When we have an improved player drops module, the drops will
-          // be available on the PGMPlayerDeathEvent. KitMatchModule can listen
-          // for that and deal with the locked armor itself.
-          kitMatchModule.lockArmorSlot(player, ArmorType.byArmorSlot(slot), false);
         }
       }
     }

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -28,6 +28,8 @@ match.disabled.enderChest = Ender chests are disabled
 
 match.disabled.bed = Beds are disabled
 
+match.item.locked = This item cannot be removed from its slot
+
 match.class.title = Classes
 
 match.class.current = Current class:


### PR DESCRIPTION
Moves the locked item logic to be ItemTags on the item rather than a map of locked slots. This allows you to lock anything and not just items (armor can be locked now too). This is how it was eventually done on OCN and the logic around this has been migrated over.

Tested during the recent Bolt draft event and all seemed well.