### PR TITLE
Default to new map when same version number is used

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
@@ -229,7 +229,7 @@ public class MapLibraryImpl implements MapLibrary {
     maps.merge(
         context.getId(),
         new MapEntry(source, context.clone(), context),
-        (m1, m2) -> m1.info.getVersion().isOlderThan(m2.info.getVersion()) ? m2 : m1);
+        (m1, m2) -> m2.info.getVersion().isOlderThan(m1.info.getVersion()) ? m1 : m2);
     failed.remove(source);
 
     return context;


### PR DESCRIPTION
Updated so that the default when the map version is the same is to keep the new map, instead of the old one.

Previous logic read as `if old.version < new.version -> keep new, otherwise keep old`
The new one reads as `if new.version < old.version -> keep old, otherwise keep new`

The subtle change fixes the wrongly behavior explained in #971

Note: always keeping the new map is not a solution, as a map may be loaded from 2 different sources (multiple repositories defined on pgm with overlapping maps) in which case you want always the higher-versioned map to prevail when pgm loads them all on startup, regardless of map loading order.