### PR TITLE
Improve world border logic

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/bukkit/WorldBorders.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/WorldBorders.java
@@ -1,49 +1,60 @@
 package tc.oc.pgm.util.bukkit;
 
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.WorldBorder;
+import org.bukkit.util.NumberConversions;
+import tc.oc.pgm.util.nms.NMSHacks;
 
-public interface WorldBorders {
+public class WorldBorders {
 
-  static boolean isInsideBorder(Location location) {
-    WorldBorder border = location.getWorld().getWorldBorder();
-    Location center = border.getCenter();
-    double radius = border.getSize() / 2d;
-    return Math.abs(location.getX() - center.getX()) < radius
-        && Math.abs(location.getZ() - center.getZ()) < radius;
+  private WorldBorders() {}
+
+  public static boolean isInsideBorder(Location location) {
+    BorderRect rect = new BorderRect(location.getWorld());
+    return location.getBlockX() >= rect.xMin
+        && location.getBlockX() <= rect.xMax
+        && location.getBlockZ() >= rect.zMin
+        && location.getBlockZ() <= rect.zMax;
   }
 
-  static boolean clampToBorder(Location location) {
-    WorldBorder border = location.getWorld().getWorldBorder();
-    Location center = border.getCenter();
-    double radius = border.getSize() / 2d;
-    double xMin = center.getX() - radius;
-    double xMax = center.getX() + radius;
-    double zMin = center.getZ() - radius;
-    double zMax = center.getZ() + radius;
+  public static boolean clampToBorder(Location location) {
+    BorderRect rect = new BorderRect(location.getWorld());
 
     boolean moved = false;
 
-    if (location.getX() < xMin) {
-      location.setX(xMin);
+    if (location.getX() <= rect.xMin) {
+      location.setX(rect.xMin + 0.5);
+      moved = true;
+    } else if (location.getX() >= rect.xMax) {
+      location.setX(rect.xMax - 0.5);
       moved = true;
     }
 
-    if (location.getX() > xMax) {
-      location.setX(xMax);
+    if (location.getZ() <= rect.zMin) {
+      location.setZ(rect.zMin + 0.5);
       moved = true;
-    }
-
-    if (location.getZ() < zMin) {
-      location.setZ(zMin);
-      moved = true;
-    }
-
-    if (location.getZ() > zMax) {
-      location.setZ(zMax);
+    } else if (location.getZ() >= rect.zMax) {
+      location.setZ(rect.zMax - 0.5);
       moved = true;
     }
 
     return moved;
+  }
+
+  private static class BorderRect {
+    public final int xMin, xMax, zMin, zMax;
+
+    public BorderRect(World world) {
+      WorldBorder border = world.getWorldBorder();
+      Location center = border.getCenter();
+      double radius = border.getSize() / 2d;
+      int maxWorldSize = NMSHacks.getMaxWorldSize(world);
+
+      xMin = Math.max(NumberConversions.floor(center.getX() - radius), -maxWorldSize);
+      xMax = Math.min(NumberConversions.ceil(center.getX() + radius), maxWorldSize);
+      zMin = Math.max(NumberConversions.floor(center.getZ() - radius), -maxWorldSize);
+      zMax = Math.min(NumberConversions.ceil(center.getZ() + radius), maxWorldSize);
+    }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -439,4 +439,8 @@ public interface NMSHacks {
   static void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
     INSTANCE.postToMainThread(plugin, priority, task);
   }
+
+  static int getMaxWorldSize(World world) {
+    return INSTANCE.getMaxWorldSize(world);
+  }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksNoOp.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksNoOp.java
@@ -302,4 +302,9 @@ public abstract class NMSHacksNoOp implements NMSHacksPlatform {
     // runs the task on the next tick, not a perfect replacement
     plugin.getServer().getScheduler().runTask(plugin, task);
   }
+
+  @Override
+  public int getMaxWorldSize(World world) {
+    return 29999984; // Vanilla's default
+  }
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksPlatform.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacksPlatform.java
@@ -208,4 +208,6 @@ public interface NMSHacksPlatform {
   AttributeMap buildAttributeMap(Player player);
 
   void postToMainThread(Plugin plugin, boolean priority, Runnable task);
+
+  int getMaxWorldSize(World world);
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/v1_8/NMSHacks1_8.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/v1_8/NMSHacks1_8.java
@@ -966,6 +966,11 @@ public class NMSHacks1_8 extends NMSHacksNoOp {
     return 20.0;
   }
 
+  @Override
+  public int getMaxWorldSize(World world) {
+    return ((CraftWorld) world).getHandle().getWorldBorder().l();
+  }
+
   enum TeamPacketFields {
     a,
     b,


### PR DESCRIPTION
Currently worldborder checks are not lenient enough for odd-block sized borders, like if the border is at half the block, the vanilla client will let you walk the full block, but pgm will teleport you back. This makes borders very annoying as valid vanilla movements will cause setbacks.

Ontop of that, world borders in vanilla are actually composed of not just size and center, but also a max world size. This means the world borders can actually be rectangles, and therefore can't be checked with a simple `abs(x - center.x) < radius`, as that just doesn't hold true. To add insult to injury, bukkit exposes none of this and pretends borders are always square, completely ignoring on the api-side the existance of max world size, which means in pgm you could fly right thru the max world size.

To end, a funny rectangular world border:
![image](https://github.com/PGMDev/PGM/assets/11789291/475423d5-f2cb-4294-aec3-4e5234165d27)
