### PR TITLE
Swap OpenJDK 8 Docker image for server image

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -116,7 +116,7 @@
                 <version>3.3.1</version>
                 <configuration>
                     <from>
-                        <image>shipilev/openjdk-shenandoah:8</image>
+                        <image>shipilev/openjdk:8</image>
                     </from>
                     <to>
                         <image>pgm</image>


### PR DESCRIPTION
This changes the Docker image for the server image build to the [following OpenJDK 8 image](https://hub.docker.com/layers/shipilev/openjdk/8/images/sha256-0757764259faac2c824276b356aecdd3a49693527acd19366c1ec93652b75b6d?context=explore). Draft since I can't verify whether this is built with Shenandoah GC support.

Closes #1172