### PR TITLE
Fix mode commands unwanted syntax

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,7 +68,7 @@
                             <include>org.eclipse.jgit:org.eclipse.jgit:*</include>
                             <include>org.slf4j:slf4j-api:*</include>
                             <include>fr.minuskube.inv:smart-invs</include>
-                            <include>net.objecthunter:exp4j:*</include>
+                            <include>me.github.Pablete1234:exp4j:*</include>
                             <include>io.github.bananapuncher714:nbteditor:*</include>
                         </includes>
                     </artifactSet>

--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -30,7 +30,7 @@ import tc.oc.pgm.util.text.TextFormatter;
 @CommandMethod("mode|modes")
 public final class ModeCommand {
 
-  @CommandMethod("mode|modes next")
+  @CommandMethod("next")
   @CommandDescription("Show the next objective mode")
   public void next(Audience audience, ObjectiveModesMatchModule modes) {
     List<ModeChangeCountdown> countdowns = modes.getActiveCountdowns();
@@ -94,7 +94,7 @@ public final class ModeCommand {
     new ModesPaginatedResult(header, resultsPerPage, modes).display(audience, modeList, page);
   }
 
-  @CommandMethod("mode|modes push <time>")
+  @CommandMethod("push <time>")
   @CommandDescription("Reschedule all objective modes with active countdowns")
   @CommandPermission(Permissions.GAMEPLAY)
   public void push(
@@ -133,7 +133,7 @@ public final class ModeCommand {
     audience.sendMessage(builder);
   }
 
-  @CommandMethod("mode|modes start <mode> [time]")
+  @CommandMethod("start <mode> [time]")
   @CommandDescription("Starts an objective mode")
   @CommandPermission(Permissions.GAMEPLAY)
   public void start(


### PR DESCRIPTION
When recently tweaking modes command to support `/modes` to default to `/modes list` i left over some extra stuff i was testing, causing needing to do like `/mode mode next`.

Also fixes exp4j not being included in the jar