### PR TITLE
Fix obs always being forced

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/JoinCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/JoinCommand.java
@@ -11,6 +11,7 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.join.JoinMatchModule;
+import tc.oc.pgm.join.JoinRequest;
 
 public final class JoinCommand {
 
@@ -38,6 +39,6 @@ public final class JoinCommand {
   @CommandDescription("Leave the match")
   @CommandPermission(Permissions.LEAVE)
   public void leave(JoinMatchModule joiner, MatchPlayer player) {
-    joiner.leave(player);
+    joiner.leave(player, JoinRequest.empty());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/TeamCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/TeamCommand.java
@@ -23,6 +23,7 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.join.JoinMatchModule;
+import tc.oc.pgm.join.JoinRequest;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.Audience;
@@ -44,7 +45,7 @@ public final class TeamCommand {
     final Party oldParty = joiner.getParty();
 
     if (team != null && !(team instanceof Competitor)) {
-      join.leave(joiner);
+      join.leave(joiner, JoinRequest.force());
     } else {
       join.forceJoin(joiner, (Competitor) team);
     }

--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -155,7 +155,7 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
     return handler.join(joining, request, result);
   }
 
-  public boolean leave(MatchPlayer leaving) {
+  public boolean leave(MatchPlayer leaving, JoinRequest request) {
     if (cancelQueuedJoin(leaving)) return true;
 
     if (leaving.getParty() instanceof ObserverParty) {
@@ -169,7 +169,7 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
       return false;
     }
 
-    return match.setParty(leaving, match.getDefaultParty());
+    return match.setParty(leaving, match.getDefaultParty(), request);
   }
 
   public QueuedParty getQueuedParticipants() {

--- a/core/src/main/java/tc/oc/pgm/join/JoinRequest.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinRequest.java
@@ -10,6 +10,9 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.teams.Team;
 
 public class JoinRequest {
+  private static final JoinRequest FORCE = new JoinRequest(null, 1, EnumSet.of(Flag.FORCE));
+  private static final JoinRequest EMPTY = new JoinRequest(null, 1, EnumSet.noneOf(Flag.class));
+
   private final @Nullable Team team;
   private final int players;
   private final ImmutableSet<Flag> flags;
@@ -34,6 +37,14 @@ public class JoinRequest {
 
   public static JoinRequest group(@Nullable Team team, int size, Set<Flag> flags) {
     return new JoinRequest(team, size, flags);
+  }
+
+  public static JoinRequest empty() {
+    return EMPTY;
+  }
+
+  public static JoinRequest force() {
+    return FORCE;
   }
 
   @Nullable

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -465,7 +465,10 @@ public class MatchImpl implements Match {
   @Override
   public boolean setParty(MatchPlayer player, Party party, @Nullable JoinRequest request) {
     if (request == null)
-      request = JoinRequest.of(party instanceof Team ? (Team) party : null, JoinRequest.Flag.FORCE);
+      request =
+          party instanceof Team
+              ? JoinRequest.of((Team) party, JoinRequest.Flag.FORCE)
+              : JoinRequest.force();
     return setOrClearPlayerParty(player, assertNotNull(party), request);
   }
 

--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -373,7 +373,7 @@ public class PickerMatchModule implements MatchModule, Listener {
         jmm.join(player, JoinRequest.fromPlayer(player, null));
       }
     } else if (hand.getType() == Button.LEAVE.material && left) {
-      jmm.leave(player);
+      jmm.leave(player, JoinRequest.empty());
     }
 
     if (handled) {
@@ -763,7 +763,7 @@ public class PickerMatchModule implements MatchModule, Listener {
         .execute(
             () -> {
               if (bukkit.isOnline()) {
-                match.needModule(JoinMatchModule.class).leave(player);
+                match.needModule(JoinMatchModule.class).leave(player, JoinRequest.empty());
               }
             });
   }


### PR DESCRIPTION
Ever since the #1175 making changes to how combatlog knows about forced joins, it's made joining observers no longer checked against combatlog, as all requests to /obs were running a default match.setParty, which, unless told otherwise, considers it a forced join.

Now things like `/team force Player obs` will always force you (regardless of combatlog) while things like `/obs` are non-forced joins and so, require you pass the checks.