### PR TITLE
Fix prevented team force due to combatlog & improve api

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -91,7 +91,7 @@ public class BlitzMatchModule implements MatchModule, Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void handleLeave(final PlayerPartyChangeEvent event) {
     int lives = this.lifeManager.getLives(event.getPlayer().getId());
     if (event.getOldParty() instanceof Competitor && lives > 0) {

--- a/core/src/main/java/tc/oc/pgm/events/PlayerParticipationEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerParticipationEvent.java
@@ -5,25 +5,35 @@ import static net.kyori.adventure.text.Component.translatable;
 import net.kyori.adventure.text.Component;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerEvent;
+import tc.oc.pgm.join.JoinRequest;
 
 public abstract class PlayerParticipationEvent extends MatchPlayerEvent implements Cancellable {
 
   private final Competitor competitor;
+  private final JoinRequest request;
   private boolean cancelled;
   private @Nullable Component cancelReason;
 
-  protected PlayerParticipationEvent(MatchPlayer player, Competitor competitor) {
+  protected PlayerParticipationEvent(
+      MatchPlayer player, Competitor competitor, JoinRequest request) {
     super(player);
     this.competitor = competitor;
+    this.request = request;
   }
 
   /** NOTE: this Competitor MAY not be in the match at this point */
   public Competitor getCompetitor() {
     return competitor;
+  }
+
+  @NotNull
+  public JoinRequest getRequest() {
+    return request;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/events/PlayerParticipationStartEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerParticipationStartEvent.java
@@ -15,17 +15,8 @@ import tc.oc.pgm.join.JoinRequest;
  * <p>If cancellation is not required, {@link PlayerPartyChangeEvent} should be used instead.
  */
 public class PlayerParticipationStartEvent extends PlayerParticipationEvent {
-
-  private final JoinRequest request;
-
   public PlayerParticipationStartEvent(
       @NotNull MatchPlayer player, @NotNull Competitor competitor, @NotNull JoinRequest request) {
-    super(player, competitor);
-    this.request = request;
-  }
-
-  @NotNull
-  public JoinRequest getRequest() {
-    return request;
+    super(player, competitor, request);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/events/PlayerParticipationStopEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerParticipationStopEvent.java
@@ -1,7 +1,10 @@
 package tc.oc.pgm.events;
 
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.join.JoinRequest;
 
 /**
  * Called immediately before a player leaves a {@link Competitor}. This differs from {@link
@@ -13,7 +16,21 @@ import tc.oc.pgm.api.player.MatchPlayer;
  * <p>If cancellation is not required, {@link PlayerPartyChangeEvent} should be used instead.
  */
 public class PlayerParticipationStopEvent extends PlayerParticipationEvent {
-  public PlayerParticipationStopEvent(MatchPlayer player, Competitor competitor) {
-    super(player, competitor);
+
+  private final @Nullable Party nextParty;
+
+  public PlayerParticipationStopEvent(
+      MatchPlayer player, Competitor competitor, JoinRequest request, @Nullable Party nextParty) {
+    super(player, competitor, request);
+    this.nextParty = nextParty;
+  }
+
+  /**
+   * The next party the player will try to join after ending this participation.
+   *
+   * @return the next party, or null if the player is disconnecting
+   */
+  public @Nullable Party getNextParty() {
+    return nextParty;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/Filterable.java
+++ b/core/src/main/java/tc/oc/pgm/filters/Filterable.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.MatchQuery;
 import tc.oc.pgm.api.filter.query.Query;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.util.Audience;
 
 /**
@@ -37,6 +38,13 @@ public interface Filterable<Q extends MatchQuery> extends MatchQuery, Audience {
   default <F extends Filterable<?>> F getFilterableAncestor(Class<F> type) {
     if (type.isInstance(this)) {
       return (F) this;
+    } else if (Match.class.isAssignableFrom(type)) {
+      // When disconnecting the player's party is set to null. A monostable filter calling
+      // #filterable(match) will end with null due to player -> (null) party -> match,
+      // however going straight to match works fine.
+      // A use-case for this is a time filter used for blitz. Doing /obs won't eliminate you,
+      // leaving the server does. This is due to the filter not finding the match and disallowing.
+      return (F) this.getMatch();
     } else {
       @Nullable Filterable<? super Q> parent = getFilterableParent();
       return parent == null ? null : parent.getFilterableAncestor(type);

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -516,11 +517,12 @@ public class MatchImpl implements Match {
 
       if (oldParty instanceof Competitor) {
         PlayerParticipationEvent request =
-            new PlayerParticipationStopEvent(player, (Competitor) oldParty);
+            new PlayerParticipationStopEvent(player, (Competitor) oldParty, joinRequest, newParty);
         callEvent(request);
-        if (request.isCancelled()
-            && newParty != null) { // Can't cancel this if the player is leaving the match
-          player.sendWarning(request.getCancelReason());
+        // Can't cancel this if the player is leaving the match
+        if (request.isCancelled() && newParty != null) {
+          if (!Objects.equals(Component.empty(), request.getCancelReason()))
+            player.sendWarning(request.getCancelReason());
           return false;
         }
       }
@@ -529,9 +531,10 @@ public class MatchImpl implements Match {
         PlayerParticipationEvent request =
             new PlayerParticipationStartEvent(player, (Competitor) newParty, joinRequest);
         callEvent(request);
-        if (request.isCancelled()
-            && oldParty != null) { // Can't cancel this if the player is joining the match
-          player.sendWarning(request.getCancelReason());
+        // Can't cancel this if the player is joining the match
+        if (request.isCancelled() && oldParty != null) {
+          if (!Objects.equals(Component.empty(), request.getCancelReason()))
+            player.sendWarning(request.getCancelReason());
           return false;
         }
       }

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/CombatLogTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/CombatLogTracker.java
@@ -28,6 +28,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.PlayerParticipationStopEvent;
+import tc.oc.pgm.join.JoinRequest;
 import tc.oc.pgm.tracker.TrackerMatchModule;
 import tc.oc.pgm.util.material.Materials;
 
@@ -210,6 +211,7 @@ public class CombatLogTracker implements Listener {
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onParticipationStop(PlayerParticipationStopEvent event) {
     if (event.getMatch().isRunning()
+        && !event.getRequest().has(JoinRequest.Flag.FORCE)
         && this.getImminentDeath(event.getPlayer().getBukkit()) != null) {
       event.cancel(translatable("leave.err.combatLog"));
       event.setCancelled(true);


### PR DESCRIPTION
Fixes a couple bugs or missing apis in the join logic:

 - Combat logging prevention on PGM (prevents running /obs while falling off the map) doesn't respect force join. This could essentially mean a team-switch kit not being applied just because you're falling, potentially breaking maps.
 - Participation stop event has been given the join request that originates it, as well as the next team, so that better decisions can be taken (like the combat logging fix if forced). This is relevant if you want to cancel the event to do other logic in 3rd party plugins (see, events or ingame).
  - Blitz filters are incorrectly applied when leaving the server (work fine if you just leave the team via /obs).