### PR TITLE
Implement basic command flag suggestion filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
@@ -22,6 +22,7 @@ import cloud.commandframework.exceptions.InvalidSyntaxException;
 import cloud.commandframework.exceptions.NoPermissionException;
 import cloud.commandframework.exceptions.parsing.ParserException;
 import cloud.commandframework.execution.CommandExecutionCoordinator;
+import cloud.commandframework.execution.FilteringCommandSuggestionProcessor;
 import cloud.commandframework.extra.confirmation.CommandConfirmationManager;
 import cloud.commandframework.meta.CommandMeta;
 import cloud.commandframework.minecraft.extras.MinecraftHelp;
@@ -85,9 +86,11 @@ public abstract class CommandGraph<P extends Plugin> {
         context ->
             context.getCommandContext().store(CommandKeys.INPUT_QUEUE, context.getInputQueue()));
 
-    // By default, suggestions run by a filtered processor.
-    // By default, it prevents suggestions like "s" -> "Something" or "someh" -> "Something"
-    manager.commandSuggestionProcessor((cpc, strings) -> strings);
+    // Basic suggestion filtering processor which avoids suggesting flags when not applicable
+    manager.commandSuggestionProcessor(
+        new FilteringCommandSuggestionProcessor<>(
+            FilteringCommandSuggestionProcessor.Filter.Simple.contextFree(
+                (s, i) -> i.isEmpty() || s.startsWith("-") == s.startsWith(i))));
 
     return manager;
   }

--- a/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/CommandGraph.java
@@ -29,6 +29,7 @@ import cloud.commandframework.minecraft.extras.MinecraftHelp;
 import cloud.commandframework.paper.PaperCommandManager;
 import io.leangen.geantyref.TypeToken;
 import java.lang.reflect.Type;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import net.kyori.adventure.text.Component;
@@ -90,7 +91,10 @@ public abstract class CommandGraph<P extends Plugin> {
     manager.commandSuggestionProcessor(
         new FilteringCommandSuggestionProcessor<>(
             FilteringCommandSuggestionProcessor.Filter.Simple.contextFree(
-                (s, i) -> i.isEmpty() || s.startsWith("-") == s.startsWith(i))));
+                (s, i) ->
+                    i.isEmpty()
+                        || !s.startsWith("-")
+                        || s.toLowerCase(Locale.ROOT).startsWith(i.toLowerCase(Locale.ROOT)))));
 
     return manager;
   }


### PR DESCRIPTION
Our current no-filter approach suggests command flags first (and incorrectly) instead of partly formed inputs.

Currently running `/ban den[tab]` changes the input to `/ban --silent` and then `/ban --time`.

This change means that command flags will only be suggested if:
- Input string currently empty
- Input string starts with a flag `-`/`--`
- Matches the start of the command flag

The above `ban` command example is from Community which extends the PGM command graph, to see an example baked in to PGM the `/setnext` command can be used which has `--force` and `--reset` flags.