### PR TITLE
Improve json detection for formatted text

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/text/TextParser.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextParser.java
@@ -45,6 +45,9 @@ public final class TextParser {
   private static final Pattern INF = Pattern.compile("^((\\+|-)?oo)$", Pattern.CASE_INSENSITIVE);
   private static final Pattern DOT = Pattern.compile("\\s*\\.\\s*");
   private static final Pattern COMMA = Pattern.compile("\\s*,\\s*");
+  // [{ "prop" : ... }], {prop: ...} or ['prop': ...}, looks like json, but could be invalid
+  private static final Pattern PROBABLY_JSON =
+      Pattern.compile("[\\[{][ \\[{]*\\s*([\"']?)\\w+\\1\\s*:.*[\\[}]+", Pattern.CASE_INSENSITIVE);
   private static final Range<Integer> NONNEG = Range.atLeast(0);
 
   /**
@@ -413,7 +416,7 @@ public final class TextParser {
   public static Component parseComponent(String text) throws TextException {
     assertNotNull(text, "cannot parse component from null");
 
-    if (text.startsWith("{\"") && text.endsWith("\"}")) {
+    if (PROBABLY_JSON.matcher(text).matches()) {
       try {
         return GsonComponentSerializer.gson().deserialize(text);
       } catch (JsonSyntaxException e) {
@@ -444,7 +447,7 @@ public final class TextParser {
   public static Component parseComponentSection(String text) {
     assertNotNull(text, "cannot parse component from null");
 
-    if (text.startsWith("{\"") && text.endsWith("\"}")) {
+    if (PROBABLY_JSON.matcher(text).matches()) {
       try {
         return GsonComponentSerializer.gson().deserialize(text);
       } catch (Throwable t) {


### PR DESCRIPTION
Currently we only parse xml strings as json if the strictly start with `{"` and end with `"}`, this works fine for strings like: `{"text": "a", "color": "red"}` but fails very quickly when you try to do anything slightly more complex like `{text:"a",clickEvent:{...}}`, since neither the start nor the end will have a `"` following the `}`. Furthermore we can't really relax the constraint for the `"` since we may have strings like `{teamA} - {teamB}` using replacements to fill in variables.

This pr instead uses a regex to see if it's looking a bit more json-like, checking for it strictly:
 - Starting with `[` or `{`, with potentially many of them and spaces in the middle
 - Followed by `"property"` or `'property'` or simply `property` (with matching start/end quotes)
 - Followed by `:`
 - Ending in one or many of `]` or `}`

I think the logic for trying to match for a first property-looking text with a : separator should be enough to catch all valid jsons and avoid matching non-json strings, which need to have diff treatment