### PR TITLE
Refactor NMSHacks to make multi-version support easier

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/actions/FillAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/FillAction.java
@@ -9,6 +9,7 @@ import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.query.BlockQuery;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 public class FillAction extends AbstractAction<Match> {
 
@@ -32,7 +33,7 @@ public class FillAction extends AbstractAction<Match> {
       if (filter != null && filter.query(new BlockQuery(block)).isDenied()) continue;
 
       BlockState newState = block.getState();
-      newState.setMaterialData(materialData);
+      NMSHacks.setBlockStateData(newState, materialData);
 
       if (events) {
         BlockFormEvent event = new BlockFormEvent(block, newState);

--- a/core/src/main/java/tc/oc/pgm/api/event/BlockTransformEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/event/BlockTransformEvent.java
@@ -20,6 +20,7 @@ import tc.oc.pgm.blockdrops.BlockDrops;
 import tc.oc.pgm.util.block.BlockStates;
 import tc.oc.pgm.util.event.GeneralizedEvent;
 import tc.oc.pgm.util.event.entity.ExplosionPrimeByEntityEvent;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 /** Called when a {@link Block} transforms from one {@link BlockState} to another. */
 public class BlockTransformEvent extends GeneralizedEvent {
@@ -97,8 +98,7 @@ public class BlockTransformEvent extends GeneralizedEvent {
       return newState;
     } else {
       final BlockState state = newState.getBlock().getState();
-      state.setType(drops.replacement.getItemType());
-      state.setData(drops.replacement);
+      NMSHacks.setBlockStateData(state, drops.replacement);
       return state;
     }
   }

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -142,7 +142,7 @@ public class BlitzMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onBlitzPlayerEliminated(final BlitzPlayerEliminatedEvent event) {
-    this.eliminatedPlayers.add(event.getPlayer().getBukkit().getUniqueId());
+    this.eliminatedPlayers.add(event.getPlayer().getId());
 
     World world = event.getMatch().getWorld();
     Location death = event.getDeathLocation();
@@ -162,8 +162,7 @@ public class BlitzMatchModule implements MatchModule, Listener {
   private void handleElimination(final MatchPlayer player, Competitor competitor) {
     if (!eliminatedPlayers.add(player.getBukkit().getUniqueId())) return;
 
-    match.callEvent(
-        new BlitzPlayerEliminatedEvent(player, competitor, player.getBukkit().getLocation()));
+    match.callEvent(new BlitzPlayerEliminatedEvent(player, competitor, player.getLocation()));
 
     checkEnd();
   }
@@ -179,8 +178,7 @@ public class BlitzMatchModule implements MatchModule, Listener {
         .execute(
             () -> {
               ImmutableSet.copyOf(match.getParticipants()).stream()
-                  .filter(
-                      participating -> isPlayerEliminated(participating.getBukkit().getUniqueId()))
+                  .filter(participating -> isPlayerEliminated(participating.getId()))
                   .forEach(participating -> match.setParty(participating, match.getDefaultParty()));
 
               match.calculateVictory();

--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
@@ -37,6 +37,7 @@ import tc.oc.pgm.util.event.PlayerPunchBlockEvent;
 import tc.oc.pgm.util.event.PlayerTrampleBlockEvent;
 import tc.oc.pgm.util.event.entity.EntityDespawnInVoidEvent;
 import tc.oc.pgm.util.material.Materials;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
 public class BlockDropsMatchModule implements MatchModule, Listener {
@@ -106,7 +107,7 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
   }
 
   private void dropItems(BlockDrops drops, MatchPlayer player, Location location, double yield) {
-    if (player == null || player.getBukkit().getGameMode() != GameMode.CREATIVE) {
+    if (player == null || player.getGameMode() != GameMode.CREATIVE) {
       Random random = match.getRandom();
       for (Map.Entry<ItemStack, Double> entry : drops.items.entrySet()) {
         if (random.nextFloat() < yield * entry.getValue()) {
@@ -142,8 +143,7 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
 
       if (!event.isCancelled()) {
         BlockState state = block.getState();
-        state.setType(drops.replacement.getItemType());
-        state.setData(drops.replacement);
+        NMSHacks.setBlockStateData(state, drops.replacement);
         state.update(true, true);
       }
     }
@@ -280,7 +280,7 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
 
     replaceBlock(drops, event.getBlock(), player);
 
-    Location location = player.getBukkit().getLocation();
+    Location location = player.getLocation();
     dropObjects(drops, player, location, 1d, false);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsRuleSet.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsRuleSet.java
@@ -100,7 +100,6 @@ public class BlockDropsRuleSet {
     if (event instanceof BlockBreakEvent) {
       rightToolUsed =
           NMSHacks.canMineBlock(material, ((BlockBreakEvent) event).getPlayer().getItemInHand());
-      ;
     } else {
       rightToolUsed = true;
     }

--- a/core/src/main/java/tc/oc/pgm/flag/LegacyFlagBeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/LegacyFlagBeamMatchModule.java
@@ -37,6 +37,7 @@ import tc.oc.pgm.flag.state.Carried;
 import tc.oc.pgm.flag.state.Spawned;
 import tc.oc.pgm.util.inventory.ItemBuilder;
 import tc.oc.pgm.util.nms.NMSHacks;
+import tc.oc.pgm.util.nms.entity.fake.FakeEntity;
 
 @ListenerScope(MatchScope.LOADED)
 public class LegacyFlagBeamMatchModule implements MatchModule, Listener {
@@ -133,8 +134,8 @@ public class LegacyFlagBeamMatchModule implements MatchModule, Listener {
 
   class Beam {
     private final Flag flag;
-    private final NMSHacks.FakeEntity base, legacyBase;
-    private final List<NMSHacks.FakeEntity> segments;
+    private final FakeEntity base, legacyBase;
+    private final List<FakeEntity> segments;
 
     private final Set<MatchPlayer> viewers = new HashSet<>();
 
@@ -142,13 +143,13 @@ public class LegacyFlagBeamMatchModule implements MatchModule, Listener {
       this.flag = flag;
 
       ItemStack wool = new ItemBuilder().material(Material.WOOL).color(flag.getDyeColor()).build();
-      this.base = new NMSHacks.FakeArmorStand(match.getWorld(), wool);
-      this.legacyBase = new NMSHacks.FakeWitherSkull(match.getWorld());
+      this.base = NMSHacks.fakeArmorStand(match.getWorld(), wool);
+      this.legacyBase = NMSHacks.fakeWitherSkull(match.getWorld());
       this.segments =
           range(0, 64) // ~100 blocks is the height which the particles appear to be reasonably
               // visible (similar amount to amount closest to the flag), we limit this to 64 blocks
               // to reduce load on the client
-              .mapToObj(i -> new NMSHacks.FakeArmorStand(match.getWorld(), wool))
+              .mapToObj(i -> NMSHacks.fakeArmorStand(match.getWorld(), wool))
               .collect(Collectors.toList());
     }
 
@@ -169,7 +170,7 @@ public class LegacyFlagBeamMatchModule implements MatchModule, Listener {
       return Optional.of(location);
     }
 
-    private NMSHacks.FakeEntity base(MatchPlayer player) {
+    private FakeEntity base(MatchPlayer player) {
       return player.isLegacy() ? legacyBase : base;
     }
 
@@ -194,7 +195,7 @@ public class LegacyFlagBeamMatchModule implements MatchModule, Listener {
       update(player);
     }
 
-    private void spawn(Player player, NMSHacks.FakeEntity entity) {
+    private void spawn(Player player, FakeEntity entity) {
       location().ifPresent(l -> entity.spawn(player, l));
     }
 

--- a/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
@@ -53,6 +53,7 @@ import tc.oc.pgm.kits.WalkSpeedKit;
 import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.attribute.Attribute;
+import tc.oc.pgm.util.attribute.AttributeInstance;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.nms.NMSHacks;
@@ -341,25 +342,30 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
             ChatColor.LIGHT_PURPLE + TextTranslations.translate("preview.doubleJump", viewer));
       }
 
-      double knockbackResistance =
-          matchHolder.getAttribute(Attribute.GENERIC_KNOCKBACK_RESISTANCE).getValue();
-      if (knockbackResistance > 0) {
-        specialLore.add(
-            ChatColor.LIGHT_PURPLE
-                + TextTranslations.translate(
-                    "preview.knockbackResistance",
-                    viewer,
-                    (int) Math.ceil(knockbackResistance * 100)));
+      AttributeInstance knockbackAttribute =
+          matchHolder.getAttribute(Attribute.GENERIC_KNOCKBACK_RESISTANCE);
+      if (knockbackAttribute != null) {
+        double knockbackResistance = knockbackAttribute.getValue();
+        if (knockbackResistance > 0) {
+          specialLore.add(
+              ChatColor.LIGHT_PURPLE
+                  + TextTranslations.translate(
+                      "preview.knockbackResistance",
+                      viewer,
+                      (int) Math.ceil(knockbackResistance * 100)));
+        }
       }
 
-      double knockbackReduction = holder.getKnockbackReduction();
-      if (knockbackReduction > 0) {
-        specialLore.add(
-            ChatColor.LIGHT_PURPLE
-                + TextTranslations.translate(
-                    "preview.knockbackReduction",
-                    viewer,
-                    (int) Math.ceil(knockbackReduction * 100)));
+      if (BukkitUtils.isSportPaper()) {
+        double knockbackReduction = holder.getKnockbackReduction();
+        if (knockbackReduction > 0) {
+          specialLore.add(
+              ChatColor.LIGHT_PURPLE
+                  + TextTranslations.translate(
+                      "preview.knockbackReduction",
+                      viewer,
+                      (int) Math.ceil(knockbackReduction * 100)));
+        }
       }
 
       double walkSpeed = holder.getWalkSpeed();

--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -68,6 +68,7 @@ import tc.oc.pgm.util.bukkit.Events;
 import tc.oc.pgm.util.event.block.BlockFallEvent;
 import tc.oc.pgm.util.event.entity.ExplosionPrimeByEntityEvent;
 import tc.oc.pgm.util.material.Materials;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 public class BlockTransformListener implements Listener {
   private static final BlockFace[] NEIGHBORS = {
@@ -488,8 +489,7 @@ public class BlockTransformListener implements Listener {
         new PistonExtensionMaterial(Material.PISTON_EXTENSION);
     pistonExtension.setFacingDirection(event.getDirection());
     BlockState pistonExtensionState = event.getBlock().getRelative(event.getDirection()).getState();
-    pistonExtensionState.setType(pistonExtension.getItemType());
-    pistonExtensionState.setData(pistonExtension);
+    NMSHacks.setBlockStateData(pistonExtensionState, pistonExtension);
     newStates.put(event.getBlock(), pistonExtensionState);
 
     this.onPistonMove(event, event.getBlocks(), newStates);

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -54,6 +54,7 @@ import tc.oc.pgm.util.UsernameFormatUtils;
 import tc.oc.pgm.util.bukkit.WorldBorders;
 import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
 import tc.oc.pgm.util.nms.NMSHacks;
+import tc.oc.pgm.util.skin.Skin;
 import tc.oc.pgm.util.text.TemporalComponent;
 import tc.oc.pgm.util.text.TextTranslations;
 
@@ -369,7 +370,10 @@ public class PGMListener implements Listener {
   @EventHandler // We only need to store skins for the post match stats
   public void storeSkinOnMatchJoin(PlayerJoinMatchEvent event) {
     final MatchPlayer player = event.getPlayer();
-    PGM.get().getDatastore().setSkin(player.getId(), NMSHacks.getPlayerSkin(player.getBukkit()));
+    Skin playerSkin = NMSHacks.getPlayerSkin(player.getBukkit());
+    if (playerSkin != null) {
+      PGM.get().getDatastore().setSkin(player.getId(), playerSkin);
+    }
   }
 
   public void setGameRule(MatchLoadEvent event, String gameRule, boolean gameRuleValue) {

--- a/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
@@ -360,10 +360,9 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
         for (Player player : Bukkit.getOnlinePlayers()) {
           if (viewer.canSee(player) && viewer != player) players.add(player.getName());
         }
+        String prefix = ChatColor.AQUA.toString();
         NMSHacks.sendPacket(
-            viewer,
-            NMSHacks.teamCreatePacket(
-                "dummy", "dummy", ChatColor.AQUA.toString(), "", false, false, players));
+            viewer, NMSHacks.teamCreatePacket("dummy", "dummy", prefix, "", false, false, players));
       }
 
       int tpPerSecond = Integer.MAX_VALUE;
@@ -400,7 +399,7 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
       }
 
       // After all players have been teleported, remove the dummy team
-      NMSHacks.sendPacket(NMSHacks.teamRemovePacket("dummy"));
+      NMSHacks.sendDestroyTeamDummyPacket();
 
       match.callEvent(new MatchAfterLoadEvent(match));
 

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -54,7 +54,6 @@ import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.attribute.Attribute;
 import tc.oc.pgm.util.attribute.AttributeInstance;
 import tc.oc.pgm.util.attribute.AttributeMap;
-import tc.oc.pgm.util.attribute.AttributeMapImpl;
 import tc.oc.pgm.util.attribute.AttributeModifier;
 import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.named.NameStyle;
@@ -95,7 +94,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     this.visible = new AtomicBoolean(false);
     this.protocolReady = new AtomicBoolean(ViaUtils.isReady(player));
     this.protocolVersion = new AtomicInteger(ViaUtils.getProtocolVersion(player));
-    this.attributeMap = new AttributeMapImpl(player);
+    this.attributeMap = NMSHacks.buildAttributeMap(player);
   }
 
   @Override
@@ -329,7 +328,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
         NMSHacks.spawnFreezeEntity(bukkit, FROZEN_VEHICLE_ENTITY_ID, isLegacy());
         NMSHacks.entityAttach(bukkit, bukkit.getEntityId(), FROZEN_VEHICLE_ENTITY_ID, false);
       } else {
-        NMSHacks.destroyEntities(bukkit, FROZEN_VEHICLE_ENTITY_ID);
+        NMSHacks.sendPacket(bukkit, NMSHacks.destroyEntitiesPacket(FROZEN_VEHICLE_ENTITY_ID));
       }
       resetInteraction();
     }

--- a/core/src/main/java/tc/oc/pgm/portals/PortalTransform.java
+++ b/core/src/main/java/tc/oc/pgm/portals/PortalTransform.java
@@ -56,7 +56,9 @@ public interface PortalTransform extends InvertibleOperator<PortalTransform> {
 
     private Location mutate(Location v) {
       Vector mutated = mutate(v.toVector());
-      v.set(mutated.getX(), mutated.getY(), mutated.getZ());
+      v.setX(mutated.getX());
+      v.setY(mutated.getY());
+      v.setZ(mutated.getZ());
       v.setYaw((float) yaw.apply(v.getYaw()));
       v.setPitch((float) pitch.apply(v.getPitch()));
       return v;
@@ -138,7 +140,9 @@ public interface PortalTransform extends InvertibleOperator<PortalTransform> {
     public Location apply(Location v) {
       v = v.clone();
       Vector region = to.getRandom(random);
-      v.set(region.getX(), region.getY(), region.getZ());
+      v.setX(region.getX());
+      v.setY(region.getY());
+      v.setZ(region.getZ());
       return v;
     }
 

--- a/core/src/main/java/tc/oc/pgm/renewable/Renewable.java
+++ b/core/src/main/java/tc/oc/pgm/renewable/Renewable.java
@@ -30,6 +30,7 @@ import tc.oc.pgm.util.block.BlockVectorSet;
 import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.material.MaterialCounter;
 import tc.oc.pgm.util.material.Materials;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 public class Renewable implements Listener, Tickable {
 
@@ -266,8 +267,7 @@ public class Renewable implements Listener, Tickable {
     Location location = pos.toLocation(match.getWorld());
     Block block = location.getBlock();
     BlockState newState = location.getBlock().getState();
-    newState.setType(material.getItemType());
-    newState.setData(material);
+    NMSHacks.setBlockStateData(newState, material);
 
     BlockRenewEvent event = new BlockRenewEvent(block, newState, this);
     match.callEvent(event); // Our own handler will get this and remove the block from the pool

--- a/core/src/main/java/tc/oc/pgm/snapshot/BudgetWorldEdit.java
+++ b/core/src/main/java/tc/oc/pgm/snapshot/BudgetWorldEdit.java
@@ -8,6 +8,7 @@ import org.bukkit.util.BlockVector;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.util.BlockData;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 /**
  * Utils to save, remove and paste blocks in some {@link Region} in some {@link Match} using the
@@ -33,7 +34,7 @@ class BudgetWorldEdit {
     for (BlockData blockData : snapshot.getMaterials(region)) {
 
       BlockState state = blockData.getBlock(world, offset).getState();
-      state.setMaterialData(blockData.getMaterialData());
+      NMSHacks.setBlockStateData(state, blockData.getMaterialData());
       state.update(true, true);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/snapshot/WorldSnapshot.java
+++ b/core/src/main/java/tc/oc/pgm/snapshot/WorldSnapshot.java
@@ -52,7 +52,8 @@ public class WorldSnapshot {
     ChunkSnapshot chunkSnapshot = chunkSnapshots.get(chunkVector);
     if (chunkSnapshot != null) {
       BlockVector chunkPos = chunkVector.worldToChunk(x, y, z);
-      state.setMaterialData(
+      NMSHacks.setBlockStateData(
+          state,
           new MaterialData(
               chunkSnapshot.getBlockTypeId(
                   chunkPos.getBlockX(), chunkPos.getBlockY(), chunkPos.getBlockZ()),

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnablePotion.java
@@ -12,6 +12,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.spawner.Spawnable;
 import tc.oc.pgm.spawner.Spawner;
 import tc.oc.pgm.util.nms.NMSHacks;
+import tc.oc.pgm.util.nms.entity.potion.EntityPotion;
 
 public class SpawnablePotion implements Spawnable {
   private final ItemStack potionItem;
@@ -31,7 +32,7 @@ public class SpawnablePotion implements Spawnable {
 
   @Override
   public void spawn(Location location, Match match) {
-    NMSHacks.EntityPotion entityPotion = new NMSHacks.EntityPotion(location, potionItem);
+    EntityPotion entityPotion = NMSHacks.entityPotion(location, potionItem);
     entityPotion.spawn();
     entityPotion
         .getBukkitEntity()

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTMatchModule.java
@@ -69,6 +69,17 @@ public class TNTMatchModule implements MatchModule, Listener {
     }
   }
 
+  private static Sound FUSE_SOUND = chooseFuseSound();
+
+  private static Sound chooseFuseSound() {
+    try {
+      return Sound.FUSE;
+    } catch (NoSuchFieldError error) {
+      // TODO: make or use a 1.8 -> 1.9+ sound conversion api
+      return Sound.valueOf("ENTITY_TNT_PRIMED");
+    }
+  }
+
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void handleInstantActivation(BlockPlaceEvent event) {
     if (this.properties.instantIgnite && event.getBlock().getType() == Material.TNT) {
@@ -88,7 +99,7 @@ public class TNTMatchModule implements MatchModule, Listener {
 
       if (callPrimeEvent(tnt, event.getPlayer())) {
         event.setCancelled(true); // Allow the block to be placed if priming is cancelled
-        world.playSound(tnt.getLocation(), Sound.FUSE, 1, 1);
+        world.playSound(tnt.getLocation(), FUSE_SOUND, 1, 1);
 
         ItemStack inHand = event.getPlayer().getItemInHand();
         if (inHand.getAmount() == 1) {

--- a/core/src/main/java/tc/oc/pgm/tntrender/TNTRenderMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tntrender/TNTRenderMatchModule.java
@@ -68,18 +68,19 @@ public class TNTRenderMatchModule implements MatchModule, Listener {
 
     public PrimedTnt(TNTPrimed entity) {
       this.entity = entity;
-      this.lastLocation = currentLocation = entity.getLocation().toBlockLocation();
+      this.lastLocation = currentLocation = toBlockLocation(entity.getLocation());
     }
 
     public boolean update() {
       if (entity.isDead()) {
-        for (MatchPlayer viewer : viewers)
+        for (MatchPlayer viewer : viewers) {
           NMSHacks.sendBlockChange(currentLocation, viewer.getBukkit(), null);
+        }
         return true;
       }
 
       this.lastLocation = currentLocation;
-      this.currentLocation = entity.getLocation().toBlockLocation();
+      this.currentLocation = toBlockLocation(entity.getLocation());
       this.moved = !currentLocation.equals(lastLocation);
 
       for (MatchPlayer player : match.getPlayers()) {
@@ -100,5 +101,14 @@ public class TNTRenderMatchModule implements MatchModule, Listener {
         NMSHacks.sendBlockChange(lastLocation, player.getBukkit(), null);
       }
     }
+  }
+
+  private static Location toBlockLocation(Location location) {
+    // Spigot 1.8 doesn't have Location.toBlockLocation()
+    Location blockLoc = location.clone();
+    blockLoc.setX(blockLoc.getBlockX());
+    blockLoc.setY(blockLoc.getBlockY());
+    blockLoc.setZ(blockLoc.getBlockZ());
+    return blockLoc;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/block/BlockStates.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/BlockStates.java
@@ -6,6 +6,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.material.MaterialData;
 import org.bukkit.util.BlockVector;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 public interface BlockStates {
 
@@ -37,8 +38,7 @@ public interface BlockStates {
 
   static BlockState create(World world, BlockVector pos, MaterialData materialData) {
     BlockState state = pos.toLocation(world).getBlock().getState();
-    state.setType(materialData.getItemType());
-    state.setData(materialData);
+    NMSHacks.setBlockStateData(state, materialData);
     return state;
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/concurrent/RateLimiter.java
+++ b/util/src/main/java/tc/oc/pgm/util/concurrent/RateLimiter.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.util.concurrent;
 
-import org.bukkit.Bukkit;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 public class RateLimiter {
   private final int minDelay, maxDelay;
@@ -36,7 +36,7 @@ public class RateLimiter {
     long nextUpdate =
         (endedAt - now)
             + ((endedAt - startedAt) * timeRatio)
-            + (long) Math.max(0, (20 - Bukkit.getServer().spigot().getTPS()[0]) * tpsRatio);
+            + (long) Math.max(0, (20 - NMSHacks.getTPS()) * tpsRatio);
 
     return Math.max(timedOutUntil - now, 0) + Math.min(Math.max(minDelay, nextUpdate), maxDelay);
   }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -81,12 +81,11 @@ public final class InventoryUtils {
       PotionMeta meta = (PotionMeta) potion.getItemMeta();
       if (meta.hasCustomEffects()) {
         return meta.getCustomEffects();
-      } else {
+      } else if (potion.getType() == Material.POTION) { // Sanity check, SpawnablePotionBukkit
         return Potion.fromItemStack(potion).getEffects();
       }
-    } else {
-      return Collections.emptyList();
     }
+    return Collections.emptyList();
   }
 
   public static @Nullable PotionEffectType getPrimaryEffectType(ItemStack potion) {

--- a/util/src/main/java/tc/oc/pgm/util/nms/EnumPlayerInfoAction.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/EnumPlayerInfoAction.java
@@ -1,0 +1,9 @@
+package tc.oc.pgm.util.nms;
+
+public enum EnumPlayerInfoAction {
+  ADD_PLAYER,
+  UPDATE_GAME_MODE,
+  UPDATE_LATENCY,
+  UPDATE_DISPLAY_NAME,
+  REMOVE_PLAYER,
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -1,253 +1,377 @@
 package tc.oc.pgm.util.nms;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.SetMultimap;
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.minecraft.server.v1_8_R3.*;
-import net.minecraft.server.v1_8_R3.Item;
-import net.minecraft.server.v1_8_R3.WorldBorder;
-import org.bukkit.*;
+import java.util.logging.Logger;
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.v1_8_R3.CraftChunk;
-import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
-import org.bukkit.craftbukkit.v1_8_R3.block.CraftBlock;
-import org.bukkit.craftbukkit.v1_8_R3.entity.*;
-import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
-import org.bukkit.craftbukkit.v1_8_R3.scoreboard.CraftTeam;
-import org.bukkit.craftbukkit.v1_8_R3.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.WorldCreator;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.inventory.DoubleChestInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.material.MaterialData;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.NameTagVisibility;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.ClassLogger;
+import tc.oc.pgm.util.attribute.AttributeMap;
 import tc.oc.pgm.util.attribute.AttributeModifier;
 import tc.oc.pgm.util.block.RayBlockIntersection;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
-import tc.oc.pgm.util.bukkit.ViaUtils;
-import tc.oc.pgm.util.reflect.ReflectionUtils;
+import tc.oc.pgm.util.nms.entity.fake.FakeEntity;
+import tc.oc.pgm.util.nms.entity.potion.EntityPotion;
 import tc.oc.pgm.util.skin.Skin;
-import tc.oc.pgm.util.skin.Skins;
 
 public interface NMSHacks {
 
+  NMSHacksPlatform INSTANCE = chooseNMSHacks();
+
+  static NMSHacksPlatform chooseNMSHacks() {
+    NMSHacksPlatform choice;
+    Logger logger = ClassLogger.get(NMSHacks.class);
+
+    try {
+      if (BukkitUtils.isSportPaper()) {
+        choice = new NMSHacksSportPaper();
+        logger.info("Using NMSHacksSportPaper");
+      } else {
+        choice = new NMSHacks1_8();
+        logger.info("Using NMSHacks1_8");
+      }
+    } catch (Throwable throwable) {
+      logger.severe("You are trying to run PGM on an unsupported version!");
+      throw throwable;
+    }
+    return choice;
+  }
+
   AtomicInteger ENTITY_IDS = new AtomicInteger(Integer.MAX_VALUE);
 
-  static EntityTrackerEntry getTrackerEntry(net.minecraft.server.v1_8_R3.Entity nms) {
-    return ((WorldServer) nms.getWorld()).getTracker().trackedEntities.get(nms.getId());
-  }
-
-  static EntityTrackerEntry getTrackerEntry(Entity entity) {
-    return getTrackerEntry(((CraftEntity) entity).getHandle());
-  }
-
-  static void sendPacket(Object packet) {
-    for (Player pl : Bukkit.getOnlinePlayers()) {
-      sendPacket(pl, packet);
-    }
+  static int allocateEntityId() {
+    return ENTITY_IDS.decrementAndGet();
   }
 
   static void sendPacket(Player bukkitPlayer, Object packet) {
-    if (bukkitPlayer.isOnline()) {
-      EntityPlayer nmsPlayer = ((CraftPlayer) bukkitPlayer).getHandle();
-      nmsPlayer.playerConnection.sendPacket((Packet) packet);
-    }
+    INSTANCE.sendPacket(bukkitPlayer, packet);
   }
 
-  static void sendPacketToViewers(Entity entity, Object packet) {
-    sendPacketToViewers(entity, packet, false);
+  static void playDeathAnimation(Player player) {
+    INSTANCE.playDeathAnimation(player);
   }
 
-  static void sendPacketToViewers(Entity entity, Object packet, boolean excludeSpectators) {
-    EntityTrackerEntry entry = getTrackerEntry(entity);
-    for (EntityPlayer viewer : ((Set<EntityPlayer>) entry.trackedPlayers)) {
-      if (excludeSpectators) {
-        Entity spectatorTarget = viewer.getBukkitEntity().getSpectatorTarget();
-        if (spectatorTarget != null && spectatorTarget.getUniqueId().equals(entity.getUniqueId()))
-          continue;
-      }
-      viewer.playerConnection.sendPacket((Packet) packet);
-    }
+  static Object teleportEntityPacket(int entityId, Location location) {
+    return INSTANCE.teleportEntityPacket(entityId, location);
   }
 
-  /** Immediately send the given entity's metadata to all viewers in range */
-  static void sendEntityMetadataToViewers(Entity entity, boolean complete) {
-    sendPacketToViewers(entity, entityMetadataPacket(entity.getEntityId(), entity, complete));
+  static Object entityMetadataPacket(int entityId, Entity entity, boolean complete) {
+    return INSTANCE.entityMetadataPacket(entityId, entity, complete);
   }
 
-  Constructor<PacketPlayOutPlayerInfo.PlayerInfoData> playerInfoDataConstructor =
-      getPlayerInfoDataConstructor();
-
-  static Constructor<PacketPlayOutPlayerInfo.PlayerInfoData> getPlayerInfoDataConstructor() {
-    try {
-      Constructor<PacketPlayOutPlayerInfo.PlayerInfoData> constructor =
-          PacketPlayOutPlayerInfo.PlayerInfoData.class.getConstructor(
-              PacketPlayOutPlayerInfo.class,
-              GameProfile.class,
-              int.class,
-              WorldSettings.EnumGamemode.class,
-              IChatBaseComponent.class);
-
-      constructor.setAccessible(true);
-      return constructor;
-    } catch (NoSuchMethodException e) {
-      throw new RuntimeException(e);
-    }
+  static void skipFireworksLaunch(Firework firework) {
+    INSTANCE.skipFireworksLaunch(firework);
   }
 
-  static PacketPlayOutPlayerInfo.PlayerInfoData playerListPacketData(
-      PacketPlayOutPlayerInfo packet,
+  static void fakePlayerItemPickup(Player player, Item item) {
+    INSTANCE.fakePlayerItemPickup(player, item);
+  }
+
+  static boolean isCraftItemArrowEntity(org.bukkit.entity.Item item) {
+    return INSTANCE.isCraftItemArrowEntity(item);
+  }
+
+  static void freezeEntity(Entity entity) {
+    INSTANCE.freezeEntity(entity);
+  }
+
+  static void setFireballDirection(Fireball entity, Vector direction) {
+    INSTANCE.setFireballDirection(entity, direction);
+  }
+
+  static void removeAndAddAllTabPlayers(Player viewer) {
+    INSTANCE.removeAndAddAllTabPlayers(viewer);
+  }
+
+  static void sendLegacyWearing(Player player, int slot, ItemStack item) {
+    INSTANCE.sendLegacyWearing(player, slot, item);
+  }
+
+  static EntityPotion entityPotion(Location location, ItemStack potionItem) {
+    return INSTANCE.entityPotion(location, potionItem);
+  }
+
+  static void sendBlockChange(Location loc, Player player, @Nullable Material material) {
+    INSTANCE.sendBlockChange(loc, player, material);
+  }
+
+  static void updateChunkSnapshot(ChunkSnapshot snapshot, org.bukkit.block.BlockState blockState) {
+    INSTANCE.updateChunkSnapshot(snapshot, blockState);
+  }
+
+  static void setKnockbackReduction(Player player, float amount) {
+    INSTANCE.setKnockbackReduction(player, amount);
+  }
+
+  static void showInvisibles(Player player, boolean showInvisibles) {
+    INSTANCE.showInvisibles(player, showInvisibles);
+  }
+
+  static void setAffectsSpawning(Player player, boolean affectsSpawning) {
+    INSTANCE.setAffectsSpawning(player, affectsSpawning);
+  }
+
+  static void clearArrowsInPlayer(Player player) {
+    INSTANCE.clearArrowsInPlayer(player);
+  }
+
+  static void showBorderWarning(Player player, boolean show) {
+    INSTANCE.showBorderWarning(player, show);
+  }
+
+  static PotionEffectType getPotionEffectType(String key) {
+    return INSTANCE.getPotionEffectType(key);
+  }
+
+  static org.bukkit.enchantments.Enchantment getEnchantment(String key) {
+    return INSTANCE.getEnchantment(key);
+  }
+
+  static long getMonotonicTime(World world) {
+    return INSTANCE.getMonotonicTime(world);
+  }
+
+  static int getPing(Player player) {
+    return INSTANCE.getPing(player);
+  }
+
+  static Object entityEquipmentPacket(int entityId, int slot, ItemStack armor) {
+    return INSTANCE.entityEquipmentPacket(entityId, slot, armor);
+  }
+
+  static void entityAttach(Player player, int entityID, int vehicleID, boolean leash) {
+    INSTANCE.entityAttach(player, entityID, vehicleID, leash);
+  }
+
+  static void resumeServer() {
+    INSTANCE.resumeServer();
+  }
+
+  static Inventory createFakeInventory(Player viewer, Inventory realInventory) {
+    return INSTANCE.createFakeInventory(viewer, realInventory);
+  }
+
+  static FakeEntity fakeWitherSkull(World world) {
+    return INSTANCE.fakeWitherSkull(world);
+  }
+
+  static FakeEntity fakeArmorStand(World world, ItemStack head) {
+    return INSTANCE.fakeArmorStand(world, head);
+  }
+
+  static Set<Block> getBlocks(Chunk bukkitChunk, Material material) {
+    return INSTANCE.getBlocks(bukkitChunk, material);
+  }
+
+  static Object spawnPlayerPacket(int entityId, UUID uuid, Location location, Player player) {
+    return INSTANCE.spawnPlayerPacket(entityId, uuid, location, player);
+  }
+
+  static Object destroyEntitiesPacket(int... entityIds) {
+    return INSTANCE.destroyEntitiesPacket(entityIds);
+  }
+
+  static Object createPlayerInfoPacket(EnumPlayerInfoAction action) {
+    return INSTANCE.createPlayerInfoPacket(action);
+  }
+
+  static void setPotionParticles(Player player, boolean enabled) {
+    INSTANCE.setPotionParticles(player, enabled);
+  }
+
+  static ItemStack craftItemCopy(ItemStack item) {
+    return INSTANCE.craftItemCopy(item);
+  }
+
+  static RayBlockIntersection getTargetedBLock(Player player) {
+    return INSTANCE.getTargetedBLock(player);
+  }
+
+  static boolean playerInfoDataListNotEmpty(Object packet) {
+    return INSTANCE.playerInfoDataListNotEmpty(packet);
+  }
+
+  static Object playerListPacketData(
+      Object packetPlayOutPlayerInfo,
       UUID uuid,
       String name,
       GameMode gamemode,
       int ping,
       @Nullable Skin skin,
       @Nullable String renderedDisplayName) {
-    GameProfile profile = new GameProfile(uuid, name);
-    if (skin != null) {
-      for (Map.Entry<String, Collection<Property>> entry :
-          Skins.toProperties(skin).asMap().entrySet()) {
-        profile.getProperties().putAll(entry.getKey(), entry.getValue());
-      }
-    }
-
-    if (BukkitUtils.isSportPaper()) {
-      try {
-        PacketPlayOutPlayerInfo.PlayerInfoData data =
-            packet.constructData(
-                profile,
-                ping,
-                gamemode == null ? null : WorldSettings.EnumGamemode.getById(gamemode.getValue()),
-                null); // ELECTROID
-        data.jsonDisplayName = renderedDisplayName;
-        return data;
-      } catch (NoSuchFieldError ignored) {
-      } // Using an old SportPaper version, fallback to spigot reflection
-    }
-
-    try {
-      WorldSettings.EnumGamemode enumGamemode =
-          gamemode == null ? null : WorldSettings.EnumGamemode.getById(gamemode.getValue());
-      IChatBaseComponent iChatBaseComponent =
-          renderedDisplayName == null
-              ? null
-              : IChatBaseComponent.ChatSerializer.a(renderedDisplayName);
-
-      return playerInfoDataConstructor.newInstance(
-          packet, profile, ping, enumGamemode, iChatBaseComponent);
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-      throw new RuntimeException(e);
-    }
+    return INSTANCE.playerListPacketData(
+        packetPlayOutPlayerInfo, uuid, name, gamemode, ping, skin, renderedDisplayName);
   }
 
-  Field playerInfoActionField = ReflectionUtils.getField(PacketPlayOutPlayerInfo.class, "a");
-
-  static PacketPlayOutPlayerInfo createPlayerInfoPacket(
-      PacketPlayOutPlayerInfo.EnumPlayerInfoAction action) {
-    PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo();
-    if (BukkitUtils.isSportPaper()) {
-      packet.a = action;
-    } else {
-      ReflectionUtils.setField(packet, action, playerInfoActionField);
-    }
-    return packet;
+  static void addPlayerInfoToPacket(Object packet, UUID uuid, int ping) {
+    INSTANCE.addPlayerInfoToPacket(
+        packet,
+        playerListPacketData(
+            packet, uuid, uuid.toString().substring(0, 16), null, ping, null, null));
   }
 
-  static PacketPlayOutPlayerInfo.PlayerInfoData playerListPacketData(
-      PacketPlayOutPlayerInfo packet, UUID uuid, String renderedDisplayName) {
-    return playerListPacketData(
-        packet, uuid, "|" + uuid.toString().substring(0, 15), null, 0, null, renderedDisplayName);
+  static void addPlayerInfoToPacket(Object packet, UUID uuid) {
+    INSTANCE.addPlayerInfoToPacket(
+        packet, playerListPacketData(packet, uuid, null, null, 0, null, null));
   }
 
-  static PacketPlayOutPlayerInfo.PlayerInfoData playerListPacketData(
-      PacketPlayOutPlayerInfo packet, UUID uuid) {
-    return playerListPacketData(packet, uuid, null, null, 0, null, null);
+  static void addPlayerInfoToPacket(Object packet, UUID uuid, String renderedDisplayName) {
+    INSTANCE.addPlayerInfoToPacket(
+        packet,
+        playerListPacketData(
+            packet,
+            uuid,
+            "|" + uuid.toString().substring(0, 15),
+            null,
+            0,
+            null,
+            renderedDisplayName));
   }
 
-  static PacketPlayOutPlayerInfo.PlayerInfoData playerListPacketData(
-      PacketPlayOutPlayerInfo packet, UUID uuid, int ping) {
-    return playerListPacketData(
-        packet, uuid, uuid.toString().substring(0, 16), null, ping, null, null);
+  static void addPlayerInfoToPacket(
+      Object packetPlayOutPlayerInfo,
+      UUID uuid,
+      String name,
+      GameMode gamemode,
+      int ping,
+      @Nullable Skin skin,
+      @Nullable String renderedDisplayName) {
+    INSTANCE.addPlayerInfoToPacket(
+        packetPlayOutPlayerInfo,
+        playerListPacketData(
+            packetPlayOutPlayerInfo, uuid, name, gamemode, ping, skin, renderedDisplayName));
+  }
+
+  static void setSkullMetaOwner(SkullMeta meta, String name, UUID uuid, Skin skin) {
+    INSTANCE.setSkullMetaOwner(meta, name, uuid, skin);
+  }
+
+  static WorldCreator detectWorld(String worldName) {
+    return INSTANCE.detectWorld(worldName);
+  }
+
+  static void setAbsorption(LivingEntity entity, double health) {
+    INSTANCE.setAbsorption(entity, health);
+  }
+
+  static double getAbsorption(LivingEntity entity) {
+    return INSTANCE.getAbsorption(entity);
+  }
+
+  @Deprecated
+  static Set<MaterialData> getBlockStates(Material material) {
+    return INSTANCE.getBlockStates(material);
+  }
+
+  static void setBlockStateData(BlockState state, MaterialData materialData) {
+    INSTANCE.setBlockStateData(state, materialData);
+  }
+
+  static Skin getPlayerSkin(Player player) {
+    return INSTANCE.getPlayerSkin(player);
+  }
+
+  static Skin getPlayerSkinForViewer(Player player, Player viewer) {
+    return INSTANCE.getPlayerSkinForViewer(player, viewer);
+  }
+
+  static void updateVelocity(Player player) {
+    INSTANCE.updateVelocity(player);
+  }
+
+  static boolean teleportRelative(
+      Player player,
+      org.bukkit.util.Vector deltaPos,
+      float deltaYaw,
+      float deltaPitch,
+      PlayerTeleportEvent.TeleportCause cause) {
+    return INSTANCE.teleportRelative(player, deltaPos, deltaYaw, deltaPitch, cause);
+  }
+
+  static void spawnFreezeEntity(Player player, int entityId, boolean legacy) {
+    INSTANCE.spawnFreezeEntity(player, entityId, legacy);
   }
 
   /**
-   * Removes all players from the tab for the viewer and re-adds them
+   * Test if the given tool is capable of "efficiently" mining the given block.
    *
-   * @param viewer The viewer to send the packets to
+   * <p>Derived from CraftBlock.itemCausesDrops()
    */
-  static void removeAndAddAllTabPlayers(Player viewer) {
-    List<EntityPlayer> players = new ArrayList<>();
-    for (Player player : Bukkit.getOnlinePlayers()) {
-      if (viewer.canSee(player) || player == viewer)
-        players.add(((CraftPlayer) player).getHandle());
-    }
-
-    sendPacket(
-        viewer,
-        new PacketPlayOutPlayerInfo(
-            PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, players));
-    sendPacket(
-        viewer,
-        new PacketPlayOutPlayerInfo(
-            PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, players));
+  @Deprecated
+  static boolean canMineBlock(MaterialData blockMaterial, ItemStack tool) {
+    return INSTANCE.canMineBlock(blockMaterial, tool);
   }
 
-  Field bField = ReflectionUtils.getField(PacketPlayOutPlayerInfo.class, "b");
-
-  static List<PacketPlayOutPlayerInfo.PlayerInfoData> getPlayerInfoDataList(
-      PacketPlayOutPlayerInfo packet) {
-    // SportPaper makes this field public
-    if (BukkitUtils.isSportPaper()) {
-      return packet.b;
-    } else {
-      return (List<PacketPlayOutPlayerInfo.PlayerInfoData>)
-          ReflectionUtils.readField(packet, bField);
-    }
+  static void resetDimension(World world) {
+    INSTANCE.resetDimension(world);
   }
 
-  enum TeamPacketFields {
-    a,
-    b,
-    c,
-    d,
-    e,
-    g,
-    h,
-    i;
+  static void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials) {
+    INSTANCE.setCanDestroy(itemMeta, materials);
+  }
 
-    Field field;
+  static Set<Material> getCanDestroy(ItemMeta itemMeta) {
+    return INSTANCE.getCanDestroy(itemMeta);
+  }
 
-    TeamPacketFields() {
-      field = ReflectionUtils.getField(PacketPlayOutScoreboardTeam.class, name());
-    }
+  static void setCanPlaceOn(ItemMeta itemMeta, Collection<Material> materials) {
+    INSTANCE.setCanPlaceOn(itemMeta, materials);
+  }
 
-    public Field getField() {
-      return field;
+  static Set<Material> getCanPlaceOn(ItemMeta itemMeta) {
+    return INSTANCE.getCanPlaceOn(itemMeta);
+  }
+
+  static void copyAttributeModifiers(ItemMeta destination, ItemMeta source) {
+    INSTANCE.copyAttributeModifiers(destination, source);
+  }
+
+  static void applyAttributeModifiers(
+      SetMultimap<String, AttributeModifier> attributeModifiers, ItemMeta meta) {
+    INSTANCE.applyAttributeModifiers(attributeModifiers, meta);
+  }
+
+  static double getTPS() {
+    return INSTANCE.getTPS();
+  }
+
+  static void sendDestroyTeamDummyPacket() {
+    Object packet = teamRemovePacket("dummy");
+    for (Player pl : Bukkit.getOnlinePlayers()) {
+      sendPacket(pl, packet);
     }
   }
 
-  static Packet teamPacket(
+  static Object teamPacket(
       int operation,
       String name,
       String displayName,
@@ -257,66 +381,19 @@ public interface NMSHacks {
       boolean seeFriendlyInvisibles,
       NameTagVisibility nameTagVisibility,
       Collection<String> players) {
-
-    PacketPlayOutScoreboardTeam packet = new PacketPlayOutScoreboardTeam();
-
-    if (BukkitUtils.isSportPaper()) {
-      packet.a = name;
-      packet.b = displayName;
-      packet.c = prefix;
-      packet.d = suffix;
-      packet.e = nameTagVisibility == null ? null : CraftTeam.bukkitToNotch(nameTagVisibility).e;
-      // packet.f = color
-      packet.g = players;
-      packet.h = operation;
-      if (friendlyFire) {
-        packet.i |= 1;
-      }
-      if (seeFriendlyInvisibles) {
-        packet.i |= 2;
-      }
-    } else {
-      ReflectionUtils.setField(packet, name, TeamPacketFields.a.getField());
-      ReflectionUtils.setField(packet, displayName, TeamPacketFields.b.getField());
-      ReflectionUtils.setField(packet, prefix, TeamPacketFields.c.getField());
-      ReflectionUtils.setField(packet, suffix, TeamPacketFields.d.getField());
-
-      String e = null;
-      if (nameTagVisibility != null) {
-        switch (nameTagVisibility) {
-          case ALWAYS:
-            e = "always";
-            break;
-          case NEVER:
-            e = "never";
-            break;
-          case HIDE_FOR_OTHER_TEAMS:
-            e = "hideForOtherTeams";
-            break;
-          case HIDE_FOR_OWN_TEAM:
-            e = "hideForOwnTeam";
-            break;
-        }
-      }
-
-      ReflectionUtils.setField(packet, e, TeamPacketFields.e.getField());
-      ReflectionUtils.setField(packet, players, TeamPacketFields.g.getField());
-      ReflectionUtils.setField(packet, operation, TeamPacketFields.h.getField());
-
-      int i = (int) ReflectionUtils.readField(packet, TeamPacketFields.i.getField());
-      if (friendlyFire) {
-        i |= 1;
-      }
-      if (seeFriendlyInvisibles) {
-        i |= 2;
-      }
-
-      ReflectionUtils.setField(packet, i, TeamPacketFields.i.getField());
-    }
-    return packet;
+    return INSTANCE.teamPacket(
+        operation,
+        name,
+        displayName,
+        prefix,
+        suffix,
+        friendlyFire,
+        seeFriendlyInvisibles,
+        nameTagVisibility,
+        players);
   }
 
-  static Packet teamCreatePacket(
+  static Object teamCreatePacket(
       String name,
       String displayName,
       String prefix,
@@ -336,11 +413,11 @@ public interface NMSHacks {
         players);
   }
 
-  static Packet teamRemovePacket(String name) {
+  static Object teamRemovePacket(String name) {
     return teamPacket(1, name, null, null, null, false, false, null, Lists.<String>newArrayList());
   }
 
-  static Packet teamUpdatePacket(
+  static Object teamUpdatePacket(
       String name,
       String displayName,
       String prefix,
@@ -359,1031 +436,19 @@ public interface NMSHacks {
         Lists.newArrayList());
   }
 
-  static Packet teamJoinPacket(String name, Collection<String> players) {
+  static Object teamJoinPacket(String name, Collection<String> players) {
     return teamPacket(3, name, null, null, null, false, false, null, players);
   }
 
-  static Packet teamLeavePacket(String name, Collection<String> players) {
+  static Object teamLeavePacket(String name, Collection<String> players) {
     return teamPacket(4, name, null, null, null, false, false, null, players);
   }
 
-  static int allocateEntityId() {
-    return ENTITY_IDS.decrementAndGet();
+  static AttributeMap buildAttributeMap(Player player) {
+    return INSTANCE.buildAttributeMap(player);
   }
 
-  static void sendLegacyWearing(Player player, int slot, ItemStack item) {
-    Packet<?> packet =
-        new PacketPlayOutEntityEquipment(
-            player.getEntityId(), slot, CraftItemStack.asNMSCopy(item));
-    EntityTrackerEntry entry = getTrackerEntry(player);
-    for (EntityPlayer viewer : entry.trackedPlayers) {
-      if (ViaUtils.getProtocolVersion(viewer.getBukkitEntity()) <= ViaUtils.VERSION_1_7)
-        viewer.playerConnection.sendPacket(packet);
-    }
-  }
-
-  class EntityMetadata {
-    public final DataWatcher dataWatcher;
-
-    public EntityMetadata(DataWatcher watcher) {
-      dataWatcher = watcher;
-    }
-
-    static EntityMetadata clone(DataWatcher original) {
-      List<DataWatcher.WatchableObject> values = original.c();
-      DataWatcher copy = new DataWatcher(null);
-      for (DataWatcher.WatchableObject value : values) {
-        copy.a(value.a(), value.b());
-      }
-      return new EntityMetadata(copy);
-    }
-
-    static EntityMetadata clone(Entity entity) {
-      return clone(((CraftEntity) entity).getHandle().getDataWatcher());
-    }
-
-    @Override
-    public EntityMetadata clone() {
-      return clone(this.dataWatcher);
-    }
-  }
-
-  static Packet destroyEntitiesPacket(int... entityIds) {
-    return new PacketPlayOutEntityDestroy(entityIds);
-  }
-
-  static void destroyEntities(Player player, int... entityIds) {
-    sendPacket(player, destroyEntitiesPacket(entityIds));
-  }
-
-  static Packet spawnPlayerPacket(int entityId, UUID uuid, Location location, Player player) {
-    return spawnPlayerPacket(entityId, uuid, location, null, EntityMetadata.clone(player));
-  }
-
-  enum NamedEntitySpawnFields {
-    a,
-    b,
-    c,
-    d,
-    e,
-    f,
-    g,
-    h,
-    i,
-    j;
-
-    Field field;
-
-    NamedEntitySpawnFields() {
-      field = ReflectionUtils.getField(PacketPlayOutNamedEntitySpawn.class, name());
-    }
-
-    public Field getField() {
-      return field;
-    }
-  }
-
-  static Packet spawnPlayerPacket(
-      int entityId, UUID uuid, Location location, ItemStack heldItem, EntityMetadata metadata) {
-    if (BukkitUtils.isSportPaper()) {
-      return new PacketPlayOutNamedEntitySpawn(
-          entityId,
-          uuid,
-          location.getX(),
-          location.getY(),
-          location.getZ(),
-          (byte) location.getYaw(),
-          (byte) location.getPitch(),
-          CraftItemStack.asNMSCopy(heldItem),
-          metadata.dataWatcher);
-    } else {
-      PacketPlayOutNamedEntitySpawn packet = new PacketPlayOutNamedEntitySpawn();
-
-      ReflectionUtils.setField(packet, entityId, NamedEntitySpawnFields.a.getField());
-      ReflectionUtils.setField(packet, uuid, NamedEntitySpawnFields.b.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getX() * 32.0D), NamedEntitySpawnFields.c.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getY() * 32.0D), NamedEntitySpawnFields.d.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getZ() * 32.0D), NamedEntitySpawnFields.e.getField());
-      ReflectionUtils.setField(
-          packet,
-          (byte) ((int) (((byte) location.getYaw()) * 256.0F / 360.0F)),
-          NamedEntitySpawnFields.f.getField());
-      ReflectionUtils.setField(
-          packet,
-          (byte) ((int) (((byte) location.getPitch()) * 256.0F / 360.0F)),
-          NamedEntitySpawnFields.g.getField());
-      ReflectionUtils.setField(
-          packet,
-          heldItem == null ? 0 : Item.getId(CraftItemStack.asNMSCopy(heldItem).getItem()),
-          NamedEntitySpawnFields.h.getField());
-      ReflectionUtils.setField(packet, metadata.dataWatcher, NamedEntitySpawnFields.i.getField());
-      ReflectionUtils.setField(
-          packet, metadata.dataWatcher.b(), NamedEntitySpawnFields.j.getField());
-
-      return packet;
-    }
-  }
-
-  static void spawnLivingEntity(
-      Player player, EntityType type, int entityId, Location location, EntityMetadata metadata) {
-    sendPacket(player, spawnLivingEntityPacket(type, entityId, location, metadata));
-  }
-
-  enum LivingEntitySpawnFields {
-    a,
-    b,
-    c,
-    d,
-    e,
-    i,
-    j,
-    k,
-    l;
-
-    Field field;
-
-    LivingEntitySpawnFields() {
-      field = ReflectionUtils.getField(PacketPlayOutSpawnEntityLiving.class, name());
-    }
-
-    public Field getField() {
-      return field;
-    }
-  }
-
-  @SuppressWarnings("deprecation")
-  static Packet spawnLivingEntityPacket(
-      EntityType type, int entityId, Location location, EntityMetadata metadata) {
-    if (BukkitUtils.isSportPaper()) {
-      return new PacketPlayOutSpawnEntityLiving(
-          entityId,
-          (byte) type.getTypeId(),
-          location.getX(),
-          location.getY(),
-          location.getZ(),
-          location.getYaw(),
-          location.getPitch(),
-          location.getPitch(),
-          0,
-          0,
-          0,
-          metadata.dataWatcher);
-    } else {
-      PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving();
-
-      ReflectionUtils.setField(packet, entityId, LivingEntitySpawnFields.a.getField());
-      ReflectionUtils.setField(
-          packet, (byte) type.getTypeId(), LivingEntitySpawnFields.b.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getX() * 32.0D), LivingEntitySpawnFields.c.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getY() * 32.0D), LivingEntitySpawnFields.d.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getZ() * 32.0D), LivingEntitySpawnFields.e.getField());
-      ReflectionUtils.setField(
-          packet,
-          (byte) ((int) (((byte) location.getYaw()) * 256.0F / 360.0F)),
-          LivingEntitySpawnFields.i.getField());
-      ReflectionUtils.setField(
-          packet,
-          (byte) ((int) (((byte) location.getPitch()) * 256.0F / 360.0F)),
-          LivingEntitySpawnFields.j.getField());
-      ReflectionUtils.setField(
-          packet,
-          (byte) ((int) (((byte) location.getPitch()) * 256.0F / 360.0F)),
-          LivingEntitySpawnFields.k.getField());
-      ReflectionUtils.setField(packet, metadata.dataWatcher, LivingEntitySpawnFields.l.getField());
-
-      return packet;
-    }
-  }
-
-  static void spawnEntity(Player player, int type, int entityId, Location location) {
-    sendPacket(player, spawnEntityPacket(type, entityId, location));
-  }
-
-  enum EntitySpawnFields {
-    a,
-    b,
-    c,
-    d,
-    h,
-    i,
-    j;
-
-    Field field;
-
-    EntitySpawnFields() {
-      field = ReflectionUtils.getField(PacketPlayOutSpawnEntity.class, name());
-    }
-
-    public Field getField() {
-      return field;
-    }
-  }
-
-  static Packet spawnEntityPacket(int type, int entityId, Location location) {
-    if (BukkitUtils.isSportPaper()) {
-      return new PacketPlayOutSpawnEntity(
-          entityId,
-          location.getX(),
-          location.getY(),
-          location.getZ(),
-          0,
-          0,
-          0,
-          (int) location.getPitch(),
-          (int) location.getYaw(),
-          type,
-          0);
-    } else {
-      PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity();
-
-      ReflectionUtils.setField(packet, entityId, EntitySpawnFields.a.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getX() * 32.0D), EntitySpawnFields.b.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getY() * 32.0D), EntitySpawnFields.c.getField());
-      ReflectionUtils.setField(
-          packet, MathHelper.floor(location.getZ() * 32.0D), EntitySpawnFields.d.getField());
-      ReflectionUtils.setField(
-          packet,
-          (byte) ((int) (((byte) location.getYaw()) * 256.0F / 360.0F)),
-          EntitySpawnFields.h.getField());
-      ReflectionUtils.setField(
-          packet,
-          (byte) ((int) (((byte) location.getPitch()) * 256.0F / 360.0F)),
-          EntitySpawnFields.i.getField());
-      ReflectionUtils.setField(packet, type, EntitySpawnFields.j.getField());
-
-      return packet;
-    }
-  }
-
-  static void spawnFreezeEntity(Player player, int entityId, boolean legacy) {
-    if (legacy) {
-      Location location = player.getLocation().add(0, 0.286, 0);
-      if (location.getY() < -64) {
-        location.setY(-64);
-        player.teleport(location);
-      }
-
-      NMSHacks.spawnEntity(player, 66, entityId, location);
-    } else {
-      Location loc = player.getLocation().subtract(0, 1.1, 0);
-
-      NMSHacks.EntityMetadata metadata = NMSHacks.createEntityMetadata();
-      NMSHacks.setEntityMetadata(metadata, false, false, false, false, true, (short) 0);
-      NMSHacks.setArmorStandFlags(metadata, false, false, false, false);
-      NMSHacks.spawnLivingEntity(player, EntityType.ARMOR_STAND, entityId, loc, metadata);
-    }
-  }
-
-  enum EntityAttachFields {
-    a,
-    b,
-    c;
-
-    Field field;
-
-    EntityAttachFields() {
-      field = ReflectionUtils.getField(PacketPlayOutAttachEntity.class, name());
-    }
-
-    public Field getField() {
-      return field;
-    }
-  }
-
-  static void entityAttach(Player player, int entityID, int vehicleID, boolean leash) {
-    if (BukkitUtils.isSportPaper()) {
-      sendPacket(player, new PacketPlayOutAttachEntity(entityID, vehicleID, leash));
-    } else {
-      PacketPlayOutAttachEntity packet = new PacketPlayOutAttachEntity();
-
-      ReflectionUtils.setField(packet, (byte) (leash ? 1 : 0), EntityAttachFields.a.getField());
-      ReflectionUtils.setField(packet, entityID, EntityAttachFields.b.getField());
-      ReflectionUtils.setField(packet, vehicleID, EntityAttachFields.c.getField());
-
-      sendPacket(player, packet);
-    }
-  }
-
-  static Packet teleportEntityPacket(int entityId, Location location) {
-    return new PacketPlayOutEntityTeleport(
-        entityId, // Entity ID
-        (int) (location.getX() * 32), // World X * 32
-        (int) (location.getY() * 32), // World Y * 32
-        (int) (location.getZ() * 32), // World Z * 32
-        (byte) (location.getYaw() * 256 / 360), // Yaw
-        (byte) (location.getPitch() * 256 / 360), // Pitch
-        true); // On Ground + Height Correction
-  }
-
-  static Packet entityMetadataPacket(int entityId, Entity entity, boolean complete) {
-    return new PacketPlayOutEntityMetadata(
-        entityId,
-        ((CraftEntity) entity).getHandle().getDataWatcher(),
-        complete); // true = all values, false = only dirty values
-  }
-
-  static EntityMetadata createEntityMetadata() {
-    return new EntityMetadata(new DataWatcher(null));
-  }
-
-  static void setEntityMetadata(EntityMetadata metadata, byte flags, short air) {
-    DataWatcher dataWatcher = metadata.dataWatcher;
-    dataWatcher.a(0, (byte) flags);
-    dataWatcher.a(1, (short) air);
-  }
-
-  static void setEntityMetadata(
-      EntityMetadata metadata,
-      boolean onFire,
-      boolean crouched,
-      boolean sprinting,
-      boolean eatingOrBlocking,
-      boolean invisible,
-      short air) {
-    int flags = 0;
-    if (onFire) flags |= 0x01;
-    if (crouched) flags |= 0x02;
-    if (sprinting) flags |= 0x08;
-    if (eatingOrBlocking) flags |= 0x10;
-    if (invisible) flags |= 0x20;
-    setEntityMetadata(metadata, (byte) flags, air);
-  }
-
-  static void setArmorStandFlags(
-      EntityMetadata metadata, boolean small, boolean gravity, boolean arms, boolean baseplate) {
-    int flags = 0;
-    if (small) flags |= 0x01;
-    if (gravity) flags |= 0x02;
-    if (arms) flags |= 0x04;
-    if (baseplate) flags |= 0x08;
-    metadata.dataWatcher.a(10, (byte) flags);
-  }
-
-  Method enablePotionParticlesMethod = ReflectionUtils.getMethod(EntityLiving.class, "B");
-  Method disablePotionParticlesMethod = ReflectionUtils.getMethod(EntityLiving.class, "bj");
-
-  static void setPotionParticles(Player player, boolean enabled) {
-    if (BukkitUtils.isSportPaper()) {
-      player.setPotionParticles(enabled);
-    } else {
-      CraftPlayer craftPlayer = (CraftPlayer) player;
-      EntityPlayer handle = craftPlayer.getHandle();
-
-      if (enabled) {
-        ReflectionUtils.callMethod(enablePotionParticlesMethod, handle);
-      } else {
-        ReflectionUtils.callMethod(disablePotionParticlesMethod, handle);
-      }
-    }
-  }
-
-  static void clearArrowsInPlayer(Player player) {
-    ((CraftPlayer) player).getHandle().o(0);
-  }
-
-  /**
-   * Test if the given tool is capable of "efficiently" mining the given block.
-   *
-   * <p>Derived from CraftBlock.itemCausesDrops()
-   */
-  static boolean canMineBlock(MaterialData blockMaterial, ItemStack tool) {
-    if (!blockMaterial.getItemType().isBlock()) {
-      throw new IllegalArgumentException("Material '" + blockMaterial + "' is not a block");
-    }
-
-    net.minecraft.server.v1_8_R3.Block nmsBlock =
-        CraftMagicNumbers.getBlock(blockMaterial.getItemType());
-    net.minecraft.server.v1_8_R3.Item nmsTool =
-        tool == null ? null : CraftMagicNumbers.getItem(tool.getType());
-
-    return nmsBlock != null
-        && (nmsBlock.getMaterial().isAlwaysDestroyable()
-            || (nmsTool != null && nmsTool.canDestroySpecialBlock(nmsBlock)));
-  }
-
-  static long getMonotonicTime(World world) {
-    return ((CraftWorld) world).getHandle().getTime();
-  }
-
-  static void sendMessage(Player player, BaseComponent[] message, int position) {
-    PacketPlayOutChat packet = new PacketPlayOutChat(null, (byte) position);
-    packet.components = message;
-    sendPacket(player, packet);
-  }
-
-  static void showBorderWarning(Player player, boolean show) {
-    WorldBorder border = new WorldBorder();
-    border.setWarningDistance(show ? Integer.MAX_VALUE : 0);
-    sendPacket(
-        player,
-        new PacketPlayOutWorldBorder(
-            border, PacketPlayOutWorldBorder.EnumWorldBorderAction.SET_WARNING_BLOCKS));
-  }
-
-  Field entityMetadataWatchableField =
-      ReflectionUtils.getField(PacketPlayOutEntityMetadata.class, "b");
-
-  static void playDeathAnimation(Player player) {
-    EntityPlayer handle = ((CraftPlayer) player).getHandle();
-    PacketPlayOutEntityMetadata metadata =
-        new PacketPlayOutEntityMetadata(handle.getId(), handle.getDataWatcher(), false);
-
-    // Add/replace health to zero
-    boolean replaced = false;
-    DataWatcher.WatchableObject zeroHealth =
-        new DataWatcher.WatchableObject(3, 6, 0f); // type 3 (float), index 6 (health)
-
-    List<DataWatcher.WatchableObject> b =
-        (List<DataWatcher.WatchableObject>)
-            ReflectionUtils.readField(metadata, entityMetadataWatchableField);
-    if (b != null) {
-      for (int i = 0; i < b.size(); i++) {
-        DataWatcher.WatchableObject wo = b.get(i);
-        if (wo.a() == 6) {
-          b.set(i, zeroHealth);
-          replaced = true;
-        }
-      }
-    }
-
-    if (!replaced) {
-      if (b != null) b.add(zeroHealth);
-      else
-        ReflectionUtils.setField(
-            metadata, Collections.singletonList(zeroHealth), entityMetadataWatchableField);
-    }
-
-    Location location = player.getLocation();
-    PacketPlayOutBed useBed =
-        new PacketPlayOutBed(
-            ((CraftPlayer) player).getHandle(),
-            new BlockPosition(location.getX(), location.getY(), location.getZ()));
-
-    Packet<?> teleport = teleportEntityPacket(player.getEntityId(), location);
-
-    sendPacketToViewers(player, metadata, true);
-    sendPacketToViewers(player, useBed, true);
-    sendPacketToViewers(player, teleport, true);
-  }
-
-  static org.bukkit.enchantments.Enchantment getEnchantment(String key) {
-    Enchantment enchantment = Enchantment.getByName(key);
-    return enchantment == null ? null : org.bukkit.enchantments.Enchantment.getById(enchantment.id);
-  }
-
-  static PotionEffectType getPotionEffectType(String key) {
-    MobEffectList nms = MobEffectList.b(key);
-    return nms == null ? null : PotionEffectType.getById(nms.id);
-  }
-
-  static Set<MaterialData> getBlockStates(Material material) {
-    ImmutableSet.Builder<MaterialData> materials = ImmutableSet.builder();
-    Block nmsBlock = CraftMagicNumbers.getBlock(material);
-    List<IBlockData> states =
-        ReflectionUtils.readField(BlockStateList.class, nmsBlock.P(), List.class, "e");
-    if (states != null) {
-      for (IBlockData state : states) {
-        int data = nmsBlock.toLegacyData(state);
-        materials.add(material.getNewData((byte) data));
-      }
-    }
-    return materials.build();
-  }
-
-  static void setAbsorption(LivingEntity entity, double health) {
-    ((CraftLivingEntity) entity).getHandle().setAbsorptionHearts((float) health);
-  }
-
-  static double getAbsorption(LivingEntity entity) {
-    return ((CraftLivingEntity) entity).getHandle().getAbsorptionHearts();
-  }
-
-  static int getPing(Player player) {
-    return ((CraftPlayer) player).getHandle().ping;
-  }
-
-  static Packet entityEquipmentPacket(int entityId, int slot, ItemStack armor) {
-    return new PacketPlayOutEntityEquipment(entityId, slot, CraftItemStack.asNMSCopy(armor));
-  }
-
-  static Skin getPlayerSkin(Player player) {
-    CraftPlayer craftPlayer = (CraftPlayer) player;
-    return Skins.fromProperties(craftPlayer.getProfile().getProperties());
-  }
-
-  static void updateVelocity(Player player) {
-    EntityPlayer handle = ((CraftPlayer) player).getHandle();
-    handle.velocityChanged = false;
-    handle.playerConnection.sendPacket(new PacketPlayOutEntityVelocity(handle));
-  }
-
-  static boolean teleportRelative(
-      Player player,
-      org.bukkit.util.Vector deltaPos,
-      float deltaYaw,
-      float deltaPitch,
-      PlayerTeleportEvent.TeleportCause cause) {
-    CraftPlayer craftPlayer = (CraftPlayer) player;
-
-    if (craftPlayer.getHandle().playerConnection == null
-        || craftPlayer.getHandle().playerConnection.isDisconnected()) {
-      return false;
-    }
-
-    // From = Players current Location
-    Location from = player.getLocation();
-    // To = Players new Location if Teleport is Successful
-    Location to = from.clone().add(deltaPos);
-    to.setYaw(to.getYaw() + deltaYaw);
-    to.setPitch(to.getPitch() + deltaPitch);
-
-    // Create & Call the Teleport Event.
-    PlayerTeleportEvent event = new PlayerTeleportEvent(player, from, to, cause);
-    Bukkit.getPluginManager().callEvent(event);
-
-    // Return False to inform the Plugin that the Teleport was unsuccessful/cancelled.
-    if (event.isCancelled()) {
-      return false;
-    }
-
-    craftPlayer.getHandle().playerConnection.teleport(to);
-    return true;
-  }
-
-  Field skullProfileField =
-      ReflectionUtils.getField(
-          "org.bukkit.craftbukkit.v1_8_R3.inventory.CraftMetaSkull", "profile");
-
-  static void setSkullMetaOwner(SkullMeta meta, String name, UUID uuid, Skin skin) {
-    GameProfile gameProfile = new GameProfile(uuid, name);
-    Skins.setProperties(skin, gameProfile.getProperties());
-    ReflectionUtils.setField(meta, gameProfile, skullProfileField);
-  }
-
-  static Set<org.bukkit.block.Block> getBlocks(Chunk bukkitChunk, Material material) {
-    CraftChunk craftChunk = (CraftChunk) bukkitChunk;
-    Set<org.bukkit.block.Block> blocks = new HashSet<>();
-
-    net.minecraft.server.v1_8_R3.Block nmsBlock = CraftMagicNumbers.getBlock(material);
-    net.minecraft.server.v1_8_R3.Chunk chunk = craftChunk.getHandle();
-
-    for (ChunkSection section : chunk.getSections()) {
-      if (section == null || section.a()) continue; // ChunkSection.a() -> true if section is empty
-
-      char[] blockIds = section.getIdArray();
-      for (int i = 0; i < blockIds.length; i++) {
-        // This does a lookup in the block registry, but does not create any objects, so should be
-        // pretty efficient
-        IBlockData blockData = (IBlockData) net.minecraft.server.v1_8_R3.Block.d.a(blockIds[i]);
-        if (blockData != null && blockData.getBlock() == nmsBlock) {
-          blocks.add(
-              bukkitChunk.getBlock(i & 0xf, section.getYPosition() | (i >> 8), (i >> 4) & 0xf));
-        }
-      }
-    }
-
-    return blocks;
-  }
-
-  static WorldCreator detectWorld(String worldName) {
-    IDataManager sdm =
-        new ServerNBTManager(Bukkit.getServer().getWorldContainer(), worldName, true);
-    WorldData worldData = sdm.getWorldData();
-    if (worldData == null) return null;
-
-    return new WorldCreator(worldName)
-        .generateStructures(worldData.shouldGenerateMapFeatures())
-        .generatorSettings(worldData.getGeneratorOptions())
-        .seed(worldData.getSeed())
-        .type(org.bukkit.WorldType.getByName(worldData.getType().name()));
-  }
-
-  Field worldServerField = ReflectionUtils.getField(CraftWorld.class, "world");
-  Field dimensionField = ReflectionUtils.getField(WorldServer.class, "dimension");
-  Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
-
-  static void resetDimension(World world) {
-    try {
-      modifiersField.setInt(dimensionField, dimensionField.getModifiers() & ~Modifier.FINAL);
-
-      dimensionField.set(worldServerField.get(world), 11);
-    } catch (IllegalAccessException e) {
-      // No-op, newer version of Java have disabled modifying final fields
-    }
-  }
-
-  static RayBlockIntersection getTargetedBLock(Player player) {
-    Location start = player.getEyeLocation();
-    World world = player.getWorld();
-    Vector startVector = start.toVector();
-    Vector end =
-        start
-            .toVector()
-            .add(
-                start.getDirection().multiply(player.getGameMode() == GameMode.CREATIVE ? 6 : 4.5));
-    MovingObjectPosition hit =
-        ((CraftWorld) world)
-            .getHandle()
-            .rayTrace(
-                new Vec3D(startVector.getX(), startVector.getY(), startVector.getZ()),
-                new Vec3D(end.getX(), end.getY(), end.getZ()),
-                false,
-                false,
-                false);
-    if (hit != null && hit.type == MovingObjectPosition.EnumMovingObjectType.BLOCK) {
-      return new RayBlockIntersection(
-          world.getBlockAt(hit.a().getX(), hit.a().getY(), hit.a().getZ()),
-          CraftBlock.notchToBlockFace(hit.direction),
-          new Vector(hit.pos.a, hit.pos.b, hit.pos.c));
-    } else {
-      return null;
-    }
-  }
-
-  static ItemStack craftItemCopy(ItemStack item) {
-    return CraftItemStack.asCraftCopy(item);
-  }
-
-  String CAN_DESTROY = "CanDestroy";
-  String CAN_PLACE_ON = "CanPlaceOn";
-
-  static void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials) {
-    if (BukkitUtils.isSportPaper()) {
-      // Since this is handled by SportPaper this can't be done through unhandled tags
-      itemMeta.setCanDestroy(materials);
-    }
-    setMaterialList(itemMeta, materials, CAN_DESTROY);
-  }
-
-  static Set<Material> getCanDestroy(ItemMeta itemMeta) {
-    if (BukkitUtils.isSportPaper()) {
-      // Since this is handled by SportPaper this can't be done through unhandled tags
-      return itemMeta.getCanDestroy();
-    }
-    return getMaterialCollection(itemMeta, CAN_DESTROY);
-  }
-
-  static void setCanPlaceOn(ItemMeta itemMeta, Collection<Material> materials) {
-    if (BukkitUtils.isSportPaper()) {
-      // Since this is handled by SportPaper this can't be done through unhandled tags
-      itemMeta.setCanPlaceOn(materials);
-    }
-    setMaterialList(itemMeta, materials, CAN_PLACE_ON);
-  }
-
-  static Set<Material> getCanPlaceOn(ItemMeta itemMeta) {
-    if (BukkitUtils.isSportPaper()) {
-      // Since this is handled by SportPaper this can't be done through unhandled tags
-      return itemMeta.getCanPlaceOn();
-    }
-    return getMaterialCollection(itemMeta, CAN_PLACE_ON);
-  }
-
-  Field unhandledTagsField =
-      ReflectionUtils.getField(
-          "org.bukkit.craftbukkit.v1_8_R3.inventory.CraftMetaItem", "unhandledTags");
-
-  static Map<String, NBTBase> getUnhandledTags(ItemMeta meta) {
-    return (Map<String, NBTBase>) ReflectionUtils.readField(meta, unhandledTagsField);
-  }
-
-  static void setMaterialList(
-      ItemMeta itemMeta, Collection<Material> materials, String canPlaceOn) {
-    Map<String, NBTBase> unhandledTags = getUnhandledTags(itemMeta);
-    NBTTagList canDestroyList =
-        unhandledTags.containsKey(canPlaceOn)
-            ? (NBTTagList) unhandledTags.get(canPlaceOn)
-            : new NBTTagList();
-    for (Material material : materials) {
-      Block block = Block.getById(material.getId());
-      if (block != null) {
-        canDestroyList.add(new NBTTagString(Block.REGISTRY.c(block).toString()));
-      }
-    }
-    if (!canDestroyList.isEmpty()) unhandledTags.put(canPlaceOn, canDestroyList);
-  }
-
-  Field nbtListField = ReflectionUtils.getField(NBTTagList.class, "list");
-
-  static Set<Material> getMaterialCollection(ItemMeta itemMeta, String key) {
-    Map<String, NBTBase> unhandledTags = getUnhandledTags(itemMeta);
-    if (!unhandledTags.containsKey(key)) return EnumSet.noneOf(Material.class);
-    EnumSet<Material> materialSet = EnumSet.noneOf(Material.class);
-    NBTTagList canDestroyList = (NBTTagList) unhandledTags.get(key);
-
-    for (NBTBase item : (List<NBTBase>) ReflectionUtils.readField(canDestroyList, nbtListField)) {
-      NBTTagString nbtTagString = (NBTTagString) item;
-      String blockString = nbtTagString.a_();
-      materialSet.add(Material.getMaterial(Block.getId(Block.getByName(blockString))));
-    }
-
-    return materialSet;
-  }
-
-  static void copyAttributeModifiers(ItemMeta destination, ItemMeta source) {
-    // Since SportPaper handles attributes they don't show up in unhandledTags
-    if (BukkitUtils.isSportPaper()) {
-      for (String attribute : source.getModifiedAttributes()) {
-        for (org.bukkit.attribute.AttributeModifier modifier :
-            source.getAttributeModifiers(attribute)) {
-          destination.addAttributeModifier(attribute, modifier);
-        }
-      }
-    } else {
-      SetMultimap<String, tc.oc.pgm.util.attribute.AttributeModifier> attributeModifiers =
-          NMSHacks.getAttributeModifiers(source);
-      attributeModifiers.putAll(NMSHacks.getAttributeModifiers(destination));
-      NMSHacks.applyAttributeModifiers(attributeModifiers, destination);
-    }
-  }
-
-  static void applyAttributeModifiers(
-      SetMultimap<String, AttributeModifier> attributeModifiers, ItemMeta meta) {
-    if (BukkitUtils.isSportPaper()) {
-      for (Map.Entry<String, AttributeModifier> entry : attributeModifiers.entries()) {
-        AttributeModifier attributeModifier = entry.getValue();
-        meta.addAttributeModifier(
-            entry.getKey(),
-            new org.bukkit.attribute.AttributeModifier(
-                attributeModifier.getUniqueId(),
-                attributeModifier.getName(),
-                attributeModifier.getAmount(),
-                org.bukkit.attribute.AttributeModifier.Operation.fromOpcode(
-                    attributeModifier.getOperation().ordinal())));
-      }
-    } else {
-      NBTTagList list = new NBTTagList();
-      for (Map.Entry<String, AttributeModifier> entry : attributeModifiers.entries()) {
-        AttributeModifier modifier = entry.getValue();
-        NBTTagCompound tag = new NBTTagCompound();
-        tag.setString("Name", modifier.getName());
-        tag.setDouble("Amount", modifier.getAmount());
-        tag.setInt("Operation", modifier.getOperation().ordinal());
-        tag.setLong("UUIDMost", modifier.getUniqueId().getMostSignificantBits());
-        tag.setLong("UUIDLeast", modifier.getUniqueId().getLeastSignificantBits());
-        tag.setString("AttributeName", entry.getKey());
-        list.add(tag);
-      }
-
-      Map<String, NBTBase> unhandledTags = getUnhandledTags(meta);
-      unhandledTags.put("AttributeModifiers", list);
-    }
-  }
-
-  static SetMultimap<String, AttributeModifier> getAttributeModifiers(ItemMeta meta) {
-    Map<String, NBTBase> unhandledTags = getUnhandledTags(meta);
-    if (unhandledTags.containsKey("AttributeModifiers")) {
-      final SetMultimap<String, AttributeModifier> attributeModifiers = HashMultimap.create();
-      final NBTTagList modTags = (NBTTagList) unhandledTags.get("AttributeModifiers");
-      for (int i = 0; i < modTags.size(); i++) {
-        final NBTTagCompound modTag = modTags.get(i);
-        attributeModifiers.put(
-            modTag.getString("AttributeName"),
-            new AttributeModifier(
-                new UUID(modTag.getLong("UUIDMost"), modTag.getLong("UUIDLeast")),
-                modTag.getString("Name"),
-                modTag.getDouble("Amount"),
-                AttributeModifier.Operation.fromOpcode(modTag.getInt("Operation"))));
-      }
-      return attributeModifiers;
-    } else {
-      return HashMultimap.create();
-    }
-  }
-
-  static Inventory createFakeInventory(Player viewer, Inventory realInventory) {
-    if (BukkitUtils.isSportPaper() && realInventory.hasCustomName()) {
-      return realInventory instanceof DoubleChestInventory
-          ? Bukkit.createInventory(viewer, realInventory.getSize(), realInventory.getName())
-          : Bukkit.createInventory(viewer, realInventory.getType(), realInventory.getName());
-    } else {
-      return realInventory instanceof DoubleChestInventory
-          ? Bukkit.createInventory(viewer, realInventory.getSize())
-          : Bukkit.createInventory(viewer, realInventory.getType());
-    }
-  }
-
-  // Not relevant if not SportPaper
-  static void resumeServer() {
-    if (BukkitUtils.isSportPaper() && Bukkit.getServer().isSuspended())
-      Bukkit.getServer().setSuspended(false);
-  }
-
-  static void setAffectsSpawning(Player player, boolean affectsSpawning) {
-    if (BukkitUtils.isSportPaper()) {
-      player.spigot().setAffectsSpawning(affectsSpawning);
-    }
-  }
-
-  static void showInvisibles(Player player, boolean showInvisibles) {
-    if (BukkitUtils.isSportPaper()) {
-      player.showInvisibles(showInvisibles);
-    }
-  }
-
-  static void setKnockbackReduction(Player player, float amount) {
-    // Not possible outside of SportPaper
-    if (BukkitUtils.isSportPaper()) {
-      player.setKnockbackReduction(amount);
-    }
-  }
-
-  static void updateChunkSnapshot(ChunkSnapshot snapshot, org.bukkit.block.BlockState blockState) {
-    // ChunkSnapshot is immutable outside of SportPaper
-    if (BukkitUtils.isSportPaper()) {
-      snapshot.updateBlock(blockState);
-    }
-  }
-
-  static void sendBlockChange(Location loc, Player player, @Nullable Material material) {
-    if (material != null) player.sendBlockChange(loc, material, (byte) 0);
-    else player.sendBlockChange(loc, loc.getBlock().getType(), loc.getBlock().getData());
-  }
-
-  interface FakeEntity {
-    int entityId();
-
-    Entity entity();
-
-    void spawn(Player viewer, Location location, org.bukkit.util.Vector velocity);
-
-    default void spawn(Player viewer, Location location) {
-      spawn(viewer, location, new org.bukkit.util.Vector(0, 0, 0));
-    }
-
-    default void destroy(Player viewer) {
-      sendPacket(viewer, destroyEntitiesPacket(entityId()));
-    }
-
-    default void teleport(Player viewer, Location location) {
-      sendPacket(viewer, teleportEntityPacket(entityId(), location));
-    }
-
-    default void ride(Player viewer, Entity rider) {
-      entityAttach(viewer, rider.getEntityId(), entityId(), false);
-    }
-
-    default void mount(Player viewer, Entity vehicle) {
-      entityAttach(viewer, entityId(), vehicle.getEntityId(), false);
-    }
-
-    default void wear(Player viewer, int slot, ItemStack item) {
-      sendPacket(viewer, entityEquipmentPacket(entityId(), slot, item));
-    }
-  }
-
-  abstract class FakeEntityImpl<T extends net.minecraft.server.v1_8_R3.Entity>
-      implements FakeEntity {
-    protected final T entity;
-
-    protected FakeEntityImpl(T entity) {
-      this.entity = entity;
-    }
-
-    @Override
-    public Entity entity() {
-      return entity.getBukkitEntity();
-    }
-
-    @Override
-    public void spawn(Player viewer, Location location, Vector velocity) {
-      entity.setPositionRotation(
-          location.getX(),
-          location.getY(),
-          location.getZ(),
-          location.getYaw(),
-          location.getPitch());
-      entity.motX = velocity.getX();
-      entity.motY = velocity.getY();
-      entity.motZ = velocity.getZ();
-      sendPacket(viewer, spawnPacket());
-    }
-
-    abstract Packet<?> spawnPacket();
-
-    @Override
-    public int entityId() {
-      return entity.getId();
-    }
-  }
-
-  class FakeLivingEntity<T extends EntityLiving> extends FakeEntityImpl<T> {
-
-    protected FakeLivingEntity(T entity) {
-      super(entity);
-    }
-
-    protected Packet<?> spawnPacket() {
-      return new PacketPlayOutSpawnEntityLiving(entity);
-    }
-  }
-
-  class FakeArmorStand extends FakeLivingEntity<EntityArmorStand> {
-
-    private final ItemStack head;
-
-    public FakeArmorStand(World world, ItemStack head) {
-      super(new EntityArmorStand(((CraftWorld) world).getHandle()));
-      this.head = head;
-
-      entity.setInvisible(true);
-      NBTTagCompound tag = entity.getNBTTag();
-      if (tag == null) {
-        tag = new NBTTagCompound();
-      }
-      entity.c(tag);
-      tag.setBoolean("Silent", true);
-      tag.setBoolean("Invulnerable", true);
-      tag.setBoolean("NoGravity", true);
-      tag.setBoolean("NoAI", true);
-      entity.f(tag);
-    }
-
-    @Override
-    public void spawn(Player viewer, Location location, Vector velocity) {
-      super.spawn(viewer, location, velocity);
-      if (head != null) wear(viewer, 4, head);
-    }
-  }
-
-  class FakeWitherSkull extends FakeEntityImpl<EntityWitherSkull> {
-    public FakeWitherSkull(World world) {
-      super(new EntityWitherSkull(((CraftWorld) world).getHandle()));
-    }
-
-    protected Packet<?> spawnPacket() {
-      return new PacketPlayOutSpawnEntity(entity, 66);
-    }
-
-    @Override
-    public void wear(Player viewer, int slot, ItemStack item) {}
-  }
-
-  class EntityPotion extends net.minecraft.server.v1_8_R3.EntityPotion {
-    public EntityPotion(Location location, ItemStack potionItem) {
-      super(
-          ((CraftWorld) location.getWorld()).getHandle(),
-          location.getX(),
-          location.getY(),
-          location.getZ(),
-          CraftItemStack.asNMSCopy(potionItem));
-    }
-
-    public void spawn() {
-      world.addEntity(this);
-    }
-  }
-
-  static void setFireworksExpectedLifespan(Firework firework, int ticks) {
-    ((CraftFirework) firework).getHandle().expectedLifespan = ticks;
-  }
-
-  static void setFireworksTicksFlown(Firework firework, int ticks) {
-    EntityFireworks entityFirework = ((CraftFirework) firework).getHandle();
-    entityFirework.ticksFlown = ticks;
-  }
-
-  static void skipFireworksLaunch(Firework firework) {
-    setFireworksExpectedLifespan(firework, 2);
-    setFireworksTicksFlown(firework, 2);
-    sendEntityMetadataToViewers(firework, false);
-  }
-
-  static boolean isCraftItemArrowEntity(org.bukkit.entity.Item item) {
-    return ((CraftItem) item).getHandle() instanceof EntityArrow;
-  }
-
-  static void fakePlayerItemPickup(Player player, org.bukkit.entity.Item item) {
-    float pitch = (((float) (Math.random() - Math.random()) * 0.7F + 1.0F) * 2.0F);
-    item.getWorld().playSound(item.getLocation(), org.bukkit.Sound.ITEM_PICKUP, 0.2F, pitch);
-
-    NMSHacks.sendPacketToViewers(
-        item, new PacketPlayOutCollect(item.getEntityId(), player.getEntityId()));
-
-    item.remove();
-  }
-
-  static void freezeEntity(Entity entity) {
-    net.minecraft.server.v1_8_R3.Entity nmsEntity = ((CraftEntity) entity).getHandle();
-    NBTTagCompound tag = new NBTTagCompound();
-    nmsEntity.c(tag); // save to tag
-    tag.setBoolean("NoAI", true);
-    tag.setBoolean("NoGravity", true);
-    nmsEntity.f(tag); // load from tag
-  }
-
-  static void setFireballDirection(Fireball entity, Vector direction) {
-    EntityFireball fireball = ((CraftFireball) entity).getHandle();
-    fireball.dirX = direction.getX() * 0.1D;
-    fireball.dirY = direction.getY() * 0.1D;
-    fireball.dirZ = direction.getZ() * 0.1D;
+  static void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
+    INSTANCE.postToMainThread(plugin, priority, task);
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks1_8.java
@@ -1,0 +1,1118 @@
+package tc.oc.pgm.util.nms;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.SetMultimap;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import net.minecraft.server.v1_8_R3.BlockPosition;
+import net.minecraft.server.v1_8_R3.BlockStateList;
+import net.minecraft.server.v1_8_R3.ChunkSection;
+import net.minecraft.server.v1_8_R3.DataWatcher;
+import net.minecraft.server.v1_8_R3.EntityArrow;
+import net.minecraft.server.v1_8_R3.EntityFireball;
+import net.minecraft.server.v1_8_R3.EntityFireworks;
+import net.minecraft.server.v1_8_R3.EntityLiving;
+import net.minecraft.server.v1_8_R3.EntityPlayer;
+import net.minecraft.server.v1_8_R3.EntityTrackerEntry;
+import net.minecraft.server.v1_8_R3.IBlockData;
+import net.minecraft.server.v1_8_R3.IChatBaseComponent;
+import net.minecraft.server.v1_8_R3.IDataManager;
+import net.minecraft.server.v1_8_R3.MathHelper;
+import net.minecraft.server.v1_8_R3.MinecraftServer;
+import net.minecraft.server.v1_8_R3.MobEffectList;
+import net.minecraft.server.v1_8_R3.MovingObjectPosition;
+import net.minecraft.server.v1_8_R3.NBTBase;
+import net.minecraft.server.v1_8_R3.NBTTagCompound;
+import net.minecraft.server.v1_8_R3.NBTTagList;
+import net.minecraft.server.v1_8_R3.NBTTagString;
+import net.minecraft.server.v1_8_R3.Packet;
+import net.minecraft.server.v1_8_R3.PacketPlayOutAttachEntity;
+import net.minecraft.server.v1_8_R3.PacketPlayOutBed;
+import net.minecraft.server.v1_8_R3.PacketPlayOutCollect;
+import net.minecraft.server.v1_8_R3.PacketPlayOutEntityDestroy;
+import net.minecraft.server.v1_8_R3.PacketPlayOutEntityEquipment;
+import net.minecraft.server.v1_8_R3.PacketPlayOutEntityMetadata;
+import net.minecraft.server.v1_8_R3.PacketPlayOutEntityTeleport;
+import net.minecraft.server.v1_8_R3.PacketPlayOutEntityVelocity;
+import net.minecraft.server.v1_8_R3.PacketPlayOutNamedEntitySpawn;
+import net.minecraft.server.v1_8_R3.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_8_R3.PacketPlayOutScoreboardTeam;
+import net.minecraft.server.v1_8_R3.PacketPlayOutSpawnEntity;
+import net.minecraft.server.v1_8_R3.PacketPlayOutSpawnEntityLiving;
+import net.minecraft.server.v1_8_R3.PacketPlayOutWorldBorder;
+import net.minecraft.server.v1_8_R3.ServerNBTManager;
+import net.minecraft.server.v1_8_R3.Vec3D;
+import net.minecraft.server.v1_8_R3.WorldBorder;
+import net.minecraft.server.v1_8_R3.WorldData;
+import net.minecraft.server.v1_8_R3.WorldServer;
+import net.minecraft.server.v1_8_R3.WorldSettings;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_8_R3.CraftChunk;
+import org.bukkit.craftbukkit.v1_8_R3.CraftServer;
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_8_R3.block.CraftBlock;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftFireball;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftFirework;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftItem;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftLivingEntity;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_8_R3.util.CraftMagicNumbers;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.inventory.DoubleChestInventory;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.material.MaterialData;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scoreboard.NameTagVisibility;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.attribute.AttributeMap;
+import tc.oc.pgm.util.attribute.AttributeModifier;
+import tc.oc.pgm.util.block.RayBlockIntersection;
+import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.bukkit.ViaUtils;
+import tc.oc.pgm.util.nms.attribute.AttributeMap1_8;
+import tc.oc.pgm.util.nms.entity.fake.FakeEntity;
+import tc.oc.pgm.util.nms.entity.fake.armorstand.FakeArmorStand1_8;
+import tc.oc.pgm.util.nms.entity.fake.wither.FakeWitherSkull1_8;
+import tc.oc.pgm.util.nms.entity.potion.EntityPotion;
+import tc.oc.pgm.util.nms.entity.potion.EntityPotion1_8;
+import tc.oc.pgm.util.reflect.ReflectionUtils;
+import tc.oc.pgm.util.skin.Skin;
+import tc.oc.pgm.util.skin.Skins;
+
+public class NMSHacks1_8 extends NMSHacksNoOp {
+  @Override
+  public void sendPacket(Player bukkitPlayer, Object packet) {
+    if (bukkitPlayer.isOnline()) {
+      EntityPlayer nmsPlayer = ((CraftPlayer) bukkitPlayer).getHandle();
+      nmsPlayer.playerConnection.sendPacket((Packet) packet);
+    }
+  }
+
+  @Override
+  public void sendPacketToViewers(Entity entity, Object packet, boolean excludeSpectators) {
+    net.minecraft.server.v1_8_R3.Entity nms = ((CraftEntity) entity).getHandle();
+    EntityTrackerEntry entry =
+        ((WorldServer) nms.getWorld()).getTracker().trackedEntities.get(nms.getId());
+    for (EntityPlayer viewer : entry.trackedPlayers) {
+      if (excludeSpectators) {
+        Entity spectatorTarget = viewer.getBukkitEntity().getSpectatorTarget();
+        if (spectatorTarget != null && spectatorTarget.getUniqueId().equals(entity.getUniqueId()))
+          continue;
+      }
+      viewer.playerConnection.sendPacket((Packet) packet);
+    }
+  }
+
+  static Field entityMetadataWatchableField =
+      ReflectionUtils.getField(PacketPlayOutEntityMetadata.class, "b");
+
+  @Override
+  public void playDeathAnimation(Player player) {
+    EntityPlayer handle = ((CraftPlayer) player).getHandle();
+    PacketPlayOutEntityMetadata metadata =
+        new PacketPlayOutEntityMetadata(handle.getId(), handle.getDataWatcher(), false);
+
+    // Add/replace health to zero
+    boolean replaced = false;
+    DataWatcher.WatchableObject zeroHealth =
+        new DataWatcher.WatchableObject(3, 6, 0f); // type 3 (float), index 6 (health)
+
+    List<DataWatcher.WatchableObject> b =
+        (List<DataWatcher.WatchableObject>)
+            ReflectionUtils.readField(metadata, entityMetadataWatchableField);
+    if (b != null) {
+      for (int i = 0; i < b.size(); i++) {
+        DataWatcher.WatchableObject wo = b.get(i);
+        if (wo.a() == 6) {
+          b.set(i, zeroHealth);
+          replaced = true;
+        }
+      }
+    }
+
+    if (!replaced) {
+      if (b != null) b.add(zeroHealth);
+      else
+        ReflectionUtils.setField(
+            metadata, Collections.singletonList(zeroHealth), entityMetadataWatchableField);
+    }
+
+    Location location = player.getLocation();
+    PacketPlayOutBed useBed =
+        new PacketPlayOutBed(
+            ((CraftPlayer) player).getHandle(),
+            new BlockPosition(location.getX(), location.getY(), location.getZ()));
+
+    Object teleport = teleportEntityPacket(player.getEntityId(), location);
+
+    sendPacketToViewers(player, metadata, true);
+    sendPacketToViewers(player, useBed, true);
+    sendPacketToViewers(player, teleport, true);
+  }
+
+  @Override
+  public Object teleportEntityPacket(int entityId, Location location) {
+    return new PacketPlayOutEntityTeleport(
+        entityId, // Entity ID
+        (int) (location.getX() * 32), // World X * 32
+        (int) (location.getY() * 32), // World Y * 32
+        (int) (location.getZ() * 32), // World Z * 32
+        (byte) (location.getYaw() * 256 / 360), // Yaw
+        (byte) (location.getPitch() * 256 / 360), // Pitch
+        true); // On Ground + Height Correction
+  }
+
+  @Override
+  public Object entityMetadataPacket(int entityId, Entity entity, boolean complete) {
+    return new PacketPlayOutEntityMetadata(
+        entityId,
+        ((CraftEntity) entity).getHandle().getDataWatcher(),
+        complete); // true = all values, false = only dirty values
+  }
+
+  @Override
+  public void skipFireworksLaunch(Firework firework) {
+    EntityFireworks entityFirework = ((CraftFirework) firework).getHandle();
+    entityFirework.expectedLifespan = 2;
+    entityFirework.ticksFlown = 2;
+    sendPacketToViewers(
+        firework, entityMetadataPacket(firework.getEntityId(), firework, false), false);
+  }
+
+  @Override
+  public void fakePlayerItemPickup(Player player, Item item) {
+    float pitch = (((float) (Math.random() - Math.random()) * 0.7F + 1.0F) * 2.0F);
+    item.getWorld().playSound(item.getLocation(), org.bukkit.Sound.ITEM_PICKUP, 0.2F, pitch);
+
+    sendPacketToViewers(
+        item, new PacketPlayOutCollect(item.getEntityId(), player.getEntityId()), false);
+
+    item.remove();
+  }
+
+  @Override
+  public boolean isCraftItemArrowEntity(Item item) {
+    return ((CraftItem) item).getHandle() instanceof EntityArrow;
+  }
+
+  @Override
+  public void freezeEntity(Entity entity) {
+    net.minecraft.server.v1_8_R3.Entity nmsEntity = ((CraftEntity) entity).getHandle();
+    NBTTagCompound tag = new NBTTagCompound();
+    nmsEntity.c(tag); // save to tag
+    tag.setBoolean("NoAI", true);
+    tag.setBoolean("NoGravity", true);
+    nmsEntity.f(tag); // load from tag
+  }
+
+  @Override
+  public void setFireballDirection(Fireball entity, Vector direction) {
+    EntityFireball fireball = ((CraftFireball) entity).getHandle();
+    fireball.dirX = direction.getX() * 0.1D;
+    fireball.dirY = direction.getY() * 0.1D;
+    fireball.dirZ = direction.getZ() * 0.1D;
+  }
+
+  @Override
+  public void removeAndAddAllTabPlayers(Player viewer) {
+    List<EntityPlayer> players = new ArrayList<>();
+    for (Player player : Bukkit.getOnlinePlayers()) {
+      if (viewer.canSee(player) || player == viewer)
+        players.add(((CraftPlayer) player).getHandle());
+    }
+
+    sendPacket(
+        viewer,
+        new PacketPlayOutPlayerInfo(
+            PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, players));
+    sendPacket(
+        viewer,
+        new PacketPlayOutPlayerInfo(
+            PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, players));
+  }
+
+  @Override
+  public void sendLegacyWearing(Player player, int slot, ItemStack item) {
+    Packet<?> packet =
+        new PacketPlayOutEntityEquipment(
+            player.getEntityId(), slot, CraftItemStack.asNMSCopy(item));
+    net.minecraft.server.v1_8_R3.Entity nms = ((CraftEntity) player).getHandle();
+    EntityTrackerEntry entry =
+        ((WorldServer) nms.getWorld()).getTracker().trackedEntities.get(nms.getId());
+    for (EntityPlayer viewer : entry.trackedPlayers) {
+      if (ViaUtils.getProtocolVersion(viewer.getBukkitEntity()) <= ViaUtils.VERSION_1_7)
+        viewer.playerConnection.sendPacket(packet);
+    }
+  }
+
+  @Override
+  public EntityPotion entityPotion(Location location, ItemStack potionItem) {
+    return new EntityPotion1_8(location, potionItem);
+  }
+
+  @Override
+  public void sendBlockChange(Location loc, Player player, @Nullable Material material) {
+    if (material != null) player.sendBlockChange(loc, material, (byte) 0);
+    else player.sendBlockChange(loc, loc.getBlock().getType(), loc.getBlock().getData());
+  }
+
+  @Override
+  public void clearArrowsInPlayer(Player player) {
+    ((CraftPlayer) player).getHandle().o(0);
+  }
+
+  @Override
+  public void showBorderWarning(Player player, boolean show) {
+    WorldBorder border = new WorldBorder();
+    border.setWarningDistance(show ? Integer.MAX_VALUE : 0);
+    Object packet =
+        new PacketPlayOutWorldBorder(
+            border, PacketPlayOutWorldBorder.EnumWorldBorderAction.SET_WARNING_BLOCKS);
+    sendPacket(player, packet);
+  }
+
+  @Override
+  public PotionEffectType getPotionEffectType(String key) {
+    MobEffectList nms = MobEffectList.b(key);
+    return nms == null ? null : PotionEffectType.getById(nms.id);
+  }
+
+  @Override
+  public Enchantment getEnchantment(String key) {
+    net.minecraft.server.v1_8_R3.Enchantment enchantment =
+        net.minecraft.server.v1_8_R3.Enchantment.getByName(key);
+    return enchantment == null ? null : org.bukkit.enchantments.Enchantment.getById(enchantment.id);
+  }
+
+  @Override
+  public long getMonotonicTime(World world) {
+    return ((CraftWorld) world).getHandle().getTime();
+  }
+
+  @Override
+  public int getPing(Player player) {
+    return ((CraftPlayer) player).getHandle().ping;
+  }
+
+  @Override
+  public Object entityEquipmentPacket(int entityId, int slot, ItemStack armor) {
+    return new PacketPlayOutEntityEquipment(entityId, slot, CraftItemStack.asNMSCopy(armor));
+  }
+
+  enum EntityAttachFields {
+    a,
+    b,
+    c;
+
+    Field field;
+
+    EntityAttachFields() {
+      field = ReflectionUtils.getField(PacketPlayOutAttachEntity.class, name());
+    }
+
+    public Field getField() {
+      return field;
+    }
+  }
+
+  @Override
+  public void entityAttach(Player player, int entityID, int vehicleID, boolean leash) {
+    PacketPlayOutAttachEntity packet = new PacketPlayOutAttachEntity();
+
+    ReflectionUtils.setField(packet, (byte) (leash ? 1 : 0), EntityAttachFields.a.getField());
+    ReflectionUtils.setField(packet, entityID, EntityAttachFields.b.getField());
+    ReflectionUtils.setField(packet, vehicleID, EntityAttachFields.c.getField());
+
+    sendPacket(player, packet);
+  }
+
+  @Override
+  public Inventory createFakeInventory(Player viewer, Inventory realInventory) {
+    return realInventory instanceof DoubleChestInventory
+        ? Bukkit.createInventory(viewer, realInventory.getSize())
+        : Bukkit.createInventory(viewer, realInventory.getType());
+  }
+
+  @Override
+  public FakeEntity fakeWitherSkull(World world) {
+    return new FakeWitherSkull1_8(world);
+  }
+
+  @Override
+  public FakeEntity fakeArmorStand(World world, ItemStack head) {
+    return new FakeArmorStand1_8(world, head);
+  }
+
+  @Override
+  public Set<Block> getBlocks(Chunk bukkitChunk, Material material) {
+    CraftChunk craftChunk = (CraftChunk) bukkitChunk;
+    Set<org.bukkit.block.Block> blocks = new HashSet<>();
+
+    net.minecraft.server.v1_8_R3.Block nmsBlock = CraftMagicNumbers.getBlock(material);
+    net.minecraft.server.v1_8_R3.Chunk chunk = craftChunk.getHandle();
+
+    for (ChunkSection section : chunk.getSections()) {
+      if (section == null || section.a()) continue; // ChunkSection.a() -> true if section is empty
+
+      char[] blockIds = section.getIdArray();
+      for (int i = 0; i < blockIds.length; i++) {
+        // This does a lookup in the block registry, but does not create any objects, so should be
+        // pretty efficient
+        IBlockData blockData = (IBlockData) net.minecraft.server.v1_8_R3.Block.d.a(blockIds[i]);
+        if (blockData != null && blockData.getBlock() == nmsBlock) {
+          blocks.add(
+              bukkitChunk.getBlock(i & 0xf, section.getYPosition() | (i >> 8), (i >> 4) & 0xf));
+        }
+      }
+    }
+
+    return blocks;
+  }
+
+  @Override
+  public Object spawnPlayerPacket(int entityId, UUID uuid, Location location, Player player) {
+    DataWatcher dataWatcher = copyDataWatcher(player);
+
+    PacketPlayOutNamedEntitySpawn packet = new PacketPlayOutNamedEntitySpawn();
+
+    ReflectionUtils.setField(packet, entityId, NamedEntitySpawnFields.a.getField());
+    ReflectionUtils.setField(packet, uuid, NamedEntitySpawnFields.b.getField());
+    ReflectionUtils.setField(
+        packet, MathHelper.floor(location.getX() * 32.0D), NamedEntitySpawnFields.c.getField());
+    ReflectionUtils.setField(
+        packet, MathHelper.floor(location.getY() * 32.0D), NamedEntitySpawnFields.d.getField());
+    ReflectionUtils.setField(
+        packet, MathHelper.floor(location.getZ() * 32.0D), NamedEntitySpawnFields.e.getField());
+    ReflectionUtils.setField(
+        packet,
+        (byte) ((int) (((byte) location.getYaw()) * 256.0F / 360.0F)),
+        NamedEntitySpawnFields.f.getField());
+    ReflectionUtils.setField(
+        packet,
+        (byte) ((int) (((byte) location.getPitch()) * 256.0F / 360.0F)),
+        NamedEntitySpawnFields.g.getField());
+    ReflectionUtils.setField(
+        packet,
+        null == null
+            ? 0
+            : net.minecraft.server.v1_8_R3.Item.getId(CraftItemStack.asNMSCopy(null).getItem()),
+        NamedEntitySpawnFields.h.getField());
+    ReflectionUtils.setField(packet, dataWatcher, NamedEntitySpawnFields.i.getField());
+    ReflectionUtils.setField(packet, dataWatcher.b(), NamedEntitySpawnFields.j.getField());
+
+    return packet;
+  }
+
+  @NotNull
+  protected static DataWatcher copyDataWatcher(Player player) {
+    DataWatcher original = ((CraftPlayer) player).getHandle().getDataWatcher();
+    List<DataWatcher.WatchableObject> values = original.c();
+    DataWatcher copy = new DataWatcher(null);
+    for (DataWatcher.WatchableObject value : values) {
+      copy.a(value.a(), value.b());
+    }
+    return copy;
+  }
+
+  @Override
+  public Object destroyEntitiesPacket(int... entityIds) {
+    return new PacketPlayOutEntityDestroy(entityIds);
+  }
+
+  Field playerInfoActionField = ReflectionUtils.getField(PacketPlayOutPlayerInfo.class, "a");
+
+  @Override
+  public Object createPlayerInfoPacket(EnumPlayerInfoAction action) {
+    PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo();
+    ReflectionUtils.setField(packet, convertEnumPlayerInfoAction(action), playerInfoActionField);
+    return packet;
+  }
+
+  static Method enablePotionParticlesMethod = ReflectionUtils.getMethod(EntityLiving.class, "B");
+  static Method disablePotionParticlesMethod = ReflectionUtils.getMethod(EntityLiving.class, "bj");
+
+  @Override
+  public void setPotionParticles(Player player, boolean enabled) {
+    CraftPlayer craftPlayer = (CraftPlayer) player;
+    EntityPlayer handle = craftPlayer.getHandle();
+
+    if (enabled) {
+      ReflectionUtils.callMethod(enablePotionParticlesMethod, handle);
+    } else {
+      ReflectionUtils.callMethod(disablePotionParticlesMethod, handle);
+    }
+  }
+
+  @Override
+  public ItemStack craftItemCopy(ItemStack item) {
+    return CraftItemStack.asCraftCopy(item);
+  }
+
+  @Override
+  public RayBlockIntersection getTargetedBLock(Player player) {
+    Location start = player.getEyeLocation();
+    World world = player.getWorld();
+    Vector startVector = start.toVector();
+    Vector end =
+        start
+            .toVector()
+            .add(
+                start.getDirection().multiply(player.getGameMode() == GameMode.CREATIVE ? 6 : 4.5));
+    MovingObjectPosition hit =
+        ((CraftWorld) world)
+            .getHandle()
+            .rayTrace(
+                new Vec3D(startVector.getX(), startVector.getY(), startVector.getZ()),
+                new Vec3D(end.getX(), end.getY(), end.getZ()),
+                false,
+                false,
+                false);
+    if (hit != null && hit.type == MovingObjectPosition.EnumMovingObjectType.BLOCK) {
+      return new RayBlockIntersection(
+          world.getBlockAt(hit.a().getX(), hit.a().getY(), hit.a().getZ()),
+          CraftBlock.notchToBlockFace(hit.direction),
+          new Vector(hit.pos.a, hit.pos.b, hit.pos.c));
+    } else {
+      return null;
+    }
+  }
+
+  Field bField = ReflectionUtils.getField(PacketPlayOutPlayerInfo.class, "b");
+
+  @Override
+  public boolean playerInfoDataListNotEmpty(Object packet) {
+    List<PacketPlayOutPlayerInfo.PlayerInfoData> result;
+    PacketPlayOutPlayerInfo playOutPlayerInfo = (PacketPlayOutPlayerInfo) packet;
+    // SportPaper makes this field public
+    if (BukkitUtils.isSportPaper()) {
+      result = playOutPlayerInfo.b;
+    } else {
+      result =
+          (List<PacketPlayOutPlayerInfo.PlayerInfoData>)
+              ReflectionUtils.readField(playOutPlayerInfo, bField);
+    }
+    return !result.isEmpty();
+  }
+
+  Constructor<PacketPlayOutPlayerInfo.PlayerInfoData> playerInfoDataConstructor =
+      getPlayerInfoDataConstructor();
+
+  static Constructor<PacketPlayOutPlayerInfo.PlayerInfoData> getPlayerInfoDataConstructor() {
+    try {
+      Constructor<PacketPlayOutPlayerInfo.PlayerInfoData> constructor =
+          PacketPlayOutPlayerInfo.PlayerInfoData.class.getConstructor(
+              PacketPlayOutPlayerInfo.class,
+              GameProfile.class,
+              int.class,
+              WorldSettings.EnumGamemode.class,
+              IChatBaseComponent.class);
+
+      constructor.setAccessible(true);
+      return constructor;
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Object playerListPacketData(
+      Object packetPlayOutPlayerInfo,
+      UUID uuid,
+      String name,
+      GameMode gamemode,
+      int ping,
+      @Nullable Skin skin,
+      @Nullable String renderedDisplayName) {
+    GameProfile profile = new GameProfile(uuid, name);
+    if (skin != null) {
+      for (Map.Entry<String, Collection<Property>> entry :
+          Skins.toProperties(skin).asMap().entrySet()) {
+        profile.getProperties().putAll(entry.getKey(), entry.getValue());
+      }
+    }
+
+    try {
+      WorldSettings.EnumGamemode enumGamemode =
+          gamemode == null ? null : WorldSettings.EnumGamemode.getById(gamemode.getValue());
+      IChatBaseComponent iChatBaseComponent =
+          renderedDisplayName == null
+              ? null
+              : IChatBaseComponent.ChatSerializer.a(renderedDisplayName);
+
+      return playerInfoDataConstructor.newInstance(
+          packetPlayOutPlayerInfo, profile, ping, enumGamemode, iChatBaseComponent);
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void addPlayerInfoToPacket(Object packet, Object playerInfoData) {
+    List<PacketPlayOutPlayerInfo.PlayerInfoData> result;
+    PacketPlayOutPlayerInfo playOutPlayerInfo = (PacketPlayOutPlayerInfo) packet;
+
+    result =
+        (List<PacketPlayOutPlayerInfo.PlayerInfoData>)
+            ReflectionUtils.readField(playOutPlayerInfo, bField);
+
+    result.add((PacketPlayOutPlayerInfo.PlayerInfoData) playerInfoData);
+  }
+
+  Field skullProfileField =
+      ReflectionUtils.getField(
+          "org.bukkit.craftbukkit.v1_8_R3.inventory.CraftMetaSkull", "profile");
+
+  @Override
+  public void setSkullMetaOwner(SkullMeta meta, String name, UUID uuid, Skin skin) {
+    GameProfile gameProfile = new GameProfile(uuid, name);
+    Skins.setProperties(skin, gameProfile.getProperties());
+    ReflectionUtils.setField(meta, gameProfile, skullProfileField);
+  }
+
+  @Override
+  public WorldCreator detectWorld(String worldName) {
+    IDataManager sdm =
+        new ServerNBTManager(Bukkit.getServer().getWorldContainer(), worldName, true);
+    WorldData worldData = sdm.getWorldData();
+    if (worldData == null) return null;
+
+    return new WorldCreator(worldName)
+        .generateStructures(worldData.shouldGenerateMapFeatures())
+        .generatorSettings(worldData.getGeneratorOptions())
+        .seed(worldData.getSeed())
+        .type(org.bukkit.WorldType.getByName(worldData.getType().name()));
+  }
+
+  @Override
+  public void setAbsorption(LivingEntity entity, double health) {
+    ((CraftLivingEntity) entity).getHandle().setAbsorptionHearts((float) health);
+  }
+
+  @Override
+  public double getAbsorption(LivingEntity entity) {
+    return ((CraftLivingEntity) entity).getHandle().getAbsorptionHearts();
+  }
+
+  @Override
+  public Set<MaterialData> getBlockStates(Material material) {
+    ImmutableSet.Builder<MaterialData> materials = ImmutableSet.builder();
+    net.minecraft.server.v1_8_R3.Block nmsBlock = CraftMagicNumbers.getBlock(material);
+    List<IBlockData> states =
+        ReflectionUtils.readField(BlockStateList.class, nmsBlock.P(), List.class, "e");
+    if (states != null) {
+      for (IBlockData state : states) {
+        int data = nmsBlock.toLegacyData(state);
+        materials.add(material.getNewData((byte) data));
+      }
+    }
+    return materials.build();
+  }
+
+  @Override
+  public Skin getPlayerSkin(Player player) {
+    CraftPlayer craftPlayer = (CraftPlayer) player;
+    return Skins.fromProperties(craftPlayer.getProfile().getProperties());
+  }
+
+  @Override
+  public Skin getPlayerSkinForViewer(Player player, Player viewer) {
+    return getPlayerSkin(player);
+  }
+
+  @Override
+  public void updateVelocity(Player player) {
+    EntityPlayer handle = ((CraftPlayer) player).getHandle();
+    handle.velocityChanged = false;
+    handle.playerConnection.sendPacket(new PacketPlayOutEntityVelocity(handle));
+  }
+
+  @Override
+  public boolean teleportRelative(
+      Player player,
+      Vector deltaPos,
+      float deltaYaw,
+      float deltaPitch,
+      PlayerTeleportEvent.TeleportCause cause) {
+    CraftPlayer craftPlayer = (CraftPlayer) player;
+
+    if (craftPlayer.getHandle().playerConnection == null
+        || craftPlayer.getHandle().playerConnection.isDisconnected()) {
+      return false;
+    }
+
+    // From = Players current Location
+    Location from = player.getLocation();
+    // To = Players new Location if Teleport is Successful
+    Location to = from.clone().add(deltaPos);
+    to.setYaw(to.getYaw() + deltaYaw);
+    to.setPitch(to.getPitch() + deltaPitch);
+
+    // Create & Call the Teleport Event.
+    PlayerTeleportEvent event = new PlayerTeleportEvent(player, from, to, cause);
+    Bukkit.getPluginManager().callEvent(event);
+
+    // Return False to inform the Plugin that the Teleport was unsuccessful/cancelled.
+    if (event.isCancelled()) {
+      return false;
+    }
+
+    craftPlayer.getHandle().playerConnection.teleport(to);
+    return true;
+  }
+
+  enum LivingEntitySpawnFields {
+    a,
+    b,
+    c,
+    d,
+    e,
+    i,
+    j,
+    k,
+    l;
+
+    Field field;
+
+    LivingEntitySpawnFields() {
+      field = ReflectionUtils.getField(PacketPlayOutSpawnEntityLiving.class, name());
+    }
+
+    public Field getField() {
+      return field;
+    }
+  }
+
+  enum EntitySpawnFields {
+    a,
+    b,
+    c,
+    d,
+    h,
+    i,
+    j;
+
+    Field field;
+
+    EntitySpawnFields() {
+      field = ReflectionUtils.getField(PacketPlayOutSpawnEntity.class, name());
+    }
+
+    public Field getField() {
+      return field;
+    }
+  }
+
+  @Override
+  public void sendSpawnEntityPacket(Player player, int entityId, Location location) {
+    PacketPlayOutSpawnEntity packet = new PacketPlayOutSpawnEntity();
+
+    ReflectionUtils.setField(packet, entityId, EntitySpawnFields.a.getField());
+    ReflectionUtils.setField(
+        packet, MathHelper.floor(location.getX() * 32.0D), EntitySpawnFields.b.getField());
+    ReflectionUtils.setField(
+        packet, MathHelper.floor(location.getY() * 32.0D), EntitySpawnFields.c.getField());
+    ReflectionUtils.setField(
+        packet, MathHelper.floor(location.getZ() * 32.0D), EntitySpawnFields.d.getField());
+    ReflectionUtils.setField(
+        packet,
+        (byte) ((int) (((byte) location.getYaw()) * 256.0F / 360.0F)),
+        EntitySpawnFields.h.getField());
+    ReflectionUtils.setField(
+        packet,
+        (byte) ((int) (((byte) location.getPitch()) * 256.0F / 360.0F)),
+        EntitySpawnFields.i.getField());
+    ReflectionUtils.setField(packet, 66, EntitySpawnFields.j.getField());
+
+    sendPacket(player, packet);
+  }
+
+  @Override
+  public void spawnFreezeEntity(Player player, int entityId, boolean legacy) {
+    if (legacy) {
+      Location location = player.getLocation().add(0, 0.286, 0);
+      if (location.getY() < -64) {
+        location.setY(-64);
+        player.teleport(location);
+      }
+
+      sendSpawnEntityPacket(player, entityId, location);
+    } else {
+      Location loc = player.getLocation().subtract(0, 1.1, 0);
+
+      DataWatcher dataWatcher = new DataWatcher(null);
+      int flags = 0;
+      flags |= 0x20;
+      dataWatcher.a(0, (byte) flags);
+      dataWatcher.a(1, (short) 0);
+      int flags1 = 0;
+      dataWatcher.a(10, (byte) flags1);
+      PacketPlayOutSpawnEntityLiving packet = new PacketPlayOutSpawnEntityLiving();
+
+      ReflectionUtils.setField(packet, entityId, LivingEntitySpawnFields.a.getField());
+      ReflectionUtils.setField(
+          packet, (byte) EntityType.ARMOR_STAND.getTypeId(), LivingEntitySpawnFields.b.getField());
+      ReflectionUtils.setField(
+          packet, MathHelper.floor(loc.getX() * 32.0D), LivingEntitySpawnFields.c.getField());
+      ReflectionUtils.setField(
+          packet, MathHelper.floor(loc.getY() * 32.0D), LivingEntitySpawnFields.d.getField());
+      ReflectionUtils.setField(
+          packet, MathHelper.floor(loc.getZ() * 32.0D), LivingEntitySpawnFields.e.getField());
+      ReflectionUtils.setField(
+          packet,
+          (byte) ((int) (((byte) loc.getYaw()) * 256.0F / 360.0F)),
+          LivingEntitySpawnFields.i.getField());
+      ReflectionUtils.setField(
+          packet,
+          (byte) ((int) (((byte) loc.getPitch()) * 256.0F / 360.0F)),
+          LivingEntitySpawnFields.j.getField());
+      ReflectionUtils.setField(
+          packet,
+          (byte) ((int) (((byte) loc.getPitch()) * 256.0F / 360.0F)),
+          LivingEntitySpawnFields.k.getField());
+      ReflectionUtils.setField(packet, dataWatcher, LivingEntitySpawnFields.l.getField());
+
+      sendPacket(player, packet);
+    }
+  }
+
+  @Override
+  public boolean canMineBlock(MaterialData blockMaterial, ItemStack tool) {
+    if (!blockMaterial.getItemType().isBlock()) {
+      throw new IllegalArgumentException("Material '" + blockMaterial + "' is not a block");
+    }
+
+    net.minecraft.server.v1_8_R3.Block nmsBlock =
+        CraftMagicNumbers.getBlock(blockMaterial.getItemType());
+    net.minecraft.server.v1_8_R3.Item nmsTool =
+        tool == null ? null : CraftMagicNumbers.getItem(tool.getType());
+
+    return nmsBlock != null
+        && (nmsBlock.getMaterial().isAlwaysDestroyable()
+            || (nmsTool != null && nmsTool.canDestroySpecialBlock(nmsBlock)));
+  }
+
+  Field worldServerField = ReflectionUtils.getField(CraftWorld.class, "world");
+  Field dimensionField = ReflectionUtils.getField(WorldServer.class, "dimension");
+  Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
+
+  @Override
+  public void resetDimension(World world) {
+    try {
+      modifiersField.setInt(dimensionField, dimensionField.getModifiers() & ~Modifier.FINAL);
+
+      dimensionField.set(worldServerField.get(world), 11);
+    } catch (IllegalAccessException e) {
+      // No-op, newer version of Java have disabled modifying final fields
+    }
+  }
+
+  Field unhandledTagsField =
+      ReflectionUtils.getField(
+          "org.bukkit.craftbukkit.v1_8_R3.inventory.CraftMetaItem", "unhandledTags");
+  static Field nbtListField = ReflectionUtils.getField(NBTTagList.class, "list");
+
+  @Override
+  public Set<Material> getMaterialCollection(ItemMeta itemMeta, String key) {
+    Map<String, NBTBase> unhandledTags =
+        (Map<String, NBTBase>) ReflectionUtils.readField(itemMeta, unhandledTagsField);
+    if (!unhandledTags.containsKey(key)) return EnumSet.noneOf(Material.class);
+    EnumSet<Material> materialSet = EnumSet.noneOf(Material.class);
+    NBTTagList canDestroyList = (NBTTagList) unhandledTags.get(key);
+
+    for (NBTBase item : (List<NBTBase>) ReflectionUtils.readField(canDestroyList, nbtListField)) {
+      NBTTagString nbtTagString = (NBTTagString) item;
+      String blockString = nbtTagString.a_();
+      materialSet.add(
+          Material.getMaterial(
+              net.minecraft.server.v1_8_R3.Block.getId(
+                  net.minecraft.server.v1_8_R3.Block.getByName(blockString))));
+    }
+
+    return materialSet;
+  }
+
+  @Override
+  public void setMaterialCollection(
+      ItemMeta itemMeta, Collection<Material> materials, String canPlaceOn) {
+    Map<String, NBTBase> unhandledTags =
+        (Map<String, NBTBase>) ReflectionUtils.readField(itemMeta, unhandledTagsField);
+    NBTTagList canDestroyList =
+        unhandledTags.containsKey(canPlaceOn)
+            ? (NBTTagList) unhandledTags.get(canPlaceOn)
+            : new NBTTagList();
+    for (Material material : materials) {
+      net.minecraft.server.v1_8_R3.Block block =
+          net.minecraft.server.v1_8_R3.Block.getById(material.getId());
+      if (block != null) {
+        canDestroyList.add(
+            new NBTTagString(net.minecraft.server.v1_8_R3.Block.REGISTRY.c(block).toString()));
+      }
+    }
+    if (!canDestroyList.isEmpty()) unhandledTags.put(canPlaceOn, canDestroyList);
+  }
+
+  @Override
+  public void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials) {
+    setMaterialCollection(itemMeta, materials, "CanDestroy");
+  }
+
+  @Override
+  public Set<Material> getCanDestroy(ItemMeta itemMeta) {
+    return getMaterialCollection(itemMeta, "CanDestroy");
+  }
+
+  @Override
+  public void setCanPlaceOn(ItemMeta itemMeta, Collection<Material> materials) {
+    setMaterialCollection(itemMeta, materials, "CanPlaceOn");
+  }
+
+  @Override
+  public Set<Material> getCanPlaceOn(ItemMeta itemMeta) {
+    return getMaterialCollection(itemMeta, "CanPlaceOn");
+  }
+
+  @Override
+  public void copyAttributeModifiers(ItemMeta destination, ItemMeta source) {
+    SetMultimap<String, tc.oc.pgm.util.attribute.AttributeModifier> attributeModifiers =
+        getAttributeModifiers(source);
+    attributeModifiers.putAll(getAttributeModifiers(destination));
+    applyAttributeModifiers(attributeModifiers, destination);
+  }
+
+  @Override
+  public void applyAttributeModifiers(
+      SetMultimap<String, AttributeModifier> attributeModifiers, ItemMeta meta) {
+    NBTTagList list = new NBTTagList();
+    for (Map.Entry<String, AttributeModifier> entry : attributeModifiers.entries()) {
+      AttributeModifier modifier = entry.getValue();
+      NBTTagCompound tag = new NBTTagCompound();
+      tag.setString("Name", modifier.getName());
+      tag.setDouble("Amount", modifier.getAmount());
+      tag.setInt("Operation", modifier.getOperation().ordinal());
+      tag.setLong("UUIDMost", modifier.getUniqueId().getMostSignificantBits());
+      tag.setLong("UUIDLeast", modifier.getUniqueId().getLeastSignificantBits());
+      tag.setString("AttributeName", entry.getKey());
+      list.add(tag);
+    }
+
+    Map<String, NBTBase> unhandledTags =
+        (Map<String, NBTBase>) ReflectionUtils.readField(meta, unhandledTagsField);
+    unhandledTags.put("AttributeModifiers", list);
+  }
+
+  @Override
+  public SetMultimap<String, AttributeModifier> getAttributeModifiers(ItemMeta meta) {
+    Map<String, NBTBase> unhandledTags =
+        (Map<String, NBTBase>) ReflectionUtils.readField(meta, unhandledTagsField);
+    if (unhandledTags.containsKey("AttributeModifiers")) {
+      final SetMultimap<String, AttributeModifier> attributeModifiers = HashMultimap.create();
+      final NBTTagList modTags = (NBTTagList) unhandledTags.get("AttributeModifiers");
+      for (int i = 0; i < modTags.size(); i++) {
+        final NBTTagCompound modTag = modTags.get(i);
+        attributeModifiers.put(
+            modTag.getString("AttributeName"),
+            new AttributeModifier(
+                new UUID(modTag.getLong("UUIDMost"), modTag.getLong("UUIDLeast")),
+                modTag.getString("Name"),
+                modTag.getDouble("Amount"),
+                AttributeModifier.Operation.fromOpcode(modTag.getInt("Operation"))));
+      }
+      return attributeModifiers;
+    } else {
+      return HashMultimap.create();
+    }
+  }
+
+  @Override
+  public double getTPS() {
+    return 20.0;
+  }
+
+  enum TeamPacketFields {
+    a,
+    b,
+    c,
+    d,
+    e,
+    g,
+    h,
+    i;
+
+    Field field;
+
+    TeamPacketFields() {
+      field = ReflectionUtils.getField(PacketPlayOutScoreboardTeam.class, name());
+    }
+
+    public Field getField() {
+      return field;
+    }
+  }
+
+  @Override
+  public Object teamPacket(
+      int operation,
+      String name,
+      String displayName,
+      String prefix,
+      String suffix,
+      boolean friendlyFire,
+      boolean seeFriendlyInvisibles,
+      NameTagVisibility nameTagVisibility,
+      Collection<String> players) {
+
+    PacketPlayOutScoreboardTeam packet = new PacketPlayOutScoreboardTeam();
+
+    ReflectionUtils.setField(packet, name, TeamPacketFields.a.getField());
+    ReflectionUtils.setField(packet, displayName, TeamPacketFields.b.getField());
+    ReflectionUtils.setField(packet, prefix, TeamPacketFields.c.getField());
+    ReflectionUtils.setField(packet, suffix, TeamPacketFields.d.getField());
+
+    String e = null;
+    if (nameTagVisibility != null) {
+      switch (nameTagVisibility) {
+        case ALWAYS:
+          e = "always";
+          break;
+        case NEVER:
+          e = "never";
+          break;
+        case HIDE_FOR_OTHER_TEAMS:
+          e = "hideForOtherTeams";
+          break;
+        case HIDE_FOR_OWN_TEAM:
+          e = "hideForOwnTeam";
+          break;
+      }
+    }
+
+    ReflectionUtils.setField(packet, e, TeamPacketFields.e.getField());
+    ReflectionUtils.setField(packet, players, TeamPacketFields.g.getField());
+    ReflectionUtils.setField(packet, operation, TeamPacketFields.h.getField());
+
+    int i = (int) ReflectionUtils.readField(packet, TeamPacketFields.i.getField());
+    if (friendlyFire) {
+      i |= 1;
+    }
+    if (seeFriendlyInvisibles) {
+      i |= 2;
+    }
+
+    ReflectionUtils.setField(packet, i, TeamPacketFields.i.getField());
+
+    return packet;
+  }
+
+  @Override
+  public AttributeMap buildAttributeMap(Player player) {
+    return new AttributeMap1_8(player);
+  }
+
+  public <T> ListenableFutureTask<T> constructFutureTask(Runnable task) {
+    final ListenableFutureTask<T> future = ListenableFutureTask.create(task, null);
+    return future;
+  }
+
+  static Field TASK_QUEUE = ReflectionUtils.getField(MinecraftServer.class, "j");
+
+  @Override
+  public void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
+    MinecraftServer server = ((CraftServer) plugin.getServer()).getHandle().getServer();
+    server.a(Executors.callable(task));
+
+    //    ListenableFutureTask<Object> futureTask = constructFutureTask(task);
+    //    Queue<FutureTask<?>> taskQueue = (Queue<FutureTask<?>>) ReflectionUtils.readField(server,
+    // TASK_QUEUE);
+    //    synchronized (taskQueue) {
+    //      taskQueue.add(futureTask);
+    //    }
+  }
+
+  @NotNull
+  protected static PacketPlayOutPlayerInfo.EnumPlayerInfoAction convertEnumPlayerInfoAction(
+      EnumPlayerInfoAction action) {
+    PacketPlayOutPlayerInfo.EnumPlayerInfoAction nmsAction;
+    switch (action) {
+      case ADD_PLAYER:
+        nmsAction = PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER;
+        break;
+      case UPDATE_GAME_MODE:
+        nmsAction = PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_GAME_MODE;
+        break;
+      case UPDATE_LATENCY:
+        nmsAction = PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_LATENCY;
+        break;
+      case UPDATE_DISPLAY_NAME:
+        nmsAction = PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_DISPLAY_NAME;
+        break;
+      case REMOVE_PLAYER:
+      default:
+        nmsAction = PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER;
+        break;
+    }
+    return nmsAction;
+  }
+
+  public enum NamedEntitySpawnFields {
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+    g,
+    h,
+    i,
+    j;
+
+    Field field;
+
+    NamedEntitySpawnFields() {
+      field = ReflectionUtils.getField(PacketPlayOutNamedEntitySpawn.class, name());
+    }
+
+    public Field getField() {
+      return field;
+    }
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksNoOp.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksNoOp.java
@@ -1,0 +1,200 @@
+package tc.oc.pgm.util.nms;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.BlockState;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.DoubleChestInventory;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.MaterialData;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+import tc.oc.pgm.util.attribute.AttributeMap;
+import tc.oc.pgm.util.nms.attribute.AttributeMapNoOp;
+import tc.oc.pgm.util.nms.entity.fake.FakeEntity;
+import tc.oc.pgm.util.nms.entity.fake.FakeEntityNoOp;
+import tc.oc.pgm.util.nms.entity.potion.EntityPotion;
+import tc.oc.pgm.util.nms.entity.potion.EntityPotionBukkit;
+import tc.oc.pgm.util.reflect.MinecraftReflectionUtils;
+import tc.oc.pgm.util.reflect.ReflectionUtils;
+
+public abstract class NMSHacksNoOp implements NMSHacksPlatform {
+
+  @Override
+  public boolean isCraftItemArrowEntity(Item item) {
+    return item.getType() == EntityType.ARROW;
+  }
+
+  @Override
+  public EntityPotion entityPotion(Location location, ItemStack potionItem) {
+    return new EntityPotionBukkit(location, potionItem);
+  }
+
+  @Override
+  public PotionEffectType getPotionEffectType(String key) {
+    String strippedKey = key.toLowerCase().replace(" ", "").replace("_", "");
+
+    // Some effects can be parsed by getByName, this only has cases for those that cannot
+    switch (strippedKey) {
+      case "slowness":
+        return PotionEffectType.SLOW;
+      case "haste":
+        return PotionEffectType.FAST_DIGGING;
+      case "miningfatigue":
+        return PotionEffectType.SLOW_DIGGING;
+      case "strength":
+        return PotionEffectType.INCREASE_DAMAGE;
+      case "instanthealth":
+        return PotionEffectType.HEAL;
+      case "instantdamage":
+        return PotionEffectType.HARM;
+      case "jumpboost":
+        return PotionEffectType.JUMP;
+      case "nausea":
+        return PotionEffectType.CONFUSION;
+      case "resistance":
+        return PotionEffectType.DAMAGE_RESISTANCE;
+      default:
+        return PotionEffectType.getByName(key);
+    }
+  }
+
+  @Override
+  public Enchantment getEnchantment(String key) {
+    String strippedKey = key.toLowerCase().replace(" ", "").replace("_", "");
+
+    switch (strippedKey) {
+      case "protection":
+        return Enchantment.PROTECTION_ENVIRONMENTAL;
+      case "fireprotection":
+        return Enchantment.PROTECTION_FIRE;
+      case "featherfalling":
+        return Enchantment.PROTECTION_FALL;
+      case "blastprotection":
+        return Enchantment.PROTECTION_EXPLOSIONS;
+      case "projectileprotection":
+        return Enchantment.PROTECTION_PROJECTILE;
+      case "respiration":
+        return Enchantment.OXYGEN;
+      case "aquaaffinity":
+        return Enchantment.WATER_WORKER;
+      case "thorns":
+        return Enchantment.THORNS;
+      case "depthstrider":
+        return Enchantment.DEPTH_STRIDER;
+      case "sharpness":
+        return Enchantment.DAMAGE_ALL;
+      case "smite":
+        return Enchantment.DAMAGE_UNDEAD;
+      case "baneofarthropods":
+        return Enchantment.DAMAGE_ARTHROPODS;
+      case "knockback":
+        return Enchantment.KNOCKBACK;
+      case "fireaspect":
+        return Enchantment.FIRE_ASPECT;
+      case "looting":
+        return Enchantment.LOOT_BONUS_MOBS;
+      case "efficiency":
+        return Enchantment.DIG_SPEED;
+      case "silktouch":
+        return Enchantment.SILK_TOUCH;
+      case "unbreaking":
+        return Enchantment.DURABILITY;
+      case "fortune":
+        return Enchantment.LOOT_BONUS_BLOCKS;
+      case "power":
+        return Enchantment.ARROW_DAMAGE;
+      case "punch":
+        return Enchantment.ARROW_KNOCKBACK;
+      case "flame":
+        return Enchantment.ARROW_FIRE;
+      case "infinity":
+        return Enchantment.ARROW_INFINITE;
+      case "luckofthesea":
+        return Enchantment.LUCK;
+      case "lure":
+        return Enchantment.LURE;
+      default:
+        return Enchantment.getByName(key);
+    }
+  }
+
+  static Class<?> craftWorldClass = MinecraftReflectionUtils.getCraftBukkitClass("CraftWorld");
+  static Method getHandleMethod = ReflectionUtils.getMethod(craftWorldClass, "getHandle");
+  static Class<?> nmsWorldClass = MinecraftReflectionUtils.getNMSClass("World");
+  static Method getTimeMethod = ReflectionUtils.getMethod(nmsWorldClass, "getTime");
+
+  @Override
+  public long getMonotonicTime(World world) {
+    Object handle = ReflectionUtils.callMethod(getHandleMethod, world);
+    return (long) ReflectionUtils.callMethod(getTimeMethod, handle);
+  }
+
+  @Override
+  public int getPing(Player player) {
+    return 100;
+  }
+
+  @Override
+  public Inventory createFakeInventory(Player viewer, Inventory realInventory) {
+    return realInventory instanceof DoubleChestInventory
+        ? Bukkit.createInventory(viewer, realInventory.getSize())
+        : Bukkit.createInventory(viewer, realInventory.getType());
+  }
+
+  @Override
+  public FakeEntity fakeWitherSkull(World world) {
+    return new FakeEntityNoOp();
+  }
+
+  @Override
+  public FakeEntity fakeArmorStand(World world, ItemStack head) {
+    return new FakeEntityNoOp();
+  }
+
+  @Override
+  public ItemStack craftItemCopy(ItemStack item) {
+    return item.clone();
+  }
+
+  @Override
+  public Set<MaterialData> getBlockStates(Material material) {
+    // TODO: MaterialData is not version compatible
+    Set<MaterialData> materialDataSet = new HashSet<>();
+    for (byte i = 0; i < 16; i++) {
+      materialDataSet.add(new MaterialData(material, i));
+    }
+    return materialDataSet;
+  }
+
+  @Override
+  public void setBlockStateData(BlockState state, MaterialData materialData) {
+    state.setType(materialData.getItemType());
+    state.setData(materialData);
+  }
+
+  @Override
+  public double getTPS() {
+    return 20.0;
+  }
+
+  @Override
+  public AttributeMap buildAttributeMap(Player player) {
+    return new AttributeMapNoOp();
+  }
+
+  @Override
+  public void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
+    // runs the task on the next tick, not a perfect replacement
+    plugin.getServer().getScheduler().runTask(plugin, task);
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksPlatform.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksPlatform.java
@@ -1,0 +1,205 @@
+package tc.oc.pgm.util.nms;
+
+import com.google.common.collect.SetMultimap;
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
+import org.bukkit.Chunk;
+import org.bukkit.ChunkSnapshot;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.material.MaterialData;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scoreboard.NameTagVisibility;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.attribute.AttributeMap;
+import tc.oc.pgm.util.attribute.AttributeModifier;
+import tc.oc.pgm.util.block.RayBlockIntersection;
+import tc.oc.pgm.util.nms.entity.fake.FakeEntity;
+import tc.oc.pgm.util.nms.entity.potion.EntityPotion;
+import tc.oc.pgm.util.skin.Skin;
+
+public interface NMSHacksPlatform {
+
+  void sendPacket(Player bukkitPlayer, Object packet);
+
+  void sendPacketToViewers(Entity entity, Object packet, boolean excludeSpectators);
+
+  void playDeathAnimation(Player player);
+
+  Object teleportEntityPacket(int entityId, Location location);
+
+  Object entityMetadataPacket(int entityId, Entity entity, boolean complete);
+
+  void skipFireworksLaunch(Firework firework);
+
+  void fakePlayerItemPickup(Player player, Item item);
+
+  boolean isCraftItemArrowEntity(org.bukkit.entity.Item item);
+
+  void freezeEntity(Entity entity);
+
+  void setFireballDirection(Fireball entity, Vector direction);
+
+  void removeAndAddAllTabPlayers(Player viewer);
+
+  void sendLegacyWearing(Player player, int slot, ItemStack item);
+
+  EntityPotion entityPotion(Location location, ItemStack potionItem);
+
+  void sendBlockChange(Location loc, Player player, @Nullable Material material);
+
+  default void updateChunkSnapshot(
+      ChunkSnapshot snapshot, org.bukkit.block.BlockState blockState) {}
+
+  default void setKnockbackReduction(Player player, float amount) {}
+
+  default void showInvisibles(Player player, boolean showInvisibles) {}
+
+  default void setAffectsSpawning(Player player, boolean affectsSpawning) {}
+
+  void clearArrowsInPlayer(Player player);
+
+  void showBorderWarning(Player player, boolean show);
+
+  PotionEffectType getPotionEffectType(String key);
+
+  org.bukkit.enchantments.Enchantment getEnchantment(String key);
+
+  long getMonotonicTime(World world);
+
+  int getPing(Player player);
+
+  Object entityEquipmentPacket(int entityId, int slot, ItemStack armor);
+
+  void entityAttach(Player player, int entityID, int vehicleID, boolean leash);
+
+  default void resumeServer() {}
+
+  Inventory createFakeInventory(Player viewer, Inventory realInventory);
+
+  FakeEntity fakeWitherSkull(World world);
+
+  FakeEntity fakeArmorStand(World world, ItemStack head);
+
+  Set<Block> getBlocks(Chunk bukkitChunk, Material material);
+
+  Object spawnPlayerPacket(int entityId, UUID uuid, Location location, Player player);
+
+  Object destroyEntitiesPacket(int... entityIds);
+
+  Object createPlayerInfoPacket(EnumPlayerInfoAction action);
+
+  void setPotionParticles(Player player, boolean enabled);
+
+  ItemStack craftItemCopy(ItemStack item);
+
+  RayBlockIntersection getTargetedBLock(Player player);
+
+  boolean playerInfoDataListNotEmpty(Object packet);
+
+  Object playerListPacketData(
+      Object packetPlayOutPlayerInfo,
+      UUID uuid,
+      String name,
+      GameMode gamemode,
+      int ping,
+      @Nullable Skin skin,
+      @Nullable String renderedDisplayName);
+
+  void addPlayerInfoToPacket(Object packet, Object playerInfoData);
+
+  void setSkullMetaOwner(SkullMeta meta, String name, UUID uuid, Skin skin);
+
+  WorldCreator detectWorld(String worldName);
+
+  void setAbsorption(LivingEntity entity, double health);
+
+  double getAbsorption(LivingEntity entity);
+
+  @Deprecated
+  Set<MaterialData> getBlockStates(Material material);
+
+  // TODO: Material api
+  void setBlockStateData(BlockState state, MaterialData materialData);
+
+  Skin getPlayerSkin(Player player);
+
+  Skin getPlayerSkinForViewer(Player player, Player viewer);
+
+  void updateVelocity(Player player);
+
+  boolean teleportRelative(
+      Player player,
+      org.bukkit.util.Vector deltaPos,
+      float deltaYaw,
+      float deltaPitch,
+      PlayerTeleportEvent.TeleportCause cause);
+
+  void sendSpawnEntityPacket(Player player, int entityId, Location location);
+
+  void spawnFreezeEntity(Player player, int entityId, boolean legacy);
+
+  /**
+   * Test if the given tool is capable of "efficiently" mining the given block.
+   *
+   * <p>Derived from CraftBlock.itemCausesDrops()
+   */
+  boolean canMineBlock(MaterialData blockMaterial, ItemStack tool);
+
+  void resetDimension(World world);
+
+  Set<Material> getMaterialCollection(ItemMeta itemMeta, String key);
+
+  void setMaterialCollection(ItemMeta itemMeta, Collection<Material> materials, String canPlaceOn);
+
+  void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials);
+
+  Set<Material> getCanDestroy(ItemMeta itemMeta);
+
+  void setCanPlaceOn(ItemMeta itemMeta, Collection<Material> materials);
+
+  Set<Material> getCanPlaceOn(ItemMeta itemMeta);
+
+  void copyAttributeModifiers(ItemMeta destination, ItemMeta source);
+
+  void applyAttributeModifiers(
+      SetMultimap<String, AttributeModifier> attributeModifiers, ItemMeta meta);
+
+  SetMultimap<String, AttributeModifier> getAttributeModifiers(ItemMeta meta);
+
+  double getTPS();
+
+  Object teamPacket(
+      int operation,
+      String name,
+      String displayName,
+      String prefix,
+      String suffix,
+      boolean friendlyFire,
+      boolean seeFriendlyInvisibles,
+      NameTagVisibility nameTagVisibility,
+      Collection<String> players);
+
+  AttributeMap buildAttributeMap(Player player);
+
+  void postToMainThread(Plugin plugin, boolean priority, Runnable task);
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksSportPaper.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksSportPaper.java
@@ -1,0 +1,268 @@
+package tc.oc.pgm.util.nms;
+
+import com.google.common.collect.SetMultimap;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import net.minecraft.server.v1_8_R3.DataWatcher;
+import net.minecraft.server.v1_8_R3.PacketPlayOutAttachEntity;
+import net.minecraft.server.v1_8_R3.PacketPlayOutNamedEntitySpawn;
+import net.minecraft.server.v1_8_R3.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_8_R3.PacketPlayOutScoreboardTeam;
+import net.minecraft.server.v1_8_R3.PacketPlayOutSpawnEntity;
+import net.minecraft.server.v1_8_R3.PacketPlayOutSpawnEntityLiving;
+import org.bukkit.Bukkit;
+import org.bukkit.ChunkSnapshot;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.BlockState;
+import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_8_R3.scoreboard.CraftTeam;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.DoubleChestInventory;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.material.MaterialData;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scoreboard.NameTagVisibility;
+import tc.oc.pgm.util.attribute.AttributeModifier;
+import tc.oc.pgm.util.skin.Skin;
+
+public class NMSHacksSportPaper extends NMSHacks1_8 {
+  @Override
+  public void updateChunkSnapshot(ChunkSnapshot snapshot, BlockState blockState) {
+    snapshot.updateBlock(blockState);
+  }
+
+  @Override
+  public void setBlockStateData(BlockState state, MaterialData materialData) {
+    state.setMaterialData(materialData);
+  }
+
+  @Override
+  public void setKnockbackReduction(Player player, float amount) {
+    player.setKnockbackReduction(amount);
+  }
+
+  @Override
+  public void showInvisibles(Player player, boolean showInvisibles) {
+    player.showInvisibles(showInvisibles);
+  }
+
+  @Override
+  public void setAffectsSpawning(Player player, boolean affectsSpawning) {
+    player.spigot().setAffectsSpawning(affectsSpawning);
+  }
+
+  @Override
+  public void entityAttach(Player player, int entityID, int vehicleID, boolean leash) {
+    sendPacket(player, new PacketPlayOutAttachEntity(entityID, vehicleID, leash));
+  }
+
+  @Override
+  public void resumeServer() {
+    if (Bukkit.getServer().isSuspended()) Bukkit.getServer().setSuspended(false);
+  }
+
+  @Override
+  public Inventory createFakeInventory(Player viewer, Inventory realInventory) {
+    if (realInventory.hasCustomName()) {
+      return realInventory instanceof DoubleChestInventory
+          ? Bukkit.createInventory(viewer, realInventory.getSize(), realInventory.getName())
+          : Bukkit.createInventory(viewer, realInventory.getType(), realInventory.getName());
+    } else {
+      return realInventory instanceof DoubleChestInventory
+          ? Bukkit.createInventory(viewer, realInventory.getSize())
+          : Bukkit.createInventory(viewer, realInventory.getType());
+    }
+  }
+
+  @Override
+  public Object spawnPlayerPacket(int entityId, UUID uuid, Location location, Player player) {
+    DataWatcher dataWatcher = copyDataWatcher(player);
+    return new PacketPlayOutNamedEntitySpawn(
+        entityId,
+        uuid,
+        location.getX(),
+        location.getY(),
+        location.getZ(),
+        (byte) location.getYaw(),
+        (byte) location.getPitch(),
+        CraftItemStack.asNMSCopy(null),
+        dataWatcher);
+  }
+
+  @Override
+  public Object createPlayerInfoPacket(EnumPlayerInfoAction action) {
+    PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo();
+    packet.a = convertEnumPlayerInfoAction(action);
+    return packet;
+  }
+
+  @Override
+  public void setPotionParticles(Player player, boolean enabled) {
+    player.setPotionParticles(enabled);
+  }
+
+  @Override
+  public boolean playerInfoDataListNotEmpty(Object packet) {
+    return !((PacketPlayOutPlayerInfo) packet).b.isEmpty();
+  }
+
+  @Override
+  public void addPlayerInfoToPacket(Object packet, Object playerInfoData) {
+    ((PacketPlayOutPlayerInfo) packet)
+        .b.add((PacketPlayOutPlayerInfo.PlayerInfoData) playerInfoData);
+  }
+
+  @Override
+  public void sendSpawnEntityPacket(Player player, int entityId, Location location) {
+    sendPacket(
+        player,
+        new PacketPlayOutSpawnEntity(
+            entityId,
+            location.getX(),
+            location.getY(),
+            location.getZ(),
+            0,
+            0,
+            0,
+            (int) location.getPitch(),
+            (int) location.getYaw(),
+            66,
+            0));
+  }
+
+  @Override
+  public void spawnFreezeEntity(Player player, int entityId, boolean legacy) {
+    if (legacy) {
+      Location location = player.getLocation().add(0, 0.286, 0);
+      if (location.getY() < -64) {
+        location.setY(-64);
+        player.teleport(location);
+      }
+
+      sendSpawnEntityPacket(player, entityId, location);
+    } else {
+      Location loc = player.getLocation().subtract(0, 1.1, 0);
+      int flags = 0;
+      flags |= 0x20;
+      DataWatcher dataWatcher = new DataWatcher(null);
+      dataWatcher.a(0, (byte) (byte) flags);
+      dataWatcher.a(1, (short) (short) 0);
+      int flags1 = 0;
+      dataWatcher.a(10, (byte) flags1);
+      sendPacket(
+          player,
+          new PacketPlayOutSpawnEntityLiving(
+              entityId,
+              (byte) EntityType.ARMOR_STAND.getTypeId(),
+              loc.getX(),
+              loc.getY(),
+              loc.getZ(),
+              loc.getYaw(),
+              loc.getPitch(),
+              loc.getPitch(),
+              0,
+              0,
+              0,
+              dataWatcher));
+    }
+  }
+
+  @Override
+  public Skin getPlayerSkinForViewer(Player player, Player viewer) {
+    return player.hasFakeSkin(viewer)
+        ? new Skin(player.getFakeSkin(viewer).getData(), player.getFakeSkin(viewer).getSignature())
+        : getPlayerSkin(player);
+  }
+
+  @Override
+  public void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials) {
+    itemMeta.setCanDestroy(materials);
+  }
+
+  @Override
+  public Set<Material> getCanDestroy(ItemMeta itemMeta) {
+    return itemMeta.getCanDestroy();
+  }
+
+  @Override
+  public void setCanPlaceOn(ItemMeta itemMeta, Collection<Material> materials) {
+    itemMeta.setCanPlaceOn(materials);
+  }
+
+  @Override
+  public Set<Material> getCanPlaceOn(ItemMeta itemMeta) {
+    return itemMeta.getCanPlaceOn();
+  }
+
+  @Override
+  public void copyAttributeModifiers(ItemMeta destination, ItemMeta source) {
+    for (String attribute : source.getModifiedAttributes()) {
+      for (org.bukkit.attribute.AttributeModifier modifier :
+          source.getAttributeModifiers(attribute)) {
+        destination.addAttributeModifier(attribute, modifier);
+      }
+    }
+  }
+
+  @Override
+  public void applyAttributeModifiers(
+      SetMultimap<String, AttributeModifier> attributeModifiers, ItemMeta meta) {
+    for (Map.Entry<String, AttributeModifier> entry : attributeModifiers.entries()) {
+      AttributeModifier attributeModifier = entry.getValue();
+      meta.addAttributeModifier(
+          entry.getKey(),
+          new org.bukkit.attribute.AttributeModifier(
+              attributeModifier.getUniqueId(),
+              attributeModifier.getName(),
+              attributeModifier.getAmount(),
+              org.bukkit.attribute.AttributeModifier.Operation.fromOpcode(
+                  attributeModifier.getOperation().ordinal())));
+    }
+  }
+
+  @Override
+  public double getTPS() {
+    return Bukkit.getServer().spigot().getTPS()[0];
+  }
+
+  @Override
+  public Object teamPacket(
+      int operation,
+      String name,
+      String displayName,
+      String prefix,
+      String suffix,
+      boolean friendlyFire,
+      boolean seeFriendlyInvisibles,
+      NameTagVisibility nameTagVisibility,
+      Collection<String> players) {
+    PacketPlayOutScoreboardTeam packet = new PacketPlayOutScoreboardTeam();
+
+    packet.a = name;
+    packet.b = displayName;
+    packet.c = prefix;
+    packet.d = suffix;
+    packet.e = nameTagVisibility == null ? null : CraftTeam.bukkitToNotch(nameTagVisibility).e;
+    // packet.f = color
+    packet.g = players;
+    packet.h = operation;
+    if (friendlyFire) {
+      packet.i |= 1;
+    }
+    if (seeFriendlyInvisibles) {
+      packet.i |= 2;
+    }
+
+    return packet;
+  }
+
+  @Override
+  public void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
+    Bukkit.getServer().postToMainThread(plugin, true, task);
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/attribute/AttributeInstance1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/attribute/AttributeInstance1_8.java
@@ -1,17 +1,20 @@
-package tc.oc.pgm.util.attribute;
+package tc.oc.pgm.util.nms.attribute;
 
 import static tc.oc.pgm.util.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import tc.oc.pgm.util.attribute.Attribute;
+import tc.oc.pgm.util.attribute.AttributeInstance;
+import tc.oc.pgm.util.attribute.AttributeModifier;
 
-public class AttributeInstanceImpl implements AttributeInstance {
+public class AttributeInstance1_8 implements AttributeInstance {
 
   private final net.minecraft.server.v1_8_R3.AttributeInstance handle;
   private final Attribute attribute;
 
-  public AttributeInstanceImpl(
+  public AttributeInstance1_8(
       net.minecraft.server.v1_8_R3.AttributeInstance handle, Attribute attribute) {
     this.handle = handle;
     this.attribute = attribute;

--- a/util/src/main/java/tc/oc/pgm/util/nms/attribute/AttributeMap1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/attribute/AttributeMap1_8.java
@@ -1,21 +1,20 @@
-package tc.oc.pgm.util.attribute;
+package tc.oc.pgm.util.nms.attribute;
 
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import net.minecraft.server.v1_8_R3.AttributeMapBase;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
+import tc.oc.pgm.util.attribute.Attribute;
+import tc.oc.pgm.util.attribute.AttributeInstance;
+import tc.oc.pgm.util.attribute.AttributeMap;
 
-public class AttributeMapImpl implements AttributeMap {
+public class AttributeMap1_8 implements AttributeMap {
 
   private final AttributeMapBase handle;
 
-  public AttributeMapImpl(Player player) {
+  public AttributeMap1_8(Player player) {
     handle = ((CraftPlayer) player).getHandle().getAttributeMap();
-  }
-
-  public AttributeMapImpl(AttributeMapBase handle) {
-    this.handle = handle;
   }
 
   @Override
@@ -23,7 +22,7 @@ public class AttributeMapImpl implements AttributeMap {
     assertNotNull(attribute, "attribute");
     net.minecraft.server.v1_8_R3.AttributeInstance nms = handle.a(toMinecraft(attribute.name()));
 
-    return (nms == null) ? null : new AttributeInstanceImpl(nms, attribute);
+    return (nms == null) ? null : new AttributeInstance1_8(nms, attribute);
   }
 
   static String toMinecraft(String bukkit) {

--- a/util/src/main/java/tc/oc/pgm/util/nms/attribute/AttributeMapNoOp.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/attribute/AttributeMapNoOp.java
@@ -1,0 +1,12 @@
+package tc.oc.pgm.util.nms.attribute;
+
+import tc.oc.pgm.util.attribute.Attribute;
+import tc.oc.pgm.util.attribute.AttributeInstance;
+import tc.oc.pgm.util.attribute.AttributeMap;
+
+public class AttributeMapNoOp implements AttributeMap {
+  @Override
+  public AttributeInstance getAttribute(Attribute attribute) {
+    return null;
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/FakeEntity.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/FakeEntity.java
@@ -1,0 +1,44 @@
+package tc.oc.pgm.util.nms.entity.fake;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.util.nms.NMSHacks;
+
+public interface FakeEntity {
+  int entityId();
+
+  Entity entity();
+
+  void spawn(Player viewer, Location location, org.bukkit.util.Vector velocity);
+
+  default void spawn(Player viewer, Location location) {
+    spawn(viewer, location, new org.bukkit.util.Vector(0, 0, 0));
+  }
+
+  default void destroy(Player viewer) {
+    int[] entityIds = new int[] {entityId()};
+    NMSHacks.sendPacket(viewer, NMSHacks.destroyEntitiesPacket(entityIds));
+  }
+
+  default void teleport(Player viewer, Location location) {
+    NMSHacks.sendPacket(viewer, NMSHacks.teleportEntityPacket(entityId(), location));
+  }
+
+  default void ride(Player viewer, Entity rider) {
+    int entityID = rider.getEntityId();
+    int vehicleID = entityId();
+    NMSHacks.entityAttach(viewer, entityID, vehicleID, false);
+  }
+
+  default void mount(Player viewer, Entity vehicle) {
+    int entityID = entityId();
+    int vehicleID = vehicle.getEntityId();
+    NMSHacks.entityAttach(viewer, entityID, vehicleID, false);
+  }
+
+  default void wear(Player viewer, int slot, ItemStack item) {
+    NMSHacks.sendPacket(viewer, NMSHacks.entityEquipmentPacket(entityId(), slot, item));
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/FakeEntityImpl1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/FakeEntityImpl1_8.java
@@ -1,0 +1,39 @@
+package tc.oc.pgm.util.nms.entity.fake;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.util.nms.NMSHacks;
+
+public abstract class FakeEntityImpl1_8<T extends net.minecraft.server.v1_8_R3.Entity>
+    implements FakeEntity {
+  protected final T entity;
+
+  protected FakeEntityImpl1_8(T entity) {
+    this.entity = entity;
+  }
+
+  @Override
+  public Entity entity() {
+    return entity.getBukkitEntity();
+  }
+
+  @Override
+  public void spawn(Player viewer, Location location, Vector velocity) {
+    entity.setPositionRotation(
+        location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
+    entity.motX = velocity.getX();
+    entity.motY = velocity.getY();
+    entity.motZ = velocity.getZ();
+    Object packet = spawnPacket();
+    NMSHacks.sendPacket(viewer, packet);
+  }
+
+  public abstract Object spawnPacket();
+
+  @Override
+  public int entityId() {
+    return entity.getId();
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/FakeEntityNoOp.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/FakeEntityNoOp.java
@@ -1,0 +1,22 @@
+package tc.oc.pgm.util.nms.entity.fake;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+
+public class FakeEntityNoOp implements FakeEntity {
+
+  @Override
+  public int entityId() {
+    return 0;
+  }
+
+  @Override
+  public Entity entity() {
+    return null;
+  }
+
+  @Override
+  public void spawn(Player viewer, Location location, Vector velocity) {}
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/FakeLivingEntity1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/FakeLivingEntity1_8.java
@@ -1,0 +1,15 @@
+package tc.oc.pgm.util.nms.entity.fake;
+
+import net.minecraft.server.v1_8_R3.EntityLiving;
+import net.minecraft.server.v1_8_R3.PacketPlayOutSpawnEntityLiving;
+
+public class FakeLivingEntity1_8<T extends EntityLiving> extends FakeEntityImpl1_8<T> {
+
+  protected FakeLivingEntity1_8(T entity) {
+    super(entity);
+  }
+
+  public Object spawnPacket() {
+    return new PacketPlayOutSpawnEntityLiving(entity);
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/armorstand/FakeArmorStand1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/armorstand/FakeArmorStand1_8.java
@@ -1,0 +1,39 @@
+package tc.oc.pgm.util.nms.entity.fake.armorstand;
+
+import net.minecraft.server.v1_8_R3.EntityArmorStand;
+import net.minecraft.server.v1_8_R3.NBTTagCompound;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.util.nms.entity.fake.FakeLivingEntity1_8;
+
+public class FakeArmorStand1_8 extends FakeLivingEntity1_8<EntityArmorStand> {
+
+  private final ItemStack head;
+
+  public FakeArmorStand1_8(World world, ItemStack head) {
+    super(new EntityArmorStand(((CraftWorld) world).getHandle()));
+    this.head = head;
+
+    entity.setInvisible(true);
+    NBTTagCompound tag = entity.getNBTTag();
+    if (tag == null) {
+      tag = new NBTTagCompound();
+    }
+    entity.c(tag);
+    tag.setBoolean("Silent", true);
+    tag.setBoolean("Invulnerable", true);
+    tag.setBoolean("NoGravity", true);
+    tag.setBoolean("NoAI", true);
+    entity.f(tag);
+  }
+
+  @Override
+  public void spawn(Player viewer, Location location, Vector velocity) {
+    super.spawn(viewer, location, velocity);
+    if (head != null) wear(viewer, 4, head);
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/wither/FakeWitherSkull1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/fake/wither/FakeWitherSkull1_8.java
@@ -1,0 +1,22 @@
+package tc.oc.pgm.util.nms.entity.fake.wither;
+
+import net.minecraft.server.v1_8_R3.EntityWitherSkull;
+import net.minecraft.server.v1_8_R3.PacketPlayOutSpawnEntity;
+import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.util.nms.entity.fake.FakeEntityImpl1_8;
+
+public class FakeWitherSkull1_8 extends FakeEntityImpl1_8<EntityWitherSkull> {
+  public FakeWitherSkull1_8(World world) {
+    super(new EntityWitherSkull(((CraftWorld) world).getHandle()));
+  }
+
+  public Object spawnPacket() {
+    return new PacketPlayOutSpawnEntity(entity, 66);
+  }
+
+  @Override
+  public void wear(Player viewer, int slot, ItemStack item) {}
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/potion/EntityPotion.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/potion/EntityPotion.java
@@ -1,0 +1,10 @@
+package tc.oc.pgm.util.nms.entity.potion;
+
+import org.bukkit.entity.Entity;
+
+public interface EntityPotion {
+
+  public void spawn();
+
+  Entity getBukkitEntity();
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/potion/EntityPotion1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/potion/EntityPotion1_8.java
@@ -1,0 +1,32 @@
+package tc.oc.pgm.util.nms.entity.potion;
+
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
+import org.bukkit.entity.Entity;
+import org.bukkit.inventory.ItemStack;
+
+public class EntityPotion1_8 implements EntityPotion {
+
+  private net.minecraft.server.v1_8_R3.EntityPotion handle;
+
+  public EntityPotion1_8(Location location, ItemStack potionItem) {
+    handle =
+        new net.minecraft.server.v1_8_R3.EntityPotion(
+            ((CraftWorld) location.getWorld()).getHandle(),
+            location.getX(),
+            location.getY(),
+            location.getZ(),
+            CraftItemStack.asNMSCopy(potionItem));
+  }
+
+  @Override
+  public void spawn() {
+    handle.spawnIn(handle.getWorld());
+  }
+
+  @Override
+  public Entity getBukkitEntity() {
+    return handle.getBukkitEntity();
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/potion/EntityPotionBukkit.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/potion/EntityPotionBukkit.java
@@ -1,0 +1,31 @@
+package tc.oc.pgm.util.nms.entity.potion;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ThrownPotion;
+import org.bukkit.inventory.ItemStack;
+
+public class EntityPotionBukkit implements EntityPotion {
+
+  private final Location location;
+  private final ItemStack potionItem;
+  private ThrownPotion bukkitPotionEntity = null;
+
+  public EntityPotionBukkit(Location location, ItemStack potionItem) {
+    this.location = location;
+    this.potionItem = potionItem;
+  }
+
+  @Override
+  public void spawn() {
+    this.bukkitPotionEntity =
+        (ThrownPotion) this.location.getWorld().spawnEntity(location, EntityType.SPLASH_POTION);
+    bukkitPotionEntity.setItem(potionItem);
+  }
+
+  @Override
+  public Entity getBukkitEntity() {
+    return this.bukkitPotionEntity;
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/reflect/MinecraftReflectionUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/reflect/MinecraftReflectionUtils.java
@@ -1,0 +1,19 @@
+package tc.oc.pgm.util.reflect;
+
+import org.bukkit.Bukkit;
+
+public interface MinecraftReflectionUtils {
+  String VERSION = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+
+  static Class<?> getBukkitClass(String classPath) {
+    return ReflectionUtils.getClassFromName("org.bukkit." + classPath);
+  }
+
+  static Class<?> getCraftBukkitClass(String classPath) {
+    return ReflectionUtils.getClassFromName("org.bukkit.craftbukkit." + VERSION + "." + classPath);
+  }
+
+  static Class<?> getNMSClass(String classPath) {
+    return ReflectionUtils.getClassFromName("net.minecraft.server." + VERSION + "." + classPath);
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/tablist/PlayerTabEntry.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/PlayerTabEntry.java
@@ -77,11 +77,7 @@ public class PlayerTabEntry extends DynamicTabEntry {
     }
 
     // TODO: find different solution for non-SportPaper servers
-    return this.player.hasFakeSkin(viewer)
-        ? new Skin(
-            this.player.getFakeSkin(viewer).getData(),
-            this.player.getFakeSkin(viewer).getSignature())
-        : NMSHacks.getPlayerSkin(this.player);
+    return NMSHacks.getPlayerSkinForViewer(player, viewer);
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
@@ -5,36 +5,29 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import net.kyori.adventure.text.Component;
-import net.minecraft.server.v1_8_R3.Packet;
-import net.minecraft.server.v1_8_R3.PacketPlayOutPlayerInfo;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.nms.EnumPlayerInfoAction;
 import tc.oc.pgm.util.nms.NMSHacks;
 import tc.oc.pgm.util.text.TextTranslations;
 
 public class TabRender {
   private final TabView view;
 
-  private final PacketPlayOutPlayerInfo removePacket;
-  private final PacketPlayOutPlayerInfo addPacket;
-  private final PacketPlayOutPlayerInfo updatePacket;
-  private final PacketPlayOutPlayerInfo updatePingPacket;
-  private final List<Packet> deferredPackets;
+  private final Object removePacket;
+  private final Object addPacket;
+  private final Object updatePacket;
+  private final Object updatePingPacket;
+  private final List<Object> deferredPackets;
 
   public TabRender(TabView view) {
     this.view = view;
 
-    this.removePacket =
-        NMSHacks.createPlayerInfoPacket(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER);
-    this.addPacket =
-        NMSHacks.createPlayerInfoPacket(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER);
-    this.updatePacket =
-        NMSHacks.createPlayerInfoPacket(
-            PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
-    this.updatePingPacket =
-        NMSHacks.createPlayerInfoPacket(
-            PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_LATENCY);
+    this.removePacket = NMSHacks.createPlayerInfoPacket(EnumPlayerInfoAction.REMOVE_PLAYER);
+    this.addPacket = NMSHacks.createPlayerInfoPacket(EnumPlayerInfoAction.ADD_PLAYER);
+    this.updatePacket = NMSHacks.createPlayerInfoPacket(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME);
+    this.updatePingPacket = NMSHacks.createPlayerInfoPacket(EnumPlayerInfoAction.UPDATE_LATENCY);
     this.deferredPackets = new ArrayList<>();
   }
 
@@ -42,7 +35,7 @@ public class TabRender {
     return "\u0001TabView" + String.format("%03d", slot);
   }
 
-  private void send(Packet packet) {
+  private void send(Object packet) {
     NMSHacks.sendPacket(this.view.getViewer(), packet);
   }
 
@@ -52,28 +45,24 @@ public class TabRender {
 
   private void appendAddition(TabEntry entry, int index) {
     String renderedDisplayName = this.getJson(entry);
-    NMSHacks.getPlayerInfoDataList(this.addPacket)
-        .add(
-            NMSHacks.playerListPacketData(
-                this.addPacket,
-                entry.getId(),
-                entry.getName(this.view),
-                entry.getGamemode(),
-                entry.getPing(),
-                entry.getSkin(this.view),
-                renderedDisplayName));
+    NMSHacks.addPlayerInfoToPacket(
+        this.addPacket,
+        entry.getId(),
+        entry.getName(this.view),
+        entry.getGamemode(),
+        entry.getPing(),
+        entry.getSkin(this.view),
+        renderedDisplayName);
 
     // Due to a client bug, display name is ignored in ADD_PLAYER packets,
     // so we have to send an UPDATE_DISPLAY_NAME afterward.
-    NMSHacks.getPlayerInfoDataList(this.updatePacket)
-        .add(NMSHacks.playerListPacketData(this.updatePacket, entry.getId(), renderedDisplayName));
+    NMSHacks.addPlayerInfoToPacket(this.updatePacket, entry.getId(), renderedDisplayName);
 
     this.updateFakeEntity(entry, true);
   }
 
   private void appendRemoval(TabEntry entry) {
-    NMSHacks.getPlayerInfoDataList(this.removePacket)
-        .add(NMSHacks.playerListPacketData(this.removePacket, entry.getId()));
+    NMSHacks.addPlayerInfoToPacket(this.removePacket, entry.getId());
 
     int entityId = entry.getFakeEntityId(this.view);
     if (entityId >= 0) {
@@ -94,13 +83,13 @@ public class TabRender {
   }
 
   public void finish() {
-    if (!NMSHacks.getPlayerInfoDataList(this.removePacket).isEmpty()) this.send(this.removePacket);
-    if (!NMSHacks.getPlayerInfoDataList(this.addPacket).isEmpty()) this.send(this.addPacket);
-    if (!NMSHacks.getPlayerInfoDataList(this.updatePacket).isEmpty()) this.send(this.updatePacket);
-    if (!NMSHacks.getPlayerInfoDataList(this.updatePingPacket).isEmpty())
+    if (NMSHacks.playerInfoDataListNotEmpty(this.removePacket)) this.send(this.removePacket);
+    if (NMSHacks.playerInfoDataListNotEmpty(this.addPacket)) this.send(this.addPacket);
+    if (NMSHacks.playerInfoDataListNotEmpty(this.updatePacket)) this.send(this.updatePacket);
+    if (NMSHacks.playerInfoDataListNotEmpty(this.updatePingPacket))
       this.send(this.updatePingPacket);
 
-    for (Packet packet : this.deferredPackets) {
+    for (Object packet : this.deferredPackets) {
       this.send(packet);
     }
   }
@@ -112,15 +101,8 @@ public class TabRender {
 
   public void createSlot(TabEntry entry, int index) {
     String teamName = this.teamName(index);
-    this.send(
-        NMSHacks.teamCreatePacket(
-            teamName,
-            teamName,
-            "",
-            "",
-            false,
-            false,
-            Collections.singleton(entry.getName(this.view))));
+    Collection<String> players = Collections.singleton(entry.getName(this.view));
+    this.send(NMSHacks.teamCreatePacket(teamName, teamName, "", "", false, false, players));
     this.appendAddition(entry, index);
   }
 
@@ -145,13 +127,11 @@ public class TabRender {
   }
 
   public void updateEntry(TabEntry entry, int index) {
-    NMSHacks.getPlayerInfoDataList(this.updatePacket)
-        .add(NMSHacks.playerListPacketData(this.updatePacket, entry.getId(), this.getJson(entry)));
+    NMSHacks.addPlayerInfoToPacket(this.updatePacket, entry.getId(), this.getJson(entry));
   }
 
   public void updatePing(TabEntry entry, int index) {
-    NMSHacks.getPlayerInfoDataList(this.updatePingPacket)
-        .add(NMSHacks.playerListPacketData(this.updatePingPacket, entry.getId(), entry.getPing()));
+    NMSHacks.addPlayerInfoToPacket(this.updatePingPacket, entry.getId(), entry.getPing());
   }
 
   public void setHeaderFooter(Component header, Component footer) {


### PR DESCRIPTION
## New description

This PR includes changes to make supporting other versions easier, and _should_ not include any change that alters behavior for 1.8.
This refactors the NMSHacks Interface into multiple interfaces and classes.

PGM will still only run on 1.8 with this PR.

## Old description
Felt like doing some work towards https://github.com/PGMDev/PGM/issues/852

This adds NoOp fallbacks for NMS code, which does cause some things to fail silently which is probably not exactly what we want.

This technically does allow PGM to run (poorly) on 1.9 and probably some other versions.
For example: countdowns don't work, but you can play a match with /start 0 and /cycle 0, the 5 maps that come with PGM seemed to work

Also, spigot 1.8.8 should work correctly again with this

Not sure if the style of `NMSHacksProvider.get()` is optimal, but it was easy to do / implement. I'm open to other suggestions.