### PR TITLE
Change default getName() NameStyle to VERBOSE

### DIFF
--- a/core/src/main/java/tc/oc/pgm/loot/LootableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/loot/LootableMatchModule.java
@@ -105,7 +105,10 @@ public class LootableMatchModule implements MatchModule, Listener {
     if (filterPredicate == null) return;
 
     logger.fine(
-        () -> opener.getName() + " opened a " + inventory.getHolder().getClass().getSimpleName());
+        () ->
+            opener.getNameLegacy()
+                + " opened a "
+                + inventory.getHolder().getClass().getSimpleName());
 
     // Find all Fillers that apply to the holder of the opened inventory
     final List<FillerDefinition> fillers =

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -365,7 +365,7 @@ public class StatsMatchModule implements MatchModule, Listener {
         best.add(
             translatable(
                 "match.stats.damage",
-                player(bestDamage.getKey(), NameStyle.FANCY),
+                player(bestDamage.getKey(), NameStyle.VERBOSE),
                 damageComponent(bestDamage.getValue(), NamedTextColor.GREEN)));
       }
     }
@@ -462,7 +462,9 @@ public class StatsMatchModule implements MatchModule, Listener {
   Component getMessage(
       String messageKey, Map.Entry<UUID, ? extends Number> mapEntry, TextColor color) {
     return translatable(
-        messageKey, player(mapEntry.getKey(), NameStyle.FANCY), number(mapEntry.getValue(), color));
+        messageKey,
+        player(mapEntry.getKey(), NameStyle.VERBOSE),
+        number(mapEntry.getValue(), color));
   }
 
   /** Formats raw damage to damage relative to the amount of hearths the player would have broken */

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
@@ -153,7 +153,7 @@ public class PlayerStatsMenuItem implements MenuItem {
     Component playerComponent =
         stats.getPlayerComponent() != null
             ? stats.getPlayerComponent()
-            : player(uuid, NameStyle.FANCY);
+            : player(uuid, NameStyle.VERBOSE);
 
     meta.setDisplayName(
         TextTranslations.translateLegacy(

--- a/util/src/main/java/tc/oc/pgm/util/named/Named.java
+++ b/util/src/main/java/tc/oc/pgm/util/named/Named.java
@@ -7,7 +7,7 @@ public interface Named {
   Component getName(NameStyle style);
 
   default Component getName() {
-    return getName(NameStyle.FANCY);
+    return getName(NameStyle.VERBOSE);
   }
 
   // TODO: Maybe add a note here explaining to prefer Named#getName()


### PR DESCRIPTION
This commit restores legacy behaviour. Join/leave messages (among other things) now show player nicknames.