### PR TITLE
Fix up include reloading when files change

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -255,7 +255,6 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
 
     mapSourceFactories.clear();
     mapSourceFactories.addAll(config.getMapSourceFactories());
-    mapIncludeProcessor.reload(config);
 
     if (mapOrder != null) {
       mapOrder.reload();

--- a/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.api.map;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Collection;
 import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
 
@@ -41,12 +42,9 @@ public interface MapSource {
   boolean checkForUpdates() throws MapMissingException;
 
   /**
-   * Adds an associated {@link MapInclude}
+   * Sets the collection of includes the map source references
    *
    * @param include The {@link MapInclude}
    */
-  void addMapInclude(MapInclude include);
-
-  /** Remove all associated {@link MapInclude}, used when reloading document. */
-  void clearIncludes();
+  void setIncludes(Collection<MapInclude> include);
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/includes/MapInclude.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/includes/MapInclude.java
@@ -7,13 +7,6 @@ import org.jdom2.Content;
 public interface MapInclude {
 
   /**
-   * Get a unique id which identifies this MapInclude.
-   *
-   * @return A unique id
-   */
-  String getId();
-
-  /**
    * Get the system file time from when this MapInclude file was last modified.
    *
    * @return Time of last file modification
@@ -21,15 +14,8 @@ public interface MapInclude {
   long getLastModified();
 
   /**
-   * Gets whether the associated {@link MapInclude} files have changed since last loading.
-   *
-   * @param time The current system time
-   * @return True if given time is newer than last modified time
-   */
-  boolean hasBeenModified(long time);
-
-  /**
-   * Get a collection of {@link Content} which can be merged into an existing {@link Document}
+   * Get a collection of {@link Content} which can be merged into an existing {@link Document}. If
+   * the underlying file has changed, it will re-load the xml.
    *
    * @return a collection of {@link Content}
    */

--- a/core/src/main/java/tc/oc/pgm/api/map/includes/MapIncludeProcessor.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/includes/MapIncludeProcessor.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.api.map.includes;
 
 import java.util.Collection;
 import org.jdom2.Document;
-import tc.oc.pgm.api.Config;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
 /** A processor to determine which {@link MapInclude}s should be included when loading a map * */
@@ -25,10 +24,6 @@ public interface MapIncludeProcessor {
    */
   MapInclude getMapIncludeById(String includeId);
 
-  /**
-   * Reload the processor to fetch new map includes or reload existing ones.
-   *
-   * @param config A configuration file.
-   */
-  void reload(Config config);
+  /** Reload the processor to fetch new map includes. */
+  void loadNewIncludes();
 }

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -39,8 +39,7 @@ import tc.oc.pgm.util.Version;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.SAXHandler;
 
-public class MapFactoryImpl
-    extends ModuleGraph<MapModule<?>, MapModuleFactory<? extends MapModule<?>>>
+public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?>>
     implements MapFactory {
 
   private static final ThreadLocal<SAXBuilder> DOCUMENT_FACTORY =
@@ -77,18 +76,8 @@ public class MapFactoryImpl
     }
   }
 
-  private void storeInclude(MapInclude include) {
-    this.source.addMapInclude(include);
-  }
-
   private void preLoad()
       throws IOException, JDOMException, InvalidXMLException, MapMissingException {
-    if (document != null && !source.checkForUpdates()) {
-      return; // If a document is present and there are no updates, skip loading again
-    }
-
-    source.clearIncludes();
-
     try (final InputStream stream = source.getDocument()) {
       document = DOCUMENT_FACTORY.get().build(stream);
       document.setBaseURI(source.getId());
@@ -98,8 +87,8 @@ public class MapFactoryImpl
     Collection<MapInclude> mapIncludes = includes.getMapIncludes(document);
     for (MapInclude include : mapIncludes) {
       document.getRootElement().addContent(0, include.getContent());
-      storeInclude(include);
     }
+    source.setIncludes(mapIncludes);
 
     info = new MapInfoImpl(document.getRootElement());
   }

--- a/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
@@ -132,6 +132,9 @@ public class MapLibraryImpl implements MapLibrary {
 
   @Override
   public CompletableFuture<?> loadNewMaps(boolean reset) {
+    // Try to search new includes before searching for new maps
+    includes.loadNewIncludes();
+
     final List<Iterator<? extends MapSource>> sources = new LinkedList<>();
 
     // Reload failed maps

--- a/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeProcessorImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeProcessorImpl.java
@@ -5,15 +5,18 @@ import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import tc.oc.pgm.api.Config;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
 import tc.oc.pgm.api.map.includes.MapIncludeProcessor;
@@ -83,9 +86,8 @@ public class MapIncludeProcessorImpl implements MapIncludeProcessor {
   }
 
   @Override
-  public void reload(Config config) {
-    this.includes.clear();
-
+  public void loadNewIncludes() {
+    Config config = PGM.get().getConfiguration();
     if (config.getIncludesDirectory() == null) return;
 
     File includeFiles = new File(config.getIncludesDirectory());
@@ -93,16 +95,29 @@ public class MapIncludeProcessorImpl implements MapIncludeProcessor {
       logger.warning(config.getIncludesDirectory() + " is not a directory!");
       return;
     }
+
+    Set<String> deletedIncludes = new HashSet<>(includes.keySet());
+
     File[] files = includeFiles.listFiles();
     for (File file : files) {
-      if (!file.getName().endsWith(".xml")) continue;
+      String filename = file.getName();
+      if (!filename.endsWith(".xml")) continue;
+
+      String id = filename.substring(0, filename.length() - ".xml".length());
+      // Already loaded, can ignore and continue
+      if (deletedIncludes.remove(id)) continue;
+
       try {
-        MapIncludeImpl include = new MapIncludeImpl(file);
-        this.includes.put(include.getId(), include);
+        this.includes.put(id, new MapIncludeImpl(file));
       } catch (MapMissingException | JDOMException | IOException error) {
-        logger.info("Unable to load " + file.getName() + " include document");
+        logger.log(Level.WARNING, "Failed to load " + filename + " include document", error);
         error.printStackTrace();
       }
+    }
+
+    for (String id : deletedIncludes) {
+      this.includes.remove(id);
+      logger.info("Removed deleted include file " + id);
     }
   }
 }


### PR DESCRIPTION
Fixes several inconsistencies with map XMLs reloading when includes change. At the moment the includes are created once on server startup, and never reload themselves except when doing `/pgm reload` (which reloads the config), but what that does, is create new include objects, so all maps loaded prior still use the older include contents.

It gets messy, but the main change has been to search for new includes on `/newmaps`, and to update includes any time they're asked for if the file has changed, very similar to how maps work. In theory these changes make it so PGM includes and pgm XMLs will never be out of date anymore.