### PR TITLE
Fix dead players interacting with specific packets

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/player/MatchPlayerState.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/MatchPlayerState.java
@@ -76,4 +76,9 @@ public interface MatchPlayerState extends Audience, Named {
   default boolean isPlayer(MatchPlayer player) {
     return getPlayer().map(player::equals).orElse(false);
   }
+
+  /** @return if the player can interact */
+  default boolean canInteract() {
+    return getPlayer().map(MatchPlayer::canInteract).orElse(false);
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
@@ -115,8 +115,7 @@ public class EventFilterMatchModule implements MatchModule, Listener {
   }
 
   boolean cancelUnlessInteracting(Cancellable event, MatchPlayerState player) {
-    return cancel(
-        event, !player.getParty().isParticipating(), player.getMatch().getWorld(), null, null);
+    return cancel(event, !player.canInteract(), player.getMatch().getWorld(), null, null);
   }
 
   ClickType convertClick(ClickType clickType, Player player) {


### PR DESCRIPTION
Breaking blocks in creative (punching them) usually sends a block break packet with START_DIGGING status, this causes the server to create a `PlayerInteractEvent` with `LEFT_CLICK_BLOCK`, which PGM cancels for non-interacting players. All is fine.

However, sending a block break packet with STOP BREAKING status, has completely different logic on the bukkit-side, and will only do a check for if it's valid (you sent a start digging early enough) and then proceed to create a BlockBreakEvent. PGM will turn this event into a BlockTransformEvent, which should get cancelled, but due to [a change in logic a long time ago](https://github.com/PGMDev/PGM/commit/5a5ad2e4423ee588683b213dd37ed59c655be7d5#diff-8ed26c6f28a5ad2bba3b63e3ba6609807c2b451313343a1f71af6fa59359490fL90-R95), is now only cancelled if the party is non-interacting (ie: you're in obs, or match isn't running), which excludes dead (and frozen) players, allowing for this exploit to happen.