### PR TITLE
Fix arbitrary iteration order in vote book

### DIFF
--- a/core/src/main/java/tc/oc/pgm/rotation/vote/MapPoll.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/MapPoll.java
@@ -12,8 +12,8 @@ import static tc.oc.pgm.util.text.TextException.exception;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,7 +71,7 @@ public class MapPoll {
 
   public MapPoll(Match match, List<MapInfo> maps) {
     this.match = new WeakReference<>(match);
-    this.votes = new HashMap<>();
+    this.votes = new LinkedHashMap<>();
     maps.forEach(m -> votes.put(m, new HashSet<>()));
 
     match.addListener(new VotingBookListener(this, match), MatchScope.LOADED);


### PR DESCRIPTION
Fixes iteration order when maps are added to the vote, such that they are consistent when displaying.