### PR TITLE
Add custom inventory check for item mods

### DIFF
--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyMatchModule.java
@@ -1,14 +1,17 @@
 package tc.oc.pgm.itemmeta;
 
 import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDispenseEvent;
 import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -61,10 +64,16 @@ public class ItemModifyMatchModule implements MatchModule, Listener {
 
   @EventHandler
   public void onInventoryOpen(InventoryOpenEvent event) {
-    ItemStack[] contents = event.getInventory().getContents();
+    Inventory inventory = event.getInventory();
+    // Custom GUIs use chest inventory type with player as the holder
+    if (inventory.getType() == InventoryType.CHEST && inventory.getHolder() instanceof Player) {
+      return;
+    }
+
+    ItemStack[] contents = inventory.getContents();
     for (int i = 0; i < contents.length; i++) {
       if (applyRules(contents[i])) {
-        event.getInventory().setItem(i, contents[i]);
+        inventory.setItem(i, contents[i]);
       }
     }
   }


### PR DESCRIPTION
Maps with item mods can break custom GUIs created by other plugins (or PGM itself). Item mods apply to all inventories so custom GUIs used for example team picker, settings, fx or battlepass plugins would also be modified and potentially broken by specific PGM maps.

You cannot do a type check on if the `inventory` is a `CraftInventoryCustom.MinecraftInventory` as this is a private class. Bukkit creates custom GUIs as chests with the holder set as the player so this can be used to detect custom inventory types and return before applying (normal chests do not have the owner as a player but as the world tile entity).
