### PR TITLE
Avoid reflection when using SportPaper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
         <repository>
             <id>sportpaper-github</id>
             <url>https://maven.pkg.github.com/Electroid/SportPaper</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>jitpack-io</id>

--- a/util/src/main/java/tc/oc/pgm/util/nms/v1_8/NMSHacks1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/v1_8/NMSHacks1_8.java
@@ -837,12 +837,12 @@ public class NMSHacks1_8 extends NMSHacksNoOp {
             || (nmsTool != null && nmsTool.canDestroySpecialBlock(nmsBlock)));
   }
 
-  Field worldServerField = ReflectionUtils.getField(CraftWorld.class, "world");
-  Field dimensionField = ReflectionUtils.getField(WorldServer.class, "dimension");
-  Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
-
   @Override
   public void resetDimension(World world) {
+    Field worldServerField = ReflectionUtils.getField(CraftWorld.class, "world");
+    Field dimensionField = ReflectionUtils.getField(WorldServer.class, "dimension");
+    Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
+
     try {
       modifiersField.setInt(dimensionField, dimensionField.getModifiers() & ~Modifier.FINAL);
 

--- a/util/src/main/java/tc/oc/pgm/util/nms/v1_8/NMSHacksSportPaper.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/v1_8/NMSHacksSportPaper.java
@@ -16,7 +16,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChunkSnapshot;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.BlockState;
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_8_R3.scoreboard.CraftTeam;
 import org.bukkit.entity.EntityType;
@@ -183,6 +185,15 @@ public class NMSHacksSportPaper extends NMSHacks1_8 {
     return player.hasFakeSkin(viewer)
         ? new Skin(player.getFakeSkin(viewer).getData(), player.getFakeSkin(viewer).getSignature())
         : getPlayerSkin(player);
+  }
+
+  @Override
+  public void resetDimension(World world) {
+    try {
+      ((CraftWorld) world).getHandle().dimension = 11;
+    } catch (IllegalAccessError e) {
+      super.resetDimension(world);
+    }
   }
 
   @Override


### PR DESCRIPTION
~~Depends on https://github.com/Electroid/SportPaper/pull/139~~

The reflection used in NMSHacks1_8 breaks in modern Java versions, but we can modify SportPaper and avoid that here.