### PR TITLE
Fix inline filters with single variable values

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -91,7 +91,7 @@ public class FeatureFilterParser extends FilterParser {
               + VariablesModule.Factory.VARIABLE_ID.pattern()
               + ")\\s*=\\s*("
               + XMLUtils.RANGE_DOTTED.pattern()
-              + ")");
+              + "|-?\\d*\\.?\\d+)");
 
   private @Nullable Filter parseInlineFilter(Node node, String text) throws InvalidXMLException {
     // Parse variable filter


### PR DESCRIPTION
Currently inline filters like `filter="whatever=1"` aren't working, and need to be written as `filter="whatever=1..1"`due to the regex having changed during lootables PR.