### PR TITLE
Fix shading of exp4j

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,7 +68,7 @@
                             <include>org.eclipse.jgit:org.eclipse.jgit:*</include>
                             <include>org.slf4j:slf4j-api:*</include>
                             <include>fr.minuskube.inv:smart-invs</include>
-                            <include>me.github.Pablete1234:exp4j:*</include>
+                            <include>com.github.Pablete1234:exp4j:*</include>
                             <include>io.github.bananapuncher714:nbteditor:*</include>
                         </includes>
                     </artifactSet>


### PR DESCRIPTION
Fixes a `NoClassDef` caused by the recent merge of #1268 