### PR TITLE
Allow tablist resize without enabled tablist

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -222,13 +222,13 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
 
     if (config.showTabList()) {
       matchTabManager = new MatchTabManager(this);
+    }
 
-      if (config.resizeTabList()) {
-        if (this.getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
-          TablistResizer.registerAdapter(this);
-        } else {
-          logger.warning("ProtocolLib is required when 'ui.resize' is enabled");
-        }
+    if (config.resizeTabList()) {
+      if (this.getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
+        TablistResizer.registerAdapter(this);
+      } else {
+        logger.warning("ProtocolLib is required when 'ui.resize' is enabled");
       }
     }
 


### PR DESCRIPTION
Currently having the config ui.tablist-resize set to true does nothing if tablist isn't enabled.

There's a valid use-case for this, being that you disable pgm's tablist to install your own overriden config from a separate plugin, but still want to have the resized tablist for 1.7 players