### PR TITLE
Fix leave messages sometimes showing for vanished players

### DIFF
--- a/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
+++ b/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
@@ -159,7 +159,7 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.HIGH)
+  @EventHandler(priority = EventPriority.HIGHEST)
   public void onQuit(PlayerQuitEvent event) {
     MatchPlayer player = matchManager.getPlayer(event.getPlayer());
     // If player is vanished & joined via "vanish" subdomain. Remove vanish status on quit


### PR DESCRIPTION
When players vanish by joining through a vanish subdomain, they sometimes show regular leaves messages when they disconnect.
This was caused by the vanish removal listener and the quit announce listener having the same priority https://github.com/PGMDev/PGM/blob/dev/core/src/main/java/tc/oc/pgm/listeners/JoinLeaveAnnouncer.java#L42

I've raised the priority of the vanish remove listener so that it happens after the leave message is announced.