### PR TITLE
Remove EntityLaunchEvent from carrying event list

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
@@ -8,7 +8,6 @@ import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
-import tc.oc.pgm.projectile.EntityLaunchEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.inventory.ItemMatcher;
 
@@ -23,8 +22,7 @@ public class CarryingItemFilter extends ParticipantItemFilter {
         PlayerItemTransferEvent.class,
         ApplyKitEvent.class,
         PlayerItemBreakEvent.class,
-        EntityShootBowEvent.class,
-        EntityLaunchEvent.class);
+        EntityShootBowEvent.class);
   }
 
   @Override


### PR DESCRIPTION
A `carrying` filter currently spams thrown exceptions due to changes in https://github.com/PGMDev/PGM/pull/1137.
> Unable to get MethodHandle extracting Filterable or Player for class tc.oc.pgm.projectile.EntityLaunchEvent

`EntityLaunchEvent` is a custom PGM event and has a `ProjectileSource` which does not have a handler that `FilterMatchModule` can extract hence the exception.

This PR removes `EntityLaunchEvent` from the list of relevant events for the carrying filter.

Tested the scenario where a custom projectile is used (gold ingot) and it is throwable (consumed on use) a `not` filter on `carrying` the gold ingot triggers correctly when the final projectile is thrown.

Not sure what other use cases this method was trying to catch maybe @OhPointFive can shed some light on this.