### PR TITLE
Cleanup minor map & default repo issues

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -19,6 +19,7 @@ import cloud.commandframework.annotations.specifier.Range;
 import cloud.commandframework.annotations.suggestions.Suggestions;
 import cloud.commandframework.context.CommandContext;
 import com.google.common.collect.ImmutableList;
+import java.io.File;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -407,7 +408,8 @@ public final class MapCommand {
                     .hoverEvent(showText(translatable("map.info.xml.path", NamedTextColor.GOLD))));
 
     if (root.getBaseUrl() != null && root.getRemoteHost() != null) {
-      String mapPath = root.getBaseUrl() + UriEncoder.encode(source.getRelativeXml().toString());
+      String relativeUrl = source.getRelativeXml().toString().replace(File.separatorChar, '/');
+      String mapPath = root.getBaseUrl() + UriEncoder.encode(relativeUrl);
       xmlText.append(
           text()
               .color(NamedTextColor.GREEN)

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -27,7 +27,7 @@ map:
     #
     # To enable the default maps, uncomment the repository below.
     # - uri: "https://github.com/PGMDev/Maps"
-    #  path: "maps-default"
+    #  path: "default-maps"
 
   # A path to a map pools file, or empty to disable map pools.
   pools: "map-pools.yml"


### PR DESCRIPTION
Fixes a few minor issues with current map loading, especially when default configs are used for first-time PGM users:
 - Hardcoded default repo used `default-maps` while the config had a commented out `maps-default`, both of those now align
 - Improved logging around timing out while loading maps, which can happen if you configure a big git repo on a slow connection, or have loads of usernames to resolve first time
 - Fixed links to map xml in `/map` having incorrect paths if server runs on windows