### PR TITLE
Add team scale command & add admin chat feedback for other commands

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/CancelCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/CancelCommand.java
@@ -1,26 +1,30 @@
 package tc.oc.pgm.command;
 
 import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.util.player.PlayerComponent.player;
 
 import cloud.commandframework.annotations.CommandDescription;
 import cloud.commandframework.annotations.CommandMethod;
 import cloud.commandframework.annotations.CommandPermission;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.restart.CancelRestartEvent;
 import tc.oc.pgm.restart.RestartManager;
 import tc.oc.pgm.start.StartMatchModule;
 import tc.oc.pgm.timelimit.TimeLimitCountdown;
 import tc.oc.pgm.timelimit.TimeLimitMatchModule;
 import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.named.NameStyle;
 
 public final class CancelCommand {
 
   @CommandMethod("cancel|cancelrestart|cr")
   @CommandDescription("Cancels all countdowns")
   @CommandPermission(Permissions.STOP)
-  public void cancel(Audience audience, Match match) {
+  public void cancel(CommandSender sender, Audience audience, Match match) {
     if (RestartManager.isQueued()) {
       match.callEvent(new CancelRestartEvent());
       audience.sendMessage(translatable("admin.cancelRestart.restartUnqueued", NamedTextColor.RED));
@@ -35,6 +39,7 @@ public final class CancelCommand {
 
     match.getCountdown().cancelAll();
     match.needModule(StartMatchModule.class).setAutoStart(false);
-    audience.sendMessage(translatable("admin.cancelCountdowns", NamedTextColor.GREEN));
+    ChatDispatcher.broadcastAdminChatMessage(
+        translatable("admin.cancelCountdowns.announce", player(sender, NameStyle.FANCY)), match);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/FreeForAllCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/FreeForAllCommand.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.command;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.util.player.PlayerComponent.player;
 
 import cloud.commandframework.annotations.Argument;
 import cloud.commandframework.annotations.CommandDescription;
@@ -9,9 +10,12 @@ import cloud.commandframework.annotations.CommandMethod;
 import cloud.commandframework.annotations.CommandPermission;
 import com.google.common.collect.Range;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
 import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.ffa.FreeForAllMatchModule;
-import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.listeners.ChatDispatcher;
+import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextParser;
 
 @CommandMethod("ffa|players")
@@ -21,26 +25,45 @@ public final class FreeForAllCommand {
   @CommandDescription("Set the min players")
   @CommandPermission(Permissions.RESIZE)
   public void min(
-      Audience audience, FreeForAllMatchModule ffa, @Argument("min-players") int minPlayers) {
+      Match match,
+      CommandSender sender,
+      FreeForAllMatchModule ffa,
+      @Argument("min-players") int minPlayers) {
     TextParser.assertInRange(minPlayers, Range.atLeast(0));
 
     ffa.setMinPlayers(minPlayers);
-    sendResizedMessage(audience, "min", ffa.getMinPlayers());
+    sendResizedMessage(match, sender, "min", ffa.getMinPlayers());
   }
 
   @CommandMethod("min reset")
   @CommandDescription("Reset the min players")
   @CommandPermission(Permissions.RESIZE)
-  public void min(Audience audience, FreeForAllMatchModule ffa) {
+  public void min(Match match, CommandSender sender, FreeForAllMatchModule ffa) {
     ffa.setMinPlayers(null);
-    sendResizedMessage(audience, "min", ffa.getMinPlayers());
+    sendResizedMessage(match, sender, "min", ffa.getMinPlayers());
+  }
+
+  @CommandMethod("scale <factor>")
+  @CommandDescription("Scale the max players by a given factor")
+  @CommandPermission(Permissions.RESIZE)
+  public void max(
+      Match match,
+      CommandSender sender,
+      FreeForAllMatchModule ffa,
+      @Argument("factor") double scale) {
+    int maxOverfill = (int) (ffa.getMaxOverfill() * scale);
+    int maxSize = (int) (ffa.getMaxPlayers() * scale);
+    ffa.setMaxPlayers(maxSize, maxOverfill);
+
+    sendResizedMessage(match, sender, "max", ffa.getMaxPlayers());
   }
 
   @CommandMethod("max <max-players> [max-overfill]")
   @CommandDescription("Set the max players")
   @CommandPermission(Permissions.RESIZE)
   public void max(
-      Audience audience,
+      Match match,
+      CommandSender sender,
       FreeForAllMatchModule ffa,
       @Argument("max-players") int maxPlayers,
       @Argument("max-overfill") Integer maxOverfill) {
@@ -51,22 +74,24 @@ public final class FreeForAllCommand {
 
     ffa.setMaxPlayers(maxPlayers, maxOverfill);
 
-    sendResizedMessage(audience, "max", ffa.getMaxPlayers());
+    sendResizedMessage(match, sender, "max", ffa.getMaxPlayers());
   }
 
   @CommandMethod("max reset")
   @CommandDescription("Reset the max players")
   @CommandPermission(Permissions.RESIZE)
-  public void max(Audience audience, FreeForAllMatchModule ffa) {
+  public void max(Match match, CommandSender sender, FreeForAllMatchModule ffa) {
     ffa.setMaxPlayers(null, null);
-    sendResizedMessage(audience, "max", ffa.getMaxPlayers());
+    sendResizedMessage(match, sender, "max", ffa.getMaxPlayers());
   }
 
-  private void sendResizedMessage(Audience audience, String type, int value) {
-    audience.sendMessage(
+  private void sendResizedMessage(Match match, CommandSender sender, String type, int value) {
+    ChatDispatcher.broadcastAdminChatMessage(
         translatable(
-            "match.resize." + type,
+            "match.resize.announce." + type,
+            player(sender, NameStyle.FANCY),
             translatable("match.info.players", NamedTextColor.YELLOW),
-            text(value, NamedTextColor.AQUA)));
+            text(value, NamedTextColor.AQUA)),
+        match);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/StartCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/StartCommand.java
@@ -1,6 +1,8 @@
 package tc.oc.pgm.command;
 
 import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.util.player.PlayerComponent.player;
+import static tc.oc.pgm.util.text.TemporalComponent.duration;
 import static tc.oc.pgm.util.text.TextException.exception;
 
 import cloud.commandframework.annotations.Argument;
@@ -8,12 +10,16 @@ import cloud.commandframework.annotations.CommandDescription;
 import cloud.commandframework.annotations.CommandMethod;
 import cloud.commandframework.annotations.CommandPermission;
 import java.time.Duration;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.start.StartCountdown;
 import tc.oc.pgm.start.StartMatchModule;
 import tc.oc.pgm.start.UnreadyReason;
 import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.named.NameStyle;
 
 public final class StartCommand {
 
@@ -22,6 +28,7 @@ public final class StartCommand {
   @CommandPermission(Permissions.START)
   public void start(
       Audience audience,
+      CommandSender sender,
       Match match,
       StartMatchModule start,
       @Argument("duration") Duration duration) {
@@ -41,5 +48,11 @@ public final class StartCommand {
 
     match.getCountdown().cancelAll(StartCountdown.class);
     start.forceStartCountdown(duration, null);
+    ChatDispatcher.broadcastAdminChatMessage(
+        translatable(
+            "admin.start.announce",
+            player(sender, NameStyle.FANCY),
+            duration(duration, NamedTextColor.AQUA)),
+        match);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/TimeLimitCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/TimeLimitCommand.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.command;
 
 import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
+import static tc.oc.pgm.util.player.PlayerComponent.player;
 import static tc.oc.pgm.util.text.TemporalComponent.clock;
 
 import cloud.commandframework.annotations.Argument;
@@ -11,12 +12,14 @@ import cloud.commandframework.annotations.CommandPermission;
 import java.time.Duration;
 import java.util.Optional;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.VictoryCondition;
+import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.timelimit.TimeLimit;
 import tc.oc.pgm.timelimit.TimeLimitMatchModule;
-import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.named.NameStyle;
 
 public final class TimeLimitCommand {
 
@@ -25,7 +28,7 @@ public final class TimeLimitCommand {
       "Start a time limit. Result can be 'default', 'objectives', 'tie', or the name of a team")
   @CommandPermission(Permissions.GAMEPLAY)
   public void timelimit(
-      Audience audience,
+      CommandSender sender,
       Match match,
       TimeLimitMatchModule time,
       @Argument("duration") Duration duration,
@@ -45,11 +48,12 @@ public final class TimeLimitCommand {
             true));
     time.start();
 
-    audience.sendMessage(
+    ChatDispatcher.broadcastAdminChatMessage(
         translatable(
-            "match.timeLimit.commandOutput",
-            NamedTextColor.YELLOW,
+            "match.timeLimit.announce.commandOutput",
+            player(sender, NameStyle.FANCY),
             clock(duration).color(NamedTextColor.AQUA),
-            result.map(r -> r.getDescription(match)).orElse(translatable("misc.unknown"))));
+            result.map(r -> r.getDescription(match)).orElse(translatable("misc.unknown"))),
+        match);
   }
 }

--- a/util/src/main/i18n/templates/join.properties
+++ b/util/src/main/i18n/templates/join.properties
@@ -12,10 +12,11 @@ join.ok.moved = You were moved to {0} to balance team sizes
 
 join.ok.moved.explanation = (you didn't choose a team, so we assumed you wouldn't mind)
 
-# {0} = player name
-# {1} = new team name (e.g. "Green Team")
-# {2} = old team name (e.g. "Observers")
-join.ok.force = {0} forced onto {1} from {2}
+# {0} = player name (who forced the player)
+# {1} = player name (who was forced)
+# {2} = new team name (e.g. "Green Team")
+# {3} = old team name (e.g. "Observers")
+join.ok.force.announce = {0} forced {1} onto {2} from {3}
 
 # {0} = "1"
 join.wait.singular = Waiting for {0} more player to join

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -129,20 +129,26 @@ match.shuffle.ok = Teams successfully shuffled.
 
 match.shuffle.err = You may not shuffle teams during a match.
 
-# {0} = old team name (e.g. "Blue Team")
-# {1} = new team name (e.g. "Cool Team")
-match.alias.ok = {0} successfully renamed to {1}
+# {0} = player name
+match.shuffle.announce.ok = {0} shuffled the teams.
 
 # {0} = team name (e.g. "Red Team")
 match.alias.err = A team by the name of {0} already exists.
 
-# {0} = team name (e.g. "Green Team")
-# {1} = max number of players
-match.resize.max = {0} now has a maximum size of {1} players
+# {0} = player name
+# {1} = old team name (e.g. "Blue Team")
+# {2} = new team name (e.g. "Cool Team")
+match.alias.announce.ok = {0} renamed {1} to {2}
 
-# {0} = team name (e.g. "Green Team")
-# {1} = min number of players
-match.resize.min = {0} now has a minimum size of {1} players
+# {0} = player name
+# {1} = team name (e.g. "Green Team")
+# {2} = max number of players
+match.resize.announce.max = {0} set the maximum size of {1} to {2} players
+
+# {0} = player name
+# {1} = team name (e.g. "Green Team")
+# {2} = max number of players
+match.resize.announce.min = {0} set the minimum size of {1} to {2} players
 
 # {0} = duration in colon format (e.g. "13:37" for 13 minutes and 37 seconds left)
 match.timeLimit.generic = match ends after {0}
@@ -151,9 +157,10 @@ match.timeLimit.generic = match ends after {0}
 # {1} = some criteria to win the match (e.g. "most survivors", "highest score", "most objectives")
 match.timeLimit.result = {1} after {0}
 
-# {0} = duration in colon format
-# {1} = some criteria to win the match
-match.timeLimit.commandOutput = The time limit is {0} with the result {1}
+# {0} = player name
+# {1} = duration in colon format
+# {2} = some criteria to win the match
+match.timeLimit.announce.commandOutput = {0} set the time limit for {1} with the result {2}
 
 match.error.noMatch = There is no match running at this time
 
@@ -191,7 +198,8 @@ countdown.restart = Server restarting in {0}
 
 admin.reloadConfig = Configuration reloaded
 
-admin.cancelCountdowns = All countdowns cancelled.
+# {0} = who cancelled all countdowns
+admin.cancelCountdowns.announce = {0} cancelled all countdowns.
 
 admin.autoStart.enabled = Auto-start enabled for this match
 
@@ -214,6 +222,10 @@ admin.start.matchRunning = Match is already running.
 admin.start.matchFinished = Match has finished and may not be resumed.
 
 admin.start.unknownState = Match could not be started at this time.
+
+# {0} = Who started the match
+# {1} = time until the match start
+admin.start.announce = {0} set the match to start in {1}
 
 admin.end.unknownError = Match could not be ended at this time.
 


### PR DESCRIPTION
Adds a team / ffa scale command to proportionally scale team sizes to their current sizes.
- `/team scale <team> <factor>`
- `/ffa scale <factor>`

Also moves command feedback for certain commands to admin chat.
These are:
- Team management commands
- `/cancel`
- `/start`
- `/timelimit`
