### PR TITLE
Add flag beams to payloads

### DIFF
--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointParser.java
@@ -148,6 +148,7 @@ public abstract class ControlPointParser {
       BlockVector location =
           BlockVectors.center(XMLUtils.parseVector(Node.fromRequiredAttr(el, "location")));
       double radius = XMLUtils.parseNumber(Node.fromRequiredAttr(el, "radius"), Double.class);
+      boolean showBeam = XMLUtils.parseBoolean(el.getAttribute("beam"), true);
       Filter displayFilter =
           filterParser.parseFilterProperty(el, "display-filter", StaticFilter.ALLOW);
       return new PayloadDefinition(
@@ -178,6 +179,7 @@ public abstract class ControlPointParser {
           showProgress,
           location,
           radius,
+          showBeam,
           displayFilter);
     }
 

--- a/core/src/main/java/tc/oc/pgm/payload/Payload.java
+++ b/core/src/main/java/tc/oc/pgm/payload/Payload.java
@@ -5,6 +5,7 @@ import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Minecart;
 import org.bukkit.material.Wool;
@@ -124,6 +125,24 @@ public class Payload extends ControlPoint {
               1,
               0,
               50);
+    }
+
+    if (definition.showBeam()) {
+      DyeColor dyeColor = display != null ? display.getDyeColor() : DyeColor.WHITE;
+      match
+          .getWorld()
+          .spigot()
+          .playEffect(
+              position.toLocation(match.getWorld()).clone().add(0, 56, 0),
+              Effect.TILE_DUST,
+              Material.WOOL.getId(),
+              dyeColor.getWoolData(),
+              0.15f, // radius on each axis of the particle ball
+              24f,
+              0.15f,
+              0f, // initial horizontal velocity
+              40, // number of particles
+              200); // radius in blocks to show particles
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/payload/PayloadDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/payload/PayloadDefinition.java
@@ -14,6 +14,7 @@ public class PayloadDefinition extends ControlPointDefinition {
 
   private final BlockVector location;
   private final double radius;
+  private final boolean showBeam;
   private final Filter displayFilter;
 
   public PayloadDefinition(
@@ -44,6 +45,7 @@ public class PayloadDefinition extends ControlPointDefinition {
       boolean progress,
       BlockVector location,
       double radius,
+      boolean showBeam,
       Filter displayFilter) {
     super(
         id,
@@ -73,6 +75,7 @@ public class PayloadDefinition extends ControlPointDefinition {
         progress);
     this.location = location;
     this.radius = radius;
+    this.showBeam = showBeam;
     this.displayFilter = displayFilter;
   }
 
@@ -82,6 +85,10 @@ public class PayloadDefinition extends ControlPointDefinition {
 
   public double getRadius() {
     return radius;
+  }
+
+  public boolean showBeam() {
+    return showBeam;
   }
 
   public Filter getDisplayFilter() {


### PR DESCRIPTION
Fixes #1258.

Requested by players and mapdevs, since it's hard to track down position of payloads.

This is (intentionally) not bringing legacy flag beams (zombies with wool on their heads) for simplicity, since payloads are still an experiment. This is a rather simple addition to be able to further test their capabilities in pgm.

```
<payload location="0,0,0" beam="true" />
<payload location="0,0,0" beam="false" />
```
Adds a beam attribute, working just like the one for flags. Defaults to true.