### PR TITLE
Rollback death animation change

### DIFF
--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/packets/SpPlayerPackets.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/packets/SpPlayerPackets.java
@@ -6,14 +6,16 @@ import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
 
 import java.util.Collections;
 import java.util.List;
+import net.minecraft.server.v1_8_R3.BlockPosition;
 import net.minecraft.server.v1_8_R3.DataWatcher;
 import net.minecraft.server.v1_8_R3.EntityPlayer;
+import net.minecraft.server.v1_8_R3.PacketPlayOutBed;
 import net.minecraft.server.v1_8_R3.PacketPlayOutCollect;
 import net.minecraft.server.v1_8_R3.PacketPlayOutEntityMetadata;
-import net.minecraft.server.v1_8_R3.PacketPlayOutEntityStatus;
 import net.minecraft.server.v1_8_R3.PacketPlayOutEntityVelocity;
 import net.minecraft.server.v1_8_R3.PacketPlayOutWorldBorder;
 import net.minecraft.server.v1_8_R3.WorldBorder;
+import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
@@ -31,8 +33,6 @@ public class SpPlayerPackets implements PlayerPackets, PacketSender {
   @Override
   public void playDeathAnimation(Player player) {
     EntityPlayer handle = ((CraftPlayer) player).getHandle();
-    PacketPlayOutEntityStatus deadStatus = new PacketPlayOutEntityStatus(handle, (byte) 3);
-
     PacketPlayOutEntityMetadata noHealthMeta =
         new PacketPlayOutEntityMetadata(handle.getId(), handle.getDataWatcher(), false);
 
@@ -55,9 +55,12 @@ public class SpPlayerPackets implements PlayerPackets, PacketSender {
       }
       if (!replaced) list.add(zeroHealth);
     }
-
     sendToViewers(noHealthMeta, player, true);
-    sendToViewers(deadStatus, player, true);
+
+    Location location = player.getLocation();
+    BlockPosition pos = new BlockPosition(location.getX(), location.getY(), location.getZ());
+    sendToViewers(new PacketPlayOutBed(handle, pos), player, true);
+    ENTITIES.teleportEntityPacket(player.getEntityId(), location).sendToViewers(player, true);
   }
 
   @Override


### PR DESCRIPTION
In the modern support refactors i modified the death animation to use a death status packet, as that seemed to work well for 1.8 clients turning hitboxes tiny, however this is likely the reason worn armor is client-side dropping for 1.8 clients, and it also breaks modern clients who now see no death animation.

Brought back the old method of 0 health + bed enter + teleport, which should fix the issue