### PR TITLE
Optimize tnt render by ignoring afk players

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -71,6 +71,7 @@ import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.chunk.NullChunkGenerator;
 import tc.oc.pgm.util.compatability.SportPaperListener;
 import tc.oc.pgm.util.concurrent.BukkitExecutorService;
+import tc.oc.pgm.util.listener.AfkTracker;
 import tc.oc.pgm.util.listener.ItemTransferListener;
 import tc.oc.pgm.util.listener.PlayerBlockListener;
 import tc.oc.pgm.util.listener.PlayerMoveListener;
@@ -97,6 +98,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
   private ScheduledExecutorService executorService;
   private ScheduledExecutorService asyncExecutorService;
   private InventoryManager inventoryManager;
+  private AfkTracker afkTracker;
 
   public PGMPlugin() {
     super();
@@ -220,7 +222,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
       Integration.setVanishIntegration(new SimpleVanishIntegration(matchManager, executorService));
 
     inventoryManager = new InventoryManager(this);
-    inventoryManager.init();
+    afkTracker = new AfkTracker(this);
 
     if (config.showTabList()) {
       matchTabManager = new MatchTabManager(this);
@@ -339,6 +341,11 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     return inventoryManager;
   }
 
+  @Override
+  public AfkTracker getAfkTracker() {
+    return afkTracker;
+  }
+
   private void registerCommands() {
     try {
       new PGMCommandGraph(this);
@@ -363,6 +370,8 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     registerEvents(new TNTMinecartPlacementListener());
     new BlockTransformListener(this).registerEvents();
     registerEvents(matchManager);
+    inventoryManager.init();
+    registerEvents(afkTracker);
     if (matchTabManager != null) registerEvents(matchTabManager);
     registerEvents(nameDecorationRegistry);
     registerEvents(new PGMListener(this, matchManager));

--- a/core/src/main/java/tc/oc/pgm/api/PGM.java
+++ b/core/src/main/java/tc/oc/pgm/api/PGM.java
@@ -13,6 +13,7 @@ import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.namedecorations.NameDecorationRegistry;
 import tc.oc.pgm.tablist.MatchTabManager;
+import tc.oc.pgm.util.listener.AfkTracker;
 
 /** PvP Game Manager (aka. PGM), the global {@link Plugin} to manage PvP games. */
 public interface PGM extends Plugin {
@@ -39,6 +40,8 @@ public interface PGM extends Plugin {
   ScheduledExecutorService getAsyncExecutor();
 
   InventoryManager getInventoryManager();
+
+  AfkTracker getAfkTracker();
 
   AtomicReference<PGM> GLOBAL = new AtomicReference<>(null);
 

--- a/core/src/main/java/tc/oc/pgm/api/party/Party.java
+++ b/core/src/main/java/tc/oc/pgm/api/party/Party.java
@@ -1,6 +1,8 @@
 package tc.oc.pgm.api.party;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
@@ -156,6 +158,19 @@ public interface Party extends Audience, Named, Filterable<PartyQuery>, PartyQue
   @Override
   default Collection<? extends Filterable<? extends PlayerQuery>> getFilterableChildren() {
     return this.getPlayers();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  default <R extends Filterable<?>> Collection<? extends R> getFilterableDescendants(Class<R> type) {
+    Collection<R> result = new ArrayList<>();
+    if (type.isAssignableFrom(Party.class)) {
+      result.add((R) this);
+    }
+    if (type.isAssignableFrom(MatchPlayer.class)) {
+      result.addAll((Collection<? extends R>) getPlayers());
+    }
+    return result;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/party/Party.java
+++ b/core/src/main/java/tc/oc/pgm/api/party/Party.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.api.party;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
@@ -162,7 +161,8 @@ public interface Party extends Audience, Named, Filterable<PartyQuery>, PartyQue
 
   @Override
   @SuppressWarnings("unchecked")
-  default <R extends Filterable<?>> Collection<? extends R> getFilterableDescendants(Class<R> type) {
+  default <R extends Filterable<?>> Collection<? extends R> getFilterableDescendants(
+      Class<R> type) {
     Collection<R> result = new ArrayList<>();
     if (type.isAssignableFrom(Party.class)) {
       result.add((R) this);

--- a/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.api.player;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.bukkit.GameMode;
@@ -8,6 +10,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.Tickable;
@@ -20,6 +23,7 @@ import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.attribute.Attribute;
 import tc.oc.pgm.util.attribute.AttributeInstance;
 import tc.oc.pgm.util.bukkit.ViaUtils;
+import tc.oc.pgm.util.listener.AfkTracker;
 import tc.oc.pgm.util.named.Named;
 
 /**
@@ -143,6 +147,32 @@ public interface MatchPlayer
   default boolean isLegacy() {
     return getProtocolVersion() <= ViaUtils.VERSION_1_7;
   }
+
+  /**
+   * Get when the {@link MatchPlayer} was last active in the game
+   *
+   * @return the last time player was not afk
+   */
+  default Instant getLastActive() {
+    return getActivity().getLastActive();
+  }
+
+  /**
+   * Get whether the {@link MatchPlayer} is actively moving, or afk
+   *
+   * @param duration How much time until the player is considered inactive
+   * @return true if the player moved within {@param duration}, false if the player has been afk that long
+   */
+  default boolean isActive(Duration duration) {
+    return getActivity().isActive(duration);
+  }
+
+  /**
+   * Get the AFK activity tracker for the {@link MatchPlayer}
+   *
+   * @return the afk activity tracker
+   */
+  AfkTracker.Activity getActivity();
 
   /**
    * Get whether the {@link MatchPlayer} can interact with things in the {@link Match}.

--- a/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -10,7 +10,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.Nullable;
-import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.Tickable;
@@ -161,7 +160,8 @@ public interface MatchPlayer
    * Get whether the {@link MatchPlayer} is actively moving, or afk
    *
    * @param duration How much time until the player is considered inactive
-   * @return true if the player moved within {@param duration}, false if the player has been afk that long
+   * @return true if the player moved within {@param duration}, false if the player has been afk
+   *     that long
    */
   default boolean isActive(Duration duration) {
     return getActivity().isActive(duration);

--- a/core/src/main/java/tc/oc/pgm/goals/GoalMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/goals/GoalMatchModule.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,11 +60,11 @@ public class GoalMatchModule implements MatchModule, Listener {
   }
 
   public Collection<Goal> getGoals() {
-    return goals;
+    return Collections.unmodifiableCollection(goals);
   }
 
   public Collection<Goal> getGoals(Competitor competitor) {
-    return goalsByCompetitor.get(competitor);
+    return Collections.unmodifiableCollection(goalsByCompetitor.get(competitor));
   }
 
   public Collection<Competitor> getCompetitors(Goal goal) {

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -407,7 +407,7 @@ public class MatchImpl implements Match {
 
   @Override
   public Collection<MatchPlayer> getPlayers() {
-    return ImmutableList.copyOf(players.values());
+    return Collections.unmodifiableCollection(players.values());
   }
 
   @Override
@@ -937,17 +937,15 @@ public class MatchImpl implements Match {
   @Override
   @SuppressWarnings("unchecked")
   public <R extends Filterable<?>> Collection<? extends R> getFilterableDescendants(Class<R> type) {
-    final Collection<R> result = new LinkedList<>();
+    Collection<R> result = new ArrayList<>();
     if (type.isAssignableFrom(Match.class)) {
       result.add((R) this);
     }
-    if (Party.class.isAssignableFrom(type)) {
-      result.addAll(
-          (List<R>)
-              this.getParties().stream().filter(type::isInstance).collect(Collectors.toList()));
+    if (type.isAssignableFrom(Party.class)) {
+      result.addAll((Collection<? extends R>) getParties());
     }
     if (type.isAssignableFrom(MatchPlayer.class)) {
-      result.addAll((List<R>) this.getPlayers());
+      result.addAll((Collection<? extends R>) getPlayers());
     }
     return result;
   }

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.World;

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -4,10 +4,13 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import static tc.oc.pgm.util.player.PlayerComponent.player;
 
 import java.lang.ref.WeakReference;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,6 +59,7 @@ import tc.oc.pgm.util.attribute.AttributeInstance;
 import tc.oc.pgm.util.attribute.AttributeMap;
 import tc.oc.pgm.util.attribute.AttributeModifier;
 import tc.oc.pgm.util.bukkit.ViaUtils;
+import tc.oc.pgm.util.listener.AfkTracker;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.nms.NMSHacks;
 
@@ -79,6 +83,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
   private final AtomicBoolean protocolReady;
   private final AtomicInteger protocolVersion;
   private final AttributeMap attributeMap;
+  private final AfkTracker.Activity activity;
 
   public MatchPlayerImpl(Match match, Player player) {
     this.logger =
@@ -95,6 +100,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     this.protocolReady = new AtomicBoolean(ViaUtils.isReady(player));
     this.protocolVersion = new AtomicInteger(ViaUtils.getProtocolVersion(player));
     this.attributeMap = NMSHacks.buildAttributeMap(player);
+    this.activity = PGM.get().getAfkTracker().getActivity(player);
   }
 
   @Override
@@ -188,6 +194,11 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
   @Override
   public boolean isFrozen() {
     return frozen.get();
+  }
+
+  @Override
+  public AfkTracker.Activity getActivity() {
+    return activity;
   }
 
   @Override
@@ -468,6 +479,15 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
 
   @Override
   public Collection<? extends Filterable<? extends PlayerQuery>> getFilterableChildren() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <R extends Filterable<?>> Collection<? extends R> getFilterableDescendants(Class<R> type) {
+    if (type.isAssignableFrom(getClass())) {
+      return Collections.singleton((R) this);
+    }
     return Collections.emptyList();
   }
 

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -4,13 +4,10 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import static tc.oc.pgm.util.player.PlayerComponent.player;
 
 import java.lang.ref.WeakReference;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/core/src/main/java/tc/oc/pgm/tntrender/TNTRenderMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tntrender/TNTRenderMatchModule.java
@@ -99,7 +99,8 @@ public class TNTRenderMatchModule implements MatchModule, Listener {
     }
 
     private void updatePlayer(MatchPlayer player) {
-      if (currentLocation.distanceSquared(player.getLocation()) >= MAX_DISTANCE && player.isActive(AFK_TIME)) {
+      if (currentLocation.distanceSquared(player.getLocation()) >= MAX_DISTANCE
+          && player.isActive(AFK_TIME)) {
         if (viewers.add(player)) {
           NMSHacks.sendBlockChange(currentLocation, player.getBukkit(), Material.TNT);
         } else if (moved) {

--- a/util/src/main/java/tc/oc/pgm/util/listener/AfkTracker.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/AfkTracker.java
@@ -1,5 +1,8 @@
 package tc.oc.pgm.util.listener;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -15,10 +18,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import tc.oc.pgm.util.bukkit.OnlinePlayerMapAdapter;
-
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Map;
 
 public class AfkTracker implements Listener {
 
@@ -47,11 +46,12 @@ public class AfkTracker implements Listener {
 
   @EventHandler
   public void onPlayerMove(PlayerMoveEvent event) {
-    if (event.getFrom().getYaw() != event.getTo().getYaw() &&
-        event.getFrom().getPitch() != event.getTo().getPitch()) {
+    if (event.getFrom().getYaw() != event.getTo().getYaw()
+        && event.getFrom().getPitch() != event.getTo().getPitch()) {
       track(event.getPlayer());
     }
   }
+
   @EventHandler
   public void onPlayerChat(AsyncPlayerChatEvent event) {
     track(event.getPlayer());
@@ -69,20 +69,17 @@ public class AfkTracker implements Listener {
 
   @EventHandler
   public void onInventoryOpen(InventoryOpenEvent event) {
-    if (event.getPlayer() instanceof Player)
-      track((Player) event.getPlayer());
+    if (event.getPlayer() instanceof Player) track((Player) event.getPlayer());
   }
 
   @EventHandler
   public void onInventoryClick(InventoryClickEvent event) {
-    if (event.getWhoClicked() instanceof Player)
-      track((Player) event.getWhoClicked());
+    if (event.getWhoClicked() instanceof Player) track((Player) event.getWhoClicked());
   }
 
   @EventHandler
   public void onInventoryClose(InventoryCloseEvent event) {
-    if (event.getPlayer() instanceof Player)
-      track((Player) event.getPlayer());
+    if (event.getPlayer() instanceof Player) track((Player) event.getPlayer());
   }
 
   public class Activity {
@@ -104,5 +101,4 @@ public class AfkTracker implements Listener {
       return getAfkDuration().compareTo(duration) < 0;
     }
   }
-
 }

--- a/util/src/main/java/tc/oc/pgm/util/listener/AfkTracker.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/AfkTracker.java
@@ -1,0 +1,108 @@
+package tc.oc.pgm.util.listener;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import tc.oc.pgm.util.bukkit.OnlinePlayerMapAdapter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+public class AfkTracker implements Listener {
+
+  private final Map<Player, Activity> activityMap;
+
+  // By recycling cached instants we avoid creating a ton of objects.
+  private Instant now = Instant.now();
+
+  public AfkTracker(JavaPlugin plugin) {
+    this.activityMap = new OnlinePlayerMapAdapter<>(plugin);
+    Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> now = Instant.now(), 0L, 5L);
+  }
+
+  public Activity getActivity(Player player) {
+    return activityMap.computeIfAbsent(player, pl -> new Activity());
+  }
+
+  private void track(Player player) {
+    getActivity(player).lastActive = now;
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST)
+  public void onPlayerJoin(PlayerJoinEvent event) {
+    track(event.getPlayer());
+  }
+
+  @EventHandler
+  public void onPlayerMove(PlayerMoveEvent event) {
+    if (event.getFrom().getYaw() != event.getTo().getYaw() &&
+        event.getFrom().getPitch() != event.getTo().getPitch()) {
+      track(event.getPlayer());
+    }
+  }
+  @EventHandler
+  public void onPlayerChat(AsyncPlayerChatEvent event) {
+    track(event.getPlayer());
+  }
+
+  @EventHandler
+  public void onCommand(PlayerCommandPreprocessEvent event) {
+    track(event.getPlayer());
+  }
+
+  @EventHandler
+  public void onPlayerInteract(PlayerInteractEvent event) {
+    track(event.getPlayer());
+  }
+
+  @EventHandler
+  public void onInventoryOpen(InventoryOpenEvent event) {
+    if (event.getPlayer() instanceof Player)
+      track((Player) event.getPlayer());
+  }
+
+  @EventHandler
+  public void onInventoryClick(InventoryClickEvent event) {
+    if (event.getWhoClicked() instanceof Player)
+      track((Player) event.getWhoClicked());
+  }
+
+  @EventHandler
+  public void onInventoryClose(InventoryCloseEvent event) {
+    if (event.getPlayer() instanceof Player)
+      track((Player) event.getPlayer());
+  }
+
+  public class Activity {
+    private Instant lastActive = now;
+
+    public Instant getLastActive() {
+      return lastActive;
+    }
+
+    public Duration getAfkDuration() {
+      return Duration.between(lastActive, now);
+    }
+
+    public boolean isAfk(Duration duration) {
+      return getAfkDuration().compareTo(duration) >= 0;
+    }
+
+    public boolean isActive(Duration duration) {
+      return getAfkDuration().compareTo(duration) < 0;
+    }
+  }
+
+}


### PR DESCRIPTION
Adds an afk tracker into pgm, and TNT render module uses it to determine players who have been afk for +30s to stop sending them tnt block updates. This is done in order to improve performance. A few other minor performance tweaks are included too, like avoiding creating a new immutable list of all players every time one is asked for.

In the future we could use the afk tracking to also slow down updates of tablist or scoreboard for those who are AFK, in order to further improve performance.