### PR TITLE
Fix nicked player sorting in player list

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/PlayerOrder.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/PlayerOrder.java
@@ -64,15 +64,17 @@ public class PlayerOrder implements Comparator<MatchPlayer> {
     if (aStaff && !bStaff) return -1;
     else if (bStaff && !aStaff) return 1;
 
-    // Compare the nicknames of 'a' and 'b' if both are nicked, skip group permission check
+    // Compare the nicknames of 'a' and 'b'. If both are nicked, skip group permission check
     if (aNick != null && bNick != null) return aNick.compareToIgnoreCase(bNick);
 
     // If players have different permissions, the player with the highest ranked perm
-    // that the other one does't have is first. Disguised players effectively have no perms.
+    // that the other one doesn't have is first. Disguised players effectively have no perms.
     for (Config.Group group : PGM.get().getConfiguration().getGroups()) {
+      if (group.getId().equalsIgnoreCase("default")) continue;
+
       Permission permission = group.getPermission();
-      boolean aPerm = a.hasPermission(permission);
-      boolean bPerm = b.hasPermission(permission);
+      boolean aPerm = a.hasPermission(permission) && aNick == null;
+      boolean bPerm = b.hasPermission(permission) && bNick == null;
 
       if (aPerm && !bPerm) {
         return -1;
@@ -82,6 +84,7 @@ public class PlayerOrder implements Comparator<MatchPlayer> {
     }
 
     // All else equal, order the players alphabetically
-    return a.getName().compareToIgnoreCase(b.getName());
+    return (aNick == null ? a.getName() : aNick)
+        .compareToIgnoreCase(bNick == null ? b.getName() : bNick);
   }
 }


### PR DESCRIPTION
Currently, when a player with a rank is disguised, they keep their "real" position on the player list (appearing higher on the list than unranked players), making it extremely easy to differentiate  nicked players from regular players as they're not following alphabetical order.

This PR adds some extra checks to the "group permission check" stage and after in _PlayerOrder_.

I have tested this in a local server with 4 clients.