### PR TITLE
Add map source to /map

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
+import tc.oc.pgm.map.source.MapRoot;
 
 /** A source where {@link MapInfo} documents and files are downloaded. */
 public interface MapSource {
@@ -67,4 +68,20 @@ public interface MapSource {
    * @param include The {@link MapInclude}
    */
   void setIncludes(Collection<MapInclude> include);
+
+  MapRoot getRoot();
+
+  Path getRelativeDir();
+
+  default Path getRelativeXml() {
+    return getRelativeDir().resolve(FILE);
+  }
+
+  default Path getAbsoluteDir() {
+    return getRoot().getBase().resolve(getRelativeDir());
+  }
+
+  default Path getAbsoluteXml() {
+    return getAbsoluteDir().resolve(FILE);
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -4,6 +4,7 @@ import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.event.ClickEvent.openUrl;
 import static net.kyori.adventure.text.event.ClickEvent.runCommand;
 import static net.kyori.adventure.text.event.HoverEvent.showText;
 import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
@@ -21,20 +22,26 @@ import com.google.common.collect.ImmutableList;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.TextComponent.Builder;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.yaml.snakeyaml.util.UriEncoder;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapLibrary;
+import tc.oc.pgm.api.map.MapSource;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.Phase;
+import tc.oc.pgm.map.source.MapRoot;
 import tc.oc.pgm.rotation.MapPoolManager;
 import tc.oc.pgm.rotation.pools.MapPool;
 import tc.oc.pgm.util.Audience;
@@ -252,16 +259,18 @@ public final class MapCommand {
               .getMapPoolStream()
               .filter(pool -> pool.getMaps().contains(map))
               .map(MapPool::getName)
-              .collect(Collectors.joining(", "));
+              .collect(Collectors.joining(" "));
       if (!mapPools.isEmpty()) {
         audience.sendMessage(
             text()
                 .append(mapInfoLabel("map.info.pools"))
-                .append(text(mapPools))
-                .colorIfAbsent(NamedTextColor.GOLD)
-                .decoration(TextDecoration.BOLD, false)
+                .append(text(mapPools, NamedTextColor.GOLD))
                 .build());
       }
+    }
+
+    if (!map.getSource().getRoot().isPrivate() || sender.hasPermission(Permissions.DEBUG)) {
+      audience.sendMessage(formatMapSource(sender, map));
     }
   }
 
@@ -288,11 +297,12 @@ public final class MapCommand {
                           "map.info.mapTag.hover",
                           NamedTextColor.GRAY,
                           text(mapTag, NamedTextColor.GOLD))))
+              .color(NamedTextColor.GOLD)
               .build();
 
       result.append(tag);
     }
