### PR TITLE
Implement message action replacements

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/actions/MessageAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/MessageAction.java
@@ -1,28 +1,64 @@
 package tc.oc.pgm.action.actions;
 
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.title.Title;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.Audience;
 
-public class MessageAction extends AbstractAction<Audience> {
+public class MessageAction<T extends Audience> extends AbstractAction<T> {
+  private static final Pattern REPLACEMENT_PATTERN = Pattern.compile("\\{(.+?)}");
 
   private final Component text;
   private final Component actionbar;
   private final Title title;
+  private final Map<String, Replacement<T>> replacements;
 
   public MessageAction(
-      @Nullable Component text, @Nullable Component actionbar, @Nullable Title title) {
-    super(Audience.class);
+      Class<T> scope,
+      @Nullable Component text,
+      @Nullable Component actionbar,
+      @Nullable Title title,
+      @Nullable Map<String, Replacement<T>> replacements) {
+    super(scope);
     this.text = text;
     this.actionbar = actionbar;
     this.title = title;
+    this.replacements = replacements;
   }
 
   @Override
-  public void trigger(Audience audience) {
-    if (text != null) audience.sendMessage(text);
-    if (title != null) audience.showTitle(title);
-    if (actionbar != null) audience.sendActionBar(actionbar);
+  public void trigger(T scope) {
+    if (text != null) scope.sendMessage(replace(text, scope));
+    if (title != null) scope.showTitle(replace(title, scope));
+    if (actionbar != null) scope.sendActionBar(replace(actionbar, scope));
   }
+
+  private Component replace(Component component, T scope) {
+    if (component == null || replacements == null) {
+      return component;
+    }
+
+    return component.replaceText(
+        TextReplacementConfig.builder()
+            .match(REPLACEMENT_PATTERN)
+            .replacement(
+                (match, original) -> {
+                  Replacement<T> r = replacements.get(match.group(1));
+                  return r != null ? r.apply(scope) : original;
+                })
+            .build());
+  }
+
+  private Title replace(Title title, T scope) {
+    if (replacements == null) return title;
+    return Title.title(
+        replace(title.title(), scope), replace(title.subtitle(), scope), title.times());
+  }
+
+  public interface Replacement<T extends Audience> extends Function<T, ComponentLike> {}
 }


### PR DESCRIPTION
Allows `replacements` being defined inside `message` actions. It supports a list of replacements, where the `id` of such replacement will be evaluated when sending the message to the audience, for the scope the action is ran on.

Example
```xml
    <trigger scope="player">
      <filter>
        <pulse period="1s" duration="0.5s" filter="some-region"/>
      </filter>
      <action>
        <set var="team_score" value="team_score+1"/>
        <message text="Ding {num}!">
          <replacements>
            <decimal id="num" value="team_score"/>
          </replacements>
        </message>
      </action>
    </trigger>
```

Note: Currently the only supported replacement is `decimal`, in the future more may come (thinking of players, teams, and durations). id is required in all replacements and it's what will get used to search for a `{id}` text to replace.

`decimal` replacement has a required `value` attribute, which supports formulas (eg: `team_score / 100`), and a `format` attribute, which takes in a [java decimal format pattern](https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html) such as `#.00` (always show 2 decimal places).
Eg:
`<decimal id="id" value="team_score/100" format="#.00"/>`
