### PR TITLE
Avoid null filterables being added to dirty set

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -409,7 +410,7 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
   }
 
   public void invalidate(Filterable<?> filterable) {
-    if (dirtySet.add(filterable)) {
+    if (dirtySet.add(Objects.requireNonNull(filterable))) {
       filterable.getFilterableChildren().forEach(this::invalidate);
     }
   }


### PR DESCRIPTION
In pgm the dirty set of filterables cannot contain nulls. Usually no nulls ever get there, but if something else fails, and manages to insert a null in the dirty set, it will forever be broken (for the rest of the match) and no dynamic filter dispatching will occur.

This has happened before with a registered event which had no actor (so no player/filterable scope was obtainable from it) and now it has happened with this particular instance:
```
[MatchImpl] Unable to invoke cached MethodHandle extracting Filterable for tc.oc.pgm.util.event.PlayerItemTransferEvent@1f026767
java.lang.NullPointerException
	at tc.oc.pgm.filters.FilterMatchModule.invalidate(FilterMatchModule.java:413)
	at tc.oc.pgm.filters.FilterMatchModule.lambda$registerListenersFor$17(FilterMatchModule.java:454)
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:74)
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:65)
[...]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:496)
	at tc.oc.pgm.util.listener.ItemTransferListener.callEvent(ItemTransferListener.java:606)
	at tc.oc.pgm.util.listener.ItemTransferListener.onPlayerDropItem(ItemTransferListener.java:462)
	at sun.reflect.GeneratedMethodAccessor668.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:300)
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:74)
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:65)
[...]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:496)
	at net.minecraft.server.v1_8_R3.EntityHuman.a(EntityHuman.java:630)
	at net.minecraft.server.v1_8_R3.EntityHuman.a(EntityHuman.java:583)
	at net.minecraft.server.v1_8_R3.PlayerConnection.a(PlayerConnection.java:618)
	at net.minecraft.server.v1_8_R3.PacketPlayInBlockDig.a(SourceFile:40)
	at net.minecraft.server.v1_8_R3.PacketPlayInBlockDig.a(SourceFile:10)
	at net.minecraft.server.v1_8_R3.PlayerConnectionUtils$1.run(SourceFile:13)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at net.minecraft.server.v1_8_R3.SystemUtils.a(SourceFile:44)
	at net.minecraft.server.v1_8_R3.MinecraftServer.processTasks(MinecraftServer.java:1726)
	at net.minecraft.server.v1_8_R3.DedicatedServer.processTasks(DedicatedServer.java:417)
	at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:884)
	at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:385)
	at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:823)
	at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:724)
	at java.lang.Thread.run(Thread.java:750)
```

So looking at the stacktrace in detail, seems like a packet from the player to drop an item was received, it was converted to an ItemTransferEvent, which some filter was listening to for dynamic stuff (eg: holding filter), and but then match.getPlayer(player) returned null. Unsure if the player in the event itself was null, but i'd doubt it, which means what's likely here is that a player who *isn't* in the match, dropped an item. This happened exactly in the moment where a cycle was happening, so it could've been a weird race condition in there.


Ignoring the particular case, which isn't that relevant, with this fix we avoid an exception being thrown every tick which fills up the logs and breaks pgm completely, if anything manages to invalidate a null filterable.