-    return result.color(NamedTextColor.GOLD).build();
+    return result.build();
   }
 
   private static Component createPlayerLimitComponent(CommandSender sender, MapInfo map) {
@@ -340,5 +350,41 @@ public final class MapCommand {
         .append(translatable(key, NamedTextColor.DARK_PURPLE, TextDecoration.BOLD))
         .append(text(": "))
         .build();
+  }
+
+  @NotNull
+  private ComponentLike formatMapSource(CommandSender sender, MapInfo map) {
+    MapSource source = map.getSource();
+    MapRoot root = source.getRoot();
+
+    Builder xmlText =
+        text()
+            .append(mapInfoLabel("map.info.xml"))
+            .append(
+                text(root.getDisplayName(), NamedTextColor.YELLOW)
+                    .hoverEvent(showText(text("Repository", NamedTextColor.YELLOW))))
+            .append(space())
+            .append(
+                text("/" + source.getRelativeDir().toString(), NamedTextColor.GOLD)
+                    .hoverEvent(showText(text("Relative directory", NamedTextColor.GOLD))));
+
+    if (root.getBaseUrl() != null && root.getRemoteHost() != null) {
+      String mapPath = root.getBaseUrl() + UriEncoder.encode(source.getRelativeXml().toString());
+      xmlText.append(
+          text(" [Open]", NamedTextColor.GREEN, TextDecoration.BOLD)
+              .clickEvent(openUrl(mapPath))
+              .hoverEvent(
+                  showText(
+                      text("Click to open XML in " + root.getRemoteHost(), NamedTextColor.GREEN))));
+    }
+
+    if (ShowXmlCommand.isEnabledFor(sender)) {
+      xmlText.append(
+          text(" [Editor]", NamedTextColor.AQUA, TextDecoration.BOLD)
+              .clickEvent(runCommand("/showxml " + map.getId()))
+              .hoverEvent(
+                  showText(text("Click to open XML in a local file editor", NamedTextColor.AQUA))));
+    }
+    return xmlText;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -360,31 +360,53 @@ public final class MapCommand {
     Builder xmlText =
         text()
             .append(mapInfoLabel("map.info.xml"))
-            .append(
-                text(root.getDisplayName(), NamedTextColor.YELLOW)
-                    .hoverEvent(showText(text("Repository", NamedTextColor.YELLOW))))
+            .append(getRepository(root))
             .append(space())
             .append(
                 text("/" + source.getRelativeDir().toString(), NamedTextColor.GOLD)
-                    .hoverEvent(showText(text("Relative directory", NamedTextColor.GOLD))));
+                    .hoverEvent(showText(translatable("map.info.xml.path", NamedTextColor.GOLD))));
 
     if (root.getBaseUrl() != null && root.getRemoteHost() != null) {
       String mapPath = root.getBaseUrl() + UriEncoder.encode(source.getRelativeXml().toString());
       xmlText.append(
-          text(" [Open]", NamedTextColor.GREEN, TextDecoration.BOLD)
+          text()
+              .color(NamedTextColor.GREEN)
+              .decorate(TextDecoration.BOLD)
+              .append(text(" ["))
+              .append(translatable("map.info.xml.view"))
+              .append(text("]"))
               .clickEvent(openUrl(mapPath))
-              .hoverEvent(
-                  showText(
-                      text("Click to open XML in " + root.getRemoteHost(), NamedTextColor.GREEN))));
+              .hoverEvent(showText(translatable("map.info.xml.tip", NamedTextColor.GREEN))));
     }
 
     if (ShowXmlCommand.isEnabledFor(sender)) {
       xmlText.append(
-          text(" [Editor]", NamedTextColor.AQUA, TextDecoration.BOLD)
+          text()
+              .color(NamedTextColor.AQUA)
+              .decorate(TextDecoration.BOLD)
+              .append(text(" ["))
+              .append(translatable("map.info.xml.edit"))
+              .append(text("]"))
               .clickEvent(runCommand("/showxml " + map.getId()))
-              .hoverEvent(
-                  showText(text("Click to open XML in a local file editor", NamedTextColor.AQUA))));
+              .hoverEvent(showText(translatable("map.info.xml.edit.tip", NamedTextColor.AQUA))));
     }
     return xmlText;
