### PR TITLE
Fix map load exception with MaxBuildVariable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/variables/types/MaxBuildVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/MaxBuildVariable.java
@@ -14,18 +14,20 @@ public class MaxBuildVariable extends AbstractVariable<Match> {
 
   @Override
   public void postLoad(Match match) {
-    rmm = match.moduleRequire(RegionMatchModule.class);
+    rmm = match.getModule(RegionMatchModule.class);
   }
 
   @Override
   protected double getValueImpl(Match player) {
-    Integer val = rmm.getMaxBuildHeight();
+    Integer val = rmm != null ? rmm.getMaxBuildHeight() : null;
     return val == null ? -1 : val;
   }
 
   @Override
   protected void setValueImpl(Match player, double value) {
     int val = (int) value;
-    rmm.setMaxBuildHeight(val <= -1 ? null : val);
+    if (rmm != null) {
+      rmm.setMaxBuildHeight(val <= -1 ? null : val);
+    }
   }
 }


### PR DESCRIPTION
Here's a quick fix PR! This has been causing issues where PGM will not startup properly, particularly when a max build variable is defined in a global include.


Should work as expected 👍 Let me know if you'd like any additional changes made. 