### PR TITLE
Fix relative path repos not loading any maps

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/source/MapRoot.java
+++ b/core/src/main/java/tc/oc/pgm/map/source/MapRoot.java
@@ -31,7 +31,7 @@ public class MapRoot {
       @Nullable String displayName,
       @Nullable String baseUrl,
       boolean isPrivate) {
-    this.base = assertNotNull(base);
+    this.base = assertNotNull(base).toAbsolutePath();
     this.remoteHost = remoteHost;
     this.displayName = displayName == null ? base.getFileName().toString() : displayName;
     this.baseUrl = baseUrl;


### PR DESCRIPTION
Broken by the recent update #1225 , a toAbsolutePath was lost when migrating the Path from the source factory to MapRoot