### PR TITLE
Add unused xml detection

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -63,6 +63,7 @@ public final class PGMConfig implements Config {
   private final List<MapSourceFactory> mapSourceFactories;
   private final Path mapPoolFile;
   private final Path includesDirectory;
+  private final boolean showUnusedXml;
 
   // countdown.*
   private final Duration startTime;
@@ -161,6 +162,7 @@ public final class PGMConfig implements Config {
 
     this.mapPoolFile = getPath(dataFolder.toPath(), config.getString("map.pools"));
     this.includesDirectory = getPath(dataFolder.toPath(), config.getString("map.includes"));
+    this.showUnusedXml = parseBoolean(config.getString("map.show-unused-xml", "true"));
 
     this.startTime = parseDuration(config.getString("countdown.start", "30s"));
     this.huddleTime = parseDuration(config.getString("countdown.huddle", "0s"));
@@ -473,6 +475,11 @@ public final class PGMConfig implements Config {
   @Override
   public @Nullable Path getIncludesDirectory() {
     return includesDirectory;
+  }
+
+  @Override
+  public boolean showUnusedXml() {
+    return showUnusedXml;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -69,6 +69,9 @@ public interface Config {
   @Nullable
   Path getIncludesDirectory();
 
+  /** @return If unused XML tags should be reported or ignored */
+  boolean showUnusedXml();
+
   /**
    * Gets a duration to wait before starting a match.
    *

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -33,6 +34,7 @@ import tc.oc.pgm.regions.LegacyRegionParser;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.ClassLogger;
 import tc.oc.pgm.util.Version;
+import tc.oc.pgm.util.xml.DocumentWrapper;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
@@ -106,6 +108,13 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
     for (MapModule<?> module : getModules()) {
       module.postParse(this, logger, document);
     }
+
+    ((DocumentWrapper) document)
+        .checkUnvisited(
+            node -> {
+              InvalidXMLException ex = new InvalidXMLException("Unused node, maybe a typo?", node);
+              logger.log(Level.WARNING, ex.getMessage(), ex);
+            });
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -12,6 +12,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.input.JDOMParseException;
 import tc.oc.pgm.api.Modules;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapContext;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.MapProtos;
@@ -36,6 +37,7 @@ import tc.oc.pgm.util.ClassLogger;
 import tc.oc.pgm.util.Version;
 import tc.oc.pgm.util.xml.DocumentWrapper;
 import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?>>
@@ -109,12 +111,14 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
       module.postParse(this, logger, document);
     }
 
-    ((DocumentWrapper) document)
-        .checkUnvisited(
-            node -> {
-              InvalidXMLException ex = new InvalidXMLException("Unused node, maybe a typo?", node);
-              logger.log(Level.WARNING, ex.getMessage(), ex);
-            });
+    if (PGM.get().getConfiguration().showUnusedXml()) {
+      ((DocumentWrapper) document).checkUnvisited(this::printUnvisitedNode);
+    }
+  }
+
+  private void printUnvisitedNode(Node node) {
+    InvalidXMLException ex = new InvalidXMLException("Unused node, maybe a typo?", node);
+    logger.log(Level.WARNING, ex.getMessage(), ex);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
@@ -64,7 +64,7 @@ public class MapFilePreprocessor {
     DocumentWrapper document;
     try (final InputStream stream = source.getDocument()) {
       document = (DocumentWrapper) DOCUMENT_FACTORY.get().build(stream);
-      document.setBaseURI(source.getId());
+      document.setBaseURI(source.getId() + ("default".equals(variant) ? "" : "[" + variant + "]"));
     }
 
     document.runWithoutVisitation(

--- a/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeImpl.java
@@ -14,6 +14,7 @@ import org.jdom2.JDOMException;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
+import tc.oc.pgm.util.xml.DocumentWrapper;
 
 public class MapIncludeImpl implements MapInclude {
 
@@ -30,6 +31,8 @@ public class MapIncludeImpl implements MapInclude {
   private void reload() throws MapMissingException, JDOMException, IOException {
     try (InputStream is = new FileInputStream(file)) {
       this.source = MapIncludeProcessorImpl.DOCUMENT_FACTORY.get().build(is);
+      // Includes should never visit, let the map XML visit instead
+      ((DocumentWrapper) this.source).setVisitingAllowed(false);
     } catch (FileNotFoundException e) {
       throw new MapMissingException(file.getPath(), "Unable to read map include document", e);
     } finally {

--- a/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeImpl.java
@@ -18,11 +18,14 @@ import tc.oc.pgm.util.xml.DocumentWrapper;
 
 public class MapIncludeImpl implements MapInclude {
 
+  private final String id;
   private final File file;
   private final AtomicLong lastRead;
   private Document source;
 
-  public MapIncludeImpl(File file) throws MapMissingException, JDOMException, IOException {
+  public MapIncludeImpl(String id, File file)
+      throws MapMissingException, JDOMException, IOException {
+    this.id = id;
     this.file = file;
     this.lastRead = new AtomicLong(-1);
     reload();
@@ -33,6 +36,7 @@ public class MapIncludeImpl implements MapInclude {
       this.source = MapIncludeProcessorImpl.DOCUMENT_FACTORY.get().build(is);
       // Includes should never visit, let the map XML visit instead
       ((DocumentWrapper) this.source).setVisitingAllowed(false);
+      this.source.setBaseURI("#" + id);
     } catch (FileNotFoundException e) {
       throw new MapMissingException(file.getPath(), "Unable to read map include document", e);
     } finally {

--- a/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeProcessorImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/includes/MapIncludeProcessorImpl.java
@@ -92,10 +92,9 @@ public class MapIncludeProcessorImpl implements MapIncludeProcessor {
       if (deletedIncludes.remove(id)) continue;
 
       try {
-        this.includes.put(id, new MapIncludeImpl(file));
+        this.includes.put(id, new MapIncludeImpl(id, file));
       } catch (MapMissingException | JDOMException | IOException error) {
         logger.log(Level.WARNING, "Failed to load " + filename + " include document", error);
-        error.printStackTrace();
       }
     }
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -35,6 +35,10 @@ map:
   # A path to the includes folder, or empty to disable map includes.
   includes: "includes"
 
+  # Show unused XML nodes as map errors. Helps with finding typos in xml.
+  show-unused-xml: true
+
+
 # Sets the duration of various countdowns.
 #
 #  "30s"  = 30 seconds

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/Platform.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/Platform.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.util.bukkit;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import org.bukkit.Bukkit;
+import org.bukkit.Server;
 import tc.oc.pgm.util.ClassLogger;
 import tc.oc.pgm.util.nms.NMSHacksNoOp;
 import tc.oc.pgm.util.nms.NMSHacksPlatform;
@@ -32,7 +33,8 @@ public enum Platform {
   public static Platform SERVER_PLATFORM = computeServerPlatform();
 
   private static Platform computeServerPlatform() {
-    String versionString = Bukkit.getServer().getVersion();
+    Server sv = Bukkit.getServer();
+    String versionString = sv == null ? "" : sv.getVersion();
     for (Platform platform : Platform.values()) {
       if (versionString.contains(platform.variant)
           && versionString.contains("MC: " + platform.majorVersion)) {

--- a/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.util.xml;
 
+import com.google.common.collect.Sets;
+import java.util.Set;
 import java.util.function.Consumer;
 import org.jdom2.Attribute;
 import org.jdom2.Content;
@@ -9,6 +11,8 @@ import org.jdom2.Element;
 import org.jdom2.Namespace;
 
 public class DocumentWrapper extends Document {
+
+  private static final Set<String> IGNORED = Sets.newHashSet("variant", "tutorial");
 
   private boolean visitingAllowed = true;
 
@@ -55,12 +59,10 @@ public class DocumentWrapper extends Document {
 
     for (int i = 0; i < el.getContentSize(); i++) {
       Content c = el.getContent(i);
-      if (c instanceof InheritingElement) {
-        InheritingElement child = (InheritingElement) c;
+      if (!(c instanceof InheritingElement)) continue;
+      InheritingElement child = (InheritingElement) c;
 
-        // Only main map reads all variants, others read just their own. Skip the check.
-        if ("variant".equals(child.getName())) continue;
-
+      if (child.getNamespace() == Namespace.NO_NAMESPACE && !IGNORED.contains(child.getName())) {
         if (!child.wasVisited()) unvisited.accept(Node.fromNullable(child));
         else checkVisited(child, unvisited);
       }

--- a/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
@@ -1,0 +1,73 @@
+package tc.oc.pgm.util.xml;
+
+import java.util.function.Consumer;
+import org.jdom2.Attribute;
+import org.jdom2.Content;
+import org.jdom2.DocType;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+public class DocumentWrapper extends Document {
+
+  private boolean visitingAllowed = true;
+
+  public DocumentWrapper() {
+    super();
+  }
+
+  public DocumentWrapper(Element rootElement, DocType docType, String baseURI) {
+    super(rootElement, docType, baseURI);
+  }
+
+  public DocumentWrapper(Element rootElement, DocType docType) {
+    super(rootElement, docType);
+  }
+
+  public DocumentWrapper(Element rootElement) {
+    super(rootElement);
+  }
+
+  public void setVisitingAllowed(boolean visitingAllowed) {
+    this.visitingAllowed = visitingAllowed;
+  }
+
+  public void runWithoutVisitation(DocumentWorker worker) throws InvalidXMLException {
+    this.visitingAllowed = false;
+    worker.run();
+    this.visitingAllowed = true;
+  }
+
+  public boolean isVisitingAllowed() {
+    return visitingAllowed;
+  }
+
+  public void checkUnvisited(Consumer<Node> unvisited) {
+    checkVisited(getRootElement(), unvisited);
+  }
+
+  private void checkVisited(Element el, Consumer<Node> unvisited) {
+    for (Attribute attribute : el.getAttributes()) {
+      if (attribute.getNamespace() == Namespace.NO_NAMESPACE
+          && !((VisitableAttribute) attribute).wasVisited())
+        unvisited.accept(Node.fromNullable(attribute));
+    }
+
+    for (int i = 0; i < el.getContentSize(); i++) {
+      Content c = el.getContent(i);
+      if (c instanceof InheritingElement) {
+        InheritingElement child = (InheritingElement) c;
+
+        // Only main map reads all variants, others read just their own. Skip the check.
+        if ("variant".equals(child.getName())) continue;
+
+        if (!child.wasVisited()) unvisited.accept(Node.fromNullable(child));
+        else checkVisited(child, unvisited);
+      }
+    }
+  }
+
+  public interface DocumentWorker {
+    void run() throws InvalidXMLException;
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/xml/InvalidXMLException.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/InvalidXMLException.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.Nullable;
 public class InvalidXMLException extends Exception {
 
   private final @Nullable Node node;
-  private final @Nullable Document document;
   private final @Nullable String documentPath;
   private final int startLine, endLine, column;
 
@@ -18,7 +17,6 @@ public class InvalidXMLException extends Exception {
       String message,
       @Nullable Node node,
       @Nullable Document document,
-      @Nullable String documentPath,
       int startLine,
       int endLine,
       int column,
@@ -26,12 +24,8 @@ public class InvalidXMLException extends Exception {
     super(message, cause);
 
     this.node = node;
-    this.document = document != null ? document : node != null ? node.getDocument() : null;
-
     this.documentPath =
-        documentPath != null
-            ? documentPath
-            : this.document != null ? this.document.getBaseURI() : null;
+        document != null ? document.getBaseURI() : node != null ? node.getDocumentPath() : null;
     this.startLine = startLine > 0 ? startLine : this.node != null ? this.node.getStartLine() : 0;
     this.endLine = endLine > 0 ? endLine : this.node != null ? this.node.getEndLine() : 0;
     this.column = column > 0 ? column : this.node != null ? this.node.getColumn() : 0;
@@ -42,15 +36,11 @@ public class InvalidXMLException extends Exception {
   }
 
   public InvalidXMLException(String message, @Nullable Node node, Throwable cause) {
-    this(message, node, null, null, 0, 0, 0, cause);
+    this(message, node, null, 0, 0, 0, cause);
   }
 
   public InvalidXMLException(String message, @Nullable Document document, Throwable cause) {
-    this(message, null, document, null, 0, 0, 0, cause);
-  }
-
-  public InvalidXMLException(String message, @Nullable String documentPath, Throwable cause) {
-    this(message, null, null, documentPath, 0, 0, 0, cause);
+    this(message, null, document, 0, 0, 0, cause);
   }
 
   public InvalidXMLException(String message, @Nullable Element element, Throwable cause) {
@@ -63,10 +53,6 @@ public class InvalidXMLException extends Exception {
 
   public InvalidXMLException(String message, Document document) {
     this(message, document, null);
-  }
-
-  public InvalidXMLException(String message, String documentPath) {
-    this(message, documentPath, null);
   }
 
   public InvalidXMLException(String message, Node node) {
@@ -86,7 +72,6 @@ public class InvalidXMLException extends Exception {
         e.getMessage(),
         null,
         e.getPartialDocument(),
-        documentPath,
         e.getLineNumber(),
         e.getLineNumber(),
         e.getColumnNumber(),
@@ -112,10 +97,6 @@ public class InvalidXMLException extends Exception {
 
   public @Nullable Node getNode() {
     return node;
-  }
-
-  public @Nullable Document getDocument() {
-    return document;
   }
 
   public @Nullable String getDocumentPath() {

--- a/util/src/main/java/tc/oc/pgm/util/xml/SAXHandler.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/SAXHandler.java
@@ -1,5 +1,9 @@
 package tc.oc.pgm.util.xml;
 
+import org.jdom2.Attribute;
+import org.jdom2.AttributeType;
+import org.jdom2.DocType;
+import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
 import org.jdom2.input.sax.SAXHandlerFactory;
@@ -29,6 +33,21 @@ public class SAXHandler extends org.jdom2.input.sax.SAXHandler {
 
   private static class JDOMFactory extends LocatedJDOMFactory {
     @Override
+    public Document document(Element rootElement, DocType docType) {
+      return new DocumentWrapper(rootElement, docType);
+    }
+
+    @Override
+    public Document document(Element rootElement, DocType docType, String baseURI) {
+      return new DocumentWrapper(rootElement, docType, baseURI);
+    }
+
+    @Override
+    public Document document(Element rootElement) {
+      return new DocumentWrapper(rootElement);
+    }
+
+    @Override
     public Element element(int line, int col, String name, Namespace namespace) {
       return new InheritingElement(name, namespace);
     }
@@ -46,6 +65,38 @@ public class SAXHandler extends org.jdom2.input.sax.SAXHandler {
     @Override
     public Element element(int line, int col, String name, String prefix, String uri) {
       return new InheritingElement(name, prefix, uri);
+    }
+
+    @Override
+    public Attribute attribute(String name, String value, Namespace namespace) {
+      return new VisitableAttribute(name, value, namespace);
+    }
+
+    @Override
+    @Deprecated
+    public Attribute attribute(String name, String value, int type, Namespace namespace) {
+      return new VisitableAttribute(name, value, AttributeType.byIndex(type), namespace);
+    }
+
+    @Override
+    public Attribute attribute(String name, String value, AttributeType type, Namespace namespace) {
+      return new VisitableAttribute(name, value, type, namespace);
+    }
+
+    @Override
+    public Attribute attribute(String name, String value) {
+      return new VisitableAttribute(name, value);
+    }
+
+    @Override
+    @Deprecated
+    public Attribute attribute(String name, String value, int type) {
+      return new VisitableAttribute(name, value, type);
+    }
+
+    @Override
+    public Attribute attribute(String name, String value, AttributeType type) {
+      return new VisitableAttribute(name, value, type);
     }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/xml/VisitableAttribute.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/VisitableAttribute.java
@@ -1,0 +1,50 @@
+package tc.oc.pgm.util.xml;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jdom2.Attribute;
+import org.jdom2.AttributeType;
+import org.jdom2.Namespace;
+
+public class VisitableAttribute extends Attribute {
+
+  private AtomicBoolean visited = new AtomicBoolean();
+
+  public VisitableAttribute() {}
+
+  public VisitableAttribute(String name, String value, Namespace namespace) {
+    super(name, value, namespace);
+  }
+
+  public VisitableAttribute(String name, String value, AttributeType type, Namespace namespace) {
+    super(name, value, type, namespace);
+  }
+
+  public VisitableAttribute(String name, String value) {
+    super(name, value);
+  }
+
+  public VisitableAttribute(String name, String value, AttributeType type) {
+    super(name, value, type);
+  }
+
+  public VisitableAttribute(String name, String value, int type) {
+    super(name, value, type);
+  }
+
+  @Override
+  public String getValue() {
+    if (((DocumentWrapper) getDocument()).isVisitingAllowed()) visited.set(true);
+    return super.getValue();
+  }
+
+  public boolean wasVisited() {
+    return visited.get();
+  }
+
+  @Override
+  public Attribute clone() {
+    VisitableAttribute copy = (VisitableAttribute) super.clone();
+    copy.visited = visited;
+    return copy;
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -63,13 +63,20 @@ public final class XMLUtils {
       int minChildDepth) {
     // Walk the tree in-order to preserve the child ordering
     List<Element> result = Lists.newArrayList();
-    for (Element child : root.getChildren()) {
+
+    InheritingElement el = (InheritingElement) root;
+
+    for (Element child :
+        minChildDepth > 0
+            ? el.getChildren(parentTagNames)
+            : childTagNames == null
+                ? root.getChildren()
+                : el.getChildren(Sets.union(parentTagNames, childTagNames))) {
       if (parentTagNames.contains(child.getName())) {
         result.addAll(
             flattenElements(
                 new InheritingElement(child), parentTagNames, childTagNames, minChildDepth - 1));
-      } else if (minChildDepth <= 0
-          && (childTagNames == null || childTagNames.contains(child.getName()))) {
+      } else {
         result.add(new InheritingElement(child));
       }
     }
@@ -1190,7 +1197,7 @@ public final class XMLUtils {
       throw new InvalidXMLException("No value provided for color", node);
     String rawColor = node.getValue();
     if (!rawColor.matches("[a-fA-F0-9]{6}")) {
-      throw new InvalidXMLException("Invalid color format", rawColor);
+      throw new InvalidXMLException("Invalid color format '" + rawColor + "'", node);
     }
     return Color.fromRGB(Integer.parseInt(rawColor, 16));
   }

--- a/util/src/test/java/tc/oc/pgm/util/xml/ParseRangeTest.java
+++ b/util/src/test/java/tc/oc/pgm/util/xml/ParseRangeTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Range;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jdom2.Attribute;
+import org.jdom2.Document;
 import org.jdom2.Namespace;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -13,7 +14,12 @@ import tc.oc.pgm.util.Pair;
 public final class ParseRangeTest {
 
   private static Node dummyNode(String value) {
-    return new Node(new Attribute("range", value, Namespace.NO_NAMESPACE));
+    Document doc = new Document();
+    InheritingElement el = new InheritingElement("a");
+    Attribute attr = new Attribute("range", value, Namespace.NO_NAMESPACE);
+    el.setAttribute(attr);
+    doc.setRootElement(el);
+    return new Node(attr);
   }
 
   @Test


### PR DESCRIPTION
Lists all elements and attributes that are present in the map XML, but pgm never gets to read. Very useful to find stuff you're doing wrong in xml, where pgm won't even read it, or typos:

A (real) example:
```xml
...
<kit id="experts-spade-kit" fdeduct-tools="false" ilter="experts-spade-equipped">
...
```
```
community-maps/ctw/standard/nyxis - 'fdeduct-tools' attribute of 'kit' element @ line 182 to 191: Unused node, maybe a typo?
community-maps/ctw/standard/nyxis - 'ilter' attribute of 'kit' element @ line 182 to 191: Unused node, maybe a typo?
```

Additionally fixed include errors being shown as part of the original file (but in the includes' line numbers), now maps will show (if they have a variant and it happened inside an include) as:
`path/to/map[variant]#include - description @ line: message`

A setting to be able to control if messages are issued has been added, defaults to true. Recommended to set to false for production servers, but keep it enabled for mapdev enviroments.

`<tutorial>` tag is explicitly whitelisted to avoid maps that define them being flagged. Also namespaced attributes or elements are ignored to allow 3rd party tags not messing with pgm, eg: `<ns:something/>`