### PR TITLE
Add edition to list of ignored unused xml tags

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
@@ -12,7 +12,7 @@ import org.jdom2.Namespace;
 
 public class DocumentWrapper extends Document {
 
-  private static final Set<String> IGNORED = Sets.newHashSet("variant", "tutorial");
+  private static final Set<String> IGNORED = Sets.newHashSet("variant", "tutorial", "edition");
 
   private boolean visitingAllowed = true;
 


### PR DESCRIPTION
Given that edition used to be a valid xml tag, many maps use it, and we may bring it back in the future, i think it's best that pgm's "unused xml" doesn't flag those attributes, similar to what we did with tutorials.