### PR TITLE
Implement click consumables

### DIFF
--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableDefinition.java
@@ -11,16 +11,20 @@ public class ConsumableDefinition extends SelfIdentifyingFeatureDefinition {
   private final ConsumeCause cause;
   /** If true, replaces vanilla behaviour, otherwise keeps vanilla behaviour */
   private final boolean override;
+  /** If the item should be consumed after use */
+  private final boolean consume;
 
   public ConsumableDefinition(
       @Nullable String id,
       Action<? super MatchPlayer> action,
       ConsumeCause cause,
-      boolean override) {
+      boolean override,
+      boolean consume) {
     super(id);
     this.action = action;
     this.cause = cause;
     this.override = override;
+    this.consume = consume;
   }
 
   public Action<? super MatchPlayer> getAction() {
@@ -33,5 +37,9 @@ public class ConsumableDefinition extends SelfIdentifyingFeatureDefinition {
 
   public boolean getOverride() {
     return override;
+  }
+
+  public boolean getConsume() {
+    return consume;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.consumable;
 
 import com.google.common.collect.ImmutableMap;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -30,6 +31,7 @@ public class ConsumableMatchModule implements MatchModule, Listener {
   }
 
   private @Nullable ConsumableDefinition getConsumableDefinition(ItemStack item) {
+    if (item == null) return null;
     return consumables.get(ItemTags.CONSUMABLE.get(item));
   }
 
@@ -41,8 +43,11 @@ public class ConsumableMatchModule implements MatchModule, Listener {
     runConsumable(event, consumable);
   }
 
-  @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.HIGH)
   private void onClick(PlayerInteractEvent event) {
+    // It's been cancelled
+    if (event.useItemInHand() == Event.Result.DENY) return;
+
     ConsumableDefinition consumable = getConsumableDefinition(event.getItem());
     if (consumable == null) return;
 
@@ -68,10 +73,7 @@ public class ConsumableMatchModule implements MatchModule, Listener {
     if (consumable.getOverride()) {
       event.setCancelled(true);
     }
-
-    boolean naturallyConsumes =
-        event instanceof PlayerItemConsumeEvent && !consumable.getOverride();
-    if (consumable.getConsume() && !naturallyConsumes) {
+    if (consumable.getConsume()) {
       InventoryUtils.consumeItem(event);
     }
 

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumeCause.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumeCause.java
@@ -1,5 +1,8 @@
 package tc.oc.pgm.consumable;
 
 public enum ConsumeCause {
-  EAT
+  EAT,
+  RIGHT_CLICK,
+  LEFT_CLICK,
+  CLICK
 }

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -127,7 +127,7 @@ public class ProjectileMatchModule implements MatchModule, Listener {
       }
 
       if (projectileDefinition.throwable) {
-        InventoryUtils.consumeItem(player);
+        InventoryUtils.consumeItem(event);
       }
 
       if (projectileDefinition.coolDown != null) {

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernInventoryUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernInventoryUtil.java
@@ -12,6 +12,10 @@ import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -64,6 +68,15 @@ public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatfor
     for (var entry : modifiers.entries()) {
       meta.addAttributeModifier(entry.getKey(), entry.getValue());
     }
+  }
+
+  @Override
+  public EquipmentSlot getUsedHand(PlayerEvent event) {
+    return switch (event) {
+      case PlayerItemConsumeEvent e -> e.getHand();
+      case PlayerInteractEvent e -> e.getHand();
+      default -> EquipmentSlot.HAND;
+    };
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpInventoryUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpInventoryUtil.java
@@ -11,6 +11,8 @@ import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.Potion;
@@ -63,6 +65,11 @@ public class SpInventoryUtil implements InventoryUtils.InventoryUtilsPlatform {
     for (var entry : modifiers.entries()) {
       meta.addAttributeModifier(entry.getKey(), entry.getValue());
     }
+  }
+
+  @Override
+  public EquipmentSlot getUsedHand(PlayerEvent event) {
+    return EquipmentSlot.HAND;
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -15,6 +15,8 @@ import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -155,14 +157,14 @@ public final class InventoryUtils {
     return stack;
   }
 
-  public static void consumeItem(Player player) {
-    PlayerInventory inv = player.getInventory();
-    int heldSlot = inv.getHeldItemSlot();
-    ItemStack itemInHand = inv.getItem(heldSlot);
+  public static void consumeItem(PlayerEvent player) {
+    PlayerInventory inv = player.getPlayer().getInventory();
+    EquipmentSlot hand = INVENTORY_UTILS.getUsedHand(player);
+    ItemStack itemInHand = inv.getItem(hand);
     if (itemInHand.getAmount() > 1) {
       itemInHand.setAmount(itemInHand.getAmount() - 1);
     } else {
-      inv.setItem(heldSlot, null);
+      inv.setItem(hand, null);
     }
   }
 
@@ -189,6 +191,8 @@ public final class InventoryUtils {
 
     void applyAttributeModifiers(
         SetMultimap<Attribute, AttributeModifier> modifiers, ItemMeta meta);
+
+    EquipmentSlot getUsedHand(PlayerEvent event);
 
     void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials);
 


### PR DESCRIPTION
Adds clickable consumables

Consumables previously had a cause limited to `eat`, now it supports `right click`, `left click` and `click` (which allows both right & left click to be used)

`override` defaults to `true`, meaning vanilla behavior is cancelled and pgm will take-over the handling of this click/eat.

A new `consume` attribute is added, which is if PGM should consume an item itself.
For `on="eat"` PGM will ignore the `consume` attribute, eating always consumes or else it creates weird client behavior.
For `on="click"` actions:
When using `override=true` (the default) you can set it to true/false to consume or not consume item on use. The default is true.
When using `override=false` tho, it gets tricky, vanilla may consume the item ontop of pgm's consumption leading to two being used up. This is the behavior:

<table><thead>
  <tr>
    <th>Override</th>
    <th>Consume</th>
    <th>Vanilla behavior</th>
    <th>result</th>
  </tr></thead>
<tbody>
  <tr>
    <td rowspan="4">false</td>
    <td rowspan="2">false</td>
    <td>no consume (eg: stick)</td>
    <td>🟢 0 used</td>
  </tr>
  <tr>
    <td>consumes (eg: snowball)</td>
    <td>🟡 1 used</td>
  </tr>
  <tr>
    <td rowspan="2">true</td>
    <td>no consume (eg: stick)</td>
    <td>🟢 1 used</td>
  </tr>
  <tr>
    <td>consumes (eg: snowball)</td>
    <td>🔴 2 used</td>
  </tr>
  <tr>
    <td rowspan="2">true</td>
    <td>false</td>
    <td rowspan="2">any case</td>
    <td>🟢 0 used</td>
  </tr>
  <tr>
    <td>true</td>
    <td>🟢 1 used</td>
  </tr>
</tbody>
</table>

🟢 = ok behavior, works as you'd expect
🟡 = weird behavior, consume=false but it has consumed
🔴 = totally wrong behavior


Example:
```xml
<kits>
  <kit id="spawn-kit">
    <item material="stick" consumable="heal" name="Healing stick!"/>
  </kit>
  <kit id="heal-click">
    <health>20</health>
  </kit>
</kits>
<consumables>
  <consumable id="heal" action="heal-click" on="click" override="true" consume="true" />
</consumables>
```

In this example we give a "healing stick", when right clicked it gets consumed and applies the heal-click action (kit) that sets player health back to 20. This is obviously a pretty simple example, but you could use actions & variables to implement custom cooldowns and other mechanisms ontop of this.