### PR TITLE
ci: bump v3 actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - id: checkout
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - id: setup-java
       name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 8
         distribution: temurin
@@ -23,7 +23,7 @@ jobs:
       run: mvn install
     - id: artifact
       name: Upload Jar
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: PGM.jar
         path: target/PGM.jar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - id: checkout
       name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - id: setup-java
       name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 8
         distribution: temurin
@@ -28,7 +28,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - id: artifact
       name: Upload Jar
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: PGM.jar
         path: target/PGM.jar


### PR DESCRIPTION
Actions based on Node 16.x.x (which many of the v3's of the official actions are) are [deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

This PR bumps them to v4 to avoid any unpleasant surprises in the future. Shouldn't break anything, I hope.