### PR TITLE
Different style for nicked + vanished players

### DIFF
--- a/core/src/main/java/tc/oc/pgm/util/player/PlayerRenderer.java
+++ b/core/src/main/java/tc/oc/pgm/util/player/PlayerRenderer.java
@@ -26,8 +26,6 @@ import tc.oc.pgm.util.named.NameStyle;
 @SuppressWarnings("UnstableApiUsage")
 public class PlayerRenderer {
   private static final TextColor DEAD_COLOR = NamedTextColor.DARK_GRAY;
-  private static final Style NICK_STYLE =
-      Style.style(TextDecoration.ITALIC).decoration(TextDecoration.STRIKETHROUGH, false);
 
   private final LoadingCache<PlayerCacheKey, Component> nameCache;
 
@@ -96,7 +94,11 @@ public class PlayerRenderer {
       name.decoration(TextDecoration.STRIKETHROUGH, true);
 
       if (data.nick != null && data.style.has(NameStyle.Flag.NICKNAME)) {
-        name.append(text(" " + data.nick, NICK_STYLE));
+        name.append(
+            text(
+                " " + data.nick,
+                Style.style(TextDecoration.ITALIC)
+                    .decoration(TextDecoration.STRIKETHROUGH, data.vanish)));
       }
     }
 


### PR DESCRIPTION
This adds an easy way to tell if a player is both nicked and vanished at the same time, visible when they send a message in chat and in commands like `/list` and `/nicks` (Community)

![nick_style](https://github.com/PGMDev/PGM/assets/11651753/ee2eb7aa-a2e3-4f69-aa56-b9f78a555a22)
(notice how both the real name and the nick are strikethrough in the third example)
