### PR TITLE
Add some missing gamemodes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -3,8 +3,10 @@ package tc.oc.pgm.api.map;
 public enum Gamemode {
   ATTACK_DEFEND("ad", "Attack/Defend", "A/D"),
   ARCADE("arcade", "Arcade", "Arcade"),
+  BEDWARS("bedwars", "Bedwars", "Bedwars"),
   BLITZ("blitz", "Blitz", "Blitz"),
   BLITZ_RAGE("br", "Blitz: Rage", "Blitz: Rage"),
+  BRIDGE("bridge", "Bridge", "Bridge"),
   CAPTURE_THE_FLAG("ctf", "Capture The Flag", "CTF"),
   CONTROL_THE_POINT("cp", "Control the Point", "CP"),
   CAPTURE_THE_WOOL("ctw", "Capture the Wool", "CTW"),
@@ -12,6 +14,7 @@ public enum Gamemode {
   DESTROY_THE_MONUMENT("dtm", "Destroy the Monument", "DTM"),
   FREE_FOR_ALL("ffa", "Free for All", "FFA"),
   FLAG_FOOTBALL("ffb", "Flag Football", "FFB"),
+  INFECTION("infection", "Infection", "Infection"),
   KING_OF_THE_HILL("koth", "King of the Hill", "KotH"),
   KING_OF_THE_FLAG("kotf", "King of the Flag", "KotF"),
   MIXED("mixed", "Mixed", "Mixed"),
@@ -20,6 +23,7 @@ public enum Gamemode {
   RACE_FOR_WOOL("rfw", "Race for Wool", "RFW"),
   SCOREBOX("scorebox", "Scorebox", "Scorebox"),
   SKYWARS("skywars", "Skywars", "Skywars"),
+  SURVIVAL_GAMES("sg", "Survival Games", "SG"),
   DEATHMATCH("tdm", "Deathmatch", "TDM"),
   OBJECTIVES("obj", "Objectives", "Objectives");
 


### PR DESCRIPTION
In preparation for the merge of lootables, PR #1077 added `skywars` as a valid gamemode for the `<gamemode>` tag, which was used in the [old skywars.xml include](https://github.com/OvercastNetwork/maps.oc.tc/blob/edfe27faaf6249198cb0518c817873796ccd1553/Include/skywars.xml#L3). This PR does the same for some other popular or established gamemodes, including [Survival Games](https://github.com/OvercastNetwork/maps.oc.tc/blob/edfe27faaf6249198cb0518c817873796ccd1553/Include/survival-games.xml#L2) (which uses lootables and was present in the original [ProjectAres source](https://github.com/OvercastNetwork/ProjectAres/blob/7484cb81fcc33814fe26812684660da4e0dbd671/API/api/src/main/java/tc/oc/api/docs/virtual/MapDoc.java#L46)), Bedwars, Bridge, and Infection.

Suggestions for other suitable gamemodes are welcome and appreciated.
<details>
<summary>Old message</summary>

> In preparation for the merge of lootables, PR #1077 added `skywars` as a valid gamemode for the `<gamemode>` tag, which was used in the [old skywars.xml include](https://github.com/OvercastNetwork/maps.oc.tc/blob/edfe27faaf6249198cb0518c817873796ccd1553/Include/skywars.xml#L3). This PR does the same for `survival`, found in the [old survival-games.xml include](https://github.com/OvercastNetwork/maps.oc.tc/blob/edfe27faaf6249198cb0518c817873796ccd1553/Include/survival-games.xml#L2). This include also used lootables, so adding compatibility seems only fitting.
I used `survival` to keep it in line with the aforementioned include and the [ProjectAres source](https://github.com/OvercastNetwork/ProjectAres/blob/7484cb81fcc33814fe26812684660da4e0dbd671/API/api/src/main/java/tc/oc/api/docs/virtual/MapDoc.java#L46), but perhaps it could be simplified to `sg`, similar to how the [Payload tag](https://github.com/PGMDev/PGM/blob/a27fc69a84c44483e670c4077bf239f39fe15dc3/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java#L18) is `pd`. Do let me know and I can make the change.
</details>