### PR TITLE
Add support for world folder in variants

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -27,6 +27,10 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   @Nullable
   String getVariant();
 
+  /** @return the subfolder in which the world is in, or null for the parent folder */
+  @Nullable
+  String getWorldFolder();
+
   /**
    * Get the proto of the map's {@link org.jdom2.Document}.
    *

--- a/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
@@ -39,10 +39,11 @@ public interface MapSource {
   /**
    * Download the {@link org.bukkit.World} files to a local directory.
    *
+   * @param folder subfolder to download, null for parent
    * @param dir An existent, but empty directory.
    * @throws MapMissingException If an error occurs while creating the files.
    */
-  void downloadTo(File dir) throws MapMissingException;
+  void downloadTo(String folder, File dir) throws MapMissingException;
 
   /**
    * Get an {@link InputStream} of the map's xml document.

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -40,6 +40,7 @@ public class MapInfoImpl implements MapInfo {
 
   private final String id;
   private final String variant;
+  private final String worldFolder;
   private final Version proto;
   private final Version version;
   private final Phase phase;
@@ -66,6 +67,7 @@ public class MapInfoImpl implements MapInfo {
     this.variant = source.getVariant();
 
     String tmpName = assertNotNull(Node.fromRequiredChildOrAttr(root, "name").getValueNormalize());
+    String tmpWorld = null;
     if (variant != null) {
       Element variantEl =
           root.getChildren("variant").stream()
@@ -76,7 +78,9 @@ public class MapInfoImpl implements MapInfo {
 
       boolean override = XMLUtils.parseBoolean(Node.fromAttr(variantEl, "override"), false);
       tmpName = (override ? "" : tmpName + ": ") + variantEl.getTextNormalize();
+      tmpWorld = variantEl.getAttributeValue("world");
     }
+    this.worldFolder = tmpWorld;
 
     this.name = tmpName;
     this.normalizedName = StringUtils.normalize(name);
@@ -124,6 +128,11 @@ public class MapInfoImpl implements MapInfo {
   @Override
   public String getVariant() {
     return variant;
+  }
+
+  @Override
+  public String getWorldFolder() {
+    return worldFolder;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/map/source/SystemMapSource.java
+++ b/core/src/main/java/tc/oc/pgm/map/source/SystemMapSource.java
@@ -33,8 +33,8 @@ class SystemMapSource implements MapSource {
     this.storedIncludes = Sets.newHashSet();
   }
 
-  private File getDirectory() throws MapMissingException {
-    final File dir = this.dir.toFile();
+  private File getDirectory(String subdir) throws MapMissingException {
+    final File dir = subdir == null ? this.dir.toFile() : this.dir.resolve(subdir).toFile();
 
     if (!dir.exists()) {
       throw new MapMissingException(dir.getPath(), "Unable to find map folder (was it moved?)");
@@ -73,8 +73,8 @@ class SystemMapSource implements MapSource {
   }
 
   @Override
-  public void downloadTo(File dst) throws MapMissingException {
-    final File src = getDirectory();
+  public void downloadTo(String worldDir, File dst) throws MapMissingException {
+    final File src = getDirectory(worldDir);
     try {
       FileUtils.copy(src, dst, true);
     } catch (IOException e) {

--- a/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
@@ -230,7 +230,7 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
 
       final File dir = getDirectory();
       if (dir.mkdirs()) {
-        map.getInfo().getSource().downloadTo(dir);
+        map.getInfo().getSource().downloadTo(map.getInfo().getWorldFolder(), dir);
       } else {
         throw new MapMissingException(dir.getPath(), "Unable to mkdirs world directory");
       }


### PR DESCRIPTION
Allows for a world attribute in variants, that specifies the world to run in:

```xml
<map>
  <name>Normal Map</name>
  <variant id="xmas" override="true" world="christmas">Christmas Map</variant>

  ...
</map>
```

Folder structure would look like:
- normal_map
  - map.xml
  - level.dat
  - region
    - 0.0.mca
  - chistmas
    - level.dat
    - region
      - 0.0.mca
