### PR TITLE
Fix carrying and holding filters not detecting some inventory changes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
@@ -7,7 +7,11 @@ import java.util.stream.Stream;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -26,7 +30,11 @@ public class CarryingItemFilter extends ParticipantItemFilter {
         PlayerItemTransferEvent.class,
         ApplyKitEvent.class,
         PlayerItemBreakEvent.class,
-        EntityShootBowEvent.class);
+        EntityShootBowEvent.class,
+        PlayerBucketFillEvent.class,
+        PlayerBucketEmptyEvent.class,
+        PlayerItemConsumeEvent.class,
+        PlayerEditBookEvent.class);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/HoldingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/HoldingItemFilter.java
@@ -4,7 +4,11 @@ import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import java.util.stream.Stream;
 import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -23,7 +27,11 @@ public class HoldingItemFilter extends ParticipantItemFilter {
         PlayerItemHeldEvent.class,
         PlayerItemTransferEvent.class,
         ApplyKitEvent.class,
-        PlayerItemBreakEvent.class);
+        PlayerItemBreakEvent.class,
+        PlayerBucketFillEvent.class,
+        PlayerBucketEmptyEvent.class,
+        PlayerItemConsumeEvent.class,
+        PlayerEditBookEvent.class);
   }
 
   @Override


### PR DESCRIPTION
Certain actions such as filling a bucket would not trigger dynamic filters for carrying lava buckets or other similar changes. I've added a few relevant events that were not previously checked for, that can modify a player's inventory.

Basically, this makes carrying and holding filters work dynamically for filling/emptying buckets and a couple other things.