### PR TITLE
Fix max build variable dependencies

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/module/ModuleGraph.java
+++ b/core/src/main/java/tc/oc/pgm/api/module/ModuleGraph.java
@@ -4,7 +4,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Stack;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -60,7 +60,7 @@ public abstract class ModuleGraph<M extends Module, F extends ModuleFactory<M>>
 
   protected void unloadAll() {
     if (loaded.compareAndSet(true, false)) {
-      modules = new HashMap<>(factories.size());
+      modules = new LinkedHashMap<>(factories.size());
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/variables/VariablesModule.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariablesModule.java
@@ -24,6 +24,7 @@ import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
 import tc.oc.pgm.blitz.BlitzMatchModule;
 import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.regions.RegionMatchModule;
 import tc.oc.pgm.score.ScoreMatchModule;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.math.Formula;
@@ -50,7 +51,11 @@ public class VariablesModule implements MapModule<VariablesMatchModule> {
 
   @Override
   public @Nullable Collection<Class<? extends MatchModule>> getWeakDependencies() {
-    return ImmutableList.of(TeamMatchModule.class, BlitzMatchModule.class, ScoreMatchModule.class);
+    return ImmutableList.of(
+        TeamMatchModule.class,
+        BlitzMatchModule.class,
+        ScoreMatchModule.class,
+        RegionMatchModule.class);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Adds the region match module as dependency for variables, and also makes load order consistent for match modules to avoid these issues happening in the future, where due to arbitrary ordering it may sometimes work and sometimes fail.