### PR TITLE
Add toggleable map phasing enforcement

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -72,6 +72,9 @@ public interface Config {
   /** @return If unused XML tags should be reported or ignored */
   boolean showUnusedXml();
 
+  /** @return Should setting dev phase maps be restricted to Devs */
+  boolean enforceDevPhase();
+
   /**
    * Gets a duration to wait before starting a match.
    *
@@ -402,18 +405,16 @@ public interface Config {
       if (getClickLink() != null && !getClickLink().isEmpty()) {
         if (addNewline) hover.append(newline());
 
-        Component clickLink =
-            translatable(
-                "chat.clickLink",
-                NamedTextColor.DARK_AQUA,
-                text(getClickLink(), NamedTextColor.AQUA, TextDecoration.UNDERLINED));
+        Component clickLink = translatable(
+            "chat.clickLink",
+            NamedTextColor.DARK_AQUA,
+            text(getClickLink(), NamedTextColor.AQUA, TextDecoration.UNDERLINED));
         hover.append(clickLink);
       }
 
-      TextComponent.Builder component =
-          text()
-              .append(text(prefix ? getPrefix() : getSuffix()))
-              .hoverEvent(showText(hover.build()));
+      TextComponent.Builder component = text()
+          .append(text(prefix ? getPrefix() : getSuffix()))
+          .hoverEvent(showText(hover.build()));
 
       if (getClickLink() != null && !getClickLink().isEmpty()) {
         component.clickEvent(openUrl(getClickLink()));

--- a/core/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/core/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -43,72 +43,69 @@ public interface Permissions {
 
   String MAPMAKER = GROUP + ".mapmaker"; // Permission group for mapmakers, defined in config.yml
 
+  String DEV = ROOT + ".dev";
+
   // Role-specific permission nodes
-  Permission DEFAULT =
-      new Permission(
-          "pgm.default",
-          PermissionDefault.TRUE,
-          new ImmutableMap.Builder<String, Boolean>()
-              .put(JOIN, true)
-              .put(LEAVE, true)
-              .put(VIEW_INVENTORY, true)
-              .build());
+  Permission DEFAULT = new Permission(
+      "pgm.default",
+      PermissionDefault.TRUE,
+      new ImmutableMap.Builder<String, Boolean>()
+          .put(JOIN, true)
+          .put(LEAVE, true)
+          .put(VIEW_INVENTORY, true)
+          .build());
 
-  Permission PREMIUM =
-      new Permission(
-          "pgm.premium",
-          PermissionDefault.FALSE,
-          new ImmutableMap.Builder<String, Boolean>()
-              .putAll(DEFAULT.getChildren())
-              .put(DEFAULT.getName(), true)
-              .put(JOIN_CHOOSE, true)
-              .put(JOIN_FULL, true)
-              .put(EXTRA_VOTE, true)
-              .build());
+  Permission PREMIUM = new Permission(
+      "pgm.premium",
+      PermissionDefault.FALSE,
+      new ImmutableMap.Builder<String, Boolean>()
+          .putAll(DEFAULT.getChildren())
+          .put(DEFAULT.getName(), true)
+          .put(JOIN_CHOOSE, true)
+          .put(JOIN_FULL, true)
+          .put(EXTRA_VOTE, true)
+          .build());
 
-  Permission MODERATOR =
-      new Permission(
-          "pgm.mod",
-          PermissionDefault.FALSE,
-          new ImmutableMap.Builder<String, Boolean>()
-              .putAll(PREMIUM.getChildren())
-              .put(PREMIUM.getName(), true)
-              .put(START, true)
-              .put(STOP, true)
-              .put(SETNEXT, true)
-              .put(ADMINCHAT, true)
-              .put(RESIZE, true)
-              .put(JOIN_FORCE, true)
-              .put(DEFUSE, true)
-              .put(STAFF, true)
-              .put(KICK, true)
-              .put(WARN, true)
-              .put(MUTE, true)
-              .put(BAN, true)
-              .put(FREEZE, true)
-              .put(VANISH, true)
-              .build());
+  Permission MODERATOR = new Permission(
+      "pgm.mod",
+      PermissionDefault.FALSE,
+      new ImmutableMap.Builder<String, Boolean>()
+          .putAll(PREMIUM.getChildren())
+          .put(PREMIUM.getName(), true)
+          .put(START, true)
+          .put(STOP, true)
+          .put(SETNEXT, true)
+          .put(ADMINCHAT, true)
+          .put(RESIZE, true)
+          .put(JOIN_FORCE, true)
+          .put(DEFUSE, true)
+          .put(STAFF, true)
+          .put(KICK, true)
+          .put(WARN, true)
+          .put(MUTE, true)
+          .put(BAN, true)
+          .put(FREEZE, true)
+          .put(VANISH, true)
+          .build());
 
-  Permission DEVELOPER =
-      new Permission(
-          "pgm.dev",
-          PermissionDefault.FALSE,
-          new ImmutableMap.Builder<String, Boolean>()
-              .putAll(MODERATOR.getChildren())
-              .put(MODERATOR.getName(), true)
-              .put(GAMEPLAY, true)
-              .put(DEBUG, true)
-              .put(RELOAD, true)
-              .build());
+  Permission DEVELOPER = new Permission(
+      DEV,
+      PermissionDefault.FALSE,
+      new ImmutableMap.Builder<String, Boolean>()
+          .putAll(MODERATOR.getChildren())
+          .put(MODERATOR.getName(), true)
+          .put(GAMEPLAY, true)
+          .put(DEBUG, true)
+          .put(RELOAD, true)
+          .build());
 
-  Permission ALL =
-      new Permission(
-          "pgm.*",
-          PermissionDefault.OP,
-          new ImmutableMap.Builder<String, Boolean>()
-              .putAll(DEVELOPER.getChildren())
-              .put(DEVELOPER.getName(), true)
-              .build());
+  Permission ALL = new Permission(
+      "pgm.*",
+      PermissionDefault.OP,
+      new ImmutableMap.Builder<String, Boolean>()
+          .putAll(DEVELOPER.getChildren())
+          .put(DEVELOPER.getName(), true)
+          .build());
 
   static void registerAll() {
     Stream.of(DEFAULT, PREMIUM, MODERATOR, DEVELOPER, ALL).forEachOrdered(Permissions::register);

--- a/core/src/main/java/tc/oc/pgm/api/map/Phase.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Phase.java
@@ -26,10 +26,6 @@ public enum Phase {
     return translatable("map.phase." + this.name().toLowerCase());
   }
 
-  public boolean prefixedBy(String query) {
-    return this.name().toLowerCase(Locale.ROOT).startsWith(query.toLowerCase(Locale.ROOT));
-  }
-
   public static Phase of(String query) {
     query = query.toLowerCase(Locale.ROOT);
     for (Phase phase : Phase.values()) {
@@ -41,7 +37,7 @@ public enum Phase {
   }
 
   public static class Phases {
-    EnumSet<Phase> phases;
+    private final EnumSet<Phase> phases;
 
     private Phases(EnumSet<Phase> phases) {
       this.phases = phases;

--- a/core/src/main/java/tc/oc/pgm/api/map/Phase.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Phase.java
@@ -64,20 +64,14 @@ public enum Phase {
     }
 
     public static Phases parse(CommandSender sender, Collection<Phases> inputPhases) {
-      EnumSet<Phase> aggregatePhases = EnumSet.noneOf(Phase.class);
-      for (Phases inputPhase : inputPhases) {
-        aggregatePhases.addAll(inputPhase.phases);
-      }
+      Phases aggregate = of(inputPhases);
+      if (!aggregate.phases.isEmpty()) return aggregate;
 
-      if (aggregatePhases.isEmpty()) {
-        EnumSet<Phase> chosenPhases = EnumSet.noneOf(Phase.class);
-        chosenPhases.addAll(EnumSet.allOf(Phase.class).stream()
-            .filter(p -> sender.hasPermission(p.permission))
-            .toList());
-        return new Phases(chosenPhases);
-      } else {
-        return new Phases(aggregatePhases);
-      }
+      EnumSet<Phase> chosenPhases = EnumSet.noneOf(Phase.class);
+      EnumSet.allOf(Phase.class).stream()
+          .filter(p -> sender.hasPermission(p.permission))
+          .forEach(chosenPhases::add);
+      return new Phases(chosenPhases);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/Phase.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Phase.java
@@ -67,11 +67,10 @@ public enum Phase {
       Phases aggregate = of(inputPhases);
       if (!aggregate.phases.isEmpty()) return aggregate;
 
-      EnumSet<Phase> chosenPhases = EnumSet.noneOf(Phase.class);
       EnumSet.allOf(Phase.class).stream()
           .filter(p -> sender.hasPermission(p.permission))
-          .forEach(chosenPhases::add);
-      return new Phases(chosenPhases);
+          .forEach(aggregate.phases::add);
+      return aggregate;
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/Phase.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Phase.java
@@ -1,17 +1,33 @@
 package tc.oc.pgm.api.map;
 
 import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.api.Permissions.DEFAULT;
+import static tc.oc.pgm.api.Permissions.DEV;
+import static tc.oc.pgm.api.Permissions.SETNEXT;
 
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.Locale;
 import net.kyori.adventure.text.Component;
+import org.bukkit.command.CommandSender;
 
 public enum Phase {
-  PRODUCTION,
-  STAGING,
-  DEVELOPMENT;
+  PRODUCTION(DEFAULT.getName()),
+  STAGING(SETNEXT),
+  DEVELOPMENT(DEV);
+
+  private final String permission;
+
+  Phase(String permission) {
+    this.permission = permission;
+  }
 
   public Component toComponent() {
     return translatable("map.phase." + this.name().toLowerCase());
+  }
+
+  public boolean prefixedBy(String query) {
+    return this.name().toLowerCase(Locale.ROOT).startsWith(query.toLowerCase(Locale.ROOT));
   }
 
   public static Phase of(String query) {
@@ -22,5 +38,50 @@ public enum Phase {
       }
     }
     return null;
+  }
+
+  public static class Phases {
+    EnumSet<Phase> phases;
+
+    private Phases(EnumSet<Phase> phases) {
+      this.phases = phases;
+    }
+
+    public boolean contains(Phase phase) {
+      return this.phases.contains(phase);
+    }
+
+    public static Phases of(Phase phase) {
+      return new Phases(phase == null ? EnumSet.noneOf(Phase.class) : EnumSet.of(phase));
+    }
+
+    public static Phases of(Collection<Phases> inputPhases) {
+      EnumSet<Phase> phases = EnumSet.noneOf(Phase.class);
+      for (Phases inputPhase : inputPhases) {
+        phases.addAll(inputPhase.phases);
+      }
+      return new Phases(phases);
+    }
+
+    public static Phases allOf() {
+      return new Phases(EnumSet.allOf(Phase.class));
+    }
+
+    public static Phases parse(CommandSender sender, Collection<Phases> inputPhases) {
+      EnumSet<Phase> aggregatePhases = EnumSet.noneOf(Phase.class);
+      for (Phases inputPhase : inputPhases) {
+        aggregatePhases.addAll(inputPhase.phases);
+      }
+
+      if (aggregatePhases.isEmpty()) {
+        EnumSet<Phase> chosenPhases = EnumSet.noneOf(Phase.class);
+        chosenPhases.addAll(EnumSet.allOf(Phase.class).stream()
+            .filter(p -> sender.hasPermission(p.permission))
+            .toList());
+        return new Phases(chosenPhases);
+      } else {
+        return new Phases(aggregatePhases);
+      }
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.command;
 
+import static tc.oc.pgm.api.Permissions.DEV;
+import static tc.oc.pgm.api.map.Phase.DEVELOPMENT;
 import static tc.oc.pgm.util.text.TextException.exception;
 
 import java.time.Duration;
@@ -10,6 +12,7 @@ import org.incendo.cloud.annotations.Command;
 import org.incendo.cloud.annotations.CommandDescription;
 import org.incendo.cloud.annotations.Flag;
 import org.incendo.cloud.annotations.Permission;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
@@ -33,6 +36,11 @@ public final class CycleCommand {
     }
 
     if (map != null && mapOrder.getNextMap() != map) {
+      if (PGM.get().getConfiguration().enforceDevPhase()
+          && DEVELOPMENT.equals(map.getPhase())
+          && !sender.hasPermission(DEV)) {
+        throw exception("map.setNext.notDev");
+      }
       mapOrder.setNextMap(map);
       MapOrderCommand.sendSetNextMessage(map, sender, match);
     }

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -69,7 +69,7 @@ public final class MapCommand {
           List<String> tags,
       @Flag(value = "author", aliases = "a") String author,
       @Flag(value = "name", aliases = "n") String name,
-      @Flag(value = "phase", aliases = "p") Phase phase) {
+      @Flag(value = "phase", aliases = "p", repeatable = true) List<Phase.Phases> phases) {
     Stream<MapInfo> search = library.getMaps(name);
     if (!tags.isEmpty()) {
       final Map<Boolean, Set<String>> tagSet = tags.stream()
@@ -83,9 +83,8 @@ public final class MapCommand {
       search = search.filter(map -> matchesTags(map, tagSet.get(false), tagSet.get(true)));
     }
 
-    // FIXME: change when cloud gets support for default flag values
-    final Phase finalPhase = phase == null ? Phase.PRODUCTION : phase;
-    search = search.filter(map -> map.getPhase() == finalPhase);
+    Phase.Phases chosenPhases = Phase.Phases.parse(sender, phases);
+    search = search.filter(map -> chosenPhases.contains(map.getPhase()));
 
     if (author != null) {
       String query = author;
@@ -246,7 +245,9 @@ public final class MapCommand {
           .append(mapInfoLabel("map.info.proto"))
           .append(text(map.getProto().toString(), NamedTextColor.GOLD))
           .build());
+    }
 
+    if (sender.hasPermission(Permissions.DEBUG) || !Phase.PRODUCTION.equals(map.getPhase())) {
       audience.sendMessage(text()
           .append(mapInfoLabel("map.info.phase"))
           .append(map.getPhase().toComponent().color(NamedTextColor.GOLD))

--- a/core/src/main/java/tc/oc/pgm/command/MapOrderCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapOrderCommand.java
@@ -2,6 +2,8 @@ package tc.oc.pgm.command;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.api.Permissions.DEV;
+import static tc.oc.pgm.api.map.Phase.DEVELOPMENT;
 import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
 import static tc.oc.pgm.util.text.TextException.exception;
 
@@ -16,6 +18,7 @@ import org.incendo.cloud.annotations.Default;
 import org.incendo.cloud.annotations.Flag;
 import org.incendo.cloud.annotations.Permission;
 import org.jetbrains.annotations.NotNull;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
@@ -35,11 +38,10 @@ public final class MapOrderCommand {
 
     if (next == null) throw exception("map.noNextMap");
 
-    audience.sendMessage(
-        translatable(
-            "map.nextMap",
-            NamedTextColor.DARK_PURPLE,
-            next.getStyledName(MapNameStyle.COLOR_WITH_AUTHORS)));
+    audience.sendMessage(translatable(
+        "map.nextMap",
+        NamedTextColor.DARK_PURPLE,
+        next.getStyledName(MapNameStyle.COLOR_WITH_AUTHORS)));
   }
 
   @Command("setnext|sn [map]")
@@ -55,6 +57,12 @@ public final class MapOrderCommand {
       @Argument("map") @Default(CURRENT) @FlagYielding MapInfo map) {
     if (RestartManager.isQueued() && !force) {
       throw exception("map.setNext.confirm");
+    }
+
+    if (PGM.get().getConfiguration().enforceDevPhase()
+        && DEVELOPMENT.equals(map.getPhase())
+        && !sender.hasPermission(DEV)) {
+      throw exception("map.setNext.notDev");
     }
 
     if (reset) {
@@ -86,12 +94,11 @@ public final class MapOrderCommand {
 
   public static void sendSetNextMessage(@NotNull MapInfo map, CommandSender sender, Match match) {
     Component mapName = text(map.getName(), NamedTextColor.GOLD);
-    Component successful =
-        translatable(
-            "map.setNext",
-            NamedTextColor.GRAY,
-            UsernameFormatUtils.formatStaffName(sender, match),
-            mapName);
+    Component successful = translatable(
+        "map.setNext",
+        NamedTextColor.GRAY,
+        UsernameFormatUtils.formatStaffName(sender, match),
+        mapName);
     ChatDispatcher.broadcastAdminChatMessage(successful, match);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/parsers/PhasesParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/PhasesParser.java
@@ -4,7 +4,6 @@ import static org.incendo.cloud.parser.ArgumentParseResult.failure;
 import static org.incendo.cloud.parser.ArgumentParseResult.success;
 import static tc.oc.pgm.util.text.TextException.invalidFormat;
 
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -34,21 +33,19 @@ public class PhasesParser extends StringLikeParser<CommandSender, Phase.Phases>
       return success(Phase.Phases.allOf());
     }
 
-    return EnumSet.allOf(Phase.class).stream()
-        .filter((phase) -> phase == Phase.of(text))
-        .min(Comparator.comparingInt((phase) -> phase.name().length()))
-        .map(phase -> success(Phase.Phases.of(phase)))
-        .orElseGet(() -> failure(invalidFormat(text, Phase.class)));
+    Phase phase = Phase.of(text);
+    if (phase == null) return failure(invalidFormat(text, Phase.class));
+    return success(Phase.Phases.of(phase));
   }
 
   @Override
   public @NonNull Iterable<@NonNull String> stringSuggestions(
       @NonNull CommandContext<CommandSender> context, @NonNull CommandInput input) {
-    final String next = input.peekString();
+    final String next = input.peekString().toLowerCase();
 
     List<String> suggestions = EnumSet.allOf(Phase.class).stream()
-        .filter((phase) -> phase == Phase.of(next))
         .map(p -> p.name().toLowerCase(Locale.ROOT))
+        .filter(name -> name.startsWith(next))
         .collect(Collectors.toList());
 
     if ("*".startsWith(next)) suggestions.add("*");

--- a/core/src/main/java/tc/oc/pgm/command/parsers/PhasesParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/PhasesParser.java
@@ -35,7 +35,7 @@ public class PhasesParser extends StringLikeParser<CommandSender, Phase.Phases>
     }
 
     return EnumSet.allOf(Phase.class).stream()
-        .filter((phase) -> phase.prefixedBy(text))
+        .filter((phase) -> phase == Phase.of(text))
         .min(Comparator.comparingInt((phase) -> phase.name().length()))
         .map(phase -> success(Phase.Phases.of(phase)))
         .orElseGet(() -> failure(invalidFormat(text, Phase.class)));
@@ -47,7 +47,7 @@ public class PhasesParser extends StringLikeParser<CommandSender, Phase.Phases>
     final String next = input.peekString();
 
     List<String> suggestions = EnumSet.allOf(Phase.class).stream()
-        .filter((phase) -> phase.prefixedBy(next))
+        .filter((phase) -> phase == Phase.of(next))
         .map(p -> p.name().toLowerCase(Locale.ROOT))
         .collect(Collectors.toList());
 

--- a/core/src/main/java/tc/oc/pgm/command/parsers/PhasesParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/PhasesParser.java
@@ -1,0 +1,57 @@
+package tc.oc.pgm.command.parsers;
+
+import static org.incendo.cloud.parser.ArgumentParseResult.failure;
+import static org.incendo.cloud.parser.ArgumentParseResult.success;
+import static tc.oc.pgm.util.text.TextException.invalidFormat;
+
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.bukkit.command.CommandSender;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
+import org.incendo.cloud.parser.ArgumentParseResult;
+import org.incendo.cloud.parser.ParserParameters;
+import org.incendo.cloud.suggestion.BlockingSuggestionProvider;
+import org.jetbrains.annotations.NotNull;
+import tc.oc.pgm.api.map.Phase;
+
+public class PhasesParser extends StringLikeParser<CommandSender, Phase.Phases>
+    implements BlockingSuggestionProvider.Strings<CommandSender> {
+
+  public PhasesParser(CommandManager<CommandSender> manager, ParserParameters options) {
+    super(manager, options);
+  }
+
+  @Override
+  public ArgumentParseResult<Phase.Phases> parse(
+      @NotNull CommandContext<CommandSender> context, @NotNull String text) {
+    if (text.equalsIgnoreCase("*")) {
+      return success(Phase.Phases.allOf());
+    }
+
+    return EnumSet.allOf(Phase.class).stream()
+        .filter((phase) -> phase.prefixedBy(text))
+        .min(Comparator.comparingInt((phase) -> phase.name().length()))
+        .map(phase -> success(Phase.Phases.of(phase)))
+        .orElseGet(() -> failure(invalidFormat(text, Phase.class)));
+  }
+
+  @Override
+  public @NonNull Iterable<@NonNull String> stringSuggestions(
+      @NonNull CommandContext<CommandSender> context, @NonNull CommandInput input) {
+    final String next = input.peekString();
+
+    List<String> suggestions = EnumSet.allOf(Phase.class).stream()
+        .filter((phase) -> phase.prefixedBy(next))
+        .map(p -> p.name().toLowerCase(Locale.ROOT))
+        .collect(Collectors.toList());
+
+    if ("*".startsWith(next)) suggestions.add("*");
+    return suggestions;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/parsers/PhasesParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/PhasesParser.java
@@ -41,7 +41,7 @@ public class PhasesParser extends StringLikeParser<CommandSender, Phase.Phases>
   @Override
   public @NonNull Iterable<@NonNull String> stringSuggestions(
       @NonNull CommandContext<CommandSender> context, @NonNull CommandInput input) {
-    final String next = input.peekString().toLowerCase();
+    final String next = input.peekString().toLowerCase(Locale.ROOT);
 
     List<String> suggestions = EnumSet.allOf(Phase.class).stream()
         .map(p -> p.name().toLowerCase(Locale.ROOT))

--- a/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
@@ -18,6 +18,7 @@ import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapLibrary;
 import tc.oc.pgm.api.map.MapOrder;
+import tc.oc.pgm.api.map.Phase;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.party.Party;
@@ -70,6 +71,7 @@ import tc.oc.pgm.command.parsers.MatchPlayerParser;
 import tc.oc.pgm.command.parsers.ModeParser;
 import tc.oc.pgm.command.parsers.OfflinePlayerParser;
 import tc.oc.pgm.command.parsers.PartyParser;
+import tc.oc.pgm.command.parsers.PhasesParser;
 import tc.oc.pgm.command.parsers.PlayerClassParser;
 import tc.oc.pgm.command.parsers.PlayerParser;
 import tc.oc.pgm.command.parsers.RotationParser;
@@ -134,15 +136,12 @@ public class PGMCommandGraph extends CommandGraph<PGM> {
 
     register(ChatDispatcher.get());
 
-    manager.command(
-        manager
-            .commandBuilder("pgm")
-            .literal("help")
-            .optional("query", StringParser.greedyStringParser())
-            .handler(
-                context ->
-                    minecraftHelp.queryCommands(
-                        context.<String>optional("query").orElse(""), context.sender())));
+    manager.command(manager
+        .commandBuilder("pgm")
+        .literal("help")
+        .optional("query", StringParser.greedyStringParser())
+        .handler(context -> minecraftHelp.queryCommands(
+            context.<String>optional("query").orElse(""), context.sender())));
   }
 
   // Injectors
@@ -196,6 +195,7 @@ public class PGMCommandGraph extends CommandGraph<PGM> {
     registerParser(Filter.class, FilterArgumentParser::new);
     registerParser(SettingKey.class, new EnumParser<>(SettingKey.class, CommandKeys.SETTING_KEY));
     registerParser(SettingValue.class, new SettingValueParser());
+    registerParser(Phase.Phases.class, PhasesParser::new);
 
     parsers.registerSuggestionProvider(
         "players", SuggestionProvider.blockingStrings(Players::suggestPlayers));

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -38,6 +38,9 @@ map:
   # Show unused XML nodes as map errors. Helps with finding typos in xml.
   show-unused-xml: true
 
+  # Only allow devs to set dev phase maps
+  enforce-dev-phase: false
+
 
 # Sets the duration of various countdowns.
 #

--- a/util/src/main/i18n/templates/map.properties
+++ b/util/src/main/i18n/templates/map.properties
@@ -67,6 +67,8 @@ map.setNext = {0} set the next map to {1}
 
 map.setNext.confirm = You may not set the next map when a restart is queued. Use -f to override.
 
+map.setNext.notDev = You do not have permission to set Development phased maps!
+
 # {0} = player name (who unset the map)
 # {1} = name of map that was unset
 map.setNext.revert = {0} has removed {1} as the next map


### PR DESCRIPTION
Adds enforcement for map phasing, controlled by config option `map.enforce-dev-phase`.

When enabled only players with the permission `pgm.dev` can set dev phased maps.

Also allows for multiple phases in the `/maps` command
- Ex: `/maps -p production -p staging`

Default phase showing behaviour for `/maps` was modified.

- For non staff it only shows prod phased maps
- For players with set next perms it also shows staging phased maps
- for players with `pgm.dev` it also shows development phased maps

The map stage now shows for all players in /maps when the stage is not production.