### PR TITLE
Implement filter command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
@@ -15,6 +15,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
 import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.util.Audience;
@@ -65,5 +66,19 @@ public class MapDevCommand {
         header,
         (v, i) ->
             text().append(text(v.getId() + ": ", NamedTextColor.AQUA), text(v.getValue(target))));
+  }
+
+  @CommandMethod("filter <filter> [target]")
+  @CommandDescription("Match a filter against a player")
+  @CommandPermission(Permissions.DEBUG)
+  public void evaluateFilter(
+      Audience audience,
+      @Argument("filter") Filter filter,
+      @Argument(value = "target", defaultValue = CURRENT) MatchPlayer target) {
+    audience.sendMessage(
+        text("Filter responded with ", NamedTextColor.YELLOW)
+            .append(text(filter.query(target) + "", NamedTextColor.AQUA))
+            .append(text(" to ", NamedTextColor.YELLOW))
+            .append(target.getName()));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/parsers/ExposedActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/ExposedActionParser.java
@@ -7,7 +7,8 @@ import org.bukkit.command.CommandSender;
 import tc.oc.pgm.action.ActionMatchModule;
 import tc.oc.pgm.action.actions.ExposedAction;
 
-public class ExposedActionParser extends MatchObjectParser<ExposedAction, ActionMatchModule> {
+public class ExposedActionParser
+    extends MatchObjectParser.Simple<ExposedAction, ActionMatchModule> {
 
   public ExposedActionParser(PaperCommandManager<CommandSender> manager, ParserParameters options) {
     super(manager, options, ExposedAction.class, ActionMatchModule.class, "actions");

--- a/core/src/main/java/tc/oc/pgm/command/parsers/FilterArgumentParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/FilterArgumentParser.java
@@ -1,0 +1,39 @@
+package tc.oc.pgm.command.parsers;
+
+import cloud.commandframework.arguments.parser.ParserParameters;
+import cloud.commandframework.paper.PaperCommandManager;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.filters.FilterMatchModule;
+
+public final class FilterArgumentParser
+    extends MatchObjectParser<Filter, Map.Entry<String, Filter>, FilterMatchModule> {
+
+  public FilterArgumentParser(
+      PaperCommandManager<CommandSender> manager, ParserParameters options) {
+    super(manager, options, Filter.class, FilterMatchModule.class, "filters");
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected Collection<Map.Entry<String, Filter>> objects(FilterMatchModule module) {
+    return StreamSupport.stream(module.getFilterContext().spliterator(), false)
+        .filter(entry -> entry != null && entry.getValue() instanceof Filter)
+        .map(entry -> (Map.Entry<String, Filter>) entry)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  protected String getName(Map.Entry<String, Filter> obj) {
+    return obj.getKey();
+  }
+
+  @Override
+  protected Filter getValue(Map.Entry<String, Filter> obj) {
+    return obj.getValue();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/parsers/ModeParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/ModeParser.java
@@ -7,7 +7,7 @@ import org.bukkit.command.CommandSender;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.modes.ObjectiveModesMatchModule;
 
-public class ModeParser extends MatchObjectParser<Mode, ObjectiveModesMatchModule> {
+public class ModeParser extends MatchObjectParser.Simple<Mode, ObjectiveModesMatchModule> {
 
   public ModeParser(PaperCommandManager<CommandSender> manager, ParserParameters options) {
     super(manager, options, Mode.class, ObjectiveModesMatchModule.class, "modes");

--- a/core/src/main/java/tc/oc/pgm/command/parsers/PlayerClassParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/PlayerClassParser.java
@@ -10,7 +10,8 @@ import tc.oc.pgm.classes.ClassMatchModule;
 import tc.oc.pgm.classes.PlayerClass;
 import tc.oc.pgm.util.text.TextException;
 
-public final class PlayerClassParser extends MatchObjectParser<PlayerClass, ClassMatchModule> {
+public final class PlayerClassParser
+    extends MatchObjectParser.Simple<PlayerClass, ClassMatchModule> {
 
   public PlayerClassParser(PaperCommandManager<CommandSender> manager, ParserParameters options) {
     super(manager, options, PlayerClass.class, ClassMatchModule.class, "classes");

--- a/core/src/main/java/tc/oc/pgm/command/parsers/TeamParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/TeamParser.java
@@ -10,7 +10,7 @@ import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.text.TextException;
 
-public final class TeamParser extends MatchObjectParser<Team, TeamMatchModule> {
+public final class TeamParser extends MatchObjectParser.Simple<Team, TeamMatchModule> {
 
   public TeamParser(PaperCommandManager<CommandSender> manager, ParserParameters options) {
     super(manager, options, Team.class, TeamMatchModule.class, "teams");

--- a/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 import tc.oc.pgm.action.actions.ExposedAction;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapLibrary;
 import tc.oc.pgm.api.map.MapOrder;
@@ -64,6 +65,7 @@ import tc.oc.pgm.command.injectors.TeamMatchModuleProvider;
 import tc.oc.pgm.command.parsers.DurationParser;
 import tc.oc.pgm.command.parsers.EnumParser;
 import tc.oc.pgm.command.parsers.ExposedActionParser;
+import tc.oc.pgm.command.parsers.FilterArgumentParser;
 import tc.oc.pgm.command.parsers.MapInfoParser;
 import tc.oc.pgm.command.parsers.MapPoolParser;
 import tc.oc.pgm.command.parsers.MatchPlayerParser;
@@ -210,6 +212,7 @@ public class PGMCommandGraph extends CommandGraph<PGM> {
     registerParser(
         TypeFactory.parameterizedClass(Optional.class, VictoryCondition.class),
         new VictoryConditionParser());
+    registerParser(Filter.class, FilterArgumentParser::new);
     registerParser(SettingKey.class, new EnumParser<>(SettingKey.class, CommandKeys.SETTING_KEY));
     registerParser(SettingValue.class, new SettingValueParser());
   }

--- a/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
@@ -105,6 +105,10 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
   // Filterables that need a check in the next tick (cleared every tick)
   private final Set<Filterable<?>> dirtySet = new HashSet<>();
 
+  public ContextStore<? super Filter> getFilterContext() {
+    return filterContext;
+  }
+
   @EventHandler
   public void onMatchLoad(MatchLoadEvent event) {
 


### PR DESCRIPTION
Implements a `/filter <filter> [target]` command, allowing map developers inspecting the filters while they're working on them.

![image](https://user-images.githubusercontent.com/11789291/224584007-ad3bf459-d0b6-4b8a-a04f-72b04758ffe8.png)
![image](https://user-images.githubusercontent.com/11789291/224584021-0dd6d227-2deb-4ec7-81a3-7ea353b54a6c.png)
