### PR TITLE
Fix /sn with no args, show sn msg when using /cycle

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
@@ -9,6 +9,7 @@ import cloud.commandframework.annotations.CommandPermission;
 import cloud.commandframework.annotations.Flag;
 import cloud.commandframework.annotations.specifier.FlagYielding;
 import java.time.Duration;
+import org.bukkit.command.CommandSender;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
@@ -21,6 +22,7 @@ public final class CycleCommand {
   @CommandDescription("Cycle to the next match")
   @CommandPermission(Permissions.START)
   public void cycle(
+      CommandSender sender,
       Match match,
       MapOrder mapOrder,
       @Argument("duration") Duration duration,
@@ -32,6 +34,7 @@ public final class CycleCommand {
 
     if (map != null && mapOrder.getNextMap() != map) {
       mapOrder.setNextMap(map);
+      MapOrderCommand.sendSetNextMessage(map, sender, match);
     }
 
     match.needModule(CycleMatchModule.class).startCountdown(duration);
@@ -41,10 +44,11 @@ public final class CycleCommand {
   @CommandDescription("Reload (cycle to) the current map")
   @CommandPermission(Permissions.START)
   public void recycle(
+      CommandSender sender,
       Match match,
       MapOrder mapOrder,
       @Argument("duration") Duration duration,
       @Flag(value = "force", aliases = "f") boolean force) {
-    cycle(match, mapOrder, duration, match.getMap(), force);
+    cycle(sender, match, mapOrder, duration, match.getMap(), force);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/MapOrderCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapOrderCommand.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.command;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
 import static tc.oc.pgm.util.text.TextException.exception;
 
 import cloud.commandframework.annotations.Argument;
@@ -13,6 +14,7 @@ import cloud.commandframework.annotations.specifier.FlagYielding;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
@@ -49,7 +51,7 @@ public final class MapOrderCommand {
       Match match,
       @Flag(value = "force", aliases = "f") boolean force,
       @Flag(value = "reset", aliases = "r") boolean reset,
-      @Argument("map") @FlagYielding MapInfo map) {
+      @Argument(value = "map", defaultValue = CURRENT) @FlagYielding MapInfo map) {
     if (RestartManager.isQueued() && !force) {
       throw exception("map.setNext.confirm");
     }
@@ -78,6 +80,10 @@ public final class MapOrderCommand {
       viewer.sendWarning(translatable("admin.cancelRestart.restartUnqueued", NamedTextColor.GREEN));
     }
 
+    sendSetNextMessage(map, sender, match);
+  }
+
+  public static void sendSetNextMessage(@NotNull MapInfo map, CommandSender sender, Match match) {
     Component mapName = text(map.getName(), NamedTextColor.GOLD);
     Component successful =
         translatable(

--- a/core/src/main/java/tc/oc/pgm/command/util/ParserConstants.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/ParserConstants.java
@@ -3,5 +3,5 @@ package tc.oc.pgm.command.util;
 public class ParserConstants {
   // Generic default constant to parse default as whatever is the current value
   // This can mean things like the current map, or the current player on MatchPlayer parser
-  public static final String CURRENT = "__DEFAULT_CURRENT__";
+  public static final String CURRENT = "$__DEFAULT_CURRENT__$";
 }


### PR DESCRIPTION
Fixes `/sn` throwing an exception instead of defaulting to re-set-nexting the current map. Also adds the broadcast to adminchat when a map is setnexted using `/cycle 10 map`