### PR TITLE
Add custom firework designs 🎆 

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -21,6 +21,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.bukkit.Color;
+import org.bukkit.FireworkEffect;
+import org.bukkit.FireworkEffect.Type;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -28,6 +30,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -260,6 +263,10 @@ public abstract class KitParser {
         case "head":
           item = parseHead(itemEl);
           break;
+
+        case "firework":
+          item = parseFirework(itemEl);
+          break;
       }
 
       if (item != null) {
@@ -396,6 +403,53 @@ public abstract class KitParser {
         XMLUtils.parseUnsignedSkin(Node.fromRequiredChildOrAttr(el, "skin")));
     itemStack.setItemMeta(meta);
     return itemStack;
+  }
+
+  public ItemStack parseFirework(Element el) throws InvalidXMLException {
+    ItemStack itemStack = parseItem(el, Material.FIREWORK);
+    FireworkMeta meta = (FireworkMeta) itemStack.getItemMeta();
+    int power = XMLUtils.parseNumber(Node.fromAttr(el, "power"), Integer.class, false, 1);
+    meta.setPower(power);
+
+    for (Element explosionEl : el.getChildren("explosion")) {
+      Type type =
+          XMLUtils.parseEnum(Node.fromAttr(explosionEl, "type"), Type.class, null, Type.BURST);
+      boolean flicker = XMLUtils.parseBoolean(Node.fromAttr(explosionEl, "flicker"), false);
+      boolean trail = XMLUtils.parseBoolean(Node.fromAttr(explosionEl, "trail"), false);
+
+      List<Color> primary = parseColors(Node.fromChildren(explosionEl, "color"));
+      List<Color> fade = parseColors(Node.fromChildren(explosionEl, "fade"));
+
+      if (primary.isEmpty()) {
+        throw new InvalidXMLException("At least one <color> must be defined", explosionEl);
+      }
+
+      meta.addEffect(
+          FireworkEffect.builder()
+              .with(type)
+              .withColor(primary)
+              .withFade(fade)
+              .flicker(flicker)
+              .trail(trail)
+              .build());
+    }
+
+    itemStack.setItemMeta(meta);
+    return itemStack;
+  }
+
+  private List<Color> parseColors(List<Node> nodes) throws InvalidXMLException {
+    List<Color> colors = Lists.newArrayList();
+    for (Node node : nodes) {
+      String rawColor = node.getValue();
+      if (rawColor != null) {
+        if (!rawColor.matches("[a-fA-F0-9]{6}")) {
+          throw new InvalidXMLException("Invalid color format", rawColor);
+        }
+        colors.add(Color.fromRGB(Integer.parseInt(rawColor, 16)));
+      }
+    }
+    return colors;
   }
 
   public ItemMatcher parseItemMatcher(Element parent) throws InvalidXMLException {

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -439,9 +439,9 @@ public abstract class KitParser {
   }
 
   private List<Color> parseColors(List<Node> nodes) throws InvalidXMLException {
-    List<Color> colors = Lists.newArrayList();
+    List<Color> colors = new ArrayList<>(nodes.size());
     for (Node node : nodes) {
-      colors.add(XMLUtils.parseHexColor(node, Color.WHITE));
+      colors.add(XMLUtils.parseHexColor(node));
     }
     return colors;
   }
@@ -563,7 +563,7 @@ public abstract class KitParser {
       LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
       Node attrColor = Node.fromAttr(el, "color");
       if (attrColor != null) {
-        armorMeta.setColor(XMLUtils.parseHexColor(attrColor, Color.WHITE));
+        armorMeta.setColor(XMLUtils.parseHexColor(attrColor));
       }
     }
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -441,13 +441,7 @@ public abstract class KitParser {
   private List<Color> parseColors(List<Node> nodes) throws InvalidXMLException {
     List<Color> colors = Lists.newArrayList();
     for (Node node : nodes) {
-      String rawColor = node.getValue();
-      if (rawColor != null) {
-        if (!rawColor.matches("[a-fA-F0-9]{6}")) {
-          throw new InvalidXMLException("Invalid color format", rawColor);
-        }
-        colors.add(Color.fromRGB(Integer.parseInt(rawColor, 16)));
-      }
+      colors.add(XMLUtils.parseHexColor(node, Color.WHITE));
     }
     return colors;
   }
@@ -567,13 +561,9 @@ public abstract class KitParser {
 
     if (meta instanceof LeatherArmorMeta) {
       LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
-      org.jdom2.Attribute attrColor = el.getAttribute("color");
+      Node attrColor = Node.fromAttr(el, "color");
       if (attrColor != null) {
-        String raw = attrColor.getValue();
-        if (!raw.matches("[a-fA-F0-9]{6}")) {
-          throw new InvalidXMLException("Invalid color format", attrColor);
-        }
-        armorMeta.setColor(Color.fromRGB(Integer.parseInt(attrColor.getValue(), 16)));
+        armorMeta.setColor(XMLUtils.parseHexColor(attrColor, Color.WHITE));
       }
     }
 

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -1130,4 +1130,15 @@ public final class XMLUtils {
 
     return Title.Times.times(fadeIn, stay, fadeOut);
   }
+
+  public static Color parseHexColor(Node node, Color def) throws InvalidXMLException {
+    String rawColor = node.getValue();
+    if (rawColor != null) {
+      if (!rawColor.matches("[a-fA-F0-9]{6}")) {
+        throw new InvalidXMLException("Invalid color format", rawColor);
+      }
+      return Color.fromRGB(Integer.parseInt(rawColor, 16));
+    }
+    return def;
+  }
 }

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -1131,14 +1131,13 @@ public final class XMLUtils {
     return Title.Times.times(fadeIn, stay, fadeOut);
   }
 
-  public static Color parseHexColor(Node node, Color def) throws InvalidXMLException {
+  public static Color parseHexColor(Node node) throws InvalidXMLException {
+    if (node == null || node.getValue() == null)
+      throw new InvalidXMLException("No value provided for color", node);
     String rawColor = node.getValue();
-    if (rawColor != null) {
-      if (!rawColor.matches("[a-fA-F0-9]{6}")) {
-        throw new InvalidXMLException("Invalid color format", rawColor);
-      }
-      return Color.fromRGB(Integer.parseInt(rawColor, 16));
+    if (!rawColor.matches("[a-fA-F0-9]{6}")) {
+      throw new InvalidXMLException("Invalid color format", rawColor);
     }
-    return def;
+    return Color.fromRGB(Integer.parseInt(rawColor, 16));
   }
 }


### PR DESCRIPTION
# Custom Firework Designs 🎆 
This PR adds the ability to define custom firework effects when giving a firework item. Alongside the existing custom parsers for books and skulls, `<firework>` will allow for custom designs to be specified in an easy to understand format. 

## XML Definition
Element | Attribute | Description
--- | --- | ---
`<firework>` | `power` | Defines the power of the firework (optional). If not specified, the power defaults to 1.
`<explosion>` | `type` | Defines the type of the effect. Valid values: `ball`, `ball large`, `burst`, `creeper`, `star`.  If not specified, type defaults to `burst`. 
  | `flicker` | Defines whether the effect should flicker (optional). Valid values are `true` and `false`. If not specified, flicker defaults to false.
  | `trail` | Defines whether the effect should have a trail (optional). Valid values are `true` and `false`. If not specified, trail defaults to false.
`<color>` |   | Defines a color of the firework. Colors are specified as a six-digit hex value. At least one color must be defined for each explosion.
`<fade>` |   | Defines a fade color for the firework (optional). Colors are specified as a six-digit hex value. Multiple fade colors can be defined for each explosion. If no fade colors are defined, the explosion will not fade.

See [here](https://pgm.dev/docs/reference/misc/colors) for more info on hex colors

## XML Example
```xml
<firework power="1">
  <!-- Defines an explosion -->
  <explosion type="creeper" flicker="true" trail="true">
    <!-- One or more colors can be defined as hex values -->
    <color>193bcf</color>
    <color>edea18</color>
    
    <!-- Defines a fade color as a hex value (optional) -->
    <fade>e2a31a</fade>
  </explosion>
  
  <!-- Another explosion with different attributes -->
  <explosion type="burst" trail="true">
    <color>b319af</color>

    <!-- Multiple fade colors can be defined -->
    <fade>e2a31a</fade>
    <fade>e2a31a</fade>
  </explosion>
</firework>
```

The resulting firework item:
<img width="485" alt="Firework example" src="https://user-images.githubusercontent.com/3377659/223069497-848ea428-a5b0-4430-b834-637d111c417b.png">
![firework-final](https://user-images.githubusercontent.com/3377659/223069836-ded2144f-93cc-47c6-adf1-32986c840997.png)

