### PR TITLE
Enable removal of the DoubleJumpKit 🐸 

### DIFF
--- a/core/src/main/java/tc/oc/pgm/doublejump/DoubleJumpKit.java
+++ b/core/src/main/java/tc/oc/pgm/doublejump/DoubleJumpKit.java
@@ -24,8 +24,7 @@ public class DoubleJumpKit extends AbstractKit {
 
   @Override
   public void applyPostEvent(MatchPlayer player, boolean force, List<ItemStack> displacedItems) {
-    DoubleJumpMatchModule djmm = player.getMatch().getModule(DoubleJumpMatchModule.class);
-    if (djmm != null) djmm.setKit(player.getBukkit(), this);
+    applyKit(player, this);
   }
 
   public float chargePerTick() {
@@ -34,5 +33,20 @@ public class DoubleJumpKit extends AbstractKit {
 
   public boolean needsRecharge() {
     return !Duration.ZERO.equals(this.rechargeTime);
+  }
+
+  @Override
+  public boolean isRemovable() {
+    return true;
+  }
+
+  @Override
+  public void remove(MatchPlayer player) {
+    applyKit(player, null);
+  }
+
+  private void applyKit(MatchPlayer player, DoubleJumpKit kit) {
+    DoubleJumpMatchModule djmm = player.getMatch().getModule(DoubleJumpMatchModule.class);
+    if (djmm != null) djmm.setKit(player.getBukkit(), kit);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/doublejump/DoubleJumpMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/doublejump/DoubleJumpMatchModule.java
@@ -85,6 +85,7 @@ public class DoubleJumpMatchModule implements MatchModule, Listener, Tickable {
       this.setCharge(jumper, 1f);
     } else {
       this.jumpers.remove(player);
+      this.removeCharge(player);
       this.refreshJump(player);
     }
   }
@@ -120,6 +121,10 @@ public class DoubleJumpMatchModule implements MatchModule, Listener, Tickable {
         jumper.player.setExp(jumper.charge);
       }
     }
+  }
+
+  private void removeCharge(Player player) {
+    player.setExp(0f);
   }
 
   private void refreshJump(Player player) {


### PR DESCRIPTION
This PR enables the removal of the `DoubleJumpKit`. I just tested locally, and it functions as expected 👍 

One minor note: I also added a `removeCharge` method to the `DoubleJumpMatchModule`. Basically removes the xp set to make it more clear that the kit has been removed, as opposed to leaving it partially or fully filled. I believe that's best approach, but just let me know if there's an alternate way to go about this.