### PR TITLE
Add take-payment action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -28,10 +28,12 @@ import tc.oc.pgm.action.actions.ReplaceItemAction;
 import tc.oc.pgm.action.actions.ScopeSwitchAction;
 import tc.oc.pgm.action.actions.SetVariableAction;
 import tc.oc.pgm.action.actions.SoundAction;
+import tc.oc.pgm.action.actions.TakePaymentAction;
 import tc.oc.pgm.api.feature.FeatureValidation;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.Filterables;
 import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.features.XMLFeatureReference;
 import tc.oc.pgm.filters.Filterable;
@@ -41,6 +43,8 @@ import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.regions.BlockBoundedValidation;
 import tc.oc.pgm.regions.RegionParser;
+import tc.oc.pgm.shops.ShopModule;
+import tc.oc.pgm.shops.menu.Payable;
 import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
@@ -351,5 +355,16 @@ public class ActionParser {
         XMLUtils.parseMaterialData(Node.fromRequiredAttr(el, "material")),
         filters.parseProperty(Node.fromAttr(el, "filter")),
         XMLUtils.parseBoolean(el.getAttribute("events"), false));
+  }
+
+  @MethodParser("take-payment")
+  public Action<? super MatchPlayer> parseTakePayment(Element el, Class<?> scope)
+      throws InvalidXMLException {
+    Payable payable = Payable.of(ShopModule.parsePayments(el, factory.getKits()));
+    if (payable.isFree()) throw new InvalidXMLException("Payment has not been defined", el);
+    return new TakePaymentAction(
+        payable,
+        parseProperty(Node.fromChildOrAttr(el, "success-action"), MatchPlayer.class, null),
+        parseProperty(Node.fromChildOrAttr(el, "fail-action"), MatchPlayer.class, null));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/TakePaymentAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TakePaymentAction.java
@@ -1,0 +1,32 @@
+package tc.oc.pgm.action.actions;
+
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.action.Action;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.shops.menu.Payable;
+
+public class TakePaymentAction extends AbstractAction<MatchPlayer> {
+
+  private final Payable payable;
+  private final @Nullable Action<? super MatchPlayer> onSuccess;
+  private final @Nullable Action<? super MatchPlayer> onFailure;
+
+  public TakePaymentAction(
+      Payable payable,
+      @Nullable Action<? super MatchPlayer> onSuccess,
+      @Nullable Action<? super MatchPlayer> onFailure) {
+    super(MatchPlayer.class);
+    this.payable = payable;
+    this.onSuccess = onSuccess;
+    this.onFailure = onFailure;
+  }
+
+  @Override
+  public void trigger(MatchPlayer player) {
+    if (payable.takePayment(player)) {
+      if (onSuccess != null) onSuccess.trigger(player);
+    } else {
+      if (onFailure != null) onFailure.trigger(player);
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/shops/menu/Icon.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/Icon.java
@@ -7,7 +7,7 @@ import tc.oc.pgm.action.Action;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.player.MatchPlayer;
 
-public class Icon {
+public class Icon implements Payable {
 
   private final ImmutableList<Payment> payments;
   private final ItemStack item;
@@ -20,10 +20,6 @@ public class Icon {
     this.item = item;
     this.filter = filter;
     this.action = action;
-  }
-
-  public boolean isFree() {
-    return payments.isEmpty() || payments.stream().anyMatch(p -> p.getPrice() < 1);
   }
 
   public List<Payment> getPayments() {

--- a/core/src/main/java/tc/oc/pgm/shops/menu/Payable.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/Payable.java
@@ -1,0 +1,53 @@
+package tc.oc.pgm.shops.menu;
+
+import java.util.List;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import tc.oc.pgm.api.player.MatchPlayer;
+
+public interface Payable {
+
+  default boolean isFree() {
+    return getPayments().isEmpty() || getPayments().stream().noneMatch(p -> p.getPrice() > 0);
+  }
+
+  List<Payment> getPayments();
+
+  default boolean canPurchase(MatchPlayer buyer) {
+    if (!buyer.getMatch().isRunning() || !buyer.isParticipating()) return false;
+    return isFree() || getPayments().stream().allMatch(p -> p.hasPayment(buyer.getInventory()));
+  }
+
+  default boolean takePayment(MatchPlayer buyer) {
+    if (!canPurchase(buyer)) return false;
+
+    if (!isFree()) {
+      PlayerInventory inventory = buyer.getInventory();
+      for (Payment payment : getPayments()) {
+        int remaining = payment.getPrice();
+        for (int slot = 0; slot < inventory.getSize() && remaining > 0; slot++) {
+          ItemStack item = inventory.getItem(slot);
+          if (item == null || !payment.matches(item)) continue;
+          if (item.getAmount() > remaining) {
+            item.setAmount(item.getAmount() - remaining);
+            inventory.setItem(slot, item);
+            remaining = 0;
+          } else {
+            inventory.setItem(slot, null);
+            remaining -= item.getAmount();
+          }
+        }
+
+        // Should never happen, canPurchase checks for payment being available in the inventory
+        if (remaining > 0) {
+          throw new IllegalStateException("Player couldn't pay for their purchase.");
+        }
+      }
+    }
+    return true;
+  }
+
+  static Payable of(List<Payment> payments) {
+    return () -> payments;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
@@ -173,7 +173,7 @@ public class ShopMenu extends InventoryMenu {
   }
 
   private ClickableItem getPurchasableItem(Icon icon) {
-    boolean canPurchase = shop.canPurchase(icon, getViewer());
+    boolean canPurchase = icon.canPurchase(getViewer());
     NamedTextColor purchaseColor = canPurchase ? NamedTextColor.GREEN : NamedTextColor.RED;
 
     List<Component> price = Lists.newArrayList();
@@ -255,12 +255,7 @@ public class ShopMenu extends InventoryMenu {
     meta.addItemFlags(ItemFlag.values());
     item.setItemMeta(meta);
 
-    return ClickableItem.of(
-        item,
-        c -> {
-          shop.purchase(icon, getViewer());
-          getViewer().getBukkit().updateInventory();
-        });
+    return ClickableItem.of(item, c -> shop.purchase(icon, getViewer()));
   }
 
   private ClickableItem getPageItem(Player player, int page, boolean next) {


### PR DESCRIPTION
As per mentioned https://github.com/PGMDev/PGM/pull/1254#issuecomment-1759728344, this adds a take-payment action, that is able to programatically (via action) trigger the user "paying" with items in their inventory:

```xml
<take-payment>
  <!-- This is syntax taken from the shops, you can define multiple items required as payment, but can be simpler for single-item payments -->
  <payment material="diamond" price="5"/>
  <payment material="emerald" price="5"/>
  <payment price="1">
      <!-- Item name is shown under the cost lore instead of the raw material name -->
      <item name="`bEnchanted Diamond" material="diamond">
          <enchantment level="2">sharpness</enchantment>
      </item>
  </payment>
  <success-action>
    <message><text>Success!</text></message>
    <kit>
        <chestplate material="diamond chestplate"/>
    </kit>
  </success-action>
  <fail-action>
    <message><text>You can't afford this!</text></message>
  </fail-action>
</take-payment>
```

When using attributes and not needing complicated prices (single item cost) it can be simplified:
```xml
<take-payment id="buy-chestplate" currency="diamond" price="5" success-action="success" fail-action="too-poor"/>

<action id="success">
  <message><text>Success!</text></message>
  <kit>
      <chestplate material="diamond chestplate"/>
  </kit>
</action>
<message id="too-poor"><text>You can't afford this!</text></message>
```

Note: has not been tested yet.
@CoWinkKeyDinkInc if you want to give this a test and confirm if it solves your use-case that'd be greatly appreciated