### PR TITLE
Fix wrong file separator

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -243,7 +243,7 @@ public final class PGMConfig implements Config {
           Normalizer.normalize(uri.getHost() + uri.getPath(), Normalizer.Form.NFD)
               .replaceAll("[^A-Za-z0-9_]", "-")
               .toLowerCase(Locale.ROOT);
-      path = "maps" + File.pathSeparator + normalizedPath;
+      path = "maps" + File.separator + normalizedPath;
     }
 
     Path base = Paths.get(path).toAbsolutePath();


### PR DESCRIPTION
Currently git maps are being stored in: `maps:github-com-user-repo` instead of `maps/github-com-user-repo` which is unintended