### PR TITLE
Fix NPE with vanished player join messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
+++ b/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
@@ -31,8 +31,8 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.api.player.event.MatchPlayerAddEvent;
 import tc.oc.pgm.api.player.event.PlayerVanishEvent;
+import tc.oc.pgm.events.PlayerJoinMatchEvent;
 
 public class SimpleVanishIntegration implements VanishIntegration, Listener {
 
@@ -178,11 +178,11 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
-  public void checkMatchPlayer(MatchPlayerAddEvent event) {
+  public void checkMatchPlayer(PlayerJoinMatchEvent event) {
     MatchPlayer player = event.getPlayer();
     // Player is joining to a team so broadcast join
-    if (event.getInitialParty() instanceof Competitor) {
-      setVanished(player, false, false);
+    if (event.getNewParty() instanceof Competitor && isVanished(player.getId())) {
+      setVanished(player, false, true);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/util/player/PlayerData.java
+++ b/core/src/main/java/tc/oc/pgm/util/player/PlayerData.java
@@ -42,7 +42,8 @@ class PlayerData {
 
     this.name = mp.getNameLegacy();
     this.nick = Integration.getNick(mp.getBukkit());
-    this.teamColor = mp.getParty().getTextColor();
+    this.teamColor =
+        mp.getParty() == null ? PlayerComponent.OFFLINE_COLOR : mp.getParty().getTextColor();
     this.dead = mp.isDead();
     this.vanish = Integration.isVanished(mp.getBukkit());
     this.online = mp.getBukkit().isOnline();


### PR DESCRIPTION
This fixes two issues which occur when a player joins the match directly on to a team (Events plugin).

When a player joins directly to a team this code make sure they're not vanished. The vanished being non-silent means a join message is shown. The current order of this event means that the players name component (showing in the fake/unvanish join) message is rendered using a team color which is null so throws an NPE.

- Switches unvanishing to use event `PlayerJoinMatchEvent` (player already has team set at this point).
- Null check on match player component to check team is set.
- Don't try unvanish someone who isn't vanished in the first place.
- Not broadcasting unvanish as the new event location means the join listener can manage the join and message.