### PR TITLE
Allow filters on class selection

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/ClassCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ClassCommand.java
@@ -65,7 +65,7 @@ public final class ClassCommand {
 
       if (cls == currentClass) {
         color = NamedTextColor.GOLD;
-      } else if (cls.canUse(player.getBukkit())) {
+      } else if (cls.canUse(player)) {
         color = NamedTextColor.GREEN;
       } else {
         color = NamedTextColor.RED;

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -47,6 +47,10 @@ match.class.notEnabled = Classes are not enabled on this map.
 
 match.class.notFound = No class matched query.
 
+match.class.filtered = You cannot change to {0} due to map rules.
+
+match.class.filtered.message = {0}
+
 # {0} = number of kills
 # {1} = number of consecutive kills
 # {2} = number of deaths

--- a/util/src/main/i18n/templates/ui.properties
+++ b/util/src/main/i18n/templates/ui.properties
@@ -182,6 +182,8 @@ picker.windowTitle.team = Pick your team
 
 picker.windowTitle.class = Choose your class
 
+picker.class.filtered = You may not pick this class due to Map rules
+
 picker.autoJoin.displayName = Auto Join
 
 picker.autoJoin.tooltip = Puts you on the team with the fewest players


### PR DESCRIPTION
My intent with this is to allow team-specific classes, similar to kits with portals, but for classes. Adding filters for class selection seemed like the best way to do it, while also allowing other usage.
You should also be able to use this for https://github.com/PGMDev/PGM/issues/800

Usage would be something like:
```xml
<class name="potato" description="lettuce" filter="only-blue" deny-message="Only the blue team can pick this class!">
...
</class>
```

This could also do some other interesting things if we added a class change action as well.
