### PR TITLE
Enforce validation of dynamic filter type for triggers

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -161,7 +161,7 @@ public class ActionParser {
     return new Trigger<>(
         cls,
         filters.parseRequiredProperty(el, "filter", DynamicFilterValidation.of(cls)),
-        parseProperty(Node.fromRequiredChildOrAttr(el, "trigger", "action"), cls));
+        parseProperty(Node.fromRequiredChildOrAttr(el, "action", "trigger"), cls));
   }
 
   private <B extends Filterable<?>> Class<B> parseScope(Element el, Class<B> scope)

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -28,6 +28,7 @@ import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.features.XMLFeatureReference;
 import tc.oc.pgm.filters.Filterable;
 import tc.oc.pgm.filters.matcher.StaticFilter;
+import tc.oc.pgm.filters.parse.DynamicFilterValidation;
 import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.regions.BlockBoundedValidation;
@@ -159,7 +160,7 @@ public class ActionParser {
     Class<T> cls = Filterables.parse(Node.fromRequiredAttr(el, "scope"));
     return new Trigger<>(
         cls,
-        filters.parseProperty(el, "filter"),
+        filters.parseRequiredProperty(el, "filter", DynamicFilterValidation.of(cls)),
         parseProperty(Node.fromRequiredChildOrAttr(el, "trigger", "action"), cls));
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/parse/DynamicFilterValidation.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/DynamicFilterValidation.java
@@ -19,8 +19,16 @@ public class DynamicFilterValidation implements FeatureValidation<FilterDefiniti
 
   private final Class<? extends Filterable<?>> type;
 
-  public DynamicFilterValidation(Class<? extends Filterable<?>> type) {
+  private DynamicFilterValidation(Class<? extends Filterable<?>> type) {
     this.type = type;
+  }
+
+  public static DynamicFilterValidation of(Class<? extends Filterable<?>> type) {
+    if (type == null) return ANY;
+    if (type == Match.class) return MATCH;
+    if (type == Party.class) return PARTY;
+    if (type == MatchPlayer.class) return PLAYER;
+    return new DynamicFilterValidation(type);
   }
 
   @Override


### PR DESCRIPTION
`<trigger filter="filter-that-requires-a-player-scope" scope="match" action="some-action"/>` would currently parse correctly, but on match cycle throw a `Filter {the filter} doesn't respond to Match scope.`

This change makes it so the error will come up at map xml parse time, as an XML error.