### PR TITLE
Add power attribute for projectiles

### DIFF
--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
@@ -11,6 +11,7 @@ import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
   protected @Nullable String name;
   protected @Nullable Double damage;
+  protected @Nullable Float power;
   protected double velocity;
   protected ClickAction clickAction;
   protected Class<? extends Entity> projectile;
@@ -24,6 +25,7 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
       @Nullable String id,
       @Nullable String name,
       @Nullable Double damage,
+      @Nullable Float power,
       double velocity,
       ClickAction clickAction,
       Class<? extends Entity> entity,
@@ -35,6 +37,7 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
     super(id);
     this.name = name;
     this.damage = damage;
+    this.power = power;
     this.velocity = velocity;
     this.clickAction = clickAction;
     this.projectile = entity;

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Explosive;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -104,6 +105,9 @@ public class ProjectileMatchModule implements MatchModule, Listener {
           projectile =
               player.getWorld().spawn(player.getEyeLocation(), projectileDefinition.projectile);
           projectile.setVelocity(velocity);
+        }
+        if (projectileDefinition.power != null && projectile instanceof Explosive) {
+          ((Explosive) projectile).setYield(projectileDefinition.power);
         }
         projectile.setMetadata(
             "projectileDefinition", new FixedMetadataValue(PGM.get(), projectileDefinition));

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
@@ -65,6 +65,9 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
                 Node.fromAttr(projectileElement, "click"), ClickAction.class, ClickAction.BOTH);
         Class<? extends Entity> entity =
             XMLUtils.parseEntityTypeAttribute(projectileElement, "projectile", Arrow.class);
+        Float power =
+            XMLUtils.parseNumber(
+                Node.fromChildOrAttr(projectileElement, "power"), Float.class, (Float) null);
         List<PotionEffect> potionKit = kitParser.parsePotions(projectileElement);
         Filter destroyFilter =
             filterParser.parseFilterProperty(projectileElement, "destroy-filter");
@@ -78,6 +81,7 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
                 id,
                 name,
                 damage,
+                power,
                 velocity,
                 clickAction,
                 entity,


### PR DESCRIPTION
Resolves https://github.com/PGMDev/PGM/issues/1232

Adds a power attribute for projectiles. If the projectile implements `Explosive` and a `power` is supplied it will set the explosive power to the specified amount.

Example usage:
```xml
<projectile id="throwable-fireball" name="Fireball" projectile="Fireball" power="5" velocity=".5" click="right" damage="8" cooldown="2s"/>
```