### PR TITLE
fix(ActionScopeValidation): use action scope in class

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionScopeValidation.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionScopeValidation.java
@@ -28,7 +28,7 @@ public class ActionScopeValidation implements FeatureValidation<ActionDefinition
           "Wrong action scope, got "
               + scope.getSimpleName()
               + " but expected "
-              + scope.getSimpleName(),
+              + this.scope.getSimpleName(),
           node);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/ActionScopeValidation.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionScopeValidation.java
@@ -22,13 +22,13 @@ public class ActionScopeValidation implements FeatureValidation<ActionDefinition
 
   @Override
   public void validate(ActionDefinition<?> definition, Node node) throws InvalidXMLException {
-    Class<?> scope = definition.getScope();
-    if (!scope.isAssignableFrom(this.scope))
+    Class<?> definitionScope = definition.getScope();
+    if (!definitionScope.isAssignableFrom(scope))
       throw new InvalidXMLException(
           "Wrong action scope, got "
-              + scope.getSimpleName()
+              + definitionScope.getSimpleName()
               + " but expected "
-              + this.scope.getSimpleName(),
+              + scope.getSimpleName(),
           node);
   }
 }


### PR DESCRIPTION
Corrects cases when specifying an invalid action scope results in incorrect errors of "Wrong action scope, got SCOPE but expected SCOPE" where the expected scope is the scope from the action definition. This PR corrects the oversight and uses the scope from the class instead.