### PR TITLE
Fix respawn filter parsing being stateful

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
@@ -49,8 +49,6 @@ public class SpawnModule implements MapModule<SpawnMatchModule> {
 
   public static class Factory implements MapModuleFactory<SpawnModule> {
 
-    private FilterParser filterParser;
-
     @Override
     public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
       return ImmutableList.of(RegionModule.class, KitModule.class);
@@ -64,7 +62,7 @@ public class SpawnModule implements MapModule<SpawnMatchModule> {
     @Override
     public SpawnModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
-      this.filterParser = factory.getFilters();
+      FilterParser filterParser = factory.getFilters();
       SpawnParser parser = new SpawnParser(factory, new PointParser(factory));
       List<Spawn> spawns = Lists.newArrayList();
 
@@ -76,15 +74,17 @@ public class SpawnModule implements MapModule<SpawnMatchModule> {
         throw new InvalidXMLException("map must have a single default spawn", doc);
       }
 
-      return new SpawnModule(parser.getDefaultSpawn(), spawns, parseRespawnOptions(doc));
+      return new SpawnModule(
+          parser.getDefaultSpawn(), spawns, parseRespawnOptions(doc, filterParser));
     }
 
-    private List<RespawnOptions> parseRespawnOptions(Document doc) throws InvalidXMLException {
+    private List<RespawnOptions> parseRespawnOptions(Document doc, FilterParser filterParser)
+        throws InvalidXMLException {
       List<RespawnOptions> respawnOptions = Lists.newArrayList();
 
       for (Element elRespawn :
           XMLUtils.flattenElements(doc.getRootElement(), "respawns", "respawn")) {
-        respawnOptions.add(getRespawnOptions(elRespawn));
+        respawnOptions.add(getRespawnOptions(elRespawn, filterParser));
       }
       // Parse root children respawn elements, Keeps old syntax and gives a default spawn if all
       // others fail
@@ -92,17 +92,22 @@ public class SpawnModule implements MapModule<SpawnMatchModule> {
           getRespawnOptions(
               doc.getRootElement().getChildren("respawn"),
               doc.getRootElement().getChild("autorespawn") != null,
-              true));
+              true,
+              filterParser));
 
       return respawnOptions;
     }
 
-    private RespawnOptions getRespawnOptions(Element element) throws InvalidXMLException {
-      return getRespawnOptions(Collections.singleton(element), false, false);
+    private RespawnOptions getRespawnOptions(Element element, FilterParser filterParser)
+        throws InvalidXMLException {
+      return getRespawnOptions(Collections.singleton(element), false, false, filterParser);
     }
 
     protected RespawnOptions getRespawnOptions(
-        Collection<Element> elements, boolean autorespawn, boolean topLevel)
+        Collection<Element> elements,
+        boolean autorespawn,
+        boolean topLevel,
+        FilterParser filterParser)
         throws InvalidXMLException {
       Duration delay = DEFAULT_RESPAWN_DELAY;
       boolean auto = autorespawn;


### PR DESCRIPTION
Currently respawn filter factory stores the filter parser as a property, this is buggy behavior as when parsing maps the method may be called multiple times concurrently for different maps, making them sometimes fail at seemingly random times:
`'filter' attribute of 'respawn' element @ line 284: No filter named 'only-red'`

Note this error (no filter named X) only exists in LegacyFilterParser (For 1.3.x maps) but the map in question is a 1.4.x map. It is trying to find filters in the factory of a DIFFERENT map.