### PR TITLE
Add support for variables acting on Blitz Lives

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -76,6 +76,16 @@ public class BlitzMatchModule implements MatchModule, Listener {
     return lifeManager.getLives(id);
   }
 
+  public void setLives(MatchPlayer matchPlayer, int lives) {
+    UUID id = matchPlayer.getId();
+    if (lives == lifeManager.getLives(id)) return;
+
+    lifeManager.setLives(id, lives);
+    if (this.config.getBroadcastLives()) {
+      this.showLivesTitle(matchPlayer);
+    }
+  }
+
   @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
   public void handleDeath(final MatchPlayerDeathEvent event) {
     MatchPlayer victim = event.getVictim();
@@ -123,21 +133,22 @@ public class BlitzMatchModule implements MatchModule, Listener {
   @EventHandler
   public void handleSpawn(final ParticipantSpawnEvent event) {
     if (this.config.getBroadcastLives()) {
-      int lives = this.lifeManager.getLives(event.getPlayer().getId());
-      event
-          .getPlayer()
-          .showTitle(
-              title(
-                  empty(),
-                  translatable(
-                      "blitz.livesRemaining",
-                      NamedTextColor.RED,
-                      translatable(
-                          lives == 1 ? "misc.life" : "misc.lives",
-                          NamedTextColor.AQUA,
-                          text(lives))),
-                  Title.Times.times(Duration.ZERO, fromTicks(60), fromTicks(20))));
+      MatchPlayer matchPlayer = event.getPlayer();
+      showLivesTitle(matchPlayer);
     }
+  }
+
+  public void showLivesTitle(MatchPlayer matchPlayer) {
+    int lives = this.lifeManager.getLives(matchPlayer.getId());
+    matchPlayer.showTitle(
+        title(
+            empty(),
+            translatable(
+                "blitz.livesRemaining",
+                NamedTextColor.RED,
+                translatable(
+                    lives == 1 ? "misc.life" : "misc.lives", NamedTextColor.AQUA, text(lives))),
+            Title.Times.times(Duration.ZERO, fromTicks(60), fromTicks(20))));
   }
 
   @EventHandler(priority = EventPriority.MONITOR)

--- a/core/src/main/java/tc/oc/pgm/blitz/LifeManager.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/LifeManager.java
@@ -41,4 +41,10 @@ public class LifeManager {
 
     return lives;
   }
+
+  public void setLives(UUID player, int lives) {
+    assertNotNull(player, "player id");
+
+    this.livesLeft.put(player, Math.max(0, lives));
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -21,6 +21,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 import tc.oc.pgm.variables.VariableDefinition;
+import tc.oc.pgm.variables.VariableType;
 import tc.oc.pgm.variables.VariablesModule;
 
 public class FeatureFilterParser extends FilterParser {
@@ -99,6 +100,9 @@ public class FeatureFilterParser extends FilterParser {
     if (varMatch.matches()) {
       VariableDefinition<?> variable =
           features.resolve(node, varMatch.group(1), VariableDefinition.class);
+      if (!variable.getVariableType().equals(VariableType.DUMMY)) {
+        throw new InvalidXMLException("Variable filters only support dummy variables!", node);
+      }
       Range<Double> range = XMLUtils.parseNumericRange(node, varMatch.group(2), Double.class);
       return new VariableFilter(variable, range);
     }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -93,6 +93,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 import tc.oc.pgm.variables.VariableDefinition;
+import tc.oc.pgm.variables.VariableType;
 
 public abstract class FilterParser implements XMLParser<Filter, FilterDefinition> {
 
@@ -661,6 +662,9 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
   public Filter parseVariableFilter(Element el) throws InvalidXMLException {
     VariableDefinition<?> varDef =
         features.resolve(Node.fromRequiredAttr(el, "var"), VariableDefinition.class);
+    if (!varDef.getVariableType().equals(VariableType.DUMMY)) {
+      throw new InvalidXMLException("Variable filters only support dummy variables!", el);
+    }
     Range<Double> range = XMLUtils.parseNumericRange(new Node(el), Double.class);
 
     if (varDef.getScope() == Party.class)

--- a/core/src/main/java/tc/oc/pgm/variables/BlitzVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/BlitzVariable.java
@@ -1,0 +1,33 @@
+package tc.oc.pgm.variables;
+
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.blitz.BlitzMatchModule;
+import tc.oc.pgm.filters.Filterable;
+
+public class BlitzVariable implements Variable<MatchPlayer> {
+
+  private final VariableDefinition<MatchPlayer> definition;
+
+  public BlitzVariable(VariableDefinition<? extends Filterable<?>> definition) {
+    this.definition = (VariableDefinition<MatchPlayer>) definition;
+  }
+
+  @Override
+  public VariableDefinition<MatchPlayer> getDefinition() {
+    return definition;
+  }
+
+  @Override
+  public double getValue(Filterable<?> context) {
+    MatchPlayer matchPlayer = context.getFilterableAncestor(MatchPlayer.class);
+    BlitzMatchModule blitzMatchModule = matchPlayer.moduleRequire(BlitzMatchModule.class);
+    return blitzMatchModule.getNumOfLives(matchPlayer.getId());
+  }
+
+  @Override
+  public void setValue(Filterable<?> context, double value) {
+    MatchPlayer matchPlayer = context.getFilterableAncestor(MatchPlayer.class);
+    BlitzMatchModule blitzMatchModule = matchPlayer.moduleRequire(BlitzMatchModule.class);
+    blitzMatchModule.setLives(matchPlayer, Math.max((int) value, 0));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/variables/DummyVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/DummyVariable.java
@@ -1,0 +1,48 @@
+package tc.oc.pgm.variables;
+
+import java.util.HashMap;
+import java.util.Map;
+import tc.oc.pgm.filters.FilterMatchModule;
+import tc.oc.pgm.filters.Filterable;
+
+public class DummyVariable<T extends Filterable<?>> implements Variable<T> {
+
+  private final VariableDefinition<T> definition;
+  private final Map<T, Double> values;
+
+  public DummyVariable(VariableDefinition<T> definition) {
+    this.definition = definition;
+    this.values = new HashMap<>();
+  }
+
+  @Override
+  public VariableDefinition<T> getDefinition() {
+    return definition;
+  }
+
+  @Override
+  public double getValue(Filterable<?> context) {
+    return values.computeIfAbsent(getAncestor(context), k -> definition.getDefault());
+  }
+
+  @Override
+  public void setValue(Filterable<?> context, double value) {
+    T ctx = getAncestor(context);
+    values.put(ctx, value);
+    // For performance reasons, let's avoid launching an event for every variable change
+    context.getMatch().needModule(FilterMatchModule.class).invalidate(ctx);
+  }
+
+  private T getAncestor(Filterable<?> context) {
+    T filterable = context.getFilterableAncestor(definition.getScope());
+    if (filterable != null) return filterable;
+
+    throw new IllegalStateException(
+        "Wrong variable scope for '"
+            + getId()
+            + "', expected "
+            + definition.getScope().getSimpleName()
+            + " which cannot be found in "
+            + context.getClass().getSimpleName());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/variables/Variable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/Variable.java
@@ -1,52 +1,16 @@
 package tc.oc.pgm.variables;
 
-import java.util.HashMap;
-import java.util.Map;
 import tc.oc.pgm.api.feature.Feature;
-import tc.oc.pgm.filters.FilterMatchModule;
 import tc.oc.pgm.filters.Filterable;
 
-public class Variable<T extends Filterable<?>> implements Feature<VariableDefinition<T>> {
-
-  private final VariableDefinition<T> definition;
-  private final Map<T, Double> values;
-
-  public Variable(VariableDefinition<T> definition) {
-    this.definition = definition;
-    this.values = new HashMap<>();
-  }
+public interface Variable<T extends Filterable<?>> extends Feature<VariableDefinition<T>> {
 
   @Override
-  public String getId() {
-    return definition.getId();
+  default String getId() {
+    return getDefinition().getId();
   }
 
-  @Override
-  public VariableDefinition<T> getDefinition() {
-    return definition;
-  }
+  double getValue(Filterable<?> context);
 
-  public double getValue(Filterable<?> context) {
-    return values.computeIfAbsent(getAncestor(context), k -> definition.getDefault());
-  }
-
-  public void setValue(Filterable<?> context, double value) {
-    T ctx = getAncestor(context);
-    values.put(ctx, value);
-    // For performance reasons, let's avoid launching an event for every variable change
-    context.getMatch().needModule(FilterMatchModule.class).invalidate(ctx);
-  }
-
-  private T getAncestor(Filterable<?> context) {
-    T filterable = context.getFilterableAncestor(definition.getScope());
-    if (filterable != null) return filterable;
-
-    throw new IllegalStateException(
-        "Wrong variable scope for '"
-            + getId()
-            + "', expected "
-            + definition.getScope().getSimpleName()
-            + " which cannot be found in "
-            + context.getClass().getSimpleName());
-  }
+  void setValue(Filterable<?> context, double value);
 }

--- a/core/src/main/java/tc/oc/pgm/variables/VariableDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariableDefinition.java
@@ -8,11 +8,13 @@ public class VariableDefinition<T extends Filterable<?>> extends SelfIdentifying
 
   private final Class<T> scope;
   private final double def;
+  private final VariableType variableType;
 
-  public VariableDefinition(String id, Class<T> scope, double def) {
+  public VariableDefinition(String id, Class<T> scope, double def, VariableType variableType) {
     super(id);
     this.scope = scope;
     this.def = def;
+    this.variableType = variableType;
   }
 
   public Class<T> getScope() {
@@ -21,6 +23,14 @@ public class VariableDefinition<T extends Filterable<?>> extends SelfIdentifying
 
   public double getDefault() {
     return def;
+  }
+
+  public Variable<?> buildInstance() {
+    return getVariableType().buildInstance(this);
+  }
+
+  public VariableType getVariableType() {
+    return variableType;
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/tc/oc/pgm/variables/VariableType.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariableType.java
@@ -1,0 +1,33 @@
+package tc.oc.pgm.variables;
+
+import java.util.function.Function;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.filters.Filterable;
+
+public enum VariableType {
+  DUMMY(DummyVariable::new, Filterable.class),
+  LIVES(BlitzVariable::new, MatchPlayer.class);
+
+  private final Function<VariableDefinition<?>, Variable<?>> supplierFunction;
+  private final Class<?>[] supportedScopes;
+
+  VariableType(
+      Function<VariableDefinition<? extends Filterable>, Variable<?>> supplierFunction,
+      Class<?>... supportedScopes) {
+    this.supplierFunction = supplierFunction;
+    this.supportedScopes = supportedScopes;
+  }
+
+  public boolean supports(Class<?> cls) {
+    for (Class<?> supportedScope : supportedScopes) {
+      if (supportedScope.isAssignableFrom(cls)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public Variable<?> buildInstance(VariableDefinition<?> definition) {
+    return supplierFunction.apply(definition);
+  }
+}


### PR DESCRIPTION
New Description:
---

So decided to go with a different approach for this. This now adds support for different types of variables. Specifically, this adds a blitz lives variable type that directly sets or gets blitz lives for a player.

Example Usage:
```xml
<variable id="playerlives" scope="player" type="lives"/>
...
<set var="playerlives" value="playerlives+1"/>
```

With this, the type can be either `dummy` or `lives`. `dummy` being the original variable type, and `lives` getting or writing blitz lives. `type` is optional and defaults to `dummy`.


Original description
---
 :warning: Syntax beyond this point is no longer valid. :warning: 

Adds a `modify-lives` action. At @zzufx's request

You can add, subtract, or set lives.
Usage would be as follows:

```xml
<modify-lives operation="add" amount="2" show-title="true"/>
```
`show-title` is optional and can be left out
```xml
<modify-lives operation="set" amount="1"/>
or
<modify-lives operation="subtract" amount="1"/>
```

The action will act on all players in a given scope, so for example you could have a team scoped set lives to 1 that would set the lives remaining for all players to 1 after an objective is completed.

Edit:
amount now supports variables and expressions
