### PR TITLE
Add custom voting book footer & extra vote logic

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -82,6 +82,10 @@ public final class PGMConfig implements Config {
   private final int griefScore;
   private final float assistPercent;
 
+  // votes.*
+  private final boolean allowExtraVotes;
+  private final int maxExtraVotes;
+
   // join.*
   private final long minPlayers;
   private final boolean limitJoin;
@@ -179,6 +183,9 @@ public final class PGMConfig implements Config {
         parseInteger(config.getString("gameplay.grief-score", "-10"), Range.atMost(0));
     this.assistPercent =
         parseFloat(config.getString("gameplay.assist-percent", "0.3"), Range.openClosed(0f, 1f));
+
+    this.allowExtraVotes = parseBoolean(config.getString("votes.allow-extra-votes", "true"));
+    this.maxExtraVotes = parseInteger(config.getString("votes.max-extra-votes", "5"));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));
@@ -649,6 +656,16 @@ public final class PGMConfig implements Config {
   @Override
   public String getMotd() {
     return motd;
+  }
+
+  @Override
+  public boolean allowExtraVotes() {
+    return allowExtraVotes;
+  }
+
+  @Override
+  public int getMaxExtraVotes() {
+    return maxExtraVotes;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -305,6 +305,20 @@ public interface Config {
   float getAssistPercent();
 
   /**
+   * Gets if extra votes are allowed based on the "pgm.vote.extra.#" permission.
+   *
+   * @return {@code true} if extra votes are enabled, {@code false} otherwise.
+   */
+  boolean allowExtraVotes();
+
+  /**
+   * Gets the maximum number of extra votes a player can use.
+   *
+   * @return The maximum number of extra votes allowed per player.
+   */
+  int getMaxExtraVotes();
+
+  /**
    * Gets a group of players, used for prefixes and player sorting.
    *
    * @return A list of groups.

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/book/VotingBookCreator.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/book/VotingBookCreator.java
@@ -7,4 +7,6 @@ import tc.oc.pgm.api.player.MatchPlayer;
 public interface VotingBookCreator {
 
   Component getMapBookComponent(MatchPlayer viewer, MapInfo map, boolean voted);
+
+  Component getMapBookFooter(MatchPlayer viewer);
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/book/VotingBookCreatorImpl.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/book/VotingBookCreatorImpl.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.rotation.vote.book;
 
+import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.event.ClickEvent.runCommand;
 import static net.kyori.adventure.text.event.HoverEvent.showText;
@@ -25,15 +26,19 @@ public class VotingBookCreatorImpl implements VotingBookCreator {
   @Override
   public Component getMapBookComponent(MatchPlayer viewer, MapInfo map, boolean voted) {
     TextComponent.Builder text = text();
-    text.append(
-        text(
-            voted ? SYMBOL_VOTED : SYMBOL_IGNORE,
-            voted ? NamedTextColor.DARK_GREEN : NamedTextColor.DARK_RED));
+    text.append(text(
+        voted ? SYMBOL_VOTED : SYMBOL_IGNORE,
+        voted ? NamedTextColor.DARK_GREEN : NamedTextColor.DARK_RED));
     text.append(text(" ").decoration(TextDecoration.BOLD, !voted)); // Fix 1px symbol diff
     text.append(text(map.getName(), NamedTextColor.GOLD, TextDecoration.BOLD));
     text.hoverEvent(showText(getHover(viewer, map, voted)));
     text.clickEvent(runCommand("/votenext -o " + map.getName()));
     return text.build();
+  }
+
+  @Override
+  public Component getMapBookFooter(MatchPlayer viewer) {
+    return empty();
   }
 
   public ComponentLike getHover(MatchPlayer viewer, MapInfo map, boolean voted) {
@@ -45,19 +50,17 @@ public class VotingBookCreatorImpl implements VotingBookCreator {
       text.append(map.getGamemode().colorIfAbsent(NamedTextColor.AQUA)).appendNewline();
     } else if (!gamemodes.isEmpty()) {
       boolean acronyms = gamemodes.size() > 1;
-      text.append(
-              TextFormatter.list(
-                  gamemodes.stream()
-                      .map(gm -> text(acronyms ? gm.getAcronym() : gm.getFullName()))
-                      .collect(Collectors.toList()),
-                  NamedTextColor.AQUA))
+      text.append(TextFormatter.list(
+              gamemodes.stream()
+                  .map(gm -> text(acronyms ? gm.getAcronym() : gm.getFullName()))
+                  .collect(Collectors.toList()),
+              NamedTextColor.AQUA))
           .appendNewline();
     }
 
-    text.append(
-        text(
-            map.getTags().stream().map(MapTag::toString).collect(Collectors.joining(" ")),
-            NamedTextColor.YELLOW));
+    text.append(text(
+        map.getTags().stream().map(MapTag::toString).collect(Collectors.joining(" ")),
+        NamedTextColor.YELLOW));
 
     return text;
   }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -77,6 +77,17 @@ gameplay:
   refill-wool: true # Should wool in wool rooms be automatically refilled?
   grief-score: -10 # Score under which players should be kept out of the match
   assist-percent: 0.3 # What percent of the damage is required for an assist 0.3 = 30% of max hp
+  
+# Changes map voting mechanics.
+votes:
+  # Players can gain extra votes based on the permission "pgm.vote.extra.#".
+  #
+  # Examples of granting extra votes:
+  #   "pgm.vote.extra.2" = double votes
+  #   "pgm.vote.extra.4" = quadruple votes
+  #
+  allow-extra-votes: true # Can players use extra votes based on their permissions?
+  max-extra-votes: 5      # Maximum number of extra votes allowed per player.
 
 # Toggles various user interfaces.
 ui:


### PR DESCRIPTION
# Add custom voting book footer & extra vote logic ❗ 

This PR introduces two neat enhancements related to voting:

1. **Voting book footer:** Third-party plugins can now modify the footer of the vote book by overriding the `getMapBookFooter` method to provide additional information. 
2. **Configurable extra vote logic:** The extra vote permission logic is now configurable, offering greater flexibility and customization to fit the needs of any server.

I've thoroughly tested both of these changes and everything has been working perfectly. If you have any feedback or suggestions, let me know and I'll address them ASAP! 👍
