### PR TITLE
Fixed bug that caused setting the picker to manual reset user settings

### DIFF
--- a/core/src/main/java/tc/oc/pgm/db/SettingsImpl.java
+++ b/core/src/main/java/tc/oc/pgm/db/SettingsImpl.java
@@ -18,7 +18,7 @@ class SettingsImpl implements Settings {
   }
 
   public static long bitSettings(SettingValue value) {
-    return 1 << (assertNotNull(value, "setting value is null").ordinal() + 1);
+    return 1L << (assertNotNull(value, "setting value is null").ordinal() + 1);
   }
 
   protected final long getBit() {


### PR DESCRIPTION
The value associated with the manual setting for picker caused the left shift of the 1 (integer) to overflow. Using a 1 of type long prevents this overflow.
This overflow probably caused the settings to be incorrectly saved or loaded to the database thereby causing a reset of the user settings after a server restart.