### PR TITLE
Add flag-tracking compass functionality

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagDefinition.java
@@ -39,6 +39,8 @@ public class FlagDefinition extends ProximityGoalDefinition {
   private final Filter pickupFilter; // Filter players who can pickup this flag
   private final Filter captureFilter; // Filter players who can capture this flag
   private final Filter dropFilter; // Filter players who can drop the flag
+  private final @Nullable Filter
+      compassFilter; // Filter for players who have their compass set to this flag
   private final @Nullable Kit pickupKit; // Kit to give on flag pickup
   private final @Nullable Kit dropKit; // Kit to give carrier when they drop the flag
   private final @Nullable Kit carryKit; // Kit to give to/take from the flag carrier
@@ -62,6 +64,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
       Filter pickupFilter,
       Filter captureFilter,
       Filter dropFilter,
+      @Nullable Filter compassFilter,
       @Nullable Kit pickupKit,
       @Nullable Kit dropKit,
       @Nullable Kit carryKit,
@@ -92,6 +95,7 @@ public class FlagDefinition extends ProximityGoalDefinition {
     this.pickupFilter = pickupFilter;
     this.captureFilter = captureFilter;
     this.dropFilter = dropFilter;
+    this.compassFilter = compassFilter;
     this.pickupKit = pickupKit;
     this.dropKit = dropKit;
     this.carryKit = carryKit;
@@ -149,6 +153,10 @@ public class FlagDefinition extends ProximityGoalDefinition {
 
   public Filter getCaptureFilter() {
     return captureFilter;
+  }
+
+  public @Nullable Filter getCompassFilter() {
+    return compassFilter;
   }
 
   public @Nullable Kit getPickupKit() {

--- a/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagParser.java
@@ -261,6 +261,7 @@ public class FlagParser {
     Filter captureFilter =
         filterParser.parseFilterProperty(el, "capture-filter", StaticFilter.ALLOW);
     Filter dropFilter = filterParser.parseFilterProperty(el, "drop-filter", StaticFilter.ALLOW);
+    Filter compassFilter = filterParser.parseFilterProperty(el, "compass-filter", null);
     Kit pickupKit = factory.getKits().parseKitProperty(el, "pickup-kit", null);
     Kit dropKit = factory.getKits().parseKitProperty(el, "drop-kit", null);
     Kit carryKit = factory.getKits().parseKitProperty(el, "carry-kit", null);
@@ -303,6 +304,7 @@ public class FlagParser {
             pickupFilter,
             captureFilter,
             dropFilter,
+            compassFilter,
             pickupKit,
             dropKit,
             carryKit,

--- a/core/src/main/java/tc/oc/pgm/flag/state/Spawned.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Spawned.java
@@ -73,5 +73,17 @@ public abstract class Spawned extends BaseState {
         }
       }
     }
+
+    if (this.flag.getDefinition().getCompassFilter() != null) {
+      this.flag
+          .getMatch()
+          .getParticipants()
+          .forEach(
+              p -> {
+                if (this.flag.getDefinition().getCompassFilter().query(p).isAllowed()) {
+                  p.getBukkit().setCompassTarget(this.getLocation());
+                }
+              });
+    }
   }
 }


### PR DESCRIPTION
Firstly, sorry for just making this without discussing the design first. Turns out I needed to get this done much sooner than I expected. Luckily it's a pretty easy implementation so if it gets thrown away & replaced by something better it's not much work lost.

This PR adds the ability to have compasses that track flags. Specifically, it uses this XML syntax:

```xml
<flag compass-filter="always">
```
or
```xml
<flag compass-filter="red-team">
<flag compass-filter="blue-team">
```

**Can you have multiple different compasses?**
I'm pretty sure a player cannot have multiple compasses with different targets in a vanilla client.

**Why put this on flags instead of compass items?**
Putting the filter on the flags, instead of on compass items, will make it clear to map makers they can't treat different compasses differently. It also makes the filter simpler if other kinds of targets are added — hills or cores could also have compass filters, and the filters will always filter players, and not some weird mishmash of objectives and locations.

**What happens if multiple filters match the player?**
Right now it would probably visually just track one, while sending updates for both. Practically I'm not really sure what could be done here. This is one of the major drawbacks of this design.

**What about tracking players?**
I'm not sure how this design could be extended for player tracking, which is the other major drawback of this design. Perhaps there's a clean way that I'm missing at 3 am, or perhaps we'll need to rethink this entirely. See #1114 for discussion on this.

**What about tracking multiple things & clicking the compass?**
This could easily be added — increment a variable when the player clicks the compass and filter on variables. I don't think right click actions are currently available, but they are planned so that's an easy future extension of this.

---

My other concern with this PR is how it filters all the players every tick. Some quick testing seems to indicate that this isn't an issue, and in my mind I'd be surprised if it was an issue expect with pathological filters, but I'm not familiar enough with PGM to be confident.