### PR TITLE
Fix potential atomicity issue for team tags

### DIFF
--- a/core/src/main/java/tc/oc/pgm/teams/TeamModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamModule.java
@@ -42,18 +42,15 @@ public class TeamModule implements MapModule<TeamMatchModule> {
   @Override
   public Collection<MapTag> getTags() {
     final int size = teams.size();
-    Collection<MapTag> tags = TAGS.get(size);
-    if (tags == null) {
-      tags =
-          ImmutableList.of(
-              new MapTag(
-                  size + "team" + (size == 1 ? "" : "s"),
-                  size + " Team" + (size == 1 ? "" : "s"),
-                  false,
-                  true));
-      TAGS.put(size, tags);
-    }
-    return tags;
+    return TAGS.computeIfAbsent(
+        size,
+        s ->
+            ImmutableList.of(
+                new MapTag(
+                    size + "team" + (size == 1 ? "" : "s"),
+                    size + " Team" + (size == 1 ? "" : "s"),
+                    false,
+                    true)));
   }
 
   @Override


### PR DESCRIPTION
It is currently possible for two team tags for the same team size to be added, even if it's a concurrent hash map, due to how they're being search-then-added. The simple fix should more strictly enforce that the tag is only created once, making them (properly) singletons