### PR TITLE
Improve compass tracking module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/compass/CompassModule.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassModule.java
@@ -14,18 +14,19 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
 import tc.oc.pgm.filters.FilterMatchModule;
+import tc.oc.pgm.flag.FlagModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class CompassModule implements MapModule<CompassMatchModule> {
 
-  private final ImmutableList<CompassTarget> compassTargets;
+  private final ImmutableList<CompassTarget<?>> compassTargets;
   private final OrderStrategy orderStrategy;
   private final boolean showDistance;
 
   public CompassModule(
-      ImmutableList<CompassTarget> compassTargets,
+      ImmutableList<CompassTarget<?>> compassTargets,
       OrderStrategy orderStrategy,
       boolean showDistance) {
     this.compassTargets = compassTargets;
@@ -45,30 +46,36 @@ public class CompassModule implements MapModule<CompassMatchModule> {
   }
 
   public static class Factory implements MapModuleFactory<CompassModule> {
+
+    @Override
+    public @Nullable Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
+      return List.of(FlagModule.class);
+    }
+
     @Override
     public @Nullable CompassModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
       CompassParser parser = new CompassParser(factory);
 
-      ImmutableList.Builder<CompassTarget> compassTargets = ImmutableList.builder();
+      ImmutableList.Builder<CompassTarget<?>> compassTargets = ImmutableList.builder();
       OrderStrategy orderStrategy = OrderStrategy.DEFINITION_ORDER;
       boolean showDistance = false;
       for (Element compassRoot : doc.getRootElement().getChildren("compass")) {
-        orderStrategy =
-            XMLUtils.parseEnum(
-                Node.fromAttr(compassRoot, "order"), OrderStrategy.class, orderStrategy);
+        orderStrategy = XMLUtils.parseEnum(
+            Node.fromAttr(compassRoot, "order"), OrderStrategy.class, orderStrategy);
         showDistance =
             XMLUtils.parseBoolean(Node.fromAttr(compassRoot, "show-distance"), showDistance);
+
         List<Element> children = compassRoot.getChildren();
-        if (children.isEmpty()) {
+        if (children.isEmpty())
           throw new InvalidXMLException("Compass tag has no targets", compassRoot);
-        }
         for (Element compassTarget : children) {
           compassTargets.add(parser.parseCompassTarget(compassTarget));
         }
       }
-
-      return new CompassModule(compassTargets.build(), orderStrategy, showDistance);
+      ImmutableList<CompassTarget<?>> targets = compassTargets.build();
+      if (targets == null) return null;
+      return new CompassModule(targets, orderStrategy, showDistance);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/compass/CompassParser.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassParser.java
@@ -6,9 +6,12 @@ import net.kyori.adventure.text.Component;
 import org.jdom2.Element;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.compass.targets.FlagCompassTarget;
 import tc.oc.pgm.compass.targets.PlayerCompassTarget;
 import tc.oc.pgm.features.FeatureDefinitionContext;
+import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.parse.FilterParser;
+import tc.oc.pgm.flag.FlagDefinition;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -17,31 +20,25 @@ import tc.oc.pgm.util.xml.XMLUtils;
 
 public class CompassParser {
 
-  private final MapFactory factory;
   private final FeatureDefinitionContext features;
   private final FilterParser filters;
   private final Map<String, Method> methodParsers;
 
   public CompassParser(MapFactory factory) {
-    this.factory = factory;
     this.features = factory.getFeatures();
     this.filters = factory.getFilters();
     this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
-  }
-
-  public boolean isTarget(Element el) {
-    return getParserFor(el) != null;
   }
 
   protected Method getParserFor(Element el) {
     return methodParsers.get(el.getName().toLowerCase());
   }
 
-  public CompassTarget parseCompassTarget(Element el) throws InvalidXMLException {
+  public CompassTarget<?> parseCompassTarget(Element el) throws InvalidXMLException {
     Method parser = getParserFor(el);
     if (parser != null) {
       try {
-        return (CompassTarget) parser.invoke(this, el);
+        return (CompassTarget<?>) parser.invoke(this, el);
       } catch (Exception e) {
         throw InvalidXMLException.coerce(e, new Node(el));
       }
@@ -52,10 +49,20 @@ public class CompassParser {
 
   @MethodParser("player")
   public PlayerCompassTarget parsePlayerTarget(Element el) throws InvalidXMLException {
+    Filter holderFilter = filters.parseProperty(el, "holder-filter", StaticFilter.ALLOW);
+    Filter targetFilter = filters.parseRequiredProperty(el, "filter");
     Component name = XMLUtils.parseFormattedText(Node.fromChildOrAttr(el, "name"));
-    Filter filter = filters.parseProperty(el, "filter");
     boolean showPlayerName = XMLUtils.parseBoolean(Node.fromAttr(el, "show-player"), false);
 
-    return new PlayerCompassTarget(filter, name, showPlayerName);
+    return new PlayerCompassTarget(holderFilter, targetFilter, name, showPlayerName);
+  }
+
+  @MethodParser("flag")
+  public FlagCompassTarget parseFlagTarget(Element el) throws InvalidXMLException {
+    Filter holderFilter = filters.parseProperty(el, "holder-filter", StaticFilter.ALLOW);
+    FlagDefinition flag = features.resolve(new Node(el), FlagDefinition.class);
+    Component name = XMLUtils.parseFormattedText(Node.fromChildOrAttr(el, "name"));
+
+    return new FlagCompassTarget(holderFilter, flag, name);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/compass/CompassTarget.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassTarget.java
@@ -1,18 +1,22 @@
 package tc.oc.pgm.compass;
 
 import java.util.Optional;
-import net.kyori.adventure.text.Component;
-import org.bukkit.Location;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 
-public interface CompassTarget {
-  Filter getFilter();
+public abstract class CompassTarget<T> {
+  private final Filter holderFilter;
 
-  Component getName(Match match, MatchPlayer player);
+  public CompassTarget(Filter holderFilter) {
+    this.holderFilter = holderFilter;
+  }
 
-  Optional<Location> getLocation(Match match, MatchPlayer player);
+  public final Optional<CompassTargetResult> getResult(MatchPlayer player) {
+    if (!holderFilter.query(player).isAllowed()) return Optional.empty();
+    return getMatching(player).flatMap(r -> buildResult(r, player));
+  }
 
-  Optional<CompassTargetResult> getResult(Match match, MatchPlayer player);
+  protected abstract Optional<T> getMatching(MatchPlayer player);
+
+  protected abstract Optional<CompassTargetResult> buildResult(T type, MatchPlayer player);
 }

--- a/core/src/main/java/tc/oc/pgm/compass/CompassTargetResult.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassTargetResult.java
@@ -17,6 +17,11 @@ public class CompassTargetResult {
     this.component = component;
   }
 
+  public static CompassTargetResult of(Location target, Location holder, Component component) {
+    double yDifference = target.getY() - holder.getY();
+    return new CompassTargetResult(target, holder.distance(target), yDifference, component);
+  }
+
   public Location getLocation() {
     return location;
   }

--- a/core/src/main/java/tc/oc/pgm/compass/targets/FlagCompassTarget.java
+++ b/core/src/main/java/tc/oc/pgm/compass/targets/FlagCompassTarget.java
@@ -1,0 +1,35 @@
+package tc.oc.pgm.compass.targets;
+
+import java.util.Optional;
+import net.kyori.adventure.text.Component;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.compass.CompassTarget;
+import tc.oc.pgm.compass.CompassTargetResult;
+import tc.oc.pgm.flag.Flag;
+import tc.oc.pgm.flag.FlagDefinition;
+
+public class FlagCompassTarget extends CompassTarget<Flag> {
+
+  private final FlagDefinition flag;
+  private final Component name;
+
+  public FlagCompassTarget(Filter holderFilter, FlagDefinition flag, Component name) {
+    super(holderFilter);
+    this.flag = flag;
+    this.name = name;
+  }
+
+  @Override
+  protected Optional<Flag> getMatching(MatchPlayer player) {
+    return Optional.of(flag.getGoal(player.getMatch()));
+  }
+
+  @Override
+  protected Optional<CompassTargetResult> buildResult(Flag flag, MatchPlayer player) {
+    if (flag.isCarrying(player)) return Optional.empty();
+    return flag.getLocation()
+        .map(loc -> CompassTargetResult.of(
+            loc, player.getLocation(), name != null ? name : flag.getComponentName()));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/compass/targets/PlayerCompassTarget.java
+++ b/core/src/main/java/tc/oc/pgm/compass/targets/PlayerCompassTarget.java
@@ -3,81 +3,50 @@ package tc.oc.pgm.compass.targets;
 import static net.kyori.adventure.text.Component.text;
 import static tc.oc.pgm.util.player.PlayerComponent.player;
 
+import java.util.Comparator;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.Location;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.compass.CompassTarget;
 import tc.oc.pgm.compass.CompassTargetResult;
 import tc.oc.pgm.filters.query.PlayerQuery;
 import tc.oc.pgm.util.named.NameStyle;
 
-public class PlayerCompassTarget implements CompassTarget {
+public class PlayerCompassTarget extends CompassTarget<MatchPlayer> {
 
-  private final Filter filter;
+  private final Filter targetFilter;
   private final Component name;
   private final boolean showPlayerName;
   private final boolean hasCustomName;
 
-  public PlayerCompassTarget(Filter filter, Component name, boolean showPlayerName) {
-    this.filter = filter;
+  public PlayerCompassTarget(
+      Filter holderFilter, Filter targetFilter, Component name, boolean showPlayerName) {
+    super(holderFilter);
+    this.targetFilter = targetFilter;
     this.hasCustomName = name != null;
     this.name = this.hasCustomName ? name : Component.translatable("compass.tracking.player");
     this.showPlayerName = showPlayerName;
   }
 
   @Override
-  public Filter getFilter() {
-    return filter;
+  protected Optional<MatchPlayer> getMatching(MatchPlayer player) {
+    return player.getMatch().getParticipants().stream()
+        .filter(target -> !target.equals(player))
+        .filter(target -> targetFilter.query(new PlayerQuery(null, target)).isAllowed())
+        .min(Comparator.comparingDouble(
+            target -> target.getLocation().distance(player.getLocation())));
   }
 
-  @Override
-  public Component getName(Match match, MatchPlayer player) {
-    if (showPlayerName) {
-      if (hasCustomName) {
-        return name.append(text(": ", NamedTextColor.WHITE))
-            .append(player(player, NameStyle.FANCY));
-      } else {
-        return player(player, NameStyle.FANCY);
-      }
-    } else {
-      return name;
-    }
+  protected Optional<CompassTargetResult> buildResult(MatchPlayer target, MatchPlayer holder) {
+    return Optional.of(
+        CompassTargetResult.of(target.getLocation(), holder.getLocation(), getName(target)));
   }
 
-  @Override
-  public Optional<Location> getLocation(Match match, MatchPlayer player) {
-    return getClosestPlayer(match, player).map(MatchPlayer::getLocation);
-  }
-
-  @Override
-  public Optional<CompassTargetResult> getResult(Match match, MatchPlayer player) {
-    Optional<MatchPlayer> playerOptional = getClosestPlayer(match, player);
-    if (playerOptional.isPresent()) {
-      MatchPlayer targetPlayer = playerOptional.get();
-      Location targetLoc = targetPlayer.getLocation();
-      Location playerLoc = player.getLocation();
-      double yDifference = targetLoc.getY() - playerLoc.getY();
-
-      return Optional.of(
-          new CompassTargetResult(
-              targetLoc, targetLoc.distance(playerLoc), yDifference, getName(match, targetPlayer)));
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  private Optional<MatchPlayer> getClosestPlayer(Match match, MatchPlayer player) {
-    return match.getParticipants().stream()
-        .filter((otherPlayer) -> !otherPlayer.equals(player))
-        .filter((otherPlayer) -> filter.response(new PlayerQuery(null, otherPlayer)))
-        .min(
-            (firstPlayer, secondPlayer) ->
-                (int)
-                    (firstPlayer.getLocation().distance(player.getLocation())
-                        - secondPlayer.getLocation().distance(player.getLocation())));
+  private Component getName(MatchPlayer player) {
+    if (!showPlayerName) return name;
+    if (!hasCustomName) return player(player, NameStyle.FANCY);
+    return name.append(text(": ", NamedTextColor.WHITE)).append(player(player, NameStyle.FANCY));
   }
 }


### PR DESCRIPTION
Fixes a few shortcomings of the initial implementation.

Adds a `holder-filter` which filters out what compass targets can be eligible for what players, eg: making blue team target a different flag than red team.
Adds a `flag` compass target, given that the player one couldn't match a flag when in it's post or dropped.
The `flag` compass target has an optional `name` attribute, will default to the flags' name

```xml
<compass>
  <player holder-filter="red-team" filter="blue-carrier" show-player="true"/>
  <flag holder-filter="red-team">blue-flag</flag>

  <player holder-filter="blue-team" filter="red-carrier" show-player="true"/>
  <flag holder-filter="blue-team" name="Some other name">red-flag</flag>
</compass>
```
![image](https://github.com/PGMDev/PGM/assets/11789291/07411c5d-9647-416e-882f-4f452690e873)

Additionally fixes the name not refreshing, presumably as a result of updating adventure, as well as fixing a few other minor bugs or potential exceptions