### PR TITLE
Clear a players cached decoration on quit

### DIFF
--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
@@ -17,6 +17,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.jetbrains.annotations.NotNull;
@@ -69,6 +70,12 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
     Player player = event.getPlayer().getBukkit();
     Party party = event.getNewParty();
     player.setDisplayName(getDecoratedName(player, party == null ? null : party.getColor()));
+  }
+
+  @EventHandler
+  public void onPlayerQuit(PlayerQuitEvent event) {
+    decorationCache.invalidate(event.getPlayer().getUniqueId());
+    PlayerComponent.RENDERER.decorationChanged(event.getPlayer().getUniqueId());
   }
 
   @EventHandler

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
@@ -72,7 +72,7 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
     player.setDisplayName(getDecoratedName(player, party == null ? null : party.getColor()));
   }
 
-  @EventHandler
+  @EventHandler(priority = EventPriority.MONITOR)
   public void onPlayerQuit(PlayerQuitEvent event) {
     decorationCache.invalidate(event.getPlayer().getUniqueId());
     PlayerComponent.RENDERER.decorationChanged(event.getPlayer().getUniqueId());


### PR DESCRIPTION
When a player is assigned or removed from a group with a flair (suffix or prefix) the current cache prevents this from updating live.

This can be confusing for players to know if they've received the rank, the next logical step for a player is to relog to see if that updates their flairs, the cache remains after players quit so this has no effect. Clearing the cache on player quit allows users to relog to invalidate their existing cache record, something that staff members could instruct a player to do.

It would also be nice to have a command that applies the same logic so that this can be run by other plugins (such as Buycraft) so that rank purchases are shown instantly. 

Couldn't come up with a good name for this command as the username cache doesn't just store the flairs but calling it something related to username cache may be confusing, I wouldn't expect players (staff or not) to be using this command so that shouldn't really matter, `/usernamecache reload [username]`, `/flair reload [username]`, `/decoration reload [username]` 🤷 ?