+  }
+
+  private ComponentLike getRepository(MapRoot root) {
+    String repoUrl =
+        root.getRemoteHost() != null ? root.getRemoteHost() + "/" + root.getDisplayName() : null;
+
+    Component hover =
+        repoUrl == null
+            ? translatable("map.info.xml.repository.local", NamedTextColor.YELLOW)
+            : translatable(
+                "map.info.xml.repository.remote",
+                NamedTextColor.YELLOW,
+                text(repoUrl, NamedTextColor.GREEN));
+
+    return text(root.getDisplayName(), NamedTextColor.YELLOW)
+        .hoverEvent(showText(hover))
+        .clickEvent(root.getBaseUrl() == null ? null : openUrl(root.getBaseUrl()));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/ShowXmlCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ShowXmlCommand.java
@@ -1,0 +1,167 @@
+package tc.oc.pgm.command;
+
+import static tc.oc.pgm.util.text.TextException.exception;
+import static tc.oc.pgm.util.text.TextException.noPermission;
+
+import cloud.commandframework.annotations.Argument;
+import cloud.commandframework.annotations.CommandDescription;
+import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.CommandPermission;
+import cloud.commandframework.annotations.specifier.Greedy;
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import java.awt.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.messaging.Messenger;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.map.MapInfo;
+
+/**
+ * Opens-up the xml file on the server side, useful if you're running a server locally for mapdev
+ * purposes on your machine. <br>
+ * If the server isn't running in a desktop environment this command won't even be registered.
+ */
+@SuppressWarnings("UnstableApiUsage")
+public final class ShowXmlCommand {
+
+  private static final ShowXmlCommand INSTANCE = new ShowXmlCommand();
+
+  private final boolean mayEnable = Desktop.isDesktopSupported();
+  private byte[] serverIp = null;
+  private String serverHostname = null;
+
+  public ShowXmlCommand() {
+    if (mayEnable) {
+      new ServerIpResolver();
+    }
+  }
+
+  public static ShowXmlCommand getInstance() {
+    return INSTANCE;
+  }
+
+  public static boolean isEnabled() {
+    return INSTANCE.mayEnable;
+  }
+
+  public static boolean isEnabledFor(CommandSender sender) {
+    return INSTANCE.canUseCommand(sender);
+  }
+
+  @CommandMethod("showxml <map>")
+  @CommandDescription("Show info about a map")
+  @CommandPermission("*")
+  public void openXml(CommandSender sender, @Argument("map") @Greedy MapInfo map) {
+    if (!canUseCommand(sender)) throw noPermission();
+
+    try {
+      Desktop.getDesktop().open(map.getSource().getAbsoluteXml().toFile());
+    } catch (IOException e) {
+      throw exception(e.getMessage());
+    }
+  }
+
+  public boolean canUseCommand(CommandSender sender) {
+    if (sender instanceof Player && sender.isOp()) {
+      InetAddress addr = ((Player) sender).getAddress().getAddress();
+      return addr.isLoopbackAddress()
+          || (serverIp != null
+              ? Arrays.equals(serverIp, addr.getAddress())
+              : serverHostname != null && serverHostname.equals(addr.getCanonicalHostName()));
+    }
+    return sender instanceof ConsoleCommandSender;
+  }
+
+  private class ServerIpResolver implements Listener, PluginMessageListener {
+    private static final String BUNGEE = "BungeeCord";
+    private final Server server;
+    private final Messenger messenger;
+
+    private boolean unregistering;
+    private boolean unregistered;
+    private String serverName;
+
+    ServerIpResolver() {
+      this.server = Bukkit.getServer();
+      this.messenger = server.getMessenger();
+
+      messenger.registerOutgoingPluginChannel(PGM.get(), BUNGEE);
+      messenger.registerIncomingPluginChannel(PGM.get(), BUNGEE, this);
+      server.getPluginManager().registerEvents(this, PGM.get());
+    }
+
+    private void unregister() {
+      unregistering = true;
+      if (!unregistered) {
+        messenger.unregisterOutgoingPluginChannel(PGM.get(), BUNGEE);
+        messenger.unregisterIncomingPluginChannel(PGM.get(), BUNGEE, this);
+        HandlerList.unregisterAll(this);
+        unregistered = true;
+      }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent e) {
+      server.getScheduler().runTaskLater(PGM.get(), () -> usePlayer(e.getPlayer()), 10L);
+    }
+
+    @Override
+    public void onPluginMessageReceived(String channel, Player player, byte[] bytes) {
+      if (!channel.equals(BUNGEE)) return;
+
+      ByteArrayDataInput in = ByteStreams.newDataInput(bytes);
+      String subchannel = in.readUTF();
+      if ("GetServer".equals(subchannel)) {
+        this.serverName = in.readUTF();
+        usePlayer(player);
+      } else if ("ServerIP".equals(subchannel)) {
+        in.readUTF(); // discard name
+        serverHostname = in.readUTF(); // read ip
+        in.readShort(); // discard port
+
+        try {
+          // Get actual address if possible
+          serverIp = InetAddress.getByName(serverHostname).getAddress();
+        } catch (UnknownHostException ignore) {
+        }
+        unregister();
+      }
+    }
+
+    private void usePlayer(Player player) {
+      if (!player.isOnline()) return;
+
+      ByteArrayDataOutput out = ByteStreams.newDataOutput();
+      if (serverName == null) {
+        out.writeUTF("GetServer");
+      } else if (serverIp == null) {
+        out.writeUTF("ServerIP");
+        out.writeUTF(serverName);
+      } else {
+        return;
+      }
+
+      player.sendPluginMessage(PGM.get(), BUNGEE, out.toByteArray());
+
+      // If no response occurs in 30s from sending, assume not running under bungee and unregister
+      if (!unregistering) {
+        unregistering = true;
+        server.getScheduler().scheduleSyncDelayedTask(PGM.get(), this::unregister, 30 * 20L);
+      }
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
@@ -49,6 +49,7 @@ import tc.oc.pgm.command.ModeCommand;
 import tc.oc.pgm.command.ProximityCommand;
 import tc.oc.pgm.command.RestartCommand;
 import tc.oc.pgm.command.SettingCommand;
+import tc.oc.pgm.command.ShowXmlCommand;
 import tc.oc.pgm.command.StartCommand;
 import tc.oc.pgm.command.StatsCommand;
 import tc.oc.pgm.command.TeamCommand;
@@ -144,6 +145,7 @@ public class PGMCommandGraph extends CommandGraph<PGM> {
     register(new TimeLimitCommand());
     register(new VotingCommand());
 
+    if (ShowXmlCommand.isEnabled()) register(ShowXmlCommand.getInstance());
     if (PGM.get().getConfiguration().isVanishEnabled()) register(new VanishCommand());
 
     register(ChatDispatcher.get());

--- a/core/src/main/java/tc/oc/pgm/map/source/MapRoot.java
+++ b/core/src/main/java/tc/oc/pgm/map/source/MapRoot.java
@@ -1,0 +1,60 @@
+package tc.oc.pgm.map.source;
+
+import static tc.oc.pgm.util.Assert.assertNotNull;
+
+import java.nio.file.Path;
+import org.jetbrains.annotations.Nullable;
+
+public class MapRoot {
+  // Repository host, if any (eg: 'github.com' or 'gitlab.com')
+  private final @Nullable String remoteHost;
+
+  // Display name for the map factory, eg: 'maps' or 'PGMDev/Maps'
+  private final String displayName;
+
+  // Repository base url, if any (eg: 'https://github.com/PGMDev/Maps/blob/master/')
+  private final @Nullable String baseUrl;
+
+  // If the repository is private
+  private final boolean isPrivate;
+
+  // The actual folder in the filesystem the map factory is mounted at
+  private final Path base;
+
+  public MapRoot(Path base) {
+    this(base, null, null, null, true);
+  }
+
+  public MapRoot(
+      Path base,
+      @Nullable String remoteHost,
+      @Nullable String displayName,
+      @Nullable String baseUrl,
+      boolean isPrivate) {
+    this.base = assertNotNull(base);
+    this.remoteHost = remoteHost;
+    this.displayName = displayName == null ? base.getFileName().toString() : displayName;
+    this.baseUrl = baseUrl;
+    this.isPrivate = isPrivate;
+  }
+
+  public @Nullable String getRemoteHost() {
+    return remoteHost;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public @Nullable String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public boolean isPrivate() {
+    return isPrivate;
+  }
+
+  public Path getBase() {
+    return base;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/map/source/PathMapSourceFactory.java
+++ b/core/src/main/java/tc/oc/pgm/map/source/PathMapSourceFactory.java
@@ -21,40 +21,43 @@ import tc.oc.pgm.api.map.factory.MapSourceFactory;
 public class PathMapSourceFactory implements MapSourceFactory {
 
   private final Set<Path> sources;
+  protected MapRoot paths;
 
-  protected final Path base;
   protected final @Nullable List<Path> children;
 
   public PathMapSourceFactory(Path base) {
-    this(base, null);
+    this(new MapRoot(base), null);
   }
 
-  public PathMapSourceFactory(Path base, @Nullable List<Path> children) {
+  public PathMapSourceFactory(MapRoot base, @Nullable List<Path> children) {
     this.sources = Collections.synchronizedSet(new ConcurrentSkipListSet<>());
-    this.base = assertNotNull(base).toAbsolutePath();
+    this.paths = assertNotNull(base);
     this.children = children;
   }
 
   protected MapSource loadSource(Path path) {
-    return new SystemMapSource(path, null);
+    return new SystemMapSource(paths, path, null);
   }
 
   private Stream<MapSource> loadNewSource(Path path) {
-    if (path == null || !path.startsWith(this.base) || !sources.add(path)) {
+    if (path == null || !path.startsWith(paths.getBase()) || !sources.add(path)) {
       return Stream.empty();
     }
 
     if (path.getFileName().equals(MapSource.FILE)) {
-      return Stream.of(loadSource(path.getParent()));
+      return Stream.of(loadSource(paths.getBase().relativize(path.getParent())));
     }
     return Stream.empty();
   }
 
   @Override
   public Stream<MapSource> loadNewSources(Consumer<MapException> exceptionHandler) {
-    if (!Files.exists(base) || !Files.isDirectory(base)) return Stream.empty();
+    if (!Files.exists(paths.getBase()) || !Files.isDirectory(paths.getBase()))
+      return Stream.empty();
 
-    return (children == null ? Stream.of(base) : children.stream().map(base::resolve))
+    return (children == null
+            ? Stream.of(paths.getBase())
+            : children.stream().map(paths.getBase()::resolve))
         .flatMap(
             b -> {
               try {

--- a/core/src/main/java/tc/oc/pgm/scoreboard/RenderContext.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/RenderContext.java
@@ -59,7 +59,7 @@ class RenderContext {
   }
 
   public void startSection() {
-    addSpace = rows.size() > 0;
+    addSpace = !rows.isEmpty();
   }
 
   public void addRow(Component row) {

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -28,7 +28,16 @@ map.info.playerLimit.vs = vs
 
 map.info.xml = XML
 
+map.info.xml.repository.local = Local repository
+map.info.xml.repository.remote = Remote repository at {0}
+
+map.info.xml.path = Map folder
+
+map.info.xml.view = View
 map.info.xml.tip = View the XML code that controls this map
+
+map.info.xml.edit = Edit
+map.info.xml.edit.tip = Edit the XML for the map in a local editor
 
 map.info.proto = Proto
 


### PR DESCRIPTION
Running /map will now show the source location for that map.

Map hosted in a github repo:
![image](https://github.com/PGMDev/PGM/assets/11789291/b3c5ac45-a2e5-4ce6-af89-ade189d2e973)

Map running from a local folder:
![image](https://github.com/PGMDev/PGM/assets/11789291/287387a0-c723-4169-8a31-1bb4967a5663)

Conditions for displaying:
 - The section itself, appears if:
   - If the user has the debug permission node (developers/mapdevs)
   - The root is a public (non-authenticated) git repository
 - `Open` button, opens the link to the map.xml in the git repo
   - Appears only when the map comes from a git repository
 - `Editor` button, opens the map.xml in your default editor, but from the server-side (client support for this is lacking).
   - Appears only on servers running with a desktop environment
   - Only shows if the client connects from the same ip as the server is hosted.
   - Requires OP permission.
   - Useful for local map development, quickly opening files and editing them on the fly.
   
Missing points: some strings are still hardcoded, should be moved into translation files