### PR TITLE
Fix illegal argument for team display name

### DIFF
--- a/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardMatchModule.java
@@ -34,6 +34,7 @@ import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.ffa.FreeForAllMatchModule;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.StringUtils;
+import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextTranslations;
 
 @ListenerScope(MatchScope.LOADED)
@@ -74,7 +75,8 @@ public class ScoreboardMatchModule implements MatchModule, Listener {
   protected void updatePartyScoreboardTeam(Party party, Team team, boolean forObservers) {
     match.getLogger().fine("Updating scoreboard team " + toString(team) + " for party " + party);
 
-    team.setDisplayName(TextTranslations.translateLegacy(party.getName()));
+    team.setDisplayName(
+        StringUtils.truncate(TextTranslations.translateLegacy(party.getName(NameStyle.FANCY)), 32));
     team.setPrefix(party.getColor().toString());
     team.setSuffix(ChatColor.WHITE.toString());
 


### PR DESCRIPTION
Currently the internal display name of scoreboard teams, for tributes (ffa), is set to the players' verbose name, so name + nick, which can lead to it overflowing the 32 char limit causing exceptions that break team switching an other parts of PGM.

```
[18:28:27] [Server thread/ERROR]: Could not pass event CompetitorAddEvent to PGM v0.16-SNAPSHOT (git-8de00f9)
org.bukkit.event.EventException: null
	[...]
	at tc.oc.pgm.match.MatchImpl.callEvent(MatchImpl.java:248) ~[?:?]
	at tc.oc.pgm.match.MatchImpl.addParty(MatchImpl.java:687) ~[?:?]
	at tc.oc.pgm.match.MatchImpl.setOrClearPlayerParty(MatchImpl.java:549) ~[?:?]
	at tc.oc.pgm.match.MatchImpl.setParty(MatchImpl.java:472) ~[?:?]
	at tc.oc.pgm.ffa.FreeForAllMatchModule.join(FreeForAllMatchModule.java:256) ~[?:?]
	at tc.oc.pgm.join.JoinMatchModule.join(JoinMatchModule.java:155) ~[?:?]
	at tc.oc.pgm.join.JoinHandler.join(JoinHandler.java:18) ~[?:?]
	at tc.oc.pgm.picker.PickerMatchModule.rightClickIcon(PickerMatchModule.java:375) ~[?:?]
	[...]
	at tc.oc.pgm.match.MatchImpl.callEvent(MatchImpl.java:248) ~[?:?]
	at tc.oc.pgm.modules.EventFilterMatchModule.callObserverInteractEvent(EventFilterMatchModule.java:210) ~[?:?]
	at tc.oc.pgm.modules.EventFilterMatchModule.onEntityInteract(EventFilterMatchModule.java:222) ~[?:?]
	[...]
	at net.minecraft.server.v1_8_R3.PlayerConnection.a(PlayerConnection.java:1496) ~[server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at net.minecraft.server.v1_8_R3.PacketPlayInUseEntity.a(PacketPlayInUseEntity.java:34) ~[server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at net.minecraft.server.v1_8_R3.PlayerConnection.lambda$a$0(PlayerConnection.java:1456) ~[server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at net.minecraft.server.v1_8_R3.SystemUtils.a(SourceFile:44) [server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at net.minecraft.server.v1_8_R3.MinecraftServer.processQueue(MinecraftServer.java:1760) [server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at net.minecraft.server.v1_8_R3.MinecraftServer.processAsapTasks(MinecraftServer.java:1754) [server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:697) [server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: java.lang.IllegalArgumentException: Display name '§c❖§e§m<name removed>§r§e§o <nick removed>' is longer than the limit of 32 characters
	at org.apache.commons.lang.Validate.isTrue(Validate.java:136) ~[server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at org.bukkit.craftbukkit.v1_8_R3.scoreboard.CraftTeam.setDisplayName(CraftTeam.java:38) ~[server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	at tc.oc.pgm.scoreboard.ScoreboardMatchModule.updatePartyScoreboardTeam(ScoreboardMatchModule.java:77) ~[?:?]
	at tc.oc.pgm.scoreboard.ScoreboardMatchModule.createPartyScoreboardTeam(ScoreboardMatchModule.java:100) ~[?:?]
	at tc.oc.pgm.scoreboard.ScoreboardMatchModule.addPartyScoreboard(ScoreboardMatchModule.java:117) ~[?:?]
	at tc.oc.pgm.scoreboard.ScoreboardMatchModule.onPartyAdd(ScoreboardMatchModule.java:235) ~[?:?]
	at jdk.internal.reflect.GeneratedMethodAccessor936.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:300) ~[server.jar:git-SportPaper-c03663e-P.2081566-SP.aff24bb-CB.e1ebe52]
	... 101 more
``