### PR TITLE
Add new settings and missing translatables

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -36,7 +36,8 @@ public enum SettingKey implements Aliased {
       Material.LEATHER_HELMET,
       PICKER_AUTO,
       PICKER_ON,
-      PICKER_OFF), // Changes when the picker is displayed
+      PICKER_OFF,
+      PICKER_MANUAL), // Changes when the picker is displayed
   JOIN(
       Arrays.asList("join", "jms"),
       Material.WOOD_DOOR,
@@ -64,6 +65,7 @@ public enum SettingKey implements Aliased {
       "sounds",
       Material.NOTE_BLOCK,
       SOUNDS_ALL,
+      SOUNDS_CHAT,
       SOUNDS_DM,
       SOUNDS_NONE), // Changes when sounds are played
   VOTE(

--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -19,9 +19,10 @@ public enum SettingValue {
   DEATH_FRIENDS(
       "death", "friends", DyeColor.GREEN), // Only send death messages involving yourself or friends
 
-  PICKER_AUTO("picker", "auto", DyeColor.ORANGE), // Display after cycle, or with permissions.
+  PICKER_AUTO("picker", "auto", DyeColor.ORANGE), // Display after cycle, or with permissions
   PICKER_ON("picker", "on", DyeColor.GREEN), // Display the picker GUI always
   PICKER_OFF("picker", "off", DyeColor.RED), // Never display the picker GUI
+  PICKER_MANUAL("picker", "manual", DyeColor.WHITE), // Only display the picker GUI if right clicked
 
   JOIN_ON("join", "all", DyeColor.ORANGE), // Send all join messages
   JOIN_FRIENDS("join", "friends", DyeColor.GREEN), // Only send friend join messages
@@ -36,7 +37,8 @@ public enum SettingValue {
   OBSERVERS_OFF("observers", "none", DyeColor.RED), // Hide observers
 
   SOUNDS_ALL("sounds", "all", DyeColor.GREEN), // Play all sounds
-  SOUNDS_DM("sounds", "messages", DyeColor.ORANGE), // Only play DM sounds
+  SOUNDS_CHAT("sounds", "chat", DyeColor.ORANGE), // Only play DM and admin sounds
+  SOUNDS_DM("sounds", "messages", DyeColor.YELLOW), // Only play DM sounds
   SOUNDS_NONE("sounds", "none", DyeColor.RED), // Never play sounds
 
   VOTE_ON("vote", "on", DyeColor.GREEN), // Show the vote book on cycle

--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -22,7 +22,6 @@ public enum SettingValue {
   PICKER_AUTO("picker", "auto", DyeColor.ORANGE), // Display after cycle, or with permissions
   PICKER_ON("picker", "on", DyeColor.GREEN), // Display the picker GUI always
   PICKER_OFF("picker", "off", DyeColor.RED), // Never display the picker GUI
-  PICKER_MANUAL("picker", "manual", DyeColor.WHITE), // Only display the picker GUI if right clicked
 
   JOIN_ON("join", "all", DyeColor.ORANGE), // Send all join messages
   JOIN_FRIENDS("join", "friends", DyeColor.GREEN), // Only send friend join messages
@@ -37,7 +36,6 @@ public enum SettingValue {
   OBSERVERS_OFF("observers", "none", DyeColor.RED), // Hide observers
 
   SOUNDS_ALL("sounds", "all", DyeColor.GREEN), // Play all sounds
-  SOUNDS_CHAT("sounds", "chat", DyeColor.ORANGE), // Only play DM and admin sounds
   SOUNDS_DM("sounds", "messages", DyeColor.YELLOW), // Only play DM sounds
   SOUNDS_NONE("sounds", "none", DyeColor.RED), // Never play sounds
 
@@ -52,7 +50,10 @@ public enum SettingValue {
 
   TIME_AUTO("time", "auto", DyeColor.ORANGE), // Player time is in sync
   TIME_DARK("time", "dark", DyeColor.GRAY), // Player time is always set to midday
-  TIME_LIGHT("time", "light", DyeColor.WHITE); // Player time is always set to midnight
+  TIME_LIGHT("time", "light", DyeColor.WHITE), // Player time is always set to midnight
+
+  PICKER_MANUAL("picker", "manual", DyeColor.WHITE), // Only display the picker GUI if right clicked
+  SOUNDS_CHAT("sounds", "chat", DyeColor.ORANGE); // Only play DM and admin sounds
 
   private final String key;
   private final String name;

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -420,6 +420,7 @@ public class ChatDispatcher implements Listener {
   public static void playSound(MatchPlayer player, Sound sound) {
     SettingValue value = player.getSettings().getValue(SettingKey.SOUNDS);
     if (value.equals(SettingValue.SOUNDS_ALL)
+        || value.equals(SettingValue.SOUNDS_CHAT)
         || (sound.equals(DM_SOUND) && value.equals(SettingValue.SOUNDS_DM))) {
       player.playSound(sound);
     }

--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -132,6 +132,8 @@ public class PickerMatchModule implements MatchModule, Listener {
         return false;
       case PICKER_ON: // When on always show the GUI
         return true;
+      case PICKER_MANUAL: // Only show the GUI when right clicked
+        return playerTriggered;
       default: // Display after map cycle, but check perms when clicking button.
         return !playerTriggered || hasPermission || hasClasses;
     }

--- a/util/src/main/i18n/templates/ui.properties
+++ b/util/src/main/i18n/templates/ui.properties
@@ -75,6 +75,8 @@ settings.death.all = View all death messages
 
 settings.death.own = View own death messages only
 
+settings.death.friends = Only view death messages from friends
+
 settings.picker = Changes when the picker is displayed
 
 settings.picker.auto = Automatically display picker based on match
@@ -83,9 +85,13 @@ settings.picker.on = Always display the picker
 
 settings.picker.off = Never display the picker
 
+settings.picker.manual = Only display the picker when right clicked
+
 settings.join = Changes when join messages are sent
 
 settings.join.on = View all join messages
+
+settings.join.friends = Only view join messages from friends
 
 settings.join.off = Hide all join messages
 
@@ -93,17 +99,23 @@ settings.message = Changes if private messages are accepted
 
 settings.message.on = Accept all private messages
 
+settings.message.friend = Only accept private messages from friends
+
 settings.message.off = Reject all private messages
 
 settings.observers = Changes if observers are visible
 
 settings.observers.on = Show all observers
 
+settings.observers.friend = Only show observer friends
+
 settings.observers.off = Hide other observers
 
 settings.sounds = Changes when sounds are played
 
 settings.sounds.all = Hear all match sounds
+
+settings.sounds.chat = Only hear chat-related sounds
 
 settings.sounds.dm = Only hear sounds from direct messages
 


### PR DESCRIPTION
Adds 2 new settings:
 - ``PICKER_MANUAL``: Don't show the team picker GUI on cycle, but still allow you to open it if you right click the helmet while you're holding it.
 - ``SOUNDS_CHAT``: Allows you to hear notifications for both DMs _and_ Admin Chat messages, but not match sounds.

This commit also adds strings for previously untranslated settings related to Friends (like ``settings.death.friends``)

![image](https://github.com/PGMDev/PGM/assets/11651753/7d173f2e-437f-4408-a72a-a1bef08db430)

All changes have been tested.