### PR TITLE
Fix potion spawners

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/nms/entity/potion/EntityPotion1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/entity/potion/EntityPotion1_8.java
@@ -22,7 +22,7 @@ public class EntityPotion1_8 implements EntityPotion {
 
   @Override
   public void spawn() {
-    handle.spawnIn(handle.getWorld());
+    handle.getWorld().addEntity(handle);
   }
 
   @Override


### PR DESCRIPTION
I used the wrong method to spawn in potions for 1.8 when refactoring EntityPotion1_8.

This means that XML potion spawners don't currently work.

This fixes that.

