### PR TITLE
Fix BlockDrop item velocity not matching vanilla block drop velocity

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
@@ -110,7 +110,11 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
       Random random = match.getRandom();
       for (Map.Entry<ItemStack, Double> entry : drops.items.entrySet()) {
         if (random.nextFloat() < yield * entry.getValue()) {
-          location.getWorld().dropItemNaturally(location, entry.getKey());
+          Location dropLocation = location.clone();
+          dropLocation.setX(dropLocation.getBlockX() + random.nextDouble() * 0.5 + 0.25);
+          dropLocation.setY(dropLocation.getBlockY() + random.nextDouble() * 0.5 + 0.25);
+          dropLocation.setZ(dropLocation.getBlockZ() + random.nextDouble() * 0.5 + 0.25);
+          dropLocation.getWorld().dropItem(dropLocation, entry.getKey());
         }
       }
     }


### PR DESCRIPTION
Resolves https://github.com/PGMDev/PGM/issues/1099

Referenced `net.minecraft.server.Block`'s item dropping method

