### PR TITLE
Fix duplicate inline filter references not working

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -52,6 +52,9 @@ public class FeatureFilterParser extends FilterParser {
 
   @Override
   public Filter parseReference(Node node, String id) throws InvalidXMLException {
+    Filter resolved = features.get(id, Filter.class);
+    if (resolved != null) return resolved;
+
     Filter inline = parseInlineFilter(node, id);
     if (inline != null) return inline;
 


### PR DESCRIPTION
Fixes duplicate inline filters complaining about no two filters being able to use the same id, when used as child nodes and not attributes.

```xml
  <any id="test-filter-1">
    <filter id="all(round-1, round-1-finished)"/>
    <filter id="all(round-2, round-2-finished)"/>
  </any>

  <all id="test-filter-2">
    <filter id="all(round-1, round-1-finished)"/>
    <filter id="all(round-2, round-2-finished)"/>
  </all>
```

In this scenario, pgm would complain that `all(round-1, round-1-finished)` is a duplicate id, because it is assuming it needs to register it, due to not being an `XMLFilterReference` (it's an all filter). This PR makes it so if a reference xml creation is for an already defined filter, it will use that one instead of creating a new one. That solves both not finding, and also adds caching to re-used inline filters that get used like this.