### PR TITLE
Dynamic offset filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/filter/ReactorFactory.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/ReactorFactory.java
@@ -45,5 +45,9 @@ public interface ReactorFactory<R extends ReactorFactory.Reactor> extends Filter
     protected void invalidate(Filterable<?> filterable) {
       this.fmm.invalidate(filterable);
     }
+
+    protected void invalidate(Filter filter, Filterable<?> filterable) {
+      this.fmm.invalidate(filter, filterable);
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/modifier/LocationQueryModifier.java
+++ b/core/src/main/java/tc/oc/pgm/filters/modifier/LocationQueryModifier.java
@@ -1,72 +1,107 @@
 package tc.oc.pgm.filters.modifier;
 
 import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockRedstoneEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.util.Vector;
+import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.ReactorFactory;
 import tc.oc.pgm.api.filter.query.BlockQuery;
 import tc.oc.pgm.api.filter.query.LocationQuery;
+import tc.oc.pgm.api.filter.query.MatchQuery;
+import tc.oc.pgm.api.filter.query.MaterialQuery;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.filters.FilterMatchModule;
+import tc.oc.pgm.util.math.OffsetVector;
 
-public abstract class LocationQueryModifier extends QueryModifier<LocationQuery, BlockQuery> {
+public class LocationQueryModifier extends QueryModifier<LocationQuery, BlockQuery> {
 
-  LocationQueryModifier(Filter filter) {
+  private final OffsetVector offset;
+
+  private LocationQueryModifier(Filter filter, OffsetVector offset) {
     super(filter, LocationQuery.class, BlockQuery.class);
+    this.offset = offset;
   }
 
-  /** Uses world coordinates (x, y, z) in either absolute or relative form */
-  public static class World extends LocationQueryModifier {
+  @Override
+  protected BlockQuery transformQuery(LocationQuery query) {
+    return new tc.oc.pgm.filters.query.BlockQuery(
+        query.getEvent(), offset.applyOffset(query.getLocation()));
+  }
 
-    private final Vector coords;
-    private final boolean[] relative;
-
-    public World(Filter filter, Vector coords, boolean[] relative) {
-      super(filter);
-      this.coords = coords;
-      this.relative = relative;
-    }
-
-    @Override
-    protected BlockQuery transformQuery(LocationQuery query) {
-      Location origin = query.getLocation();
-      Location newLoc = origin.clone();
-      newLoc.setX(relative[0] ? origin.getX() + coords.getX() : coords.getX());
-      newLoc.setY(relative[1] ? origin.getY() + coords.getY() : coords.getY());
-      newLoc.setZ(relative[2] ? origin.getZ() + coords.getZ() : coords.getZ());
-
-      return new tc.oc.pgm.filters.query.BlockQuery(query.getEvent(), newLoc);
-    }
+  public static Filter of(Filter child, OffsetVector offset) {
+    if (offset.isAbsolute()) return new Absolute(child, offset.getVector());
+    return new LocationQueryModifier(child, offset);
   }
 
   /**
-   * Uses local coordinates (left, up, front), which are always relative. These coordinates are also
-   * known as caret notation or ^ΔSway ^ΔHeave ^ΔSurge
+   * Specialization when the requested location is an absolute position. It can work without an
+   * initial location query, and becomes dynamic as long as the inner filter can respond to material
+   * queries.
    */
-  public static class Local extends LocationQueryModifier {
-    private final Vector coords;
+  private static class Absolute extends QueryModifier<MatchQuery, BlockQuery>
+      implements ReactorFactory<Absolute.Reactor> {
 
-    public Local(Filter child, Vector coords) {
-      super(child);
-      this.coords = coords;
+    private final Vector location;
+
+    private Absolute(Filter filter, Vector location) {
+      super(filter, MatchQuery.class, BlockQuery.class);
+      this.location = location;
     }
 
     @Override
-    protected BlockQuery transformQuery(LocationQuery query) {
-      Location origin = query.getLocation();
-      double x = coords.getX();
-      double y = coords.getY();
-      double z = coords.getZ();
-      Vector dirZ = origin.getDirection().normalize();
-      Location newLoc = origin.clone().add(dirZ.multiply(z));
+    protected BlockQuery transformQuery(MatchQuery query) {
+      return new tc.oc.pgm.filters.query.BlockQuery(
+          query.getEvent(), location.toLocation(query.getMatch().getWorld()));
+    }
 
-      float yaw = newLoc.getYaw() - 90;
-      Vector dirX = new Vector(-Math.sin(Math.toRadians(yaw)), 0, Math.cos(Math.toRadians(yaw)));
-      newLoc = newLoc.add(dirX.multiply(x));
+    @Override
+    public boolean isDynamic() {
+      return filter.respondsTo(MaterialQuery.class);
+    }
 
-      float pitch = newLoc.getPitch() - 90;
-      Vector dirY =
-          new Vector(0, -Math.sin(Math.toRadians(pitch)), Math.cos(Math.toRadians(pitch)));
-      newLoc = newLoc.add(dirY.multiply(y));
+    @Override
+    public Reactor createReactor(Match match, FilterMatchModule fmm) {
+      return new Reactor(match, fmm);
+    }
 
-      return new tc.oc.pgm.filters.query.BlockQuery(query.getEvent(), newLoc);
+    private class Reactor extends ReactorFactory.Reactor implements Listener {
+      public Reactor(Match match, FilterMatchModule fmm) {
+        super(match, fmm);
+        match.addListener(this, MatchScope.RUNNING);
+      }
+
+      private void invalidate(Location modified) {
+        if (modified.getBlockX() == location.getBlockX()
+            && modified.getBlockY() == location.getBlockY()
+            && modified.getBlockZ() == location.getBlockZ()) {
+          invalidate(Absolute.this, match);
+        }
+      }
+
+      @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+      public void onBlockTransform(BlockTransformEvent e) {
+        invalidate(e.getBlock().getLocation());
+      }
+
+      @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+      public void onBlockInteract(PlayerInteractEvent e) {
+        // Clicking on doors or trapdoors
+        if (e.getAction() == Action.RIGHT_CLICK_BLOCK && e.hasBlock())
+          invalidate(e.getClickedBlock().getLocation());
+      }
+
+      @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+      public void onRedstoneChange(BlockRedstoneEvent e) {
+        // Buttons, pressure plates, or other redstone circuits changing
+        invalidate(e.getBlock().getLocation());
+      }
     }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/math/OffsetVector.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/OffsetVector.java
@@ -1,0 +1,98 @@
+package tc.oc.pgm.util.math;
+
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+public abstract class OffsetVector {
+  protected final Vector vector;
+
+  protected OffsetVector(Vector vector) {
+    this.vector = vector;
+  }
+
+  public static OffsetVector of(Vector vector, boolean[] relative, boolean local) {
+    if (local) return new Local(vector);
+
+    boolean rel = relative[0];
+    if (relative[1] == rel && relative[2] == rel) {
+      return rel ? new Relative(vector) : new Absolute(vector);
+    }
+    return new Mixed(vector, relative);
+  }
+
+  public boolean isAbsolute() {
+    return this instanceof Absolute;
+  }
+
+  public Vector getVector() {
+    if (!isAbsolute())
+      throw new UnsupportedOperationException("Can only get vector for absolute vectors");
+    return vector;
+  }
+
+  public abstract Location applyOffset(Location origin);
+
+  private static class Absolute extends OffsetVector {
+    public Absolute(Vector vector) {
+      super(vector);
+    }
+
+    public Location applyOffset(Location origin) {
+      return origin.clone().set(vector.getX(), vector.getY(), vector.getZ());
+    }
+  }
+
+  private static class Relative extends OffsetVector {
+    public Relative(Vector vector) {
+      super(vector);
+    }
+
+    public Location applyOffset(Location origin) {
+      return origin.clone().add(vector);
+    }
+  }
+
+  private static class Mixed extends OffsetVector {
+    private final boolean[] relative;
+
+    public Mixed(Vector vector, boolean[] relative) {
+      super(vector);
+      this.relative = relative;
+    }
+
+    public Location applyOffset(Location origin) {
+      return origin
+          .clone()
+          .set(
+              (relative[0] ? origin.getX() : 0) + vector.getX(),
+              (relative[1] ? origin.getY() : 0) + vector.getY(),
+              (relative[2] ? origin.getZ() : 0) + vector.getZ());
+    }
+  }
+
+  /**
+   * Uses local coordinates (left, up, front), which are always relative. These coordinates are also
+   * known as caret notation or ^ΔSway ^ΔHeave ^ΔSurge
+   */
+  private static class Local extends OffsetVector {
+    public Local(Vector vector) {
+      super(vector);
+    }
+
+    public Location applyOffset(Location origin) {
+      Location newLoc = origin.clone();
+
+      double pitch = Math.toRadians(origin.getPitch() - 90);
+      double yaw = Math.toRadians(origin.getYaw() - 90);
+
+      Vector sway = new Vector(-sin(yaw), 0, cos(yaw)).multiply(vector.getX());
+      Vector heave = new Vector(0, -sin(pitch), cos(pitch)).multiply(vector.getY());
+      Vector surge = origin.getDirection().normalize().multiply(vector.getZ());
+
+      return newLoc.add(sway).add(heave).add(surge);
+    }
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -34,6 +34,7 @@ import tc.oc.pgm.util.material.matcher.AllMaterialMatcher;
 import tc.oc.pgm.util.material.matcher.BlockMaterialMatcher;
 import tc.oc.pgm.util.material.matcher.CompoundMaterialMatcher;
 import tc.oc.pgm.util.material.matcher.SingleMaterialMatcher;
+import tc.oc.pgm.util.math.OffsetVector;
 import tc.oc.pgm.util.nms.NMSHacks;
 import tc.oc.pgm.util.range.Ranges;
 import tc.oc.pgm.util.skin.Skin;
@@ -649,6 +650,21 @@ public final class XMLUtils {
     } catch (ClassNotFoundException | ClassCastException e) {
       throw new InvalidXMLException("Invalid entity type '" + value + "'", node);
     }
+  }
+
+  public static OffsetVector parseOffsetVector(Node node) throws InvalidXMLException {
+    String value = node.getValueNormalize();
+    String[] coords = value.split("\\s*,\\s*");
+    Vector vector = parseVector(node, value.replaceAll("[\\^~]", ""));
+
+    boolean local = value.startsWith("^");
+    boolean[] relative = new boolean[3];
+    for (int i = 0; i < coords.length; i++) {
+      relative[i] = coords[i].startsWith("~");
+      if (coords[i].startsWith("^") != local)
+        throw new InvalidXMLException("Cannot mix world & local coordinates", node);
+    }
+    return OffsetVector.of(vector, relative, local);
   }
 
   public static Vector parseVector(Node node, String value) throws InvalidXMLException {


### PR DESCRIPTION
Turns the `offset` filter into dynamic, as long as it's for an absolute position.
It can work by placing blocks, clicking buttons, trapdoors, or even redstone.

Examples:
```xml
  <kits>
    <lend>
      <filter>
        <offset vector="0,16,0">
          <any>
            <material>stone</material>
            <material>dirt</material>
          </any>
        </offset>
      </filter>
      <kit>
        <effect duration="oo">night vision</effect>
      </kit>
    </lend>
  </kits>
```
![dynamicoffset](https://github.com/PGMDev/PGM/assets/11789291/d1c2b76e-4e0d-459a-ba9d-fc9d004056b8)


A more convoluted example, with redstone and trapdoors even:
```xml
<filters>

  <any id="block-placed">
    <material>stone</material>
    <material>dirt</material>
    <!-- All powered button states -->
    <material>stone_button:8</material>
    <material>stone_button:9</material>
    <material>stone_button:10</material>
    <material>stone_button:11</material>
    <material>stone_button:12</material>
    <material>stone_button:13</material>
    <!-- Closed trapdoors in just 2 directions -->
    <material>trap door:0</material>
    <material>trap door:1</material>
    <all> <!-- Redstone wire, and not unpowered-->
      <material>redstone wire</material>
      <not><material>redstone wire:0</material></not>
    </all>
  </any>

  <offset id="block-placed" vector="0,16,0" filter="placed"/>
  <offset id="block-removed" vector="0,16,0" filter="not(placed)"/>
</filters>
<actions>
  <trigger scope="match" filter="block-placed">
    <action>
      <message text="Enabled!"/>
    </action>
  </trigger>
  <trigger scope="match" filter="block-removed">
    <action>
      <message text="Disabled!"/>
    </action>
  </trigger>
</actions>
<kits>
  <lend filter="block-placed">
    <kit>
      <effect duration="oo">night vision</effect>
    </kit>
  </lend>
</kits>
```
![btnpress](https://github.com/PGMDev/PGM/assets/11789291/7cdec149-7568-4a0a-8ebf-3d58b07b73ea)

