### PR TITLE
Add a Staging phase for maps

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/Phase.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Phase.java
@@ -7,6 +7,7 @@ import net.kyori.adventure.text.Component;
 
 public enum Phase {
   PRODUCTION,
+  STAGING,
   DEVELOPMENT;
 
   public Component toComponent() {

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -91,6 +91,8 @@ map.protectPortal = You may not obstruct this area
 
 map.phase.production = Production
 
+map.phase.staging = Staging
+
 map.phase.development = Development
 
 # {0} = map pool name (e.g. "Mega")


### PR DESCRIPTION
Adds a staging phase for maps.

Thought process on phases:

Dev phase:
- Can be played but should have a Mapdev or Dev watching the match

Staging phase:
- Can be played but should have at least a moderator watching the match

Prod phase:
- Can be played without staff watching the match

Further changes would be made in Community to use this in map sponsoring logic.

Further changes in PGM will be made once the Cloud 2 PR is merged https://github.com/PGMDev/PGM/pull/1319