### PR TITLE
Fix team force and shuffling without target team

### DIFF
--- a/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -336,7 +336,10 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
   @Override
   public JoinResult queryJoin(MatchPlayer joining, JoinRequest request) {
     if (request.has(JoinRequest.Flag.FORCE)) {
-      return new TeamJoinResult(JoinResultOption.JOINED, request.getTeam(), false);
+      return new TeamJoinResult(
+          JoinResultOption.JOINED,
+          request.getTeam() == null ? getEmptiestTeam() : request.getTeam(),
+          false);
     }
 
     final Team lastTeam = getLastTeam(joining.getId());


### PR DESCRIPTION
Currently, commands like `/team shuffle --a` or `/team force ElectroidFilms` (that don't specify a team) don't work, as the team field in TeamMatchModule's `internalJoin` cannot be null, so when  attempting to execute those kinds of commands you end up with this:
 
![image](https://github.com/PGMDev/PGM/assets/11651753/79021117-1c3e-46c5-93b2-ac701469dfba)

This PR restores the previous behaviour those commands used to have by re-adding [previous logic](https://github.com/PGMDev/PGM/commit/749c9c4e210db47a320a53e3ec64bcf81a21d200#diff-04ba6c355285be7f33fda6a34f58f6c6bd008972fa65c0a97bbf21f4dca61669L282) when forcing a join.