### PR TITLE
Variant improvements in pools & map command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.api.map;
 
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.Map;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.Nullable;
@@ -24,8 +25,14 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
    *
    * @return A variant for the map, if any.
    */
-  @Nullable
-  String getVariant();
+  String getVariantId();
+
+  /**
+   * Get all the variants available for the map
+   *
+   * @return a map of variants by their variant id
+   */
+  Map<String, VariantInfo> getVariants();
 
   /** @return the subfolder in which the world is in, or null for the parent folder */
   @Nullable
@@ -186,5 +193,15 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   @Override
   default int compareTo(MapInfo o) {
     return getId().compareTo(o.getId());
+  }
+
+  interface VariantInfo {
+    String getVariantId();
+
+    String getMapId();
+
+    String getMapName();
+
+    String getWorld();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapSource.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
 import tc.oc.pgm.map.source.MapRoot;
@@ -13,6 +12,7 @@ import tc.oc.pgm.map.source.MapRoot;
 /** A source where {@link MapInfo} documents and files are downloaded. */
 public interface MapSource {
   Path FILE = Paths.get("map.xml");
+  String DEFAULT_VARIANT = "default";
 
   /**
    * Get a unique identifier for the source, should be human-readable.
@@ -24,10 +24,9 @@ public interface MapSource {
   /**
    * The variant of the map this is for
    *
-   * @return the variant the source, null for the parent source
+   * @return the variant the source, DEFAULT_VARIANT for the parent source
    */
-  @Nullable
-  String getVariant();
+  String getVariantId();
 
   /**
    * A copy of the map source, tailored to a specific variant

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TextComponent.Builder;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -277,6 +278,10 @@ public final class MapCommand {
       }
     }
 
+    if (map.getVariants().size() > 1) {
+      audience.sendMessage(formatVariants(map));
+    }
+
     if (!map.getSource().getRoot().isPrivate() || sender.hasPermission(Permissions.DEBUG)) {
       audience.sendMessage(formatMapSource(sender, map));
     }
@@ -356,8 +361,35 @@ public final class MapCommand {
   private Component mapInfoLabel(String key) {
     return text()
         .append(translatable(key, NamedTextColor.DARK_PURPLE, TextDecoration.BOLD))
-        .append(text(": "))
+        .append(text(": ", NamedTextColor.WHITE))
         .build();
+  }
+
+  private ComponentLike formatVariants(MapInfo map) {
+    TextComponent.Builder text =
+        text().append(mapInfoLabel("map.info.variants")).color(NamedTextColor.GOLD);
+
+    for (MapInfo.VariantInfo variant : map.getVariants().values()) {
+      TextComponent variantComp;
+      if (map.getVariantId().equals(variant.getVariantId())) {
+        variantComp =
+            text(variant.getVariantId(), null, TextDecoration.UNDERLINED)
+                .hoverEvent(
+                    showText(translatable("map.info.variants.current", NamedTextColor.GRAY)));
+      } else {
+        variantComp =
+            text(variant.getVariantId())
+                .hoverEvent(
+                    showText(
+                        translatable(
+                            "command.maps.hover",
+                            NamedTextColor.GRAY,
+                            text(variant.getMapName(), NamedTextColor.GOLD))))
+                .clickEvent(runCommand("/map " + variant.getMapName()));
+      }
+      text.append(variantComp).append(text(" "));
+    }
+    return text;
   }
 
   @NotNull

--- a/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
@@ -54,7 +54,7 @@ public class MapFilePreprocessor {
   private MapFilePreprocessor(MapSource source, MapIncludeProcessor includeProcessor) {
     this.source = source;
     this.includeProcessor = includeProcessor;
-    this.variant = source.getVariant() == null ? "default" : source.getVariant();
+    this.variant = source.getVariantId();
     this.includes = new ArrayList<>();
     this.constants = new HashMap<>();
   }

--- a/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.map;
 
+import static tc.oc.pgm.api.map.MapSource.DEFAULT_VARIANT;
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import java.util.Collections;
@@ -202,7 +203,7 @@ public class MapLibraryImpl implements MapLibrary {
       context = factory.load();
 
       // We're not loading a specific map id, and we're not on a variant, load variants
-      if (mapId == null && source.getVariant() == null) {
+      if (mapId == null && DEFAULT_VARIANT.equals(source.getVariantId())) {
         for (String variant : factory.getVariants()) {
           loadMapSafe(source.asVariant(variant), null);
         }

--- a/core/src/main/java/tc/oc/pgm/map/source/SystemMapSource.java
+++ b/core/src/main/java/tc/oc/pgm/map/source/SystemMapSource.java
@@ -114,8 +114,8 @@ class SystemMapSource implements MapSource {
   }
 
   @Override
-  public String getVariant() {
-    return variant;
+  public String getVariantId() {
+    return variant == null ? DEFAULT_VARIANT : variant;
   }
 
   @Override

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -23,9 +23,12 @@ pools:
     dynamic: true
     players: 1
     
-    # How long should should a map cycle last?
+    # How long should a map cycle last?
     cycle-time: "15s"
 
+    # Map variants to use, in order, if they exist
+    variants:
+      - default
 
     # Voted pools support modifiers which come in the form of a formula (does not affect any other type of pool).
     #

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -45,6 +45,10 @@ map.info.source = Source
 
 map.info.folder = Folder
 
+map.info.variants = Variants
+
+map.info.variants.current = Current variant
+
 map.info.pools = Pools
 
 map.info.objective = Objective


### PR DESCRIPTION
Adds an option for pools to specify a list of variants, the maps will try to load their variants if any are available, in order:

```yml
pools:
  halloween:
    # Other stuff omitted for clarity
    variants:
      - halloween
      - hallo
    maps:
      - Map A
      - Map B
```

If any of the maps Map A or Map B have a variant with id "halloween", it will load that instead. If it doesn't have one of those, it will fall-back to "hallo", and if all fails it will end up with the default variant of the map.

Variants now also show up in /map, and you can click to look thru them:
![image](https://github.com/PGMDev/PGM/assets/11789291/f71ab338-1bc9-485d-ad31-ddea360927c4)


Additionally, added a `has-variant` conditional:
```xml
<if has-variant="halloween">
  <unless variant="halloween">
    <phase>development</phase>
  </unless>
</if>
```
If put in the global xml, this would automatically dev-phase all non-halloween variants, for maps that have a halloween variant.
