### PR TITLE
Consistently use JetBrains' annotations

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/injectors/MatchModuleInjectionService.java
+++ b/core/src/main/java/tc/oc/pgm/command/injectors/MatchModuleInjectionService.java
@@ -10,8 +10,8 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.exceptions.CommandExecutionException;
 import cloud.commandframework.types.tuples.Triplet;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.command.util.CommandUtils;
@@ -20,7 +20,7 @@ public class MatchModuleInjectionService implements InjectionService<CommandSend
 
   @Override
   public @Nullable Object handle(
-      @NonNull Triplet<CommandContext<CommandSender>, Class<?>, AnnotationAccessor> param)
+      @NotNull Triplet<CommandContext<CommandSender>, Class<?>, AnnotationAccessor> param)
       throws Exception {
     // Not a match module? we do not handle that.
     Class<?> cls = param.getSecond();

--- a/core/src/main/java/tc/oc/pgm/command/parsers/DurationParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/DurationParser.java
@@ -16,16 +16,16 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.text.TextException;
 import tc.oc.pgm.util.text.TextParser;
 
 public final class DurationParser implements ArgumentParser<CommandSender, Duration> {
 
   @Override
-  public @NonNull ArgumentParseResult<Duration> parse(
-      final @NonNull CommandContext<CommandSender> context,
-      final @NonNull Queue<String> inputQueue) {
+  public @NotNull ArgumentParseResult<Duration> parse(
+      final @NotNull CommandContext<CommandSender> context,
+      final @NotNull Queue<String> inputQueue) {
     final String input = inputQueue.peek();
     if (input == null) {
       return failure(new NoInputProvidedException(DurationParser.class, context));
@@ -40,8 +40,8 @@ public final class DurationParser implements ArgumentParser<CommandSender, Durat
   }
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      final @NonNull CommandContext<CommandSender> commandContext, final @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      final @NotNull CommandContext<CommandSender> commandContext, final @NotNull String input) {
     char[] chars = input.toLowerCase(Locale.ROOT).toCharArray();
 
     if (chars.length == 0) {

--- a/core/src/main/java/tc/oc/pgm/command/parsers/EnumParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/EnumParser.java
@@ -15,8 +15,8 @@ import java.util.Queue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.Aliased;
 import tc.oc.pgm.util.LiquidMetal;
 import tc.oc.pgm.util.StreamUtils;
@@ -45,9 +45,9 @@ public class EnumParser<E extends Enum<E>> implements ArgumentParser<CommandSend
   }
 
   @Override
-  public @NonNull ArgumentParseResult<E> parse(
-      final @NonNull CommandContext<CommandSender> context,
-      final @NonNull Queue<String> inputQueue) {
+  public @NotNull ArgumentParseResult<E> parse(
+      final @NotNull CommandContext<CommandSender> context,
+      final @NotNull Queue<String> inputQueue) {
     final String input = inputQueue.peek();
     if (input == null) {
       return failure(new NoInputProvidedException(EnumParser.class, context));
@@ -70,8 +70,8 @@ public class EnumParser<E extends Enum<E>> implements ArgumentParser<CommandSend
   }
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      final @NonNull CommandContext<CommandSender> context, final @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      final @NotNull CommandContext<CommandSender> context, final @NotNull String input) {
     return filteredOptions(context, input).collect(Collectors.toList());
   }
 

--- a/core/src/main/java/tc/oc/pgm/command/parsers/MapInfoParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/MapInfoParser.java
@@ -10,7 +10,6 @@ import cloud.commandframework.paper.PaperCommandManager;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
@@ -47,8 +46,8 @@ public final class MapInfoParser extends StringLikeParser<CommandSender, MapInfo
   }
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      @NonNull CommandContext<CommandSender> context, @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      @NotNull CommandContext<CommandSender> context, @NotNull String input) {
     List<String> inputQueue = context.get(CommandKeys.INPUT_QUEUE);
 
     // Words to keep, as they cannot be replaced (they're not the last arg)

--- a/core/src/main/java/tc/oc/pgm/command/parsers/MapPoolParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/MapPoolParser.java
@@ -14,7 +14,7 @@ import java.util.Queue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.command.util.CommandKeys;
@@ -27,9 +27,9 @@ import tc.oc.pgm.util.StringUtils;
 public final class MapPoolParser implements ArgumentParser<CommandSender, MapPool> {
 
   @Override
-  public @NonNull ArgumentParseResult<MapPool> parse(
-      final @NonNull CommandContext<CommandSender> context,
-      final @NonNull Queue<String> inputQueue) {
+  public @NotNull ArgumentParseResult<MapPool> parse(
+      final @NotNull CommandContext<CommandSender> context,
+      final @NotNull Queue<String> inputQueue) {
     MapOrder mapOrder = PGM.get().getMapOrder();
     if (!(mapOrder instanceof MapPoolManager)) return failure(exception("pool.mapPoolsDisabled"));
 
@@ -44,8 +44,8 @@ public final class MapPoolParser implements ArgumentParser<CommandSender, MapPoo
   }
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      final @NonNull CommandContext<CommandSender> context, final @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      final @NotNull CommandContext<CommandSender> context, final @NotNull String input) {
     MapOrder mapOrder = PGM.get().getMapOrder();
     if (!(mapOrder instanceof MapPoolManager)) return Collections.emptyList();
 

--- a/core/src/main/java/tc/oc/pgm/command/parsers/MatchObjectParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/MatchObjectParser.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -70,8 +69,8 @@ public abstract class MatchObjectParser<T, IT, M extends MatchModule>
   }
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      @NonNull CommandContext<CommandSender> context, @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      @NotNull CommandContext<CommandSender> context, @NotNull String input) {
     Match match = CommandUtils.getMatch(context);
     if (match == null) return Collections.emptyList();
 

--- a/core/src/main/java/tc/oc/pgm/command/parsers/PartyParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/PartyParser.java
@@ -10,7 +10,6 @@ import cloud.commandframework.context.CommandContext;
 import cloud.commandframework.paper.PaperCommandManager;
 import java.util.List;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
@@ -39,8 +38,8 @@ public final class PartyParser extends StringLikeParser<CommandSender, Party> {
   }
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      @NonNull CommandContext<CommandSender> context, @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      @NotNull CommandContext<CommandSender> context, @NotNull String input) {
     List<String> teams = teamParser.suggestions(context, input);
     if (LiquidMetal.match("obs", input)) teams.add("obs");
     return teams;

--- a/core/src/main/java/tc/oc/pgm/command/parsers/RotationParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/RotationParser.java
@@ -6,7 +6,7 @@ import cloud.commandframework.context.CommandContext;
 import java.util.List;
 import java.util.Queue;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.command.util.CommandKeys;
 import tc.oc.pgm.rotation.pools.MapPoolType;
 import tc.oc.pgm.rotation.pools.Rotation;
@@ -16,16 +16,16 @@ public final class RotationParser implements ArgumentParser<CommandSender, Rotat
   private final MapPoolParser POOL_PARSER = new MapPoolParser();
 
   @Override
-  public @NonNull ArgumentParseResult<Rotation> parse(
-      final @NonNull CommandContext<CommandSender> context,
-      final @NonNull Queue<String> inputQueue) {
+  public @NotNull ArgumentParseResult<Rotation> parse(
+      final @NotNull CommandContext<CommandSender> context,
+      final @NotNull Queue<String> inputQueue) {
     context.set(CommandKeys.POOL_TYPE, MapPoolType.ORDERED);
     return POOL_PARSER.parse(context, inputQueue).mapParsedValue(p -> (Rotation) p);
   }
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      final @NonNull CommandContext<CommandSender> context, final @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      final @NotNull CommandContext<CommandSender> context, final @NotNull String input) {
     context.set(CommandKeys.POOL_TYPE, MapPoolType.ORDERED);
     return POOL_PARSER.suggestions(context, input);
   }

--- a/core/src/main/java/tc/oc/pgm/command/parsers/TeamsParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/TeamsParser.java
@@ -13,7 +13,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.command.util.CommandUtils;
@@ -46,8 +45,8 @@ public final class TeamsParser extends StringLikeParser<CommandSender, Collectio
   }
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      @NonNull CommandContext<CommandSender> context, @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      @NotNull CommandContext<CommandSender> context, @NotNull String input) {
     List<String> teams = teamParser.suggestions(context, input);
     if ("*".startsWith(input)) teams.add("*");
     return teams;

--- a/core/src/main/java/tc/oc/pgm/command/parsers/VictoryConditionParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/VictoryConditionParser.java
@@ -16,7 +16,7 @@ import java.util.Queue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.VictoryCondition;
 import tc.oc.pgm.command.util.CommandUtils;
@@ -32,9 +32,9 @@ public final class VictoryConditionParser
     implements ArgumentParser<CommandSender, Optional<VictoryCondition>> {
 
   @Override
-  public @NonNull ArgumentParseResult<@NonNull Optional<VictoryCondition>> parse(
-      @NonNull CommandContext<@NonNull CommandSender> context,
-      @NonNull Queue<@NonNull String> inputQueue) {
+  public @NotNull ArgumentParseResult<@NotNull Optional<VictoryCondition>> parse(
+      @NotNull CommandContext<@NotNull CommandSender> context,
+      @NotNull Queue<@NotNull String> inputQueue) {
     final String input = inputQueue.poll();
     if (input == null) {
       return failure(new NoInputProvidedException(VictoryConditionParser.class, context));
@@ -61,8 +61,8 @@ public final class VictoryConditionParser
       Arrays.asList("default", "tie", "objectives", "score");
 
   @Override
-  public @NonNull List<@NonNull String> suggestions(
-      @NonNull CommandContext<CommandSender> context, @NonNull String input) {
+  public @NotNull List<@NotNull String> suggestions(
+      @NotNull CommandContext<CommandSender> context, @NotNull String input) {
     final Match match = CommandUtils.getMatch(context);
     if (match == null) return BASE_SUGGESTIONS;
 


### PR DESCRIPTION
Swap remaining Checker Framework annotations to JetBrains' for consistency