### PR TITLE
Fix issues with carrying & monostable filters

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/match/MonostableFilter.java
@@ -79,6 +79,7 @@ public class MonostableFilter extends SingleFilterFunction
       implements Tickable {
 
     protected final Class<F> scope;
+    protected Instant lastTick = Instant.MIN;
 
     // Filterables that currently pass the inner filter, mapped to the instants that they expire.
     // They are not actually removed until the inner filter goes false.
@@ -123,10 +124,11 @@ public class MonostableFilter extends SingleFilterFunction
 
       endTimes.forEach(
           (filterable, end) -> {
-            if (now.isAfter(end)) {
+            if (!now.isBefore(end) && lastTick.isBefore(end)) {
               this.invalidate(filterable);
             }
           });
+      lastTick = now;
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
@@ -1,10 +1,14 @@
 package tc.oc.pgm.filters.matcher.player;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Stream;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
@@ -26,7 +30,18 @@ public class CarryingItemFilter extends ParticipantItemFilter {
   }
 
   @Override
-  protected ItemStack[] getItems(MatchPlayer player) {
-    return player.getBukkit().getInventory().getContents();
+  protected Stream<ItemStack> getItems(MatchPlayer player) {
+    Stream<ItemStack> inventory =
+        Stream.concat(
+            Arrays.stream(player.getBukkit().getInventory().getContents()),
+            Stream.of(player.getBukkit().getItemOnCursor()));
+
+    // Potentially add the crafting grid if that's the currently open inventory
+    InventoryView invView = player.getBukkit().getOpenInventory();
+    InventoryType type = invView.getType();
+    if (type == InventoryType.CRAFTING || type == InventoryType.WORKBENCH) {
+      return Stream.concat(inventory, Arrays.stream(invView.getTopInventory().getContents()));
+    }
+    return inventory;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/HoldingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/HoldingItemFilter.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.filters.matcher.player;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
+import java.util.stream.Stream;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
@@ -26,7 +27,7 @@ public class HoldingItemFilter extends ParticipantItemFilter {
   }
 
   @Override
-  protected ItemStack[] getItems(MatchPlayer player) {
-    return new ItemStack[] {player.getBukkit().getItemInHand()};
+  protected Stream<ItemStack> getItems(MatchPlayer player) {
+    return Stream.of(player.getBukkit().getItemInHand());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/ParticipantItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/ParticipantItemFilter.java
@@ -2,6 +2,8 @@ package tc.oc.pgm.filters.matcher.player;
 
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
+import java.util.Objects;
+import java.util.stream.Stream;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -14,14 +16,10 @@ public abstract class ParticipantItemFilter extends ParticipantFilter {
     this.matcher = assertNotNull(matcher, "item");
   }
 
-  protected abstract ItemStack[] getItems(MatchPlayer player);
+  protected abstract Stream<ItemStack> getItems(MatchPlayer player);
 
   @Override
   public boolean matches(PlayerQuery query, MatchPlayer player) {
-    for (ItemStack item : getItems(player)) {
-      if (item == null) continue;
-      if (matcher.matches(item)) return true;
-    }
-    return false;
+    return getItems(player).filter(Objects::nonNull).anyMatch(matcher::matches);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/WearingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/WearingItemFilter.java
@@ -1,7 +1,9 @@
 package tc.oc.pgm.filters.matcher.player;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Stream;
 import org.bukkit.event.Event;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -9,6 +11,7 @@ import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
+import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.inventory.ItemMatcher;
 
 public class WearingItemFilter extends ParticipantItemFilter {
@@ -20,13 +23,14 @@ public class WearingItemFilter extends ParticipantItemFilter {
   public Collection<Class<? extends Event>> getRelevantEvents() {
     return ImmutableList.of(
         InventoryClickEvent.class,
+        PlayerItemTransferEvent.class,
         PlayerInteractEvent.class,
         ApplyKitEvent.class,
         PlayerItemBreakEvent.class);
   }
 
   @Override
-  protected ItemStack[] getItems(MatchPlayer player) {
-    return player.getBukkit().getInventory().getArmorContents();
+  protected Stream<ItemStack> getItems(MatchPlayer player) {
+    return Arrays.stream(player.getBukkit().getInventory().getArmorContents());
   }
 }


### PR DESCRIPTION
Fixes a couple relevant bugs:
- Carrying not taking into account item in cursor or in crafting grid, which allows the user to "hide" items from the filter
- Wearing filter not updating if you drop the item (now transfer event should cover it)
 - Monostable filter will forever invalidate every tick after passing, instead of just once. While not an issue in itself, it's not ideal nor performant to do that.