### PR TITLE
Update cloud & add variable set command

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@
                         <path>
                             <groupId>cloud.commandframework</groupId>
                             <artifactId>cloud-annotations</artifactId>
-                            <version>1.8.2</version>
+                            <version>1.8.4</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
@@ -68,6 +68,25 @@ public class MapDevCommand {
             text().append(text(v.getId() + ": ", NamedTextColor.AQUA), text(v.getValue(target))));
   }
 
+  @CommandMethod("variable set <variable> <value> [target]")
+  @CommandDescription("Inspect variables for a player")
+  @CommandPermission(Permissions.DEBUG)
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void setVariable(
+      Audience audience,
+      @Argument("variable") Variable variable,
+      @Argument("value") double value,
+      @Argument(value = "target", defaultValue = CURRENT) MatchPlayer target) {
+    variable.setValue(target, value);
+    audience.sendMessage(
+        text("Variable ", NamedTextColor.YELLOW)
+            .append(text(variable.getId(), NamedTextColor.AQUA))
+            .append(text(" set to ", NamedTextColor.YELLOW))
+            .append(text(value + "", NamedTextColor.AQUA))
+            .append(text(" for ", NamedTextColor.YELLOW))
+            .append(target.getName()));
+  }
+
   @CommandMethod("filter <filter> [target]")
   @CommandDescription("Match a filter against a player")
   @CommandPermission(Permissions.DEBUG)

--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -30,7 +30,7 @@ import tc.oc.pgm.util.text.TextFormatter;
 @CommandMethod("mode|modes")
 public final class ModeCommand {
 
-  @CommandMethod("next")
+  @CommandMethod("mode|modes next")
   @CommandDescription("Show the next objective mode")
   public void next(Audience audience, ObjectiveModesMatchModule modes) {
     List<ModeChangeCountdown> countdowns = modes.getActiveCountdowns();
@@ -64,6 +64,15 @@ public final class ModeCommand {
     audience.sendMessage(builder.build());
   }
 
+  @CommandMethod("[page]")
+  @CommandDescription("List all objective modes")
+  public void fallback(
+      Audience audience,
+      ObjectiveModesMatchModule modes,
+      @Argument(value = "page", defaultValue = "1") @Range(min = "1") int page) {
+    list(audience, modes, page);
+  }
+
   @CommandMethod("list|page [page]")
   @CommandDescription("List all objective modes")
   public void list(
@@ -85,7 +94,7 @@ public final class ModeCommand {
     new ModesPaginatedResult(header, resultsPerPage, modes).display(audience, modeList, page);
   }
 
-  @CommandMethod("push <time>")
+  @CommandMethod("mode|modes push <time>")
   @CommandDescription("Reschedule all objective modes with active countdowns")
   @CommandPermission(Permissions.GAMEPLAY)
   public void push(
@@ -124,7 +133,7 @@ public final class ModeCommand {
     audience.sendMessage(builder);
   }
 
-  @CommandMethod("start <mode> [time]")
+  @CommandMethod("mode|modes start <mode> [time]")
   @CommandDescription("Starts an objective mode")
   @CommandPermission(Permissions.GAMEPLAY)
   public void start(

--- a/core/src/main/java/tc/oc/pgm/command/parsers/MatchObjectParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/MatchObjectParser.java
@@ -10,7 +10,6 @@ import cloud.commandframework.arguments.parser.ArgumentParseResult;
 import cloud.commandframework.arguments.parser.ParserParameters;
 import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.paper.PaperCommandManager;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -90,7 +89,7 @@ public abstract class MatchObjectParser<T, IT, M extends MatchModule>
         .collect(Collectors.toList());
   }
 
-  protected abstract Collection<IT> objects(M module);
+  protected abstract Iterable<IT> objects(M module);
 
   protected abstract String getName(IT obj);
 

--- a/core/src/main/java/tc/oc/pgm/command/parsers/VariableParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/VariableParser.java
@@ -1,0 +1,25 @@
+package tc.oc.pgm.command.parsers;
+
+import cloud.commandframework.arguments.parser.ParserParameters;
+import cloud.commandframework.paper.PaperCommandManager;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.variables.Variable;
+import tc.oc.pgm.variables.VariablesMatchModule;
+
+@SuppressWarnings("rawtypes")
+public class VariableParser extends MatchObjectParser.Simple<Variable, VariablesMatchModule> {
+
+  public VariableParser(PaperCommandManager<CommandSender> manager, ParserParameters options) {
+    super(manager, options, Variable.class, VariablesMatchModule.class, "variables");
+  }
+
+  @Override
+  protected Iterable<Variable> objects(VariablesMatchModule module) {
+    return module.getVariables();
+  }
+
+  @Override
+  protected String getName(Variable variable) {
+    return variable.getId();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
@@ -79,6 +79,7 @@ import tc.oc.pgm.command.parsers.RotationParser;
 import tc.oc.pgm.command.parsers.SettingValueParser;
 import tc.oc.pgm.command.parsers.TeamParser;
 import tc.oc.pgm.command.parsers.TeamsParser;
+import tc.oc.pgm.command.parsers.VariableParser;
 import tc.oc.pgm.command.parsers.VictoryConditionParser;
 import tc.oc.pgm.listeners.ChatDispatcher;
 import tc.oc.pgm.modes.Mode;
@@ -91,6 +92,7 @@ import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.Players;
+import tc.oc.pgm.variables.Variable;
 
 public class PGMCommandGraph extends CommandGraph<PGM> {
 
@@ -211,6 +213,7 @@ public class PGMCommandGraph extends CommandGraph<PGM> {
     registerParser(TypeFactory.parameterizedClass(Collection.class, Team.class), TeamsParser::new);
     registerParser(PlayerClass.class, PlayerClassParser::new);
     registerParser(Mode.class, ModeParser::new);
+    registerParser(Variable.class, VariableParser::new);
     registerParser(ExposedAction.class, ExposedActionParser::new);
     registerParser(
         TypeFactory.parameterizedClass(Optional.class, VictoryCondition.class),

--- a/core/src/main/java/tc/oc/pgm/variables/VariablesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariablesMatchModule.java
@@ -13,8 +13,12 @@ public class VariablesMatchModule implements MatchModule, Listener {
     this.match = match;
   }
 
+  public Iterable<Variable> getVariables() {
+    return match.getFeatureContext().getAll(Variable.class);
+  }
+
   @Override
   public void load() throws ModuleLoadException {
-    match.getFeatureContext().getAll(Variable.class).forEach(v -> v.postLoad(match));
+    getVariables().forEach(v -> v.postLoad(match));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -152,25 +152,25 @@
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-core</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-annotations</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-paper</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>cloud.commandframework</groupId>
             <artifactId>cloud-minecraft-extras</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.4</version>
             <scope>compile</scope>
         </dependency>
         <!-- Allows registering brigadier mappings -->


### PR DESCRIPTION
Implements a `/variable set <varid> <value> [target]` command, which allows debugging by setting variables to specific values, optionally for a specific target player.

Additionally updates cloud to fix some tab-complete issues within commands with flags, and makes `/modes` with no extra args default to `/mode list`