### PR TITLE
Add PlayerJoinResultEvent

### DIFF
--- a/core/src/main/java/tc/oc/pgm/events/PlayerJoinResultEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerJoinResultEvent.java
@@ -1,0 +1,51 @@
+package tc.oc.pgm.events;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.player.event.MatchPlayerEvent;
+import tc.oc.pgm.join.JoinRequest;
+import tc.oc.pgm.join.JoinResult;
+
+public class PlayerJoinResultEvent extends MatchPlayerEvent implements Cancellable {
+
+  private boolean cancelled;
+  private final JoinResult joinResult;
+  private final JoinRequest joinRequest;
+
+  public PlayerJoinResultEvent(MatchPlayer player, JoinResult joinResult, JoinRequest request) {
+    super(player);
+    this.cancelled = false;
+    this.joinResult = joinResult;
+    this.joinRequest = request;
+  }
+
+  public JoinResult getJoinResult() {
+    return joinResult;
+  }
+
+  public JoinRequest getJoinRequest() {
+    return joinRequest;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return cancelled;
+  }
+
+  @Override
+  public void setCancelled(boolean cancelled) {
+    this.cancelled = cancelled;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/join/JoinHandler.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinHandler.java
@@ -1,8 +1,10 @@
 package tc.oc.pgm.join;
 
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.PlayerJoinResultEvent;
 import tc.oc.pgm.match.QueuedParty;
 import tc.oc.pgm.teams.Team;
 
@@ -15,6 +17,11 @@ public interface JoinHandler {
 
   default boolean join(MatchPlayer joining, JoinRequest request) {
     JoinResult result = queryJoin(joining, request);
+
+    PlayerJoinResultEvent joinResultEvent = new PlayerJoinResultEvent(joining, result, request);
+    PGM.get().getServer().getPluginManager().callEvent(joinResultEvent);
+    if (joinResultEvent.isCancelled()) return false;
+
     return join(joining, request, result);
   }
 

--- a/core/src/main/java/tc/oc/pgm/join/JoinResultOption.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinResultOption.java
@@ -13,8 +13,7 @@ public enum JoinResultOption implements JoinResult {
   CHOICE_DISABLED(false), // Tried to choose a specific team and team choosing is disabled
   CHOICE_DENIED(false), // Tried to choose a specific team without choose-team permission
   FULL(false), // Match/team is full
-  VANISHED(false), // Player is vanished, therefore unable to join
-  CANCELLED(false); // Another plugin cancelled the join
+  VANISHED(false); // Player is vanished, therefore unable to join
 
   public final boolean success;
 

--- a/core/src/main/java/tc/oc/pgm/join/JoinResultOption.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinResultOption.java
@@ -13,7 +13,8 @@ public enum JoinResultOption implements JoinResult {
   CHOICE_DISABLED(false), // Tried to choose a specific team and team choosing is disabled
   CHOICE_DENIED(false), // Tried to choose a specific team without choose-team permission
   FULL(false), // Match/team is full
-  VANISHED(false); // Player is vanished, therefore unable to join
+  VANISHED(false), // Player is vanished, therefore unable to join
+  CANCELLED(false); // Another plugin cancelled the join
 
   public final boolean success;
 


### PR DESCRIPTION
The intention is to allow other plugins to get the result of a join attempt and potentially cancel it.

Other plugins should send the player their own message when they cancel a join