### PR TITLE
Invalidate tablist footer only if match is running

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
+++ b/core/src/main/java/tc/oc/pgm/tablist/MatchFooterTabEntry.java
@@ -35,9 +35,27 @@ public class MatchFooterTabEntry extends DynamicTabEntry {
   public void addToView(TabView view) {
     super.addToView(view);
     if (this.tickTask == null && match.isLoaded()) {
-      Runnable tick = MatchFooterTabEntry.this::invalidate;
+      Runnable tick =
+          new Runnable() {
+            private long length;
+            private boolean running;
+
+            @Override
+            public void run() {
+              long lastLen = length;
+              boolean lastRunning = running;
+              length = match.getDuration().getSeconds();
+              running = match.isRunning();
+
+              if (this.length != lastLen || this.running != lastRunning) {
+                MatchFooterTabEntry.this.invalidate();
+              }
+            }
+          };
       this.tickTask =
-          match.getExecutor(MatchScope.LOADED).scheduleWithFixedDelay(tick, 0, 1, TimeUnit.SECONDS);
+          match
+              .getExecutor(MatchScope.LOADED)
+              .scheduleWithFixedDelay(tick, 0, 50, TimeUnit.MILLISECONDS);
     }
   }
 


### PR DESCRIPTION
Currently tablist footer is being invalidated every second during the whole match loaded time. This can lead both to seconds skipping on tablist, and prior to match start and post match end to be sending a packet every second to update something that needs no updating.

This changes the behavior so it checks every tick if the match time needs updating (either a new second, or match end which causes a color change), lowering amount of invalidations while match isn't running and making it more accurate while match is running or when it ends.