### PR TITLE
Revert "Update dependencies and use non-deprecated methods"

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -199,7 +199,7 @@ public class Carried extends Spawned implements Missing {
     if (!message.equals(this.lastMessage)) {
       this.lastMessage = message;
       this.carrier.showTitle(
-          title(empty(), message, Title.Times.times(Duration.ZERO, fromTicks(5), fromTicks(35))));
+          title(empty(), message, Title.Times.of(Duration.ZERO, fromTicks(5), fromTicks(35))));
     }
 
     ScoreMatchModule smm = this.flag.getMatch().getModule(ScoreMatchModule.class);

--- a/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
@@ -64,8 +64,7 @@ public class MatchAnnouncer implements Listener {
     match.sendMessage(translatable("broadcast.matchStart", NamedTextColor.GREEN));
 
     Component go = translatable("broadcast.go", NamedTextColor.GREEN);
-    match.showTitle(
-        title(go, empty(), Title.Times.times(Duration.ZERO, fromTicks(5), fromTicks(15))));
+    match.showTitle(title(go, empty(), Title.Times.of(Duration.ZERO, fromTicks(5), fromTicks(15))));
 
     match.playSound(SOUND_MATCH_START);
   }

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
@@ -112,7 +112,7 @@ public abstract class Spawning extends Participating {
   }
 
   public void updateTitle() {
-    Title.Times times = Title.Times.times(Duration.ZERO, fromTicks(3), fromTicks(3));
+    Title.Times times = Title.Times.of(Duration.ZERO, fromTicks(3), fromTicks(3));
 
     player.showTitle(title(getTitle(false), getSubtitle(false), times));
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,17 +93,24 @@
         <!-- Multi-protocol library for future Minecraft versions -->
         <dependency>
             <groupId>com.viaversion</groupId>
-            <artifactId>viaversion-api</artifactId>
-            <version>4.7.0</version>
+            <artifactId>viaversion</artifactId>
+            <version>4.5.1</version>
             <scope>provided</scope>
             <optional>true</optional>
+            <!-- Fix transitive dependency breaking builds -->
+            <exclusions>
+                <exclusion>
+                    <groupId>net.md-5</groupId>
+                    <artifactId>bungeecord-chat</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Send packets to players -->
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>5.1.0</version>
+            <version>5.0.0</version>
         </dependency>
 
         <!-- XML parsing library used for all "map.xml" configuration loading -->
@@ -118,19 +125,19 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.14.0</version>
+            <version>4.12.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-plain</artifactId>
-            <version>4.14.0</version>
+            <version>4.12.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.3.0</version>
+            <version>4.2.0</version>
             <scope>compile</scope>
             <!-- Exclude Spigot APIs since we already provide Bukkit -->
             <exclusions>
@@ -145,25 +152,25 @@
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-core</artifactId>
-            <version>1.8.3</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-annotations</artifactId>
-            <version>1.8.3</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-paper</artifactId>
-            <version>1.8.3</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-minecraft-extras</artifactId>
-            <version>1.8.3</version>
+            <version>1.8.2</version>
             <scope>compile</scope>
         </dependency>
         <!-- Allows registering brigadier mappings -->
@@ -178,7 +185,7 @@
         <dependency>
             <groupId>fr.mrmicky</groupId>
             <artifactId>FastBoard</artifactId>
-            <version>2.0.0</version>
+            <version>1.2.1</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
This is breaking Community on OCC; as such let's revert these dependency upgrades for now.