### PR TITLE
Add Tracking Compass Module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -20,6 +20,8 @@ import tc.oc.pgm.broadcast.BroadcastMatchModule;
 import tc.oc.pgm.broadcast.BroadcastModule;
 import tc.oc.pgm.classes.ClassMatchModule;
 import tc.oc.pgm.classes.ClassModule;
+import tc.oc.pgm.compass.CompassMatchModule;
+import tc.oc.pgm.compass.CompassModule;
 import tc.oc.pgm.consumable.ConsumableMatchModule;
 import tc.oc.pgm.consumable.ConsumableModule;
 import tc.oc.pgm.controlpoint.ControlPointMatchModule;
@@ -247,6 +249,7 @@ public final class Modules {
     register(ScoreModule.class, ScoreMatchModule.class, new ScoreModule.Factory());
     register(KitModule.class, KitMatchModule.class, new KitModule.Factory());
     register(ActionModule.class, ActionMatchModule.class, new ActionModule.Factory());
+    register(CompassModule.class, CompassMatchModule.class, new CompassModule.Factory());
     register(
         ItemDestroyModule.class, ItemDestroyMatchModule.class, new ItemDestroyModule.Factory());
     register(ToolRepairModule.class, ToolRepairMatchModule.class, new ToolRepairModule.Factory());

--- a/core/src/main/java/tc/oc/pgm/compass/CompassMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassMatchModule.java
@@ -1,0 +1,190 @@
+package tc.oc.pgm.compass;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.format.Style.style;
+import static tc.oc.pgm.util.text.TextTranslations.translateLegacy;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ItemSpawnEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.Tickable;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.time.Tick;
+import tc.oc.pgm.events.PlayerResetEvent;
+import tc.oc.pgm.spawns.events.ParticipantKitApplyEvent;
+
+public class CompassMatchModule implements MatchModule, Tickable, Listener {
+
+  private static final long REFRESH_TICKS = 20;
+  private static final long REFRESH_TICKS_UNFOCUSED = 20 * 10;
+  private final Match match;
+  private final Map<UUID, Long> lastRefresh;
+  private final ImmutableList<CompassTarget> compassTargets;
+  private final OrderStrategy orderStrategy;
+  private final boolean showDistance;
+
+  public CompassMatchModule(
+      Match match,
+      ImmutableList<CompassTarget> compassTargets,
+      OrderStrategy orderStrategy,
+      boolean showDistance) {
+    this.match = match;
+    this.lastRefresh = new ConcurrentHashMap<>();
+    this.compassTargets = compassTargets;
+    this.orderStrategy = orderStrategy;
+    this.showDistance = showDistance;
+  }
+
+  @Override
+  public synchronized void tick(Match match, Tick tick) {
+    for (Map.Entry<UUID, Long> lastRefreshEntry : lastRefresh.entrySet()) {
+      long ticksSince = tick.tick - lastRefreshEntry.getValue();
+      if (ticksSince >= REFRESH_TICKS) {
+        UUID uuid = lastRefreshEntry.getKey();
+        MatchPlayer player = this.match.getPlayer(uuid);
+        if (player == null || player.getInventory() == null || !player.isAlive()) {
+          lastRefresh.remove(player.getId());
+          continue;
+        }
+        if (!Material.COMPASS.equals(player.getInventory().getItemInHand().getType())
+            && ticksSince < REFRESH_TICKS_UNFOCUSED) {
+          continue;
+        }
+
+        lastRefresh.put(player.getId(), tick.tick);
+
+        updatePlayerCompass(player, chooseCompassTarget(player), tick.tick);
+      }
+    }
+  }
+
+  private void updatePlayerCompass(
+      MatchPlayer player, Optional<CompassTargetResult> compassResultOption, long tick) {
+    compassResultOption.ifPresent(
+        compassTargetResult ->
+            player.getBukkit().setCompassTarget(compassTargetResult.getLocation()));
+
+    PlayerInventory inventory = player.getInventory();
+    if (inventory == null) {
+      return;
+    }
+
+    ItemStack itemstack = inventory.getItemInHand();
+    if (itemstack == null || !Material.COMPASS.equals(itemstack.getType())) {
+      return;
+    }
+
+    ItemMeta itemMeta = itemstack.getItemMeta();
+
+    Component itemName =
+        compassResultOption
+            .map(this::buildComponent)
+            .orElse(translatable("compass.tracking.unknown", style(NamedTextColor.WHITE)));
+
+    itemMeta.setDisplayName(translateLegacy(itemName, player) + "§" + tick % 7);
+    itemstack.setItemMeta(itemMeta);
+
+    player.getInventory().setItemInHand(itemstack);
+  }
+
+  private Component buildComponent(CompassTargetResult compassResult) {
+    Component resultComponent = compassResult.getComponent();
+
+    TextComponent.Builder builder =
+        text()
+            .append(translatable("compass.tracking", style(NamedTextColor.GRAY)))
+            .append(text(": ", style(NamedTextColor.WHITE)))
+            .append(resultComponent);
+
+    if (showDistance) {
+      builder
+          .append(text(" "))
+          .append(
+              translatable(
+                  "compass.tracking.distance",
+                  style(NamedTextColor.AQUA),
+                  text((int) compassResult.getDistance())));
+    }
+
+    return builder.build();
+  }
+
+  private Optional<CompassTargetResult> chooseCompassTarget(MatchPlayer player) {
+    Optional<CompassTargetResult> result = Optional.empty();
+    Stream<CompassTargetResult> targetStream =
+        compassTargets.stream()
+            .map((compassTarget -> compassTarget.getResult(match, player)))
+            .filter(Optional::isPresent)
+            .map(Optional::get);
+    switch (orderStrategy) {
+      case DEFINITION_ORDER:
+        result = targetStream.findFirst();
+        break;
+      case CLOSEST:
+        result = targetStream.min(CompassTargetResult::compareTo);
+        break;
+    }
+    return result;
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onPlayerReset(PlayerResetEvent event) {
+    this.lastRefresh.put(event.getPlayer().getId(), -REFRESH_TICKS);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onItemDrop(ItemSpawnEvent event) {
+    ItemStack itemStack = event.getEntity().getItemStack();
+    if (Material.COMPASS.equals(itemStack.getType())) {
+      event.getEntity().setItemStack(new ItemStack(Material.COMPASS, itemStack.getAmount()));
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onItemMove(InventoryMoveItemEvent event) {
+    if (!(event.getDestination() instanceof PlayerInventory)) {
+      ItemStack itemStack = event.getItem();
+      if (Material.COMPASS.equals(itemStack.getType())) {
+        event.setItem(new ItemStack(Material.COMPASS, itemStack.getAmount()));
+      }
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onSpawn(ParticipantKitApplyEvent event) {
+    this.lastRefresh.put(event.getPlayer().getId(), -REFRESH_TICKS);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onHeldItem(PlayerItemHeldEvent event) {
+    ItemStack itemInHand = event.getPlayer().getItemInHand();
+    if (itemInHand != null && Material.COMPASS.equals(itemInHand.getType())) {
+      this.lastRefresh.put(event.getPlayer().getUniqueId(), -REFRESH_TICKS);
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onQuit(PlayerQuitEvent event) {
+    this.lastRefresh.remove(event.getPlayer().getUniqueId());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/compass/CompassModule.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassModule.java
@@ -1,0 +1,74 @@
+package tc.oc.pgm.compass;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Logger;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.map.MapModule;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.map.factory.MapModuleFactory;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.filters.FilterMatchModule;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLUtils;
+
+public class CompassModule implements MapModule<CompassMatchModule> {
+
+  private final ImmutableList<CompassTarget> compassTargets;
+  private final OrderStrategy orderStrategy;
+  private final boolean showDistance;
+
+  public CompassModule(
+      ImmutableList<CompassTarget> compassTargets,
+      OrderStrategy orderStrategy,
+      boolean showDistance) {
+    this.compassTargets = compassTargets;
+    this.orderStrategy = orderStrategy;
+    this.showDistance = showDistance;
+  }
+
+  @Nullable
+  @Override
+  public Collection<Class<? extends MatchModule>> getHardDependencies() {
+    return ImmutableList.of(FilterMatchModule.class);
+  }
+
+  @Override
+  public @Nullable CompassMatchModule createMatchModule(Match match) throws ModuleLoadException {
+    return new CompassMatchModule(match, compassTargets, orderStrategy, showDistance);
+  }
+
+  public static class Factory implements MapModuleFactory<CompassModule> {
+    @Override
+    public @Nullable CompassModule parse(MapFactory factory, Logger logger, Document doc)
+        throws InvalidXMLException {
+      CompassParser parser = new CompassParser(factory);
+
+      ImmutableList.Builder<CompassTarget> compassTargets = ImmutableList.builder();
+      OrderStrategy orderStrategy = OrderStrategy.DEFINITION_ORDER;
+      boolean showDistance = false;
+      for (Element compassRoot : doc.getRootElement().getChildren("compass")) {
+        orderStrategy =
+            XMLUtils.parseEnum(
+                Node.fromAttr(compassRoot, "order"), OrderStrategy.class, orderStrategy);
+        showDistance =
+            XMLUtils.parseBoolean(Node.fromAttr(compassRoot, "show-distance"), showDistance);
+        List<Element> children = compassRoot.getChildren();
+        if (children.isEmpty()) {
+          throw new InvalidXMLException("Compass tag has no targets", compassRoot);
+        }
+        for (Element compassTarget : children) {
+          compassTargets.add(parser.parseCompassTarget(compassTarget));
+        }
+      }
+
+      return new CompassModule(compassTargets.build(), orderStrategy, showDistance);
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/compass/CompassParser.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassParser.java
@@ -1,0 +1,61 @@
+package tc.oc.pgm.compass;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import net.kyori.adventure.text.Component;
+import org.jdom2.Element;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.compass.targets.PlayerCompassTarget;
+import tc.oc.pgm.features.FeatureDefinitionContext;
+import tc.oc.pgm.filters.parse.FilterParser;
+import tc.oc.pgm.util.MethodParser;
+import tc.oc.pgm.util.MethodParsers;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLUtils;
+
+public class CompassParser {
+
+  private final MapFactory factory;
+  private final FeatureDefinitionContext features;
+  private final FilterParser filters;
+  private final Map<String, Method> methodParsers;
+
+  public CompassParser(MapFactory factory) {
+    this.factory = factory;
+    this.features = factory.getFeatures();
+    this.filters = factory.getFilters();
+    this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
+  }
+
+  public boolean isTarget(Element el) {
+    return getParserFor(el) != null;
+  }
+
+  protected Method getParserFor(Element el) {
+    return methodParsers.get(el.getName().toLowerCase());
+  }
+
+  public CompassTarget parseCompassTarget(Element el) throws InvalidXMLException {
+    Method parser = getParserFor(el);
+    if (parser != null) {
+      try {
+        return (CompassTarget) parser.invoke(this, el);
+      } catch (Exception e) {
+        throw InvalidXMLException.coerce(e, new Node(el));
+      }
+    } else {
+      throw new InvalidXMLException("Unknown compass tracker type: " + el.getName(), el);
+    }
+  }
+
+  @MethodParser("player")
+  public PlayerCompassTarget parsePlayerTarget(Element el) throws InvalidXMLException {
+    Component name = XMLUtils.parseFormattedText(Node.fromChildOrAttr(el, "name"));
+    Filter filter = filters.parseProperty(el, "filter");
+    boolean showPlayerName = XMLUtils.parseBoolean(Node.fromAttr(el, "show-player"), false);
+
+    return new PlayerCompassTarget(filter, name, showPlayerName);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/compass/CompassTarget.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassTarget.java
@@ -1,0 +1,18 @@
+package tc.oc.pgm.compass;
+
+import java.util.Optional;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Location;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+
+public interface CompassTarget {
+  Filter getFilter();
+
+  Component getName(Match match, MatchPlayer player);
+
+  Optional<Location> getLocation(Match match, MatchPlayer player);
+
+  Optional<CompassTargetResult> getResult(Match match, MatchPlayer player);
+}

--- a/core/src/main/java/tc/oc/pgm/compass/CompassTargetResult.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassTargetResult.java
@@ -1,0 +1,39 @@
+package tc.oc.pgm.compass;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Location;
+
+public class CompassTargetResult {
+  private final Location location;
+  private final double distance;
+  private final double yDifference;
+  private final Component component;
+
+  public CompassTargetResult(
+      Location location, double distance, double yDifference, Component component) {
+    this.location = location;
+    this.distance = distance;
+    this.yDifference = yDifference;
+    this.component = component;
+  }
+
+  public Location getLocation() {
+    return location;
+  }
+
+  public double getDistance() {
+    return distance;
+  }
+
+  public double getYDifference() {
+    return yDifference;
+  }
+
+  public Component getComponent() {
+    return component;
+  }
+
+  public int compareTo(CompassTargetResult other) {
+    return Double.compare(this.distance, other.distance);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/compass/OrderStrategy.java
+++ b/core/src/main/java/tc/oc/pgm/compass/OrderStrategy.java
@@ -1,0 +1,6 @@
+package tc.oc.pgm.compass;
+
+public enum OrderStrategy {
+  DEFINITION_ORDER,
+  CLOSEST,
+}

--- a/core/src/main/java/tc/oc/pgm/compass/targets/PlayerCompassTarget.java
+++ b/core/src/main/java/tc/oc/pgm/compass/targets/PlayerCompassTarget.java
@@ -1,0 +1,83 @@
+package tc.oc.pgm.compass.targets;
+
+import static net.kyori.adventure.text.Component.text;
+import static tc.oc.pgm.util.player.PlayerComponent.player;
+
+import java.util.Optional;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.compass.CompassTarget;
+import tc.oc.pgm.compass.CompassTargetResult;
+import tc.oc.pgm.filters.query.PlayerQuery;
+import tc.oc.pgm.util.named.NameStyle;
+
+public class PlayerCompassTarget implements CompassTarget {
+
+  private final Filter filter;
+  private final Component name;
+  private final boolean showPlayerName;
+  private final boolean hasCustomName;
+
+  public PlayerCompassTarget(Filter filter, Component name, boolean showPlayerName) {
+    this.filter = filter;
+    this.hasCustomName = name != null;
+    this.name = this.hasCustomName ? name : Component.translatable("compass.tracking.player");
+    this.showPlayerName = showPlayerName;
+  }
+
+  @Override
+  public Filter getFilter() {
+    return filter;
+  }
+
+  @Override
+  public Component getName(Match match, MatchPlayer player) {
+    if (showPlayerName) {
+      if (hasCustomName) {
+        return name.append(text(": ", NamedTextColor.WHITE))
+            .append(player(player, NameStyle.FANCY));
+      } else {
+        return player(player, NameStyle.FANCY);
+      }
+    } else {
+      return name;
+    }
+  }
+
+  @Override
+  public Optional<Location> getLocation(Match match, MatchPlayer player) {
+    return getClosestPlayer(match, player).map(MatchPlayer::getLocation);
+  }
+
+  @Override
+  public Optional<CompassTargetResult> getResult(Match match, MatchPlayer player) {
+    Optional<MatchPlayer> playerOptional = getClosestPlayer(match, player);
+    if (playerOptional.isPresent()) {
+      MatchPlayer targetPlayer = playerOptional.get();
+      Location targetLoc = targetPlayer.getLocation();
+      Location playerLoc = player.getLocation();
+      double yDifference = targetLoc.getY() - playerLoc.getY();
+
+      return Optional.of(
+          new CompassTargetResult(
+              targetLoc, targetLoc.distance(playerLoc), yDifference, getName(match, targetPlayer)));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private Optional<MatchPlayer> getClosestPlayer(Match match, MatchPlayer player) {
+    return match.getParticipants().stream()
+        .filter((otherPlayer) -> !otherPlayer.equals(player))
+        .filter((otherPlayer) -> filter.response(new PlayerQuery(null, otherPlayer)))
+        .min(
+            (firstPlayer, secondPlayer) ->
+                (int)
+                    (firstPlayer.getLocation().distance(player.getLocation())
+                        - secondPlayer.getLocation().distance(player.getLocation())));
+  }
+}

--- a/util/src/main/i18n/templates/ui.properties
+++ b/util/src/main/i18n/templates/ui.properties
@@ -231,3 +231,10 @@ shop.item.empty = No items for sale at the moment
 
 shop.category.empty = This shop has no items for sale at the moment
 
+compass.tracking = Tracking
+
+compass.tracking.player = Player
+
+compass.tracking.distance = ({0}m)
+
+compass.tracking.unknown = No Targets Found!


### PR DESCRIPTION
Adds a module for tracking players with compasses.
Tracking other things is to be added in later PRs.
This acts on all compasses

Example XML for an FFA:
```xml
<compass show-distance="true">
        <player filter="always" show-player="true"/>
</compass>
```

![thingy](https://github.com/PGMDev/PGM/assets/9834984/d7015695-ddc1-4fb8-ab28-0bbf6eb6aff6)

Other things this supports:
- Custom Names:
```xml
<compass>
    <player filter="always" name="Wool Carrier"/>
</compass>
```
- Multiple Options:
```xml
<compass order="FIRST_DEFINED">
    <player filter="wool-carrier" name="Wool Carrier"/>
    <player filter="enemy" show-player="true" name="Nearest Enemy"/>
</compass>
```
