### PR TITLE
Implement parser for inline filters

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -1,6 +1,10 @@
 package tc.oc.pgm.filters.parse;
 
 import com.google.common.collect.Range;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureReference;
@@ -25,11 +29,6 @@ import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 import tc.oc.pgm.variables.VariableDefinition;
 import tc.oc.pgm.variables.VariablesModule;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class FeatureFilterParser extends FilterParser {
 
@@ -126,14 +125,20 @@ public class FeatureFilterParser extends FilterParser {
   private Filter buildFilter(Node node, ParsingNode parsed) throws InvalidXMLException {
     if (parsed.getChildren() == null) return parseReference(node, parsed.getBase());
     switch (parsed.getBase()) {
-      case "all": return AllFilter.of(buildChildren(node, parsed));
-      case "any": return AnyFilter.of(buildChildren(node, parsed));
-      case "one": return OneFilter.of(buildChildren(node, parsed));
-      case "not": return new InverseFilter(buildChild(node, parsed));
-      case "deny": return new DenyFilter(buildChild(node, parsed));
-      case "allow": return new AllowFilter(buildChild(node, parsed));
+      case "all":
+        return AllFilter.of(buildChildren(node, parsed));
+      case "any":
+        return AnyFilter.of(buildChildren(node, parsed));
+      case "one":
+        return OneFilter.of(buildChildren(node, parsed));
+      case "not":
+        return new InverseFilter(buildChild(node, parsed));
+      case "deny":
+        return new DenyFilter(buildChild(node, parsed));
+      case "allow":
+        return new AllowFilter(buildChild(node, parsed));
       default:
-        throw new InvalidXMLException("Unknown inline filter type " + parsed.getBase(), node);
+        throw new SyntaxException("Unknown inline filter type " + parsed.getBase(), parsed);
     }
   }
 
@@ -145,8 +150,8 @@ public class FeatureFilterParser extends FilterParser {
 
   private Filter buildChild(Node node, ParsingNode parent) throws InvalidXMLException {
     if (parent.getChildrenCount() != 1)
-      throw new InvalidXMLException("Expected exactly one child but got " + parent.getChildrenCount(), node);
+      throw new SyntaxException(
+          "Expected exactly one child but got " + parent.getChildrenCount(), parent);
     return buildFilter(node, parent.getChildren().get(0));
   }
-
 }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -1,8 +1,6 @@
 package tc.oc.pgm.filters.parse;
 
 import com.google.common.collect.Range;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureReference;
@@ -13,15 +11,25 @@ import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.filters.XMLFilterReference;
 import tc.oc.pgm.filters.matcher.match.VariableFilter;
+import tc.oc.pgm.filters.operator.AllFilter;
 import tc.oc.pgm.filters.operator.AllowFilter;
+import tc.oc.pgm.filters.operator.AnyFilter;
 import tc.oc.pgm.filters.operator.DenyFilter;
 import tc.oc.pgm.filters.operator.InverseFilter;
+import tc.oc.pgm.filters.operator.OneFilter;
 import tc.oc.pgm.util.MethodParser;
+import tc.oc.pgm.util.parser.ParsingNode;
+import tc.oc.pgm.util.parser.SyntaxException;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 import tc.oc.pgm.variables.VariableDefinition;
 import tc.oc.pgm.variables.VariablesModule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FeatureFilterParser extends FilterParser {
 
@@ -94,6 +102,15 @@ public class FeatureFilterParser extends FilterParser {
               + "|-?\\d*\\.?\\d+)");
 
   private @Nullable Filter parseInlineFilter(Node node, String text) throws InvalidXMLException {
+    // Formula-style inline filter
+    if (text.contains("(")) {
+      try {
+        return buildFilter(node, ParsingNode.parse(text));
+      } catch (SyntaxException e) {
+        throw new InvalidXMLException(e.getMessage(), node, e);
+      }
+    }
+
     // Parse variable filter
     Matcher varMatch = INLINE_VARIABLE.matcher(text);
     if (varMatch.matches()) {
@@ -103,8 +120,33 @@ public class FeatureFilterParser extends FilterParser {
       return new VariableFilter(variable, range);
     }
 
-    // TODO: Future implementations for all/and (&), any/or (|), not (!), deny (~)
-
     return null;
   }
+
+  private Filter buildFilter(Node node, ParsingNode parsed) throws InvalidXMLException {
+    if (parsed.getChildren() == null) return parseReference(node, parsed.getBase());
+    switch (parsed.getBase()) {
+      case "all": return AllFilter.of(buildChildren(node, parsed));
+      case "any": return AnyFilter.of(buildChildren(node, parsed));
+      case "one": return OneFilter.of(buildChildren(node, parsed));
+      case "not": return new InverseFilter(buildChild(node, parsed));
+      case "deny": return new DenyFilter(buildChild(node, parsed));
+      case "allow": return new AllowFilter(buildChild(node, parsed));
+      default:
+        throw new InvalidXMLException("Unknown inline filter type " + parsed.getBase(), node);
+    }
+  }
+
+  private List<Filter> buildChildren(Node node, ParsingNode parent) throws InvalidXMLException {
+    List<Filter> params = new ArrayList<>(parent.getChildrenCount());
+    for (ParsingNode child : parent.getChildren()) params.add(buildFilter(node, child));
+    return params;
+  }
+
+  private Filter buildChild(Node node, ParsingNode parent) throws InvalidXMLException {
+    if (parent.getChildrenCount() != 1)
+      throw new InvalidXMLException("Expected exactly one child but got " + parent.getChildrenCount(), node);
+    return buildFilter(node, parent.getChildren().get(0));
+  }
+
 }

--- a/util/src/main/java/tc/oc/pgm/util/parser/ParsingNode.java
+++ b/util/src/main/java/tc/oc/pgm/util/parser/ParsingNode.java
@@ -1,0 +1,87 @@
+package tc.oc.pgm.util.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ParsingNode {
+  private int start = -1;
+  private String base = "";
+  private List<ParsingNode> children;
+  private int end = -1;
+
+  private ParsingNode() {}
+
+  public static ParsingNode parse(String string) throws SyntaxException {
+    StringReader reader = new StringReader(string);
+    ParsingNode node = new ParsingNode();
+    node.parse(reader);
+    reader.done();
+    return node;
+  }
+
+  public int getStart() {
+    return start;
+  }
+
+  public int getEnd() {
+    return end;
+  }
+
+  public void parse(StringReader str) {
+    str.skipWhitespace();
+    this.start = str.getPosition();
+    this.base = str.readText();
+
+    // Standalone leaf node! a raw value with no params
+    if (!str.pollIf('(')) {
+      this.children = null;
+    } else {
+      this.base = this.base.trim();
+      this.children = new ArrayList<>();
+
+      // 0 parameter function
+      if (!str.pollIf(')')) {
+        while (true) {
+          ParsingNode node = new ParsingNode();
+          node.parse(str);
+          children.add(node);
+
+          if (str.pollIf(',')) continue;
+          if (str.pollIf(')')) break;
+
+          throw new SyntaxException("Expected one of ')' or ',' but found '" + str.peekNext() + "'", str.getPosition());
+        }
+      }
+    }
+    this.end = str.getPosition();
+  }
+
+  public String getBase() {
+    return base;
+  }
+
+  public int getChildrenCount() {
+    return children == null ? -1 : children.size();
+  }
+
+  public List<ParsingNode> getChildren() {
+    return children;
+  }
+
+  public String toString() {
+    return escape(base) + (children == null ? "" :
+        children.stream().map(ParsingNode::toString)
+            .collect(Collectors.joining(", ", "(", ")")));
+  }
+
+  public static String escape(String val) {
+    for (char c : val.toCharArray()) {
+      if (c == '(' || c == ',' || c == ')' || c == ' ')
+        return '"' + val.replaceAll("([\\\\\"])", "\\$1") + '"';
+    }
+    return val;
+  }
+
+}
+

--- a/util/src/main/java/tc/oc/pgm/util/parser/ParsingNode.java
+++ b/util/src/main/java/tc/oc/pgm/util/parser/ParsingNode.java
@@ -50,7 +50,8 @@ public class ParsingNode {
           if (str.pollIf(',')) continue;
           if (str.pollIf(')')) break;
 
-          throw new SyntaxException("Expected one of ')' or ',' but found '" + str.peekNext() + "'", str.getPosition());
+          throw new SyntaxException(
+              "Expected one of ')' or ',' but found '" + str.peekNext() + "'", str.getPosition());
         }
       }
     }
@@ -70,9 +71,12 @@ public class ParsingNode {
   }
 
   public String toString() {
-    return escape(base) + (children == null ? "" :
-        children.stream().map(ParsingNode::toString)
-            .collect(Collectors.joining(", ", "(", ")")));
+    return escape(base)
+        + (children == null
+            ? ""
+            : children.stream()
+                .map(ParsingNode::toString)
+                .collect(Collectors.joining(", ", "(", ")")));
   }
 
   public static String escape(String val) {
@@ -82,6 +86,4 @@ public class ParsingNode {
     }
     return val;
   }
-
 }
