### PR TITLE
fix(ci): pin maven-surefire-plugin to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,12 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/util/src/main/java/tc/oc/pgm/util/text/TextException.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextException.java
@@ -8,6 +8,7 @@ import static tc.oc.pgm.util.text.TextTranslations.translate;
 
 import com.google.common.collect.Range;
 import java.util.Locale;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -48,7 +49,7 @@ public class TextException extends RuntimeException
 
   @Override
   public String getLocalizedMessage() {
-    final Component localized = translate(message);
+    final Component localized = translate(message, Audience.empty());
     return PlainTextComponentSerializer.plainText().serialize(localized);
   }
 

--- a/util/src/test/java/tc/oc/pgm/util/text/TextExceptionTest.java
+++ b/util/src/test/java/tc/oc/pgm/util/text/TextExceptionTest.java
@@ -1,13 +1,15 @@
 package tc.oc.pgm.util.text;
 
+import static net.kyori.adventure.text.Component.translatable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static tc.oc.pgm.util.text.TextTranslations.translate;
 
-import java.util.Locale;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.junit.jupiter.api.Test;
 
 public final class TextExceptionTest {
-
   @Test
   void testGetLocalizedMessage() {
     final Throwable cause = new IllegalStateException();
@@ -16,10 +18,12 @@ public final class TextExceptionTest {
     assertEquals(cause, error.getCause(), "error cause is wrong");
     assertEquals("error.unknown", error.getMessage(), "error key is wrong");
 
-    // This test can only be run when the JVM has its language set to English or Root
-    final Locale jvmLocale = Locale.getDefault();
-    assumeTrue(jvmLocale == Locale.ROOT || jvmLocale == Locale.US, "jvm locale is not english");
-    assertEquals(
-        "An unknown error occurred, please see console for details.", error.getLocalizedMessage());
+    final Component unknownErrorTranslatable = translatable().key("error.unknown").build();
+    // accessing tc.oc.pgm.util.Audience crashes the test due to Bukkit not being available
+    final Component translatedError = translate(unknownErrorTranslatable, Audience.empty());
+    final String serializedError =
+        PlainTextComponentSerializer.plainText().serialize(translatedError);
+
+    assertEquals(serializedError, error.getLocalizedMessage(), "localized message is wrong");
   }
 }


### PR DESCRIPTION
This PR pins `maven-surefire-plugin` to version `3.1.2` to resolve build failures for local builds due to resolution algorithm changes in Maven 3.9.x.

On GitHub Actions (and my server running [Maven 3.8.7 from Debian repositories](https://packages.debian.org/bookworm/maven)), `maven-surefire-plugin` resolves to version `2.12.4` – which makes the build pass, but also seems to skip a significant portion of defined tests[^1]. 

However, when building PGM locally (using [Maven 3.9.1 from Fedora's repositories](https://koji.fedoraproject.org/koji/buildinfo?buildID=2244154)), `maven-surefire-plugin` is resolved to version `3.0.0` (or higher), which runs all of the defined tests. Building with Maven 3.9.5 on CI runs all defined tests, skipping the `TextException` class test that is otherwise failing, likely due to the JVM running using a different locale[^2]. This makes PGM build successfully on CI under newer Maven versions.

This PR also fixes a broken test of the `TextException` class which is crashing due to a missing Bukkit instance when `tc.oc.pgm.util.text.Audience` is accessed by getting the empty `Audience` directly. Along with this, the test for localized messages has been improved to be environment agnostic by translating the error manually using the same steps as `TextException` does and comparing the results appropriately.

[^1]: https://github.com/PGMDev/PGM/actions/runs/6867090484/job/18674723190#step:4:151
[^2]: https://github.com/TTtie/PGM/actions/runs/6961974625/job/18944710722#step:6:708