### PR TITLE
Add variable-arg min & max functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,9 +214,9 @@
 
         <!-- Simple mathematical expression evaluator library -->
         <dependency>
-            <groupId>net.objecthunter</groupId>
+            <groupId>com.github.Pablete1234</groupId>
             <artifactId>exp4j</artifactId>
-            <version>0.4.8</version>
+            <version>b561006eb0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/util/src/main/java/tc/oc/pgm/util/math/Formula.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/Formula.java
@@ -30,18 +30,32 @@ public interface Formula<T> extends ToDoubleFunction<T> {
       };
 
   Function MAX =
-      new Function("max", 2) {
+      new Function("max") {
         @Override
         public double apply(double... doubles) {
-          return Math.max(doubles[0], doubles[1]);
+          double max = doubles[0];
+          for (int i = 1; i < doubles.length; i++) max = Math.max(max, doubles[i]);
+          return max;
+        }
+
+        @Override
+        public boolean isValidArgCount(int count) {
+          return count >= 1;
         }
       };
 
   Function MIN =
-      new Function("min", 2) {
+      new Function("min") {
         @Override
         public double apply(double... doubles) {
-          return Math.min(doubles[0], doubles[1]);
+          double min = doubles[0];
+          for (int i = 1; i < doubles.length; i++) min = Math.min(min, doubles[i]);
+          return min;
+        }
+
+        @Override
+        public boolean isValidArgCount(int count) {
+          return count >= 1;
         }
       };
 


### PR DESCRIPTION
Migrates to my fork of https://github.com/Pablete1234/exp4j, where i've added support for var-arg functions. This means we can support `min(1,2,3,4)` with arbitrary amount of params instead of having to do ugly work-arrounds like `min(min(1,2), min(3,4))` due to the original limitation.