### PR TITLE
Fix structures having improper locations in some instances

### DIFF
--- a/core/src/main/java/tc/oc/pgm/structure/DynamicStructureDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/structure/DynamicStructureDefinition.java
@@ -67,7 +67,8 @@ public class DynamicStructureDefinition extends SelfIdentifyingFeatureDefinition
    * @return The offset to use when placing/clearing the structure
    */
   public BlockVector getOffset() {
-    if (position != null) return position.subtract(this.structure.getOrigin()).toBlockVector();
-    return offset;
+    if (position != null)
+      return position.clone().subtract(this.structure.getOrigin()).toBlockVector();
+    return offset.clone();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/structure/StructureDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/structure/StructureDefinition.java
@@ -45,7 +45,7 @@ public class StructureDefinition extends SelfIdentifyingFeatureDefinition {
     if (origin == null) {
       this.origin = getBounds().getMin();
     }
-    return this.origin;
+    return this.origin.clone();
   }
 
   public Bounds getBounds() {


### PR DESCRIPTION
When maps with structures are loaded for the second time the structures can be placed in incorrect locations in some instances. This fixes that.

This was caused by `StructureDefinition` and `DynamicStructureDefinition` directly returning their Vector and BlockVector location information. These classes are not immutable, meaning that when other classes used them, they modified the underlying value stored in the Definition.