### PR TITLE
Add id to arbitrary dom exceptions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -93,7 +93,11 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
     } catch (ModuleLoadException e) {
       throw new MapException(source, info, e.getFullMessage(), e);
     } catch (JDOMParseException e) {
-      final InvalidXMLException cause = InvalidXMLException.fromJDOM(e, source.getId());
+      // Set base uri so when error is displayed it shows what XML caused the issue
+      Document d = e.getPartialDocument();
+      if (d != null) d.setBaseURI(source.getId());
+
+      final InvalidXMLException cause = InvalidXMLException.fromJDOM(e);
       throw new MapException(source, info, cause.getMessage(), cause);
     } catch (Throwable t) {
       throw new MapException(source, info, "Unhandled " + t.getClass().getName(), t);

--- a/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
@@ -64,7 +64,7 @@ public class MapFilePreprocessor {
     DocumentWrapper document;
     try (final InputStream stream = source.getDocument()) {
       document = (DocumentWrapper) DOCUMENT_FACTORY.get().build(stream);
-      document.setBaseURI(source.getId() + ("default".equals(variant) ? "" : "[" + variant + "]"));
+      document.setBaseURI(source.getId());
     }
 
     document.runWithoutVisitation(

--- a/core/src/main/java/tc/oc/pgm/map/source/SystemMapSource.java
+++ b/core/src/main/java/tc/oc/pgm/map/source/SystemMapSource.java
@@ -73,7 +73,8 @@ class SystemMapSource implements MapSource {
 
   @Override
   public String getId() {
-    return "<" + root.getDisplayName() + ">/" + dir.toString();
+    String suffix = (variant != null ? "[" + variant + "]" : "");
+    return "<" + root.getDisplayName() + ">/" + dir.toString() + suffix;
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/xml/InvalidXMLException.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/InvalidXMLException.java
@@ -67,7 +67,7 @@ public class InvalidXMLException extends Exception {
     this(message, attribute, null);
   }
 
-  public static InvalidXMLException fromJDOM(JDOMParseException e, String documentPath) {
+  public static InvalidXMLException fromJDOM(JDOMParseException e) {
     return new InvalidXMLException(
         e.getMessage(),
         null,


### PR DESCRIPTION
When an arbitrary DOM exception is thrown, the uri may not have been set, leading to an error with no path being printed at all:

![image](https://github.com/PGMDev/PGM/assets/11789291/b06c3dd9-95d8-4880-a1cd-fd6c90f6fa0f)
(pic by @TheRealPear)

With the changes in this PR the error became a much more reasonable:
`[PGM] <maps>/CTW/Standard/Infernal Shadow - line 13, column 3: Error on line 13: The element type "map" must be terminated by the matching end-tag "</map>".`
