### PR TITLE
Fix 1.9 issues with bedwars maps

### DIFF
--- a/core/src/main/java/tc/oc/pgm/shops/ShopKeeper.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopKeeper.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.points.PointProvider;
+import tc.oc.pgm.util.bukkit.MetadataUtils;
 import tc.oc.pgm.util.nms.NMSHacks;
 
 public class ShopKeeper {
@@ -60,7 +61,7 @@ public class ShopKeeper {
   }
 
   public static String getKeeperId(Entity entity) {
-    MetadataValue meta = entity.getMetadata(ShopKeeper.METADATA_KEY, PGM.get());
+    MetadataValue meta = MetadataUtils.getMetadata(entity, ShopKeeper.METADATA_KEY, PGM.get());
     if (meta.asString() != null) {
       return meta.asString();
     }

--- a/core/src/main/java/tc/oc/pgm/shops/menu/Payment.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/Payment.java
@@ -5,6 +5,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.material.Materials;
 
 public class Payment {
 
@@ -43,6 +44,8 @@ public class Payment {
   }
 
   public boolean matches(ItemStack item) {
-    return this.item != null ? item.isSimilar(this.item, true) : item.getType() == currency;
+    return this.item != null
+        ? Materials.itemsSimilar(item, this.item, true, false)
+        : item.getType() == currency;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/util/MethodHandleUtils.java
+++ b/core/src/main/java/tc/oc/pgm/util/MethodHandleUtils.java
@@ -6,6 +6,7 @@ import java.lang.invoke.MethodType;
 import java.util.HashMap;
 import java.util.Map;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
@@ -31,10 +32,15 @@ public final class MethodHandleUtils {
   // #getPlayer covers events which does not provide Entity
   // as the lower boundary
   private static final String[] entityGetterNames =
-      new String[] {"getPlayer", "getActor", "getActor"};
+      new String[] {"getPlayer", "getActor", "getActor", "getEntity"};
   private static final MethodType playerMethodType = MethodType.methodType(Player.class);
   private static final MethodType[] entityMethodTypes =
-      new MethodType[] {playerMethodType, playerMethodType, MethodType.methodType(Entity.class)};
+      new MethodType[] {
+        playerMethodType,
+        playerMethodType,
+        MethodType.methodType(Entity.class),
+        MethodType.methodType(LivingEntity.class)
+      };
 
   public static MethodHandle getHandle(Class<? extends Event> event)
       throws NoSuchMethodException, IllegalAccessException {

--- a/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.util.inventory;
 import com.google.common.collect.Range;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import tc.oc.pgm.util.material.Materials;
 
 public class ItemMatcher {
 
@@ -48,7 +49,7 @@ public class ItemMatcher {
   }
 
   public boolean matches(ItemStack query) {
-    return base.isSimilar(stripMeta(query), ignoreDurability, ignoreName)
+    return Materials.itemsSimilar(base, stripMeta(query), ignoreDurability, ignoreName)
         && amount.contains(query.getAmount());
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -9,6 +9,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BannerMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.material.MaterialData;
 import tc.oc.pgm.util.block.BlockFaces;
 
@@ -85,6 +86,51 @@ public interface Materials {
 
       default:
         return material.isSolid();
+    }
+  }
+
+  static boolean itemsSimilar(
+      ItemStack first, ItemStack second, boolean skipDur, boolean skipCheckingName) {
+    if (first == second) {
+      return true;
+    }
+    if (second == null
+        || first == null
+        || !first.getType().equals(second.getType())
+        || (!skipDur && first.getDurability() != second.getDurability())) {
+      return false;
+    }
+    final boolean hasMeta1 = first.hasItemMeta();
+    final boolean hasMeta2 = second.hasItemMeta();
+    if (!hasMeta1 && !hasMeta2) {
+      return true;
+    }
+
+    final ItemMeta meta1 = hasMeta1 ? first.getItemMeta() : null;
+    final ItemMeta meta2 = hasMeta2 ? second.getItemMeta() : null;
+
+    final String prevName1 = meta1 != null ? meta1.getDisplayName() : null;
+    final String prevName2 = meta2 != null ? meta2.getDisplayName() : null;
+    if (skipCheckingName) {
+      if (meta1 != null) {
+        meta1.setDisplayName(null);
+      }
+      if (meta2 != null) {
+        meta2.setDisplayName(null);
+      }
+    }
+
+    try {
+      return Bukkit.getItemFactory().equals(meta1, meta2);
+    } finally {
+      if (skipCheckingName) {
+        if (meta1 != null) {
+          meta1.setDisplayName(prevName1);
+        }
+        if (meta2 != null) {
+          meta2.setDisplayName(prevName2);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/PGMDev/PGM/issues/1227

Fixes a few minor issues with SportPaper specific methods being used.

Also added the variant of the `ItemStack.isSimilar` method from SportPaper