### PR TITLE
Add a timelimit variable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
@@ -38,6 +38,16 @@ public class TimeLimit extends SelfIdentifyingFeatureDefinition implements Victo
     this.show = show;
   }
 
+  public TimeLimit(TimeLimit timeLimit, Duration duration) {
+    super(timeLimit.getId());
+    this.duration = assertNotNull(duration);
+    this.overtime = timeLimit.getOvertime();
+    this.maxOvertime = timeLimit.getMaxOvertime();
+    this.endOvertime = timeLimit.getEndOvertime();
+    this.result = timeLimit.getResult();
+    this.show = timeLimit.getShow();
+  }
+
   public Duration getDuration() {
     return duration;
   }

--- a/core/src/main/java/tc/oc/pgm/variables/VariableParser.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariableParser.java
@@ -24,6 +24,7 @@ import tc.oc.pgm.variables.types.DummyVariable;
 import tc.oc.pgm.variables.types.MaxBuildVariable;
 import tc.oc.pgm.variables.types.ScoreVariable;
 import tc.oc.pgm.variables.types.TeamVariableAdapter;
+import tc.oc.pgm.variables.types.TimeLimitVariable;
 
 public class VariableParser {
   // The limitation is due to them being used in exp4j formulas for.
@@ -87,6 +88,12 @@ public class VariableParser {
   @MethodParser("score")
   public VariableDefinition<Party> parseScore(Element el, String id) throws InvalidXMLException {
     return VariableDefinition.ofStatic(id, Party.class, ScoreVariable::new);
+  }
+
+  @MethodParser("timelimit")
+  public VariableDefinition<Match> parseTimeLimit(Element el, String id)
+      throws InvalidXMLException {
+    return VariableDefinition.ofStatic(id, Match.class, TimeLimitVariable::new);
   }
 
   @MethodParser("with-team")

--- a/core/src/main/java/tc/oc/pgm/variables/types/TimeLimitVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/TimeLimitVariable.java
@@ -1,0 +1,51 @@
+package tc.oc.pgm.variables.types;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.timelimit.TimeLimit;
+import tc.oc.pgm.timelimit.TimeLimitMatchModule;
+import tc.oc.pgm.variables.VariableDefinition;
+
+public class TimeLimitVariable extends AbstractVariable<Match> {
+
+  private TimeLimit oldTimeLimit;
+  private TimeLimitMatchModule tlmm;
+
+  public TimeLimitVariable(VariableDefinition<Match> definition) {
+    super(definition);
+    oldTimeLimit =
+        new TimeLimit(null, Duration.of(0, ChronoUnit.SECONDS), null, null, null, null, true);
+  }
+
+  @Override
+  public void postLoad(Match match) {
+    tlmm = match.moduleRequire(TimeLimitMatchModule.class);
+  }
+
+  @Override
+  protected double getValueImpl(Match obj) {
+    Duration remaining = tlmm.getFinalRemaining();
+    return remaining == null ? -1 : remaining.getSeconds();
+  }
+
+  @Override
+  protected void setValueImpl(Match obj, double value) {
+    TimeLimit existingTimeLimit = tlmm.getTimeLimit();
+    if (value < 0) {
+      if (existingTimeLimit != null) {
+        oldTimeLimit = existingTimeLimit;
+      }
+
+      tlmm.cancel();
+      return;
+    }
+
+    TimeLimit newTimeLimit =
+        new TimeLimit(
+            existingTimeLimit != null ? existingTimeLimit : oldTimeLimit,
+            Duration.of((long) value, ChronoUnit.SECONDS));
+    tlmm.setTimeLimit(newTimeLimit);
+    tlmm.start();
+  }
+}


### PR DESCRIPTION
Adds a match scoped `timelimit` action

Behaves like the command

Example:
```xml
<timelimit duration="10s" result="objectives"/>
```

All attributes are optional.

This has all of the same optional arguments as the command.

For @zzufx 