-

--- a/util/src/main/java/tc/oc/pgm/util/parser/StringReader.java
+++ b/util/src/main/java/tc/oc/pgm/util/parser/StringReader.java
@@ -3,93 +3,93 @@ package tc.oc.pgm.util.parser;
 import java.util.regex.Pattern;
 
 public class StringReader {
-    // "\\\\" compiles to string literal \\, which is one regex escaped \
-    private static final Pattern ESCAPES_REGEX = Pattern.compile("\\\\(.)");
+  // "\\\\" compiles to string literal \\, which is one regex escaped \
+  private static final Pattern ESCAPES_REGEX = Pattern.compile("\\\\(.)");
 
-    private final String string;
-    private int nextIdx;
+  private final String string;
+  private int nextIdx;
 
-    public StringReader(String string) {
-        this.string = string;
+  public StringReader(String string) {
+    this.string = string;
+  }
+
+  /**
+   * Reads a text (arbitrary string) as defined below: Any character is eligible, except for '(' ','
+   * ')' and any whitespace char. You may use a quoted string "string" for any char except " being
+   * eligible. Either of them may be escaped by using \, and \ can be escaped by \\.
+   *
+   * @return The next word read in full.
+   */
+  public String readText() {
+    boolean quoted = pollIf('"');
+
+    for (int i = nextIdx; i < string.length(); i++) {
+      char ch = string.charAt(i);
+      if (ch == '\\') {
+        // Skip the next char, it's been escaped
+        i++;
+      } else if (quoted ? ch == '"' : ch == '(' || ch == ',' || ch == ')' || ch == ' ') {
+        if (nextIdx == i)
+          throw new SyntaxException("Invalid text, expected at least one char", nextIdx);
+
+        String result = ESCAPES_REGEX.matcher(string.substring(nextIdx, i)).replaceAll("$1");
+        nextIdx = i + (quoted ? 1 : 0);
+        return result;
+      }
     }
 
-    /**
-     * Reads a text (arbitrary string) as defined below:
-     * Any character is eligible, except for '(' ',' ')' and any whitespace char.
-     * You may use a quoted string "string" for any char except " being eligible.
-     * Either of them may be escaped by using \, and \ can be escaped by \\.
-     * @return The next word read in full.
-     */
-    public String readText() {
-        boolean quoted = pollIf('"');
-
-        for (int i = nextIdx; i < string.length(); i++) {
-            char ch = string.charAt(i);
-            if (ch == '\\') {
-                // Skip the next char, it's been escaped
-                i++;
-            } else if (quoted ? ch == '"' : ch == '(' || ch == ',' || ch == ')' || ch == ' ') {
-                if (nextIdx == i)
-                    throw new SyntaxException("Invalid text, expected at least one char", nextIdx);
-
-                String result = ESCAPES_REGEX.matcher(string.substring(nextIdx, i)).replaceAll("$1");
-                nextIdx = i + (quoted ? 1 : 0);
-                return result;
-            }
-        }
-
-        if (quoted) {
-            throw new SyntaxException("Unfinished quoted string", nextIdx);
-        }
-
-        String remaining = string.substring(nextIdx);
-        nextIdx = string.length();
-        return remaining;
+    if (quoted) {
+      throw new SyntaxException("Unfinished quoted string", nextIdx);
     }
 
-    public void done() {
-        if (nextIdx < string.length())
-            throw new SyntaxException("Unused characters after end", nextIdx);
-    }
+    String remaining = string.substring(nextIdx);
+    nextIdx = string.length();
+    return remaining;
+  }
 
-    public char peekNext() {
-        if (nextIdx >= string.length()) return '\04'; // EOF
-        return string.charAt(nextIdx);
-    }
+  public void done() {
+    if (nextIdx < string.length())
+      throw new SyntaxException("Unused characters after end", nextIdx);
+  }
 
-    public int getPosition() {
-        return nextIdx;
-    }
+  public char peekNext() {
+    if (nextIdx >= string.length()) return '\04'; // EOF
+    return string.charAt(nextIdx);
+  }
 
-    public void skipWhitespace() {
-        for (int i = nextIdx; i < string.length(); i++) {
-            if (!Character.isWhitespace(string.charAt(i))) {
-                nextIdx = i;
-                break;
-            }
-        }
-    }
+  public int getPosition() {
+    return nextIdx;
+  }
 
-    /**
-     * Peek at the next char ignoring whitespace, if it's {@param ch}, poll it and return true
-     * @param ch the char to maybe expect next
-     * @return true if the next char is ch, and it was skipped, false otherwise
-     */
-    public boolean pollIf(char ch) {
-        for (int i = nextIdx; i < string.length(); i++) {
-            char currChar = string.charAt(i);
-            if (currChar == ch) {
-                nextIdx = i + 1;
-                return true;
-            } else if (!Character.isWhitespace(currChar)) {
-                return false;
-            }
-        }
+  public void skipWhitespace() {
+    for (int i = nextIdx; i < string.length(); i++) {
+      if (!Character.isWhitespace(string.charAt(i))) {
+        nextIdx = i;
+        break;
+      }
+    }
+  }
+
+  /**
+   * Peek at the next char ignoring whitespace, if it's {@param ch}, poll it and return true
+   *
+   * @param ch the char to maybe expect next
+   * @return true if the next char is ch, and it was skipped, false otherwise
+   */
+  public boolean pollIf(char ch) {
+    for (int i = nextIdx; i < string.length(); i++) {
+      char currChar = string.charAt(i);
+      if (currChar == ch) {
+        nextIdx = i + 1;
+        return true;
+      } else if (!Character.isWhitespace(currChar)) {
         return false;
+      }
     }
+    return false;
+  }
 
-    public String substring(int start, int end) {
-        return string.substring(start, end);
-    }
-
+  public String substring(int start, int end) {
+    return string.substring(start, end);
+  }
 }

--- a/util/src/main/java/tc/oc/pgm/util/parser/StringReader.java
+++ b/util/src/main/java/tc/oc/pgm/util/parser/StringReader.java
@@ -1,0 +1,95 @@
+package tc.oc.pgm.util.parser;
+
+import java.util.regex.Pattern;
+
+public class StringReader {
+    // "\\\\" compiles to string literal \\, which is one regex escaped \
+    private static final Pattern ESCAPES_REGEX = Pattern.compile("\\\\(.)");
+
+    private final String string;
+    private int nextIdx;
+
+    public StringReader(String string) {
+        this.string = string;
+    }
+
+    /**
+     * Reads a text (arbitrary string) as defined below:
+     * Any character is eligible, except for '(' ',' ')' and any whitespace char.
+     * You may use a quoted string "string" for any char except " being eligible.
+     * Either of them may be escaped by using \, and \ can be escaped by \\.
+     * @return The next word read in full.
+     */
+    public String readText() {
+        boolean quoted = pollIf('"');
+
+        for (int i = nextIdx; i < string.length(); i++) {
+            char ch = string.charAt(i);
+            if (ch == '\\') {
+                // Skip the next char, it's been escaped
+                i++;
+            } else if (quoted ? ch == '"' : ch == '(' || ch == ',' || ch == ')' || ch == ' ') {
+                if (nextIdx == i)
+                    throw new SyntaxException("Invalid text, expected at least one char", nextIdx);
+
+                String result = ESCAPES_REGEX.matcher(string.substring(nextIdx, i)).replaceAll("$1");
+                nextIdx = i + (quoted ? 1 : 0);
+                return result;
+            }
+        }
+
+        if (quoted) {
+            throw new SyntaxException("Unfinished quoted string", nextIdx);
+        }
+
+        String remaining = string.substring(nextIdx);
+        nextIdx = string.length();
+        return remaining;
+    }
+
+    public void done() {
+        if (nextIdx < string.length())
+            throw new SyntaxException("Unused characters after end", nextIdx);
+    }
+
+    public char peekNext() {
+        if (nextIdx >= string.length()) return '\04'; // EOF
+        return string.charAt(nextIdx);
+    }
+
+    public int getPosition() {
+        return nextIdx;
+    }
+
+    public void skipWhitespace() {
+        for (int i = nextIdx; i < string.length(); i++) {
+            if (!Character.isWhitespace(string.charAt(i))) {
+                nextIdx = i;
+                break;
+            }
+        }
+    }
+
+    /**
+     * Peek at the next char ignoring whitespace, if it's {@param ch}, poll it and return true
+     * @param ch the char to maybe expect next
+     * @return true if the next char is ch, and it was skipped, false otherwise
+     */
+    public boolean pollIf(char ch) {
+        for (int i = nextIdx; i < string.length(); i++) {
+            char currChar = string.charAt(i);
+            if (currChar == ch) {
+                nextIdx = i + 1;
+                return true;
+            } else if (!Character.isWhitespace(currChar)) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    public String substring(int start, int end) {
+        return string.substring(start, end);
+    }
+
+}

--- a/util/src/main/java/tc/oc/pgm/util/parser/SyntaxException.java
+++ b/util/src/main/java/tc/oc/pgm/util/parser/SyntaxException.java
@@ -1,0 +1,26 @@
+package tc.oc.pgm.util.parser;
+
+public class SyntaxException extends RuntimeException {
+  private final int startIdx;
+  private final int endIdx;
+
+  public SyntaxException(String message, int nextIdx) {
+    super(message);
+    this.startIdx = nextIdx;
+    this.endIdx = -1;
+  }
+
+  public SyntaxException(String message, ParsingNode node) {
+    super(message);
+    this.startIdx = node.getStart();
+    this.endIdx = node.getEnd();
+  }
+
+  public int getStartIdx() {
+    return startIdx;
+  }
+
+  public int getEndIdx() {
+    return endIdx;
+  }
+}


### PR DESCRIPTION
Adds support for formula-like definitions of inline filters.

```xml
<filters>
  <holding id="holding-gap"><item>golden apple</item></holding>
  <pulse id="can-give-gap" duration="0.05s" period="0.1s" filter="all(not(holding-gap), missing_gaps=1..)"/>
</filters>
```

Note how the pulse filter depends on an in-line defined equivalent of:
```xml
<all>
  <not><filter id="holding-gap"></not>
  <variable var="missing_gaps">1..</variable>
</all>
```

Also added some syntax highlighting to the errors:
![image](https://github.com/PGMDev/PGM/assets/11789291/bafc0952-1d95-48b1-a378-d3d0a43b40fd)
![image](https://github.com/PGMDev/PGM/assets/11789291/499262ed-2f5d-4023-bf56-fdd7bb6d19f2)


<details>
<summary> Grand dueling TM II broke, but was already fixed </summary>

Tested with all current maps loaded in occ repos and one map broke, grand dueling tournament II, due to the use of ( and ) in the filter ids:
![image](https://github.com/PGMDev/PGM/assets/11789291/514a85d9-86af-4af1-9a72-f4a0860d5ff4)
</detauls>