### PR TITLE
fix(DeathMessageBuilder): check for null potion effect

### DIFF
--- a/core/src/main/java/tc/oc/pgm/death/DeathMessageBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/death/DeathMessageBuilder.java
@@ -184,7 +184,7 @@ public class DeathMessageBuilder {
   }
 
   boolean potion(PotionInfo potionInfo) {
-    if (option("potion")) {
+    if (potionInfo.getPotionEffect() != null && option("potion")) {
       weapon = potionInfo.getName();
       return true;
     }


### PR DESCRIPTION
Fixes a NullPointerException being triggered on death when the potion type is unknown - for example, by player drinking a potion of Instant Damage themselves, resulting in the player dying from damage of type `MAGIC`. A generic "Player was killed by magic" message will be displayed instead, which may affect some maps using so called "respawn potions" found on some parkour maps by increasing their verbosity.