### PR TITLE
Improve killrewards, support action & victim action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -117,6 +117,11 @@ public class ActionParser {
   }
 
   public <B extends Filterable<?>> Action<? super B> parseProperty(
+      @Nullable Node node, Class<B> bound, Action<? super B> def) throws InvalidXMLException {
+    return node == null ? def : parseProperty(node, bound);
+  }
+
+  public <B extends Filterable<?>> Action<? super B> parseProperty(
       @NotNull Node node, Class<B> bound) throws InvalidXMLException {
     if (node.isAttribute()) return this.parseReference(node, bound);
 

--- a/core/src/main/java/tc/oc/pgm/killreward/KillReward.java
+++ b/core/src/main/java/tc/oc/pgm/killreward/KillReward.java
@@ -2,17 +2,24 @@ package tc.oc.pgm.killreward;
 
 import com.google.common.collect.ImmutableList;
 import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.action.Action;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.api.player.MatchPlayer;
 
 public class KillReward {
   public final ImmutableList<ItemStack> items;
   public final Filter filter;
-  public final Kit kit;
+  public final Action<? super MatchPlayer> action;
+  public final Action<? super MatchPlayer> victimAction;
 
-  public KillReward(ImmutableList<ItemStack> items, Filter filter, Kit kit) {
+  public KillReward(
+      ImmutableList<ItemStack> items,
+      Filter filter,
+      Action<? super MatchPlayer> action,
+      Action<? super MatchPlayer> victimAction) {
     this.items = items;
     this.filter = filter;
-    this.kit = kit;
+    this.action = action;
+    this.victimAction = victimAction;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/KitNode.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitNode.java
@@ -70,5 +70,5 @@ public class KitNode extends AbstractKit {
   }
 
   public static final KitNode EMPTY =
-      new KitNode(Collections.<Kit>emptyList(), StaticFilter.ALLOW, null, null);
+      new KitNode(Collections.emptyList(), StaticFilter.ALLOW, null, null);
 }

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -355,10 +355,10 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     List<ItemStack> displacedItems = new ArrayList<>();
     kit.apply(this, force, displacedItems);
 
-    if (displacedItems.size() > 0) {
+    if (!displacedItems.isEmpty()) {
       Collection<ItemStack> leftover =
           getInventory().addItem(displacedItems.toArray(new ItemStack[0])).values();
-      if (leftover.size() > 0) {
+      if (!leftover.isEmpty()) {
         kit.applyLeftover(this, new ArrayList<>(leftover));
       }
     }


### PR DESCRIPTION
This pull request adds some general improvements to killrewards, to add native support for `action`s (instead of needing to wrap them in a kit).

## Added victim-action

```xml
<kill-rewards>
  <kill-reward filter="red-team" victim-action="some-action" />
</kill-rewards>
```
Runs `some-action` on the victim whenever they're killed by someone from red team.

## Added support for 'action' instead of 'kit'

Example of diff ways of defining killrewards:
```xml
<map>
<kits>
  <kit id="some-kit">
      <item>diamond</item>
  </kit>
  <kit id="some-kit-with-action">
      <action>
        <set var="some_variable" value="1"/>
      </action>
  </kit>
</kits>
<actions>
  <set id="some-action" var="some_variable" value="1"/>
</actions>
<kill-rewards>
  <!-- Previously supported (and still supported) syntax: -->
  <!-- Kits defined as a reference -->
  <kill-reward kit="some-kit"/>
  <kill-reward kit="some-kit-with-action"/>
  <!-- Inline defined kits, and kit with an action -->
  <kill-reward>
    <kit>
      <item>diamond</item>
    </kit>
  </kill-reward>
  <kill-reward>
    <kit>
      <action>
        <set var="some_variable" value="1"/>
      </action>
    </kit>
  </kill-reward>
  
  <!-- Newly allowed syntax forward: -->
  <!-- Kits and actions defined as references. -->
  <kill-reward action="some-kit" /> <!-- Kits are a type of action so they can be used as an action just fine -->
  <kill-reward action="some-action" />
  <!-- Inline defined actions -->
  <kill-reward>
    <action>
      <set var="some_variable" value="1"/>
    </action>
  </kill-reward>
</kill-rewards>
</map>
```
Keep in mind action and kit are mutually exclusive, you can only use one or the other.



