### PR TITLE
Fix issues with spleef tracker

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/event/PlayerSpleefEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/event/PlayerSpleefEvent.java
@@ -2,9 +2,9 @@ package tc.oc.pgm.api.event;
 
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
-import org.bukkit.block.Block;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.ParticipantState;
@@ -13,10 +13,10 @@ import tc.oc.pgm.tracker.info.SpleefInfo;
 public class PlayerSpleefEvent extends Event {
 
   private final MatchPlayer victim;
-  private final Block block;
+  private final Vector block;
   private final SpleefInfo info;
 
-  public PlayerSpleefEvent(MatchPlayer victim, Block block, SpleefInfo info) {
+  public PlayerSpleefEvent(MatchPlayer victim, Vector block, SpleefInfo info) {
     this.victim = assertNotNull(victim);
     this.block = assertNotNull(block);
     this.info = assertNotNull(info);
@@ -30,7 +30,7 @@ public class PlayerSpleefEvent extends Event {
     return info;
   }
 
-  public Block getBlock() {
+  public Vector getBlock() {
     return block;
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/event/player/PlayerOnGroundEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/player/PlayerOnGroundEvent.java
@@ -8,7 +8,7 @@ import tc.oc.pgm.util.event.SportPaper;
 @SportPaper
 public class PlayerOnGroundEvent extends PlayerEvent {
   private static final HandlerList handlers = new HandlerList();
-  private boolean onGround;
+  private final boolean onGround;
 
   public PlayerOnGroundEvent(final Player player, boolean onGround) {
     super(player);


### PR DESCRIPTION
The spleef tracker is iterating to get all potential blocks under a player, however only actually ever checks for the block the player is in. This fixes up that bug to actually search different blocks under the player, as well as making the tracker a bit more lenient by increasing max time for spleef from 1 second to 1.5s, and radius for players from exactly their hitbox size to 0.05 more.

On top of those changes, it also changes from Block to Vector, to avoid keeping references to the world and needing to get blocks off of the world when none of the functionality requires it.