### PR TITLE
Implement exclusive attribute on dummy variables

### DIFF
--- a/core/src/main/java/tc/oc/pgm/variables/VariableParser.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariableParser.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.variables;
 
+import com.google.common.collect.Range;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -57,7 +58,10 @@ public class VariableParser {
   public VariableDefinition<?> parseDummy(Element el, String id) throws InvalidXMLException {
     Class<? extends Filterable<?>> scope = Filterables.parse(Node.fromRequiredAttr(el, "scope"));
     double def = XMLUtils.parseNumber(Node.fromAttr(el, "default"), Double.class, 0d);
-    return new VariableDefinition<>(id, scope, true, vd -> new DummyVariable<>(vd, def));
+    Integer excl =
+        XMLUtils.parseNumberInRange(
+            Node.fromAttr(el, "exclusive"), Integer.class, Range.closed(1, 50), null);
+    return new VariableDefinition<>(id, scope, true, vd -> new DummyVariable<>(vd, def, excl));
   }
 
   @MethodParser("lives")

--- a/core/src/main/java/tc/oc/pgm/variables/types/DummyVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/DummyVariable.java
@@ -1,7 +1,9 @@
 package tc.oc.pgm.variables.types;
 
+import java.lang.reflect.Array;
 import java.util.HashMap;
 import java.util.Map;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.filters.FilterMatchModule;
 import tc.oc.pgm.filters.Filterable;
 import tc.oc.pgm.variables.VariableDefinition;
@@ -11,20 +13,40 @@ public class DummyVariable<T extends Filterable<?>> extends AbstractVariable<T> 
   private final double def;
   private final Map<T, Double> values;
 
-  public DummyVariable(VariableDefinition<T> definition, double def) {
+  // Circular buffer of last additions, head marks next location to replace
+  private @Nullable final T[] additions;
+  private int head = 0;
+
+  public DummyVariable(VariableDefinition<T> definition, double def, Integer exclusive) {
     super(definition);
     this.def = def;
     this.values = new HashMap<>();
+    //noinspection unchecked
+    this.additions =
+        exclusive == null ? null : (T[]) Array.newInstance(definition.getScope(), exclusive);
   }
 
   @Override
   protected double getValueImpl(T obj) {
-    return values.computeIfAbsent(obj, k -> def);
+    return values.getOrDefault(obj, def);
   }
 
   @Override
   protected void setValueImpl(T obj, double value) {
-    values.put(obj, value);
+    Double oldVal = values.put(obj, value);
+
+    // Limit is enabled, and we're not replacing a pre-existing key
+    if (additions != null && oldVal == null) {
+      T toRemove = additions[head];
+      if (toRemove != null) {
+        values.remove(toRemove);
+        toRemove.moduleRequire(FilterMatchModule.class).invalidate(toRemove);
+      }
+
+      additions[head] = obj;
+      head = (head + 1) % additions.length;
+    }
+
     // For performance reasons, let's avoid launching an event for every variable change
     obj.moduleRequire(FilterMatchModule.class).invalidate(obj);
   }


### PR DESCRIPTION
Adds an exclusive type of dummy variable, which limits how many different values (scope keys) there can be in a dummy variable.

`exclusive` supports values between 1 and 50. Please avoid using large values, if you simply don't care about the limit, do not specify one, and it'll just be infinite,  at a smaller performance cost.
```xml
<variables>
  <variable id="last_scored" exclusive="1" scope="team" />
  <variable id="other" exclusive="2" scope="player" />
</variables>
```
In this example, the `last_scored` variable would, at most, have a value for one team. This in practice means that all other teams will always be reset to default whenever a team is set:
`<set var="last_scored" value="1234"/>` <- Sets the current scoped team value, and other teams are reset to default

For the `other` example, the "last 2" updated players will be kept, while players who got in "earlier" than that, are removed.
PlayerA triggers: `<set var="other" value="other+1"/>` <- Player A is added
PlayerB triggers: `<set var="other" value="other+1"/>` <- Player B is added
PlayerA triggers: `<set var="other" value="other+1"/>` <- Player A was already in, just gets value set to 2
PlayerC triggers: `<set var="other" value="other+1"/>` <- Player C is added, since the first added was A, A is replaced with C
Player D triggers: `<set var="other" value="other+1"/>` <- Player D is added, since the first added was B, B is replaced with D.

Realistically i don't see that much use in the second variant, but the exclusive="1" simplifies alot of use-cases that are otherways painful to reset, requiring multiple switch-scopes to get it sorted.
In this example, we want the team which gets the on-score action to add one, but the opposite team(s) to subtract one from their score, with exclusive it looks like this:
```xml
<variables>
  <score id="team_score" scope="team"/>
  <variable id="last_scored" exclusive="1" scope="team"/>
</variables>
<actions>
  <action id="on-score" scope="team">
    <set var="team_score" value="team_score+1"/>
    <set var="last_scored" value="1"/>
    <switch-scope inner="match">
      <switch-scope inner="team" filter="last_scored=0">
        <set var="team_score" value="team_score-1"/>
      </switch-scope>
    </switch-scope>
  </action>
</actions>
```

Previously, you'd need:
```xml
<variables>
  <score id="team_score" scope="team"/>
  <variable id="last_scored" scope="team"/>
</variables>
<actions>
  <action id="on-score" scope="team">
    <set var="team_score" value="team_score+1"/>
    <switch-scope inner="match">
      <switch-scope inner="team">
        <set var="last_scored" value="0"/>
      </switch-scope>
    </switch-scope>
    <set var="last_scored" value="1"/>
    <switch-scope inner="match">
      <switch-scope inner="team" filter="last_scored=0">
        <set var="team_score" value="team_score-1"/>
      </switch-scope>
    </switch-scope>
  </action>
</actions>
```

This is a nice to have as a pre-requisite for a potential future system for chat message interpolation of player/team names and score values