### PR TITLE
Workarround adventure breaking translatable comments

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -67,6 +67,7 @@ import tc.oc.pgm.rotation.RandomMapOrder;
 import tc.oc.pgm.tablist.MatchTabManager;
 import tc.oc.pgm.util.FileUtils;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.chunk.NullChunkGenerator;
 import tc.oc.pgm.util.compatability.SportPaperListener;
 import tc.oc.pgm.util.concurrent.BukkitExecutorService;
@@ -118,6 +119,8 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
 
     // Sanity test PGM is running on a supported version before doing any work
     NMSHacks.allocateEntityId();
+    // Fix before any audiences have the chance of creating
+    ViaUtils.removeViaChatFacet();
 
     Permissions.registerAll();
 

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
@@ -1,6 +1,8 @@
 package tc.oc.pgm.util.bukkit;
 
 import com.viaversion.viaversion.api.Via;
+import java.lang.reflect.Field;
+import java.util.List;
 import org.bukkit.entity.Player;
 
 public class ViaUtils {
@@ -40,5 +42,23 @@ public class ViaUtils {
 
   public static boolean isReady(Player player) {
     return !enabled() || Via.getAPI().isInjected(player.getUniqueId());
+  }
+
+  /**
+   * Adventure has a ViaFacet$Chat class, which sends text using 1.16 format for support for hex
+   * codes. The issue is by doing that, it skips all translation layers from 1.8 to 1.16, including
+   * a needed rename for translated items to work. Removing this means hex colors would be
+   * restricted to the 16 colors even for 1.16 clients (pgm doesn't use them) but translations will
+   * be correct.
+   */
+  public static void removeViaChatFacet() {
+    try {
+      Class<?> bukkitAudience = Class.forName("net.kyori.adventure.platform.bukkit.BukkitAudience");
+      Field f = bukkitAudience.getDeclaredField("CHAT");
+      f.setAccessible(true);
+      List<?> list = (List<?>) f.get(null);
+      list.removeIf(el -> el.getClass().getName().endsWith("ViaFacet$Chat"));
+    } catch (ReflectiveOperationException ignored) {
+    }
   }
 }


### PR DESCRIPTION
Adventure has a ViaFacet$Chat class, which sends text using 1.16 format for support for hex codes. The issue is by doing that, it skips all translation layers from 1.8 to 1.16, including a needed rename for translated items to work. Removing this means hex colors would be restricted to the 16 colors even for 1.16 clients (pgm doesn't use them) but translations will be correct.

With fix: 
![image](https://github.com/PGMDev/PGM/assets/11789291/00546fa2-654c-4005-b158-701a806471f8)

Without fix:
![image](https://github.com/PGMDev/PGM/assets/11789291/b2181644-5053-4210-b59a-c5fcebb590be)

Note, we already tried reaching with an issue in adventure, but got no response: https://github.com/KyoriPowered/adventure-platform/issues/137

