### PR TITLE
Allow username tabbing in channel messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
@@ -89,6 +89,7 @@ import tc.oc.pgm.rotation.vote.MapPoll;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.Players;
 
 public class PGMCommandGraph extends CommandGraph<PGM> {
 
@@ -215,5 +216,7 @@ public class PGMCommandGraph extends CommandGraph<PGM> {
     registerParser(Filter.class, FilterArgumentParser::new);
     registerParser(SettingKey.class, new EnumParser<>(SettingKey.class, CommandKeys.SETTING_KEY));
     registerParser(SettingValue.class, new SettingValueParser());
+
+    parsers.registerSuggestionProvider("players", Players::suggestPlayers);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -105,7 +105,9 @@ public class ChatDispatcher implements Listener {
   @CommandMethod("g|all [message]")
   @CommandDescription("Send a message to everyone")
   public void sendGlobal(
-      Match match, @NotNull MatchPlayer sender, @Argument("message") @Greedy String message) {
+      Match match,
+      @NotNull MatchPlayer sender,
+      @Argument(value = "message", suggestions = "players") @Greedy String message) {
     if (Integration.isVanished(sender.getBukkit())) {
       sendAdmin(match, sender, message);
       return;
@@ -127,7 +129,9 @@ public class ChatDispatcher implements Listener {
   @CommandMethod("t [message]")
   @CommandDescription("Send a message to your team")
   public void sendTeam(
-      Match match, @NotNull MatchPlayer sender, @Argument("message") @Greedy String message) {
+      Match match,
+      @NotNull MatchPlayer sender,
+      @Argument(value = "message", suggestions = "players") @Greedy String message) {
     if (Integration.isVanished(sender.getBukkit())) {
       sendAdmin(match, sender, message);
       return;
@@ -161,7 +165,9 @@ public class ChatDispatcher implements Listener {
   @CommandDescription("Send a message to operators")
   @CommandPermission(Permissions.ADMINCHAT)
   public void sendAdmin(
-      Match match, @NotNull MatchPlayer sender, @Argument("message") @Greedy String message) {
+      Match match,
+      @NotNull MatchPlayer sender,
+      @Argument(value = "message", suggestions = "players") @Greedy String message) {
     // If a player managed to send a default message without permissions, reset their chat channel
     if (!sender.getBukkit().hasPermission(Permissions.ADMINCHAT)) {
       sender.getSettings().resetValue(SettingKey.CHAT);
@@ -196,7 +202,7 @@ public class ChatDispatcher implements Listener {
       Match match,
       @NotNull MatchPlayer sender,
       @Argument("player") MatchPlayer receiver,
-      @Argument("message") @Greedy String message) {
+      @Argument(value = "message", suggestions = "players") @Greedy String message) {
     if (Integration.isVanished(sender.getBukkit())) throw exception("vanish.chat.deny");
     if (receiver.equals(sender)) throw exception("command.message.self");
 
@@ -264,7 +270,9 @@ public class ChatDispatcher implements Listener {
   @CommandMethod("reply|r <message>")
   @CommandDescription("Reply to a direct message")
   public void sendReply(
-      Match match, @NotNull MatchPlayer sender, @Argument("message") @Greedy String message) {
+      Match match,
+      @NotNull MatchPlayer sender,
+      @Argument(value = "message", suggestions = "players") @Greedy String message) {
     MatchPlayer receiver = manager.getPlayer(getLastMessagedId(sender.getBukkit()));
     if (receiver == null) throw exception("command.message.noReply", text("/msg"));
 

--- a/core/src/main/java/tc/oc/pgm/util/Players.java
+++ b/core/src/main/java/tc/oc/pgm/util/Players.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.util;
 
+import cloud.commandframework.context.CommandContext;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
@@ -9,6 +10,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.command.util.CommandKeys;
 
 public class Players {
 
@@ -52,5 +54,11 @@ public class Players {
 
   public static boolean isFriend(CommandSender viewer, Player other) {
     return viewer instanceof Player && Integration.isFriend((Player) viewer, other);
+  }
+
+  public static List<String> suggestPlayers(CommandContext<CommandSender> context, String input) {
+    List<String> queue = context.get(CommandKeys.INPUT_QUEUE);
+
+    return getPlayerNames(context.getSender(), queue.isEmpty() ? "" : queue.get(queue.size() - 1));
   }
 }


### PR DESCRIPTION
Updates the greedy string argument in the chat dispatcher commands to allow for username tab suggestions while typing.

Previously, this behaviour was the default prior to the cloud command framework changes and was also present in OCN.

With this update, you can use commands like `/a take a look at P` and tab usernames that start with "P" such as `Pugzy` or `Pablete1234`. Also suitable for when you want to say hello to someone like KingOfSquares but can't be bothered to type out their full name.