### PR TITLE
Implement damage actions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/Action.java
+++ b/core/src/main/java/tc/oc/pgm/action/Action.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.action;
 
+import tc.oc.pgm.api.filter.query.Query;
+
 /**
  * An action is a generic thing that can be triggered on an object. The object is commonly referred
  * to as the scope of the action. The most common and intuitive type of action is a kit, a kit is an
@@ -12,6 +14,17 @@ public interface Action<S> {
   Class<S> getScope();
 
   void trigger(S s);
+
+  /**
+   * Trigger the action with a specific query, this should be used by actions that act on a filter,
+   * but otherwise can be ingored.
+   *
+   * @param s the scope to act on
+   * @param event the query to use
+   */
+  default void trigger(S s, Query event) {
+    trigger(s);
+  }
 
   void untrigger(S s);
 }

--- a/core/src/main/java/tc/oc/pgm/action/XMLActionReference.java
+++ b/core/src/main/java/tc/oc/pgm/action/XMLActionReference.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.action;
 
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.features.XMLFeatureReference;
 import tc.oc.pgm.util.xml.Node;
@@ -21,6 +22,11 @@ public class XMLActionReference<S> extends XMLFeatureReference<ActionDefinition>
   @Override
   public void trigger(S s) {
     ((Action<? super S>) get()).trigger(s);
+  }
+
+  @Override
+  public void trigger(S s, Query q) {
+    ((Action<? super S>) get()).trigger(s, q);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/action/actions/ActionNode.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/ActionNode.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.action.actions;
 import com.google.common.collect.ImmutableList;
 import tc.oc.pgm.action.Action;
 import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.filters.Filterable;
 
 public class ActionNode<B extends Filterable<?>> extends AbstractAction<B> {
@@ -30,9 +31,14 @@ public class ActionNode<B extends Filterable<?>> extends AbstractAction<B> {
 
   @Override
   public void trigger(B t) {
-    if (filter.query(t).isAllowed()) {
+    trigger(t, t);
+  }
+
+  @Override
+  public void trigger(B t, Query event) {
+    if (filter.query(event).isAllowed()) {
       for (Action<? super B> action : actions) {
-        action.trigger(t);
+        action.trigger(t, event);
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/action/actions/TakePaymentAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TakePaymentAction.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.action.actions;
 
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.action.Action;
+import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.shops.menu.Payable;
 
@@ -22,11 +23,16 @@ public class TakePaymentAction extends AbstractAction<MatchPlayer> {
   }
 
   @Override
-  public void trigger(MatchPlayer player) {
+  public void trigger(MatchPlayer matchPlayer) {
+    trigger(matchPlayer, matchPlayer);
+  }
+
+  @Override
+  public void trigger(MatchPlayer player, Query q) {
     if (payable.takePayment(player)) {
-      if (onSuccess != null) onSuccess.trigger(player);
+      if (onSuccess != null) onSuccess.trigger(player, q);
     } else {
-      if (onFailure != null) onFailure.trigger(player);
+      if (onFailure != null) onFailure.trigger(player, q);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/damage/DamageModule.java
+++ b/core/src/main/java/tc/oc/pgm/damage/DamageModule.java
@@ -2,44 +2,75 @@ package tc.oc.pgm.damage;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import tc.oc.pgm.action.Action;
+import tc.oc.pgm.action.ActionModule;
+import tc.oc.pgm.action.ActionParser;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
 
 public class DamageModule implements MapModule<DamageMatchModule> {
 
   private final List<Filter> filters;
+  private final Action<? super MatchPlayer> attackerAction;
+  private final Action<? super MatchPlayer> victimAction;
 
-  public DamageModule(List<Filter> filters) {
+  public DamageModule(
+      List<Filter> filters,
+      Action<? super MatchPlayer> attackerAction,
+      Action<? super MatchPlayer> victimAction) {
     this.filters = filters;
+    this.attackerAction = attackerAction;
+    this.victimAction = victimAction;
   }
 
   @Override
   public DamageMatchModule createMatchModule(Match match) {
-    return new DamageMatchModule(match, filters);
+    return new DamageMatchModule(match, filters, attackerAction, victimAction);
   }
 
   public static class Factory implements MapModuleFactory<DamageModule> {
+
+    @Override
+    public Collection<Class<? extends MapModule<?>>> getWeakDependencies() {
+      return ImmutableList.of(ActionModule.class);
+    }
+
     @Override
     public DamageModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
+      FilterParser filterParser = factory.getFilters();
+      ActionParser actionParser = new ActionParser(factory);
+
       List<Filter> filters = new ArrayList<>();
+      Action<? super MatchPlayer> attackerAction = null;
+      Action<? super MatchPlayer> victimAction = null;
 
       for (Element elDamage : doc.getRootElement().getChildren("damage")) {
+        attackerAction = actionParser.parseProperty(
+            Node.fromAttr(elDamage, "attacker-action"), MatchPlayer.class, attackerAction);
+
+        victimAction = actionParser.parseProperty(
+            Node.fromAttr(elDamage, "victim-action"), MatchPlayer.class, victimAction);
+
         for (Element elFilter : elDamage.getChildren()) {
-          filters.add(factory.getFilters().parse(elFilter));
+          filters.add(filterParser.parse(elFilter));
         }
       }
 
       // Always load due to misc damage handling
-      return new DamageModule(ImmutableList.copyOf(filters));
+      return new DamageModule(ImmutableList.copyOf(filters), attackerAction, victimAction);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/CauseFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/CauseFilter.java
@@ -82,8 +82,7 @@ public class CauseFilter extends TypedFilter.Impl<MatchQuery> {
     EntityDamageEvent.DamageCause damageCause = null;
     DamageInfo damageInfo = null;
     boolean punchDamage = false;
-    if (event instanceof EntityDamageEvent) {
-      EntityDamageEvent damageEvent = (EntityDamageEvent) event;
+    if (event instanceof EntityDamageEvent damageEvent) {
       damageCause = damageEvent.getCause();
       damageInfo = tracker.resolveDamage(damageEvent);
       if (damageInfo instanceof MeleeInfo) {


### PR DESCRIPTION
Adds a way to run an action on the victim/attacker of damage events:

```xml
<damage attacker-action="when-attacking" victim-action="when-damaged">
  <deny>
    <cause>explosion</cause>
  </deny>
</damage>
```

Note that the inner-filter of the `damage` element is already an existing feature. The new thing here is `attacker-action` and `victim-action`, which if set, will run an action scoped on the attacker/victim whenever damage happens (and isn't filtered out).
These new actions will run with the query of the event that generated them, meaning they can be filtered using `attacker` and `victim` filter modifiers, eg:

```xml
<filters>
  <attacker id="attacker-is-red">
    <team>red</team>
  </attacker>
  <victim id="victim-is-blue">
    <team>blue</team>
  </victim>
</filters>
<actions>
  <action id="when-attacking" filter="victim-is-blue">
    <message text="You just hit a blue player"/>
  </action>
  <action id="when-damaged" filter="attacker-is-red">
    <message text="You were hit by a red player!"/>
  </action>
</actions>
```
