### PR TITLE
Update dependencies and fix text translations test

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@
                         <path>
                             <groupId>cloud.commandframework</groupId>
                             <artifactId>cloud-annotations</artifactId>
-                            <version>1.7.1</version>
+                            <version>1.8.2</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <minimizeJar>true</minimizeJar>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.viaversion</groupId>
             <artifactId>viaversion</artifactId>
-            <version>4.2.1</version>
+            <version>4.5.1</version>
             <scope>provided</scope>
             <optional>true</optional>
             <!-- Fix transitive dependency breaking builds -->
@@ -110,19 +110,19 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.11.0</version>
+            <version>4.12.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-plain</artifactId>
-            <version>4.11.0</version>
+            <version>4.12.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.1.2</version>
+            <version>4.2.0</version>
             <scope>compile</scope>
             <!-- Exclude Spigot APIs since we already provide Bukkit -->
             <exclusions>
@@ -137,32 +137,32 @@
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-core</artifactId>
-            <version>1.8.1</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-annotations</artifactId>
-            <version>1.8.1</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-paper</artifactId>
-            <version>1.8.1</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-minecraft-extras</artifactId>
-            <version>1.8.1</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
         <!-- Allows registering brigadier mappings -->
         <dependency>
             <groupId>me.lucko</groupId>
             <artifactId>commodore</artifactId>
-            <version>1.9</version>
+            <version>2.2</version>
             <scope>compile</scope>
         </dependency>
 
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -211,7 +211,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
             </plugin>
 
             <!-- Exposes git information to the build environment -->
@@ -253,7 +253,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <configuration>
                     <failOnError>false</failOnError>
                     <includeDependencySources>true</includeDependencySources>
@@ -263,12 +263,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>de.skuzzle.enforcer</groupId>
                         <artifactId>restrict-imports-enforcer-rule</artifactId>
-                        <version>2.0.0</version>
+                        <version>2.1.0</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <!-- Ensures that all classes are loaded into the jar -->
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <configuration>
                     <from>
                         <image>shipilev/openjdk-shenandoah:8</image>

--- a/util/src/test/java/tc/oc/pgm/util/text/TextTranslationsTest.java
+++ b/util/src/test/java/tc/oc/pgm/util/text/TextTranslationsTest.java
@@ -33,18 +33,21 @@ public final class TextTranslationsTest {
         }
       };
 
-  @Test
-  void testGetLocales() {
-    final Collection<Locale> locales = getLocales();
-
-    assertTrue(locales.contains(US), "source code locale not loaded");
-    assertTrue(locales.contains(Locale.getDefault()), "system locale not loaded");
-  }
-
   @ParameterizedTest
   @ValueSource(strings = {"ENGLISH", "CANADA", "UK", "ROOT"})
   void testGetNearestLocale(Locale locale) {
     assertEquals(US, getNearestLocale(locale), "nearest locale not resolved");
+  }
+
+  @Test
+  void testGetLocales() {
+    final Collection<Locale> locales = getLocales();
+    final Locale defaultLocale = Locale.getDefault();
+
+    assertTrue(locales.contains(US), "source code locale not loaded");
+    assertTrue(
+        (locales.contains(defaultLocale) || locales.contains(getNearestLocale(defaultLocale))),
+        "system locale not loaded");
   }
 
   @Test


### PR DESCRIPTION
Firstly, this PR updates all dependencies that are possible or reasonable to update (not sure what that old log4j is there for). Briefly tested a running server and everything seems to work as intended.

If we introduce a build-time dependency on JDK 11 or above, we can upgrade `fmt-maven-plugin` to the [latest version now maintained by Spotify](https://github.com/spotify/fmt-maven-plugin), but I don't know if we want to do that. For the record, I haven't built PGM with a JDK lower than 11 in ages and it always seems to run fine. Given that, and since `fmt-maven-plugin` is only used when building to check code style, such a dependency might be reasonable, but I would understand hesistancy.

What we cannot update is JGit, newer versions of which depend on a Java 11+ runtime.

Secondly, this PR fixes `TextTranslationsTest`. For some reason our tests seem to have just not been running at all, at least until CI images received an update to Maven 3.9.0. They suddenly work now, somehow. `testGetLocales` seems to assume a different enough locale from `US` will always be available, so let's run `testGetNearestLocale` first and then check for either `locales.contains(Locale.getDefault())` or `locales.contains(getNearestLocale(Locale.getDefault()))` in `testGetLocales`.