### PR TITLE
Use more exact username matching when available

### DIFF
--- a/core/src/main/java/tc/oc/pgm/util/Players.java
+++ b/core/src/main/java/tc/oc/pgm/util/Players.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.util;
 
 import cloud.commandframework.context.CommandContext;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -34,11 +35,22 @@ public class Players {
   }
 
   public static List<String> getPlayerNames(CommandSender sender, String query) {
-    return Bukkit.getOnlinePlayers().stream()
-        .filter(p -> Players.isVisible(sender, p))
-        .map(p -> Players.getVisibleName(sender, p))
-        .filter(n -> LiquidMetal.match(n, query))
-        .collect(Collectors.toList());
+    String lowerCaseQuery = query.toLowerCase(Locale.ROOT);
+    List<String> playerSuggestions =
+        Bukkit.getOnlinePlayers().stream()
+            .filter(p -> Players.isVisible(sender, p))
+            .map(p -> Players.getVisibleName(sender, p))
+            .filter(n -> LiquidMetal.match(n, query))
+            .collect(Collectors.toList());
+    List<String> prefixMatched =
+        playerSuggestions.stream()
+            .filter((suggestion) -> suggestion.toLowerCase(Locale.ROOT).startsWith(lowerCaseQuery))
+            .collect(Collectors.toList());
+    if (!prefixMatched.isEmpty()) {
+      return prefixMatched;
+    } else {
+      return playerSuggestions;
+    }
   }
 
   public static Player getPlayer(CommandSender sender, String query) {


### PR DESCRIPTION
Current username matching is overly broad for commands and results.

For example:
Running `/maps -a cs_` will not show any maps by `cs_` on the first page of results.
In this case, I've changed it such that if an exact username match is found it will only show those matches, otherwise it uses existing behavior.

Suggestions for player-targeting commands are overly broad
Running `/team force ma` and then tab completing currently prioritizes usernames like `CincoDeMayo` over something like `math1234`.
I've changed it such that if a prefix match is found it will only show those usernames that match the prefix, otherwise it will use the current behavior.