### PR TITLE
Fix minor dynamic filter issues

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/filter/query/MatchQuery.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/query/MatchQuery.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.api.filter.query;
 
 import java.util.Optional;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.ReactorFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -11,8 +12,9 @@ public interface MatchQuery extends Query {
   Match getMatch();
 
   /** Extract the most specific {@link Filterable} possible from this query */
+  @Nullable
   default Filterable<?> extractFilterable() {
-    if (this instanceof PlayerQuery) return this.getMatch().getPlayer(((PlayerQuery) this).getId());
+    if (this instanceof PlayerQuery) return ((PlayerQuery) this).getPlayer();
     if (this instanceof PartyQuery) return ((PartyQuery) this).getParty();
     return this.getMatch();
   }
@@ -29,7 +31,9 @@ public interface MatchQuery extends Query {
     return getMatch().needModule(FilterMatchModule.class).getReactor(factory);
   }
 
+  @Nullable
   default <F extends Filterable<?>> F filterable(Class<F> type) {
-    return extractFilterable().getFilterableAncestor(type);
+    Filterable<?> filterable = extractFilterable();
+    return filterable != null ? filterable.getFilterableAncestor(type) : null;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/filter/query/PlayerQuery.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/query/PlayerQuery.java
@@ -8,11 +8,12 @@ import tc.oc.pgm.api.player.MatchPlayer;
 public interface PlayerQuery extends PartyQuery, EntityTypeQuery, LocationQuery {
   UUID getId();
 
-  /*TODO this is not followed in any implementations or trusted by any other code. If this is fixed change places like
-  CarryingFlagFilter Line 33/34 at the time of this commit
-  ParticipantFilter Line 26/27
-  RegionMatchModule Line 375/376 etc...*/
-  /** Return the {@link MatchPlayer} for this player if they are online, otherwise null. */
+  /**
+   * Return the {@link MatchPlayer} for this player if available (ie: online), otherwise null. <br>
+   * Note: the player won't be returned if the query is PlayerState based and the player changed
+   * team, as the state is no longer the same, and allowing the newly-teamed player to be filtered
+   * would be faulty.
+   */
   @Nullable
   MatchPlayer getPlayer();
 }

--- a/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Table;
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -127,6 +128,9 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
               }
               this.registerListenersFor(filter.getRelevantEvents());
             });
+    // We always need to register this to handle players leaving the match cleaning-up filters.
+    // See comment in PlayerPartyChangeEvent handler for more info
+    this.registerListenersFor(Collections.singleton(PlayerPartyChangeEvent.class));
 
     // Lastly dispatch initial states of all dynamic filters for the relevant scopes
     // Has to be last since many filters depend on objects loaded in a non-consequent way during
@@ -495,6 +499,9 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
       // force all filters false that are not already false before the player leaves.
       // Listeners don't need to do any cleanup as long as they don't hold on to
       // players that don't match the filter.
+      //
+      // Example: a countdown filter with a bossbar doesn't delete the bossbar if you /cycle 0 -f,
+      // due to the player matching the filter even while the player is leaving that match.
       this.listeners
           .columnMap()
           .forEach(

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingFlagFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingFlagFilter.java
@@ -40,7 +40,7 @@ public class CarryingFlagFilter extends TypedFilter.Impl<PartyQuery> {
     if (goal == null) throw new IllegalStateException("Flag not found");
 
     if (query instanceof PlayerQuery) {
-      MatchPlayer player = match.getPlayer(((PlayerQuery) query).getId());
+      MatchPlayer player = ((PlayerQuery) query).getPlayer();
       return player != null && goal.isCarrying(player);
     } else {
       final Party party = query.getParty();

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/ParticipantFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/ParticipantFilter.java
@@ -24,8 +24,7 @@ public abstract class ParticipantFilter extends TypedFilter.Impl<PlayerQuery> {
 
   @Override
   public boolean matches(PlayerQuery query) {
-    MatchPlayer player = query.getMatch().getPlayer(query.getId());
-
+    MatchPlayer player = query.getPlayer();
     return player != null && player.getParty() instanceof Competitor && matches(query, player);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/regions/RegionMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionMatchModule.java
@@ -369,7 +369,7 @@ public class RegionMatchModule implements MatchModule, Listener {
         && ((Cancellable) query.getEvent()).isCancelled()
         && query instanceof PlayerQuery) {
 
-      MatchPlayer player = match.getPlayer(((PlayerQuery) query).getId());
+      MatchPlayer player = ((PlayerQuery) query).getPlayer();
       if (player != null) player.sendWarning(rfa.message);
     }
   }


### PR DESCRIPTION
This fixes some internal bugs with how filters (mainly, dynamic filters) are handled in edge-cases like player joins/leaves. It fixes at least one NPE, and probably a few other potential ones.
Additionally updates some comments to better explain current state of things and fixes bossbars from countdowns being left behind if a cycle occurs instantly while one is shown in a map that does not use any dynamic filter that listens to team-related events.