### PR TITLE
Do not slugify manual slugs

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -386,7 +386,7 @@ public class MapInfoImpl implements MapInfo {
         this.world = variantEl.getAttributeValue("world");
         if (slug != null) slug += "_" + variantId;
       }
-      this.mapId = assertNotNull(StringUtils.slugify(slug != null ? slug : mapName));
+      this.mapId = assertNotNull(slug != null ? slug : StringUtils.slugify(mapName));
     }
 
     @Override

--- a/util/src/main/java/tc/oc/pgm/util/StringUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/StringUtils.java
@@ -136,7 +136,7 @@ public final class StringUtils {
     return text == null
         ? ""
         : Normalizer.normalize(text, Normalizer.Form.NFD)
-            .replaceAll("[^A-Za-z0-9 ]", "")
+            .replaceAll("[^A-Za-z0-9_ ]", "")
             .toLowerCase(Locale.ROOT);
   }
 


### PR DESCRIPTION
We have accidentally been slugifying manually defined slugs, so only slugify if slug is already null

Also change the normalize method in StringUtils to not strip underscores