### PR TITLE
Fix blitz allowing join & wrongly dropping items

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -47,7 +47,7 @@ import tc.oc.pgm.api.match.event.MatchStartEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.MapPoolAdjustEvent;
 import tc.oc.pgm.events.PlayerJoinMatchEvent;
-import tc.oc.pgm.events.PlayerParticipationStopEvent;
+import tc.oc.pgm.events.PlayerLeavePartyEvent;
 import tc.oc.pgm.gamerules.GameRulesMatchModule;
 import tc.oc.pgm.modules.WorldTimeModule;
 import tc.oc.pgm.util.UsernameFormatUtils;
@@ -293,7 +293,7 @@ public class PGMListener implements Listener {
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-  public void dropItemsOnQuit(PlayerParticipationStopEvent event) {
+  public void dropItemsOnQuit(PlayerLeavePartyEvent event) {
     MatchPlayer quitter = event.getPlayer();
     if (!quitter.isAlive()) return;
 

--- a/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -247,10 +247,11 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
     return request.isForcedOr(JoinRequest.Flag.JOIN_CHOOSE);
   }
 
-  public boolean internalJoin(MatchPlayer player, Team newTeam) {
+  public boolean internalJoin(MatchPlayer player, Team newTeam, JoinRequest request) {
     assertNotNull(newTeam);
     return player.getParty() == newTeam
-        || (!Integration.isVanished(player.getBukkit()) && match.setParty(player, newTeam));
+        || (!Integration.isVanished(player.getBukkit())
+            && match.setParty(player, newTeam, request));
   }
 
   /** Return the most full participating team */
@@ -439,7 +440,7 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
           return true;
       }
 
-      if (!internalJoin(joining, teamResult.getTeam())) {
+      if (!internalJoin(joining, teamResult.getTeam(), request)) {
         return false;
       }
 


### PR DESCRIPTION
Ever since the join-request refactor, blitz has not been able to prevent mid-match joins due to them always being defaulted to force-joins when missing the join request.
Additionally, fixes a bug that will drop the players' items even if the team-switch is cancelled.