### PR TITLE
Add map source location to /map output

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapLibrary.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapLibrary.java
@@ -1,9 +1,11 @@
 package tc.oc.pgm.api.map;
 
+import java.net.URI;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapIncludeProcessor;
 
 /** A library of {@link MapInfo}s and {@link MapContext}s. */
@@ -17,6 +19,16 @@ public interface MapLibrary {
    */
   @Nullable
   MapInfo getMap(String idOrName);
+
+  /**
+   * Get the original location of a maps {@link MapSource}.
+   *
+   * @param mapInfo
+   * @return
+   * @throws MapMissingException If an error occurs while attempting to look up the location of the
+   *     source
+   */
+  URI getMapURI(MapInfo mapInfo) throws MapMissingException;
 
   /**
    * Get all {@link MapInfo}s matching the query.

--- a/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
@@ -2,11 +2,27 @@ package tc.oc.pgm.api.map;
 
 import java.io.File;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.Collection;
+import org.bukkit.World;
 import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
 
-/** A source where {@link MapInfo} documents and files are downloaded. */
+/**
+ * A directory where map documents and files are downloaded from. Methods might error if the source
+ * moves or changes after this object is created. (e.g a file moves to a new directory)
+ *
+ * <p>A valid source is a directory containing at least:
+ *
+ * <ul>
+ *   <li>An XML Document following the PGM spec(documented at <a href="https://pgm.dev">the PGM
+ *       website)</a>
+ *   <li>Files for generating a {@link World}
+ * </ul>
+ *
+ * @see MapMissingException
+ * @see MapContext
+ */
 public interface MapSource {
   String FILE = "map.xml";
 
@@ -18,7 +34,7 @@ public interface MapSource {
   String getId();
 
   /**
-   * Download the {@link org.bukkit.World} files to a local directory.
+   * Download the {@link World} files to a local directory.
    *
    * @param dir An existent, but empty directory.
    * @throws MapMissingException If an error occurs while creating the files.
@@ -32,6 +48,14 @@ public interface MapSource {
    * @return An xml document stream.
    */
   InputStream getDocument() throws MapMissingException;
+
+  /**
+   * Get the location of the source backing this {@link MapSource} in the form of an {@link URI}.
+   *
+   * @throws MapMissingException If an error occurs while attempting to look up the location of the
+   *     source
+   */
+  URI getURI() throws MapMissingException;
 
   /**
    * Get whether future calls to {@link #getDocument()} will return different results.

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -33,6 +33,7 @@ import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapLibrary;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.Phase;
+import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.rotation.MapPoolManager;
 import tc.oc.pgm.rotation.pools.MapPool;
 import tc.oc.pgm.util.Audience;
@@ -143,7 +144,8 @@ public final class MapCommand {
   public void map(
       Audience audience,
       CommandSender sender,
-      @Argument(value = "map", defaultValue = CURRENT) @Greedy MapInfo map) {
+      @Argument(value = "map", defaultValue = CURRENT) @Greedy MapInfo map)
+      throws MapMissingException {
     audience.sendMessage(
         TextFormatter.horizontalLineHeading(
             sender,
@@ -223,6 +225,13 @@ public final class MapCommand {
           text()
               .append(mapInfoLabel("map.info.phase"))
               .append(map.getPhase().toComponent().color(NamedTextColor.GOLD))
+              .build());
+
+      audience.sendMessage(
+          text()
+              .append(mapInfoLabel("map.info.directory"))
+              .append(
+                  text(PGM.get().getMapLibrary().getMapURI(map).toString(), NamedTextColor.GOLD))
               .build());
     }
 

--- a/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
@@ -4,6 +4,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import com.google.common.collect.Iterators;
 import java.lang.ref.SoftReference;
+import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -75,6 +76,16 @@ public class MapLibraryImpl implements MapLibrary {
     }
 
     return map == null ? null : map.info;
+  }
+
+  @Override
+  public URI getMapURI(MapInfo mapInfo) throws MapMissingException {
+    return maps.values().stream()
+        .filter(e -> e.info.equals(mapInfo))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Could not find URI for MapInfo: " + mapInfo))
+        .source
+        .getURI();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/map/source/SystemMapSourceFactory.java
+++ b/core/src/main/java/tc/oc/pgm/map/source/SystemMapSourceFactory.java
@@ -8,6 +8,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -116,6 +117,13 @@ public class SystemMapSourceFactory extends PathMapSourceFactory {
       } finally {
         lastRead.set(System.currentTimeMillis());
       }
+    }
+
+    @Override
+    public URI getURI() throws MapMissingException {
+      final File file = getFile();
+
+      return file.toURI();
     }
 
     @Override

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -42,6 +42,8 @@ map.info.objective = Objective
 
 map.info.phase = Phase
 
+map.info.directory = Map directory
+
 # {0} = name of a maptag (e.g "#tnt" or "#controlpoint")
 map.info.mapTag.hover = Click to list all {0} maps
 


### PR DESCRIPTION
Adds the location of the map source files in the output when using /map and have the DEBUG permission. (idea by @Pablete1234)

This is a draft because giving opening for access to `MapSource` stuff through the `MapLibrary` seems a little weird, and I'm not sure what's the best approach. I thought of upgrading the object returned from `#getMap(String)` from `MapInfo` to some new object (basically `Pair<MapSource, MapInfo>`) as well as adding a method for just getting the source directly (e.g `#getMapSource()`). Both seemed wrong as it would then imply that you could load maps directly from the `MapSource` and not through `MapLibrary#loadNewMaps()` and `MapLibrary#loadExistingMap()`. 

My final attempt is the current state of this draft PR, which seemed like a better approach, but still feels a little weird since it still gives access to some "low level" map stuff. Feedback appreciated!

Draft also because javadocs and strings are WIP