### PR TITLE
Restore Objectives as a translatable gamemode

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -24,8 +24,7 @@ public enum Gamemode {
   SCOREBOX("scorebox", "Scorebox", "Scorebox"),
   SKYWARS("skywars", "Skywars", "Skywars"),
   SURVIVAL_GAMES("sg", "Survival Games", "SG"),
-  DEATHMATCH("tdm", "Deathmatch", "TDM"),
-  OBJECTIVES("obj", "Objectives", "Objectives");
+  DEATHMATCH("tdm", "Deathmatch", "TDM");
 
   private final String id;
 

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarRenderer.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarRenderer.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.scoreboard;
 import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -84,7 +85,7 @@ class SidebarRenderer {
       }
 
       // When there are multiple, primary game modes
-      games.set(0, text(Gamemode.OBJECTIVES.getFullName(), NamedTextColor.AQUA));
+      games.set(0, translatable("gamemode.generic.name", NamedTextColor.AQUA));
       break;
     }
 

--- a/util/src/main/i18n/templates/gamemode.properties
+++ b/util/src/main/i18n/templates/gamemode.properties
@@ -1,3 +1,5 @@
+gamemode.generic.name = Objectives
+
 objective.name.monument = Monument
 
 objective.name.antenna = Antenna


### PR DESCRIPTION
When gamemode titles were hardcoded in https://github.com/PGMDev/PGM/pull/1091, it got suggested that the generic "Objectives" text that appears when some gamemodes are mixed (like DTC and DTM) could still be kept as translatable, as it's more of a special case and not an actual gamemode.

I didn't think it'd cause any confusion, so I tried doing that by simply undoing a couple of changes from that commit. I tested it on a local server and it seemed to work fine.

![image](https://github.com/PGMDev/PGM/assets/11651753/bff134ae-5a2b-498f-a1ae-e0f05c787d5a)
