### PR TITLE
Move playEffect usage to NMSHacks

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.UUID;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.event.EventHandler;
@@ -34,6 +33,7 @@ import tc.oc.pgm.events.PlayerParticipationStartEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.join.JoinRequest;
 import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
 public class BlitzMatchModule implements MatchModule, Listener {
@@ -165,7 +165,7 @@ public class BlitzMatchModule implements MatchModule, Listener {
       Location base =
           death.clone().add(new Vector(radius * Math.cos(angle), 0, radius * Math.sin(angle)));
       for (int j = 0; j <= 8; j++) {
-        world.playEffect(base, Effect.SMOKE, j);
+        NMSHacks.showBlitzSmoke(world, base, j);
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
@@ -36,7 +36,6 @@ import tc.oc.pgm.util.block.RayBlockIntersection;
 import tc.oc.pgm.util.event.PlayerPunchBlockEvent;
 import tc.oc.pgm.util.event.PlayerTrampleBlockEvent;
 import tc.oc.pgm.util.event.entity.EntityDespawnInVoidEvent;
-import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
@@ -265,7 +264,7 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
     replaceBlock(drops, hit.getBlock(), player);
     Location location = hit.getPosition().toLocation(hit.getBlock().getWorld());
 
-    Materials.playBreakEffect(location, oldMaterial);
+    NMSHacks.playBreakEffect(location, oldMaterial);
     dropObjects(drops, player, location, 1d, false);
   }
 

--- a/core/src/main/java/tc/oc/pgm/flag/state/Spawned.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Spawned.java
@@ -1,13 +1,12 @@
 package tc.oc.pgm.flag.state;
 
-import org.bukkit.Effect;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.flag.Post;
 import tc.oc.pgm.flag.event.FlagCaptureEvent;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 /**
  * Base class for flag states in which the banner is physically present somewhere in the map (i.e.
@@ -56,20 +55,8 @@ public abstract class Spawned extends BaseState {
     if (this.flag.getDefinition().showBeam()) {
       for (MatchPlayer player : flag.getMatch().getPlayers()) {
         if (this.canSeeParticles(player.getBukkit())) {
-          player
-              .getBukkit()
-              .spigot()
-              .playEffect(
-                  this.getLocation().clone().add(0, 56, 0),
-                  Effect.TILE_DUST,
-                  Material.WOOL.getId(),
-                  flag.getDyeColor().getWoolData(),
-                  0.15f, // radius on each axis of the particle ball
-                  24f,
-                  0.15f,
-                  0f, // initial horizontal velocity
-                  40, // number of particles
-                  200); // radius in blocks to show particles
+          NMSHacks.showSpawnedFlagParticles(
+              player.getBukkit(), this.getLocation(), flag.getDyeColor());
         }
       }
     }

--- a/core/src/main/java/tc/oc/pgm/modules/ProjectileTrailMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ProjectileTrailMatchModule.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.modules;
 
 import java.util.concurrent.TimeUnit;
 import org.bukkit.Color;
-import org.bukkit.Effect;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -22,6 +21,7 @@ import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
 public class ProjectileTrailMatchModule implements MatchModule, Listener {
@@ -58,39 +58,20 @@ public class ProjectileTrailMatchModule implements MatchModule, Listener {
                           .getSettings()
                           .getValue(SettingKey.EFFECTS)
                           .equals(SettingValue.EFFECTS_ON);
-                  if (colors) {
-                    player
-                        .getBukkit()
-                        .spigot()
-                        .playEffect(
-                            projectile.getLocation(),
-                            Effect.COLOURED_DUST,
-                            0,
-                            0,
-                            rgbToParticle(color.getRed()),
-                            rgbToParticle(color.getGreen()),
-                            rgbToParticle(color.getBlue()),
-                            1,
-                            0,
-                            50);
+                  if (colors && color != null) {
+                    NMSHacks.showColoredArrowParticles(
+                        player.getBukkit(), projectile.getLocation(), color);
                   } else {
                     // Play the critical effect to those who have effects off, to replicate original
                     // arrow behavior
                     if (isCriticalArrow(projectile)) {
-                      player
-                          .getBukkit()
-                          .spigot()
-                          .playEffect(
-                              projectile.getLocation(), Effect.CRIT, 0, 0, 0, 0, 0, 1, 0, 50);
+                      NMSHacks.showCriticalArrowParticles(
+                          player.getBukkit(), projectile.getLocation());
                     }
                   }
                 }
               }
             });
-  }
-
-  private float rgbToParticle(int rgb) {
-    return Math.max(0.001f, (rgb / 255.0f));
   }
 
   private boolean isCriticalArrow(Projectile projectile) {

--- a/core/src/main/java/tc/oc/pgm/payload/Payload.java
+++ b/core/src/main/java/tc/oc/pgm/payload/Payload.java
@@ -3,7 +3,6 @@ package tc.oc.pgm.payload;
 import java.time.Duration;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Minecart;
@@ -16,6 +15,7 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.controlpoint.ControlPoint;
 import tc.oc.pgm.payload.track.Track;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 public class Payload extends ControlPoint {
 
@@ -110,25 +110,8 @@ public class Payload extends ControlPoint {
           height,
           definition.getRadius() * Math.sin(angle));
       loc.add(position);
-      match
-          .getWorld()
-          .spigot()
-          .playEffect(
-              loc,
-              Effect.COLOURED_DUST,
-              0,
-              (byte) 0,
-              rgbToParticle(color.getRed()),
-              rgbToParticle(color.getGreen()),
-              rgbToParticle(color.getBlue()),
-              1,
-              0,
-              50);
+      NMSHacks.showPayloadParticles(match.getWorld(), loc, color);
     }
-  }
-
-  private float rgbToParticle(int rgb) {
-    return (float) Math.max(0.001, rgb / 255.0);
   }
 
   private void tickMinecart() {

--- a/core/src/main/java/tc/oc/pgm/renewable/Renewable.java
+++ b/core/src/main/java/tc/oc/pgm/renewable/Renewable.java
@@ -29,7 +29,6 @@ import tc.oc.pgm.util.block.BlockFaces;
 import tc.oc.pgm.util.block.BlockVectorSet;
 import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.material.MaterialCounter;
-import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.nms.NMSHacks;
 
 public class Renewable implements Listener, Tickable {
@@ -276,7 +275,7 @@ public class Renewable implements Listener, Tickable {
     newState.update(true, true);
 
     if (definition.particles || definition.sound) {
-      Materials.playBreakEffect(location, material);
+      NMSHacks.playBreakEffect(location, material);
     }
 
     return true;

--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.spawner;
 
 import java.util.Objects;
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -22,6 +21,7 @@ import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
 import tc.oc.pgm.util.bukkit.OnlinePlayerMapAdapter;
 import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
+import tc.oc.pgm.util.nms.NMSHacks;
 
 public class Spawner implements Listener, Tickable {
 
@@ -51,7 +51,7 @@ public class Spawner implements Listener, Tickable {
         final Location location =
             definition.spawnRegion.getRandom(match.getRandom()).toLocation(match.getWorld());
         spawnable.spawn(location, match);
-        match.getWorld().spigot().playEffect(location, Effect.FLAME, 0, 0, 0, 0.15f, 0, 0, 40, 64);
+        NMSHacks.showSpawnerFlameParticles(match.getWorld(), location);
         spawnedEntities = spawnedEntities + spawnable.getSpawnCount();
       }
       calculateDelay();

--- a/core/src/main/java/tc/oc/pgm/tntrender/TNTRenderMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tntrender/TNTRenderMatchModule.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.TNTPrimed;
@@ -53,10 +52,7 @@ public class TNTRenderMatchModule implements MatchModule, Listener {
     Location explosion = event.getLocation();
     for (MatchPlayer player : match.getPlayers()) {
       if (explosion.distanceSquared(player.getBukkit().getLocation()) >= MAX_DISTANCE)
-        player
-            .getBukkit()
-            .spigot()
-            .playEffect(explosion, Effect.EXPLOSION_HUGE, 0, 0, 0f, 0f, 0f, 1f, 1, 256);
+        NMSHacks.showHugeExplosionParticle(player.getBukkit(), explosion);
     }
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.util.material;
 
 import org.bukkit.Bukkit;
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Banner;
@@ -257,12 +256,5 @@ public interface Materials {
     location.setYaw(
         BlockFaces.faceToYaw(((org.bukkit.material.Banner) block.getData()).getFacing()));
     return location;
-  }
-
-  static void playBreakEffect(Location location, MaterialData material) {
-    location
-        .getWorld()
-        .playEffect(
-            location, Effect.STEP_SOUND, material.getItemTypeId() + (material.getData() << 12));
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -9,6 +9,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -51,8 +53,8 @@ public interface NMSHacks {
     return ENTITY_IDS.decrementAndGet();
   }
 
-  static void sendPacket(Player bukkitPlayer, Object packet) {
-    INSTANCE.sendPacket(bukkitPlayer, packet);
+  static void sendPacket(Player player, Object packet) {
+    INSTANCE.sendPacket(player, packet);
   }
 
   static void playDeathAnimation(Player player) {
@@ -438,5 +440,37 @@ public interface NMSHacks {
 
   static void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
     INSTANCE.postToMainThread(plugin, priority, task);
+  }
+
+  static void showPayloadParticles(World world, Location loc, Color color) {
+    INSTANCE.showPayloadParticles(world, loc, color);
+  }
+
+  static void playBreakEffect(Location location, MaterialData material) {
+    INSTANCE.playBreakEffect(location, material);
+  }
+
+  static void showSpawnedFlagParticles(Player player, Location location, DyeColor flagDyeColor) {
+    INSTANCE.showSpawnedFlagParticles(player, location, flagDyeColor);
+  }
+
+  static void showBlitzSmoke(World world, Location base, int j) {
+    INSTANCE.showBlitzSmoke(world, base, j);
+  }
+
+  static void showCriticalArrowParticles(Player player, Location projectileLocation) {
+    INSTANCE.showCriticalArrowParticles(player, projectileLocation);
+  }
+
+  static void showColoredArrowParticles(Player player, Location projectileLocation, Color color) {
+    INSTANCE.showColoredArrowParticles(player, projectileLocation, color);
+  }
+
+  static void showSpawnerFlameParticles(World world, Location location) {
+    INSTANCE.showSpawnerFlameParticles(world, location);
+  }
+
+  static void showHugeExplosionParticle(Player player, Location explosion) {
+    INSTANCE.showHugeExplosionParticle(player, explosion);
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksNoOp.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksNoOp.java
@@ -9,6 +9,9 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
+import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -301,5 +304,88 @@ public abstract class NMSHacksNoOp implements NMSHacksPlatform {
   public void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
     // runs the task on the next tick, not a perfect replacement
     plugin.getServer().getScheduler().runTask(plugin, task);
+  }
+
+  float rgbToParticle(int rgb) {
+    return (float) Math.max(0.001, rgb / 255.0);
+  }
+
+  @Override
+  public void showPayloadParticles(World world, Location loc, Color color) {
+    world
+        .spigot()
+        .playEffect(
+            loc,
+            Effect.COLOURED_DUST,
+            0,
+            (byte) 0,
+            rgbToParticle(color.getRed()),
+            rgbToParticle(color.getGreen()),
+            rgbToParticle(color.getBlue()),
+            1,
+            0,
+            50);
+  }
+
+  @Override
+  public void playBreakEffect(Location location, MaterialData material) {
+    location
+        .getWorld()
+        .playEffect(
+            location, Effect.STEP_SOUND, material.getItemTypeId() + (material.getData() << 12));
+  }
+
+  @Override
+  public void showSpawnedFlagParticles(Player player, Location location, DyeColor flagDyeColor) {
+    player
+        .spigot()
+        .playEffect(
+            location.clone().add(0, 56, 0),
+            Effect.TILE_DUST,
+            Material.WOOL.getId(),
+            flagDyeColor.getWoolData(),
+            0.15f, // radius on each axis of the particle ball
+            24f,
+            0.15f,
+            0f, // initial horizontal velocity
+            40, // number of particles
+            200); // radius in blocks to show particles
+  }
+
+  @Override
+  public void showBlitzSmoke(World world, Location base, int j) {
+    world.playEffect(base, Effect.SMOKE, j);
+  }
+
+  @Override
+  public void showCriticalArrowParticles(Player player, Location projectileLocation) {
+    player.spigot().playEffect(projectileLocation, Effect.CRIT, 0, 0, 0, 0, 0, 1, 0, 50);
+  }
+
+  @Override
+  public void showColoredArrowParticles(Player player, Location projectileLocation, Color color) {
+    player
+        .spigot()
+        .playEffect(
+            projectileLocation,
+            Effect.COLOURED_DUST,
+            0,
+            0,
+            rgbToParticle(color.getRed()),
+            rgbToParticle(color.getGreen()),
+            rgbToParticle(color.getBlue()),
+            1,
+            0,
+            50);
+  }
+
+  @Override
+  public void showSpawnerFlameParticles(World world, Location location) {
+    world.spigot().playEffect(location, Effect.FLAME, 0, 0, 0, 0.15f, 0, 0, 40, 64);
+  }
+
+  @Override
+  public void showHugeExplosionParticle(Player player, Location explosion) {
+    player.spigot().playEffect(explosion, Effect.EXPLOSION_HUGE, 0, 0, 0f, 0f, 0f, 1f, 1, 256);
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksPlatform.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksPlatform.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import java.util.UUID;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -39,7 +41,7 @@ import tc.oc.pgm.util.skin.Skin;
 
 public interface NMSHacksPlatform {
 
-  void sendPacket(Player bukkitPlayer, Object packet);
+  void sendPacket(Player player, Object packet);
 
   void sendPacketToViewers(Entity entity, Object packet, boolean excludeSpectators);
 
@@ -208,4 +210,20 @@ public interface NMSHacksPlatform {
   AttributeMap buildAttributeMap(Player player);
 
   void postToMainThread(Plugin plugin, boolean priority, Runnable task);
+
+  void showPayloadParticles(World world, Location loc, Color color);
+
+  void playBreakEffect(Location location, MaterialData material);
+
+  void showSpawnedFlagParticles(Player player, Location location, DyeColor flagDyeColor);
+
+  void showBlitzSmoke(World world, Location base, int j);
+
+  void showCriticalArrowParticles(Player player, Location projectileLocation);
+
+  void showColoredArrowParticles(Player player, Location projectileLocation, Color color);
+
+  void showSpawnerFlameParticles(World world, Location location);
+
+  void showHugeExplosionParticle(Player player, Location explosion);
 }


### PR DESCRIPTION
Moves `playEffect` usage to NMSHacks. This is one of the prerequisites needed for 1.13 support.