### PR TITLE
Create add attribute for Replace-Item Action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -300,8 +300,12 @@ public class ActionParser {
 
     boolean keepAmount = XMLUtils.parseBoolean(el.getAttribute("keep-amount"), false);
     boolean keepEnchants = XMLUtils.parseBoolean(el.getAttribute("keep-enchants"), false);
+    int add = XMLUtils.parseNumber(el.getAttribute("add"), Integer.class, 0);
+    if (add != 0 && !keepAmount) {
+      throw new InvalidXMLException("keep-amount must be enabled to use add", el);
+    }
 
-    return new ReplaceItemAction(matcher, item, keepAmount, keepEnchants);
+    return new ReplaceItemAction(matcher, item, keepAmount, keepEnchants, add);
   }
 
   @MethodParser("fill")

--- a/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
@@ -12,14 +12,16 @@ public class ReplaceItemAction extends AbstractAction<MatchPlayer> {
   private final ItemStack item;
   private final boolean keepAmount;
   private final boolean keepEnchants;
+  private final int add;
 
   public ReplaceItemAction(
-      ItemMatcher matcher, ItemStack item, boolean keepAmount, boolean keepEnchants) {
+      ItemMatcher matcher, ItemStack item, boolean keepAmount, boolean keepEnchants, int add) {
     super(MatchPlayer.class);
     this.matcher = matcher;
     this.item = item;
     this.keepAmount = keepAmount;
     this.keepEnchants = keepEnchants;
+    this.add = add;
   }
 
   @Override
@@ -45,6 +47,12 @@ public class ReplaceItemAction extends AbstractAction<MatchPlayer> {
     ItemStack newItem = item.clone();
     if (keepAmount) newItem.setAmount(current.getAmount());
     if (keepEnchants) newItem.addEnchantments(current.getEnchantments());
+    if (add != 0) {
+      newItem.setAmount(newItem.getAmount() + add);
+      if (newItem.getAmount() < 0) {
+        newItem.setAmount(0);
+      }
+    }
     ItemModifier.apply(newItem, player);
     return newItem;
   }


### PR DESCRIPTION
This PR adds a simple `add` attribute to the `<replace-item>` Action. This enables the Action to add or take away a certain number of items instead of giving the same amount back to the player. The `keep-amount` attribute must be set to true to use `add`, which takes positive or negative numbers. This lets the map maker do something like redeeming items to buy a kit.

## Example
```xml
<actions>
    <action id="switch-wolf" scope="player">
        <kit id="wolf"/>
        <!-- Gives player 1 emerald if they had 4, etc -->
        <replace-item amount="[3, 64]" add="-3" keep-amount="true">
             <find material="emerald"/>
             <replace material="emerald"/>
        </replace-item>
    </action>
    <trigger filter="redeem-wolf" action="switch-wolf" scope="player"/>
</actions>
<filters>
    <all id="redeem-wolf">
        <region id="wolf-portal"/>
        <carrying>
            <item material="emerald" amount="3"/>
        </carrying>
    </all>
</filters>
```

In this example from my XML adaptation of Hoodoo, players of the Invaders team receive emeralds that they can use to buy a class. After entering the portal with 3 or more emeralds, they are applied the `wolf` kit, 3 emeralds are removed from the player and they are teleported. All extra emeralds they have are given back to the player.