### PR TITLE
Remove unused string and add context in moderation.properties

### DIFF
--- a/util/src/main/i18n/templates/moderation.properties
+++ b/util/src/main/i18n/templates/moderation.properties
@@ -5,18 +5,18 @@ moderation.type = Type: {0}
 
 moderation.type.kick = Kicked
 
-moderation.type.mute = Muted
-
 moderation.type.warn = Warned
 
 moderation.type.ban = Permanent Ban
 
 moderation.type.name_ban = Username Ban
 
-# {0} = duration of the ban (e.g. "7 days")
+# {0} = duration of the ban (e.g. "7 day")
+# time strings can be found in the misc package(e.g. misc.day)
 moderation.type.temp_ban = {0} ban
 
 # {0} = duration of the mute (e.g. "1 hour")
+# time strings can be found in the misc package(e.g. misc.hour)
 moderation.type.mute = {0} mute
 
 # {0} = number of online staff
@@ -27,25 +27,26 @@ moderation.staff.empty = No staff online :(
 # {0} = punishment reason (e.g. "Hacking is not allowed")
 moderation.screen.kick = You were kicked for {0}
 
-# {0} = punishment reason
+# {0} = punishment reason (e.g. "Hacking is not allowed")
 moderation.screen.ban = You were permanently banned for {0}
 
-# {0} = punishment reason
+# {0} = punishment reason (e.g. "Talking about the Electroid-Starbucks papers are not allowed")
 moderation.screen.temp_ban = You were temporarily banned for {0}
 
 # {0} = banned username (e.g "OFFENSIVE_NaMe")
 moderation.screen.name_ban = You have been banned due to your username {0}
 
-# {0} = a http link (e.g. "https://example.com/rules")
+# {0} = a http(s) link (e.g. "https://example.com/rules")
 moderation.screen.rulesLink = Please review our rules at {0}
 
 # {0} = staff member name (e.g. "Notch")
 moderation.screen.signoff = Issued by {0}
 
 # {0} = duration (e.g. "2 weeks")
+# time strings can be found in the misc package(e.g. misc.weeks)
 moderation.screen.expires = Expires in {0}
 
-# {0} = mute reason
+# {0} = mute reason (e.g. "Please keep a peaceful atmosphere in chat")
 moderation.mute.message = You are unable to chat while muted: {0}
 
 moderation.mute.list = Muted Players
@@ -54,46 +55,46 @@ moderation.mute.none = There are no muted players online!
 
 moderation.mute.noReason = No reason provided
 
-# {0} = player name
+# {0} = player name (e.g. "Notch")
 moderation.mute.hover = Click to unmute {0}
 
-# {0} = player name
+# {0} = player name (e.g. "_jeb")
 moderation.mute.target = {0} is muted and unable to receive messages
 
-# {0} = player name
+# {0} = player name (e.g. "epic_username")
 moderation.mute.existing = {0} is already muted!
 
-# {0} = player name
+# {0} = player name (e.g. "Pablete1234")
 moderation.unmute.sender = You have unmuted {0}
 
 moderation.unmute.target = You have been unmuted and may now send messages
 
-# {0} = player name
+# {0} = player name (e.g. "ElectroidFilms")
 moderation.unmute.none = {0} is not muted.
 
 moderation.reports.none = There have been no recent reports!
 
 moderation.reports.header = Recent Reports
 
-# {0} = player name
+# {0} = player name (e.g. "Xx_Warrior_xX")
 moderation.reports.hover = Reported by {0}
 
 moderation.alts.header = Alt-Accounts
 
-# {0} = player name
+# {0} = player name (e.g. "KingOfSquares")
 moderation.alts.noAlts = {0} has no known alternate accounts.
 
 # {0} = ip address (e.g. "1.2.3.4")
 moderation.ipBan.invalidIP = {0} is not a valid IP address
 
-# {0} = player name
+# {0} = player name (e.g. "applenick")
 moderation.ipBan.banned = {0} has been IP banned
 
 # {0} = player name or ip address (e.g. "Notch" or "1.2.3.4")
 # {1} = number of alternate accounts
 moderation.ipBan.bannedWithAlts = {0} has been IP banned along with {1} online alts
 
-# {0} = player name
+# {0} = player name (e.g. "SethBling")
 moderation.records.lookupNone = {0} has no punishment record
 
 moderation.records.header = Punishment Info
@@ -103,24 +104,23 @@ moderation.records.history = Punishment History
 # {0} = punishment reason (e.g. "Hacking is not allowed")
 moderation.records.reason = Reason: {0}
 
-# {0} = player name
-# {1} = another player name
+# {0} = player name (e.g. "CaptainSparklez")
+# {1} = another player name (e.g. "HatFilms")
 moderation.similarIP.loginEvent = {0} has a similar IP to banned player {1}
 
-# {0} = player name
+# {0} = player name (e.g. "Seananners")
 # {1} = past duration (e.g. "5 minutes ago")
+# time strings can be found in the misc package(e.g. misc.hour)
 moderation.similarIP.hover = Banned by {0}, {1}
 
-# {0} = player name
+# {0} = player name (e.g. "Vareide")
 moderation.freeze.freeze = You have frozen {0}
 
-# {0} = player name
+# {0} = player name (e.g. "Notch")
 moderation.freeze.unfreeze = You have unfrozen {0}
 
-# {0} = player name
 moderation.freeze.frozen = You have been frozen
 
-# {0} = player name
 moderation.freeze.unfrozen = You have been unfrozen
 
 moderation.freeze.itemName = Player Freezer
@@ -129,13 +129,13 @@ moderation.freeze.itemDescription = Right-click a player to freeze/thaw them
 
 moderation.freeze.notEnabled = Freeze is not enabled
 
-# {0} = player name
+# {0} = player name (e.g. "Brottweiler")
 moderation.freeze.exempt = {0} may not be frozen
 
-# {0} = player name
+# {0} = player name (e.g. "TheMolkaPL")
 moderation.freeze.alreadyFrozen = {0} is already frozen
 
-# {0} = player name
+# {0} = player name (e.g. "direwolf20")
 moderation.freeze.alreadyThawed = {0} is not frozen
 
 # {0} = number of players
@@ -143,17 +143,17 @@ moderation.freeze.alreadyThawed = {0} is not frozen
 moderation.freeze.frozenList.online = Frozen Players ({0}): {1}
 
 # {0} = number of players
-# {1} = list of player names
+# {1} = list of player names (e.g. "Diamyx, Pugzy and Eclipsen")
 moderation.freeze.frozenList.offline = Offline Frozen Players ({0}): {1}
 
 moderation.freeze.frozenList.none = There are no frozen players!
 
-# {0} = staff player name
-# {1} = target player name
+# {0} = staff player name (e.g. "Samwellys")
+# {1} = target player name (e.g. "Furioso")
 moderation.freeze.broadcast.frozen = {0} has frozen {1}
 
-# {0} = staff player name
-# {1} = target player name
+# {0} = staff player name (e.g. "Cloudy")
+# {1} = target player name (e.g. "_jeb")
 moderation.freeze.broadcast.thaw = {0} has unfrozen {1}
 
 moderation.freeze.broadcast.hover = Click to reverse action
@@ -168,25 +168,25 @@ moderation.defuse.tooltip = Right-click to defuse TNT in a 5-block radius
 
 moderation.defuse.world = You defused world TNT.
 
-# {0} = player name
+# {0} = player name (e.g. "Hypixel")
 moderation.defuse.player = You defused {0}'s TNT.
 
-# {0} = defuser player name
-# {1} = griefer player name
-# {2} = entity name
+# {0} = defuser player name (e.g. "CaptainSparklez")
+# {1} = griefer player name (e.g. "Technoblade"
+# {2} = entity name (e.g. "Exploding Ball")
 moderation.defuse.alert.player = {0} defused {1}'s {2}.
 
-# {0} = defuser player name
-# {1} = entity name
+# {0} = defuser player name (e.g. "kashike")
+# {1} = entity name (e.g "Bomb")
 moderation.defuse.alert.world = {0} defused world {1}.
 
-# {0} = reporter player name
-# {1} = accused player name
+# {0} = reporter player name (e.g. "Monti")
+# {1} = accused player name (e.g. "Notch")
 # {2} = reason for report (e.g. "Is griefing my home")
 moderation.report.notify = {0} reported {1}: {2}
 moderation.report.acknowledge = The issue will be dealt with shortly.
 
-# {0} = number of seconds
+# {0} = number of seconds (e.g. "1", "30" etc.)
 moderation.afk.warn = You will be disconnected for inactivity in {0} seconds
 
 moderation.afk.kick = You were disconnected for inactivity


### PR DESCRIPTION
~~What?! You wanted lootables first?? Oops...~~ (#1044)

`moderation.type.mute` was duplicated after Community PR, also took the opportunity to add some context to almost every string with an argument in the same document