### PR TITLE
Support fast respawns & fix blitz bugged dead state

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -24,6 +24,7 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
@@ -277,6 +278,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     bukkit.setWalkSpeed(WalkSpeedKit.BUKKIT_DEFAULT);
     NMSHacks.clearArrowsInPlayer(bukkit);
     NMSHacks.setKnockbackReduction(bukkit, 0);
+    bukkit.setVelocity(new Vector());
 
     for (PotionEffect effect : bukkit.getActivePotionEffects()) {
       if (effect.getType() != null) {

--- a/core/src/main/java/tc/oc/pgm/spawns/RespawnOptions.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/RespawnOptions.java
@@ -25,7 +25,7 @@ public class RespawnOptions {
       Filter filter,
       @Nullable Component message) {
     this.delay = delay;
-    this.delayTicks = Math.max(TimeUtils.toTicks(delay), 20);
+    this.delayTicks = Math.max(TimeUtils.toTicks(delay), 0);
     this.auto = auto;
     this.blackout = blackout;
     this.spectate = spectate;

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -25,7 +25,6 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jetbrains.annotations.Nullable;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 import tc.oc.pgm.api.PGM;
-import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -77,8 +76,7 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
 
   public RespawnOptions getRespawnOptions(Query query) {
     return module.respawnOptions.stream()
-        .filter(
-            respawnOption -> respawnOption.filter.query(query).equals(Filter.QueryResponse.ALLOW))
+        .filter(respawn -> !respawn.filter.query(query).isDenied())
         .findFirst()
         .orElseThrow(() -> new IllegalStateException("No respawn option could be used"));
   }

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -25,6 +25,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jetbrains.annotations.Nullable;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -76,7 +77,7 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
 
   public RespawnOptions getRespawnOptions(Query query) {
     return module.respawnOptions.stream()
-        .filter(respawn -> !respawn.filter.query(query).isDenied())
+        .filter(respawn -> respawn.filter.query(query) == Filter.QueryResponse.ALLOW)
         .findFirst()
         .orElseThrow(() -> new IllegalStateException("No respawn option could be used"));
   }

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
@@ -28,7 +28,7 @@ import tc.oc.pgm.util.xml.XMLUtils;
 public class SpawnModule implements MapModule<SpawnMatchModule> {
 
   public static final Duration DEFAULT_RESPAWN_DELAY = Duration.ofMillis(2000);
-  public static final Duration MINIMUM_RESPAWN_DELAY = Duration.ofMillis(1500);
+  public static final Duration MINIMUM_RESPAWN_DELAY = Duration.ofMillis(0);
   public static final Duration IGNORE_CLICKS_DELAY = Duration.ofMillis(500);
 
   protected final Spawn defaultSpawn;

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnModule.java
@@ -28,8 +28,9 @@ import tc.oc.pgm.util.xml.XMLUtils;
 public class SpawnModule implements MapModule<SpawnMatchModule> {
 
   public static final Duration DEFAULT_RESPAWN_DELAY = Duration.ofMillis(2000);
-  public static final Duration MINIMUM_RESPAWN_DELAY = Duration.ofMillis(0);
+  public static final Duration MINIMUM_RESPAWN_DELAY = Duration.ZERO;
   public static final Duration IGNORE_CLICKS_DELAY = Duration.ofMillis(500);
+  public static final Duration MIN_KIT_DELAY = Duration.ofMillis(1000);
 
   protected final Spawn defaultSpawn;
   protected final List<Spawn> spawns;

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
@@ -36,11 +36,7 @@ public class Dead extends Spawning {
   private boolean kitted, rotted;
 
   public Dead(SpawnMatchModule smm, MatchPlayer player) {
-    this(smm, player, player.getMatch().getTick().tick);
-  }
-
-  public Dead(SpawnMatchModule smm, MatchPlayer player, long deathTick) {
-    super(smm, player, deathTick);
+    super(smm, player, player.getMatch().getTick().tick);
   }
 
   @Override
@@ -80,6 +76,9 @@ public class Dead extends Spawning {
     bukkit.removePotionEffect(PotionEffectType.BLINDNESS);
     bukkit.removePotionEffect(PotionEffectType.CONFUSION);
 
+    // If regular rotting didn't end, force-finish it to avoid client-side
+    endRotting();
+
     super.leaveState(events);
   }
 
@@ -87,21 +86,24 @@ public class Dead extends Spawning {
   public void tick() {
     long age = age();
 
-    if (!kitted && ticksUntilRespawn() <= 0) {
+    if (!kitted && ticksUntilRespawn() <= 0 && age >= 20) {
       this.kitted = true;
       // Give the player the team/class picker, after death has cleared their inventory
       player.getMatch().callEvent(new DeathKitApplyEvent(player));
       bukkit.updateInventory();
     }
 
-    if (!rotted && age >= CORPSE_ROT_TICKS) {
-      this.rotted = true;
-      // Make player invisible after the death animation is complete
-      player.setVisible(false);
-      player.resetVisibility();
-    }
+    // Make player invisible after the death animation is complete
+    if (age >= CORPSE_ROT_TICKS) endRotting();
 
     super.tick(); // May transition to a different state, so call last
+  }
+
+  private void endRotting() {
+    if (this.rotted) return;
+    this.rotted = true;
+    player.setVisible(false);
+    player.resetVisibility();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
@@ -86,7 +86,9 @@ public class Dead extends Spawning {
   public void tick() {
     long age = age();
 
-    if (!kitted && ticksUntilRespawn() <= 0 && age >= 20) {
+    if (!kitted
+        && ticksUntilRespawn() <= 0
+        && age >= TimeUtils.toTicks(SpawnModule.MIN_KIT_DELAY)) {
       this.kitted = true;
       // Give the player the team/class picker, after death has cleared their inventory
       player.getMatch().callEvent(new DeathKitApplyEvent(player));


### PR DESCRIPTION
Allows respawn delay to drop from the current minimum of 1.5s down to 0. This has some implications like rotting animation needs to be reset when leaving dead state. It should additionally fix the current blitz issue where observers will see your corpse forever rotting due to leaving the state before visibility is reset.

This has been tested and seems to have fixed the blitz issue completely, as well as allowing arbitrarily low respawn times. Additionally fixes velocity not being reset for players (which caused instant respawns to conserve velocity after death)