### PR TITLE
Add a paste-structure action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -25,6 +25,7 @@ import tc.oc.pgm.action.actions.ExposedAction;
 import tc.oc.pgm.action.actions.FillAction;
 import tc.oc.pgm.action.actions.KillEntitiesAction;
 import tc.oc.pgm.action.actions.MessageAction;
+import tc.oc.pgm.action.actions.PasteStructureAction;
 import tc.oc.pgm.action.actions.ReplaceItemAction;
 import tc.oc.pgm.action.actions.ScopeSwitchAction;
 import tc.oc.pgm.action.actions.SetVariableAction;
@@ -48,6 +49,7 @@ import tc.oc.pgm.regions.BlockBoundedValidation;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.shops.ShopModule;
 import tc.oc.pgm.shops.menu.Payable;
+import tc.oc.pgm.structure.StructureDefinition;
 import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
@@ -404,5 +406,22 @@ public class ActionParser {
             : Formula.of(yawNode.getValue(), variables.getContext(MatchPlayer.class)));
 
     return new TeleportAction(xFormula, yFormula, zFormula, pitchFormula, yawFormula);
+  }
+
+  @MethodParser("paste-structure")
+  public <T extends Filterable<?>> PasteStructureAction<T> parseStructure(
+      Element el, Class<T> scope) throws InvalidXMLException {
+    Formula<T> xFormula =
+        Formula.of(Node.fromRequiredAttr(el, "x").getValue(), variables.getContext(scope));
+    Formula<T> yFormula =
+        Formula.of(Node.fromRequiredAttr(el, "y").getValue(), variables.getContext(scope));
+    Formula<T> zFormula =
+        Formula.of(Node.fromRequiredAttr(el, "z").getValue(), variables.getContext(scope));
+
+    XMLFeatureReference<StructureDefinition> structure =
+        features.addReference(new XMLFeatureReference<>(
+            features, Node.fromRequiredAttr(el, "structure"), StructureDefinition.class));
+
+    return new PasteStructureAction<>(scope, xFormula, yFormula, zFormula, structure);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -419,8 +419,7 @@ public class ActionParser {
         Formula.of(Node.fromRequiredAttr(el, "z").getValue(), variables.getContext(scope));
 
     XMLFeatureReference<StructureDefinition> structure =
-        features.addReference(new XMLFeatureReference<>(
-            features, Node.fromRequiredAttr(el, "structure"), StructureDefinition.class));
+        features.createReference(Node.fromRequiredAttr(el, "structure"), StructureDefinition.class);
 
     return new PasteStructureAction<>(scope, xFormula, yFormula, zFormula, structure);
   }

--- a/core/src/main/java/tc/oc/pgm/action/actions/PasteStructureAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/PasteStructureAction.java
@@ -1,0 +1,36 @@
+package tc.oc.pgm.action.actions;
+
+import org.bukkit.util.Vector;
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.structure.StructureDefinition;
+import tc.oc.pgm.util.math.Formula;
+
+public class PasteStructureAction<T extends Filterable<?>> extends AbstractAction<T> {
+
+  private final Formula<T> xformula;
+  private final Formula<T> yformula;
+  private final Formula<T> zformula;
+  private final FeatureReference<StructureDefinition> structureReference;
+
+  public PasteStructureAction(
+      Class<T> scope,
+      Formula<T> xformula,
+      Formula<T> yformula,
+      Formula<T> zformula,
+      FeatureReference<StructureDefinition> structureReference) {
+    super(scope);
+    this.xformula = xformula;
+    this.yformula = yformula;
+    this.zformula = zformula;
+    this.structureReference = structureReference;
+  }
+
+  @Override
+  public void trigger(T t) {
+    Vector placeLocation =
+        new Vector(xformula.applyAsDouble(t), yformula.applyAsDouble(t), zformula.applyAsDouble(t));
+
+    structureReference.get().getStructure(t.getMatch()).placeAbsolute(placeLocation);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/action/actions/PasteStructureAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/PasteStructureAction.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.action.actions;
 
-import org.bukkit.util.Vector;
+import org.bukkit.util.BlockVector;
 import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.filters.Filterable;
 import tc.oc.pgm.structure.StructureDefinition;
@@ -28,8 +28,8 @@ public class PasteStructureAction<T extends Filterable<?>> extends AbstractActio
 
   @Override
   public void trigger(T t) {
-    Vector placeLocation =
-        new Vector(xformula.applyAsDouble(t), yformula.applyAsDouble(t), zformula.applyAsDouble(t));
+    BlockVector placeLocation = new BlockVector(
+        xformula.applyAsDouble(t), yformula.applyAsDouble(t), zformula.applyAsDouble(t));
 
     structureReference.get().getStructure(t.getMatch()).placeAbsolute(placeLocation);
   }

--- a/core/src/main/java/tc/oc/pgm/structure/Structure.java
+++ b/core/src/main/java/tc/oc/pgm/structure/Structure.java
@@ -49,7 +49,7 @@ public class Structure implements Feature<StructureDefinition> {
     snapshot.placeBlocks(region, offset);
   }
 
-  public void placeAbsolute(Vector vector) {
+  public void placeAbsolute(BlockVector vector) {
     place(new BlockVector(
         new Vector(0, 0, 0).subtract(getRegion().getBounds().getBlockMin()).add(vector)));
   }

--- a/core/src/main/java/tc/oc/pgm/structure/Structure.java
+++ b/core/src/main/java/tc/oc/pgm/structure/Structure.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.structure;
 
 import org.bukkit.Material;
 import org.bukkit.util.BlockVector;
+import org.bukkit.util.Vector;
 import tc.oc.pgm.api.feature.Feature;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
@@ -20,12 +21,11 @@ public class Structure implements Feature<StructureDefinition> {
 
     if (definition.includeAir()) this.region = definition.getRegion();
     else
-      this.region =
-          FiniteBlockRegion.fromWorld(
-              definition.getRegion(),
-              match.getWorld(),
-              b -> b.getType() != Material.AIR,
-              match.getMap().getProto());
+      this.region = FiniteBlockRegion.fromWorld(
+          definition.getRegion(),
+          match.getWorld(),
+          b -> b.getType() != Material.AIR,
+          match.getMap().getProto());
 
     snapshot.saveRegion(region);
     if (definition.clearSource()) snapshot.removeBlocks(region, new BlockVector());
@@ -47,5 +47,10 @@ public class Structure implements Feature<StructureDefinition> {
 
   public void place(BlockVector offset) {
     snapshot.placeBlocks(region, offset);
+  }
+
+  public void placeAbsolute(Vector vector) {
+    place(new BlockVector(
+        new Vector(0, 0, 0).subtract(getRegion().getBounds().getBlockMin()).add(vector)));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/structure/StructureDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/structure/StructureDefinition.java
@@ -5,6 +5,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.regions.Bounds;
@@ -53,5 +54,9 @@ public class StructureDefinition extends SelfIdentifyingFeatureDefinition {
       this.bounds = region.getBounds();
     }
     return bounds;
+  }
+
+  public Structure getStructure(Match match) {
+    return match.getFeatureContext().get(this.getId(), Structure.class);
   }
 }


### PR DESCRIPTION
Adds a paste structure action. Accepts variable x y z coordinates to allow relative pasting.

Example usecase would be a consumable item that builds a little castle around you.

Example xml:

```xml
<actions>
    <trigger scope="player">
        <filter>
            <carrying ignore-metadata="true">
                <item material="lava bucket"/>
            </carrying>
        </filter>
        <action scope="player">
                <message text="`f Carrying `6lava bucket`f."/>
                <paste-structure x="x+3" y="y" z="z+3" structure="structy"/>
        </action>
    </trigger>
</actions>
<structures>
    <structure clear="false" id="structy"><region><cuboid min="72,15,75" size="3,3,5"/></region></structure>
</structures>
<variables>
        <timelimit id="tl_2"/>
        <player-location id="x" component="x"/>
        <player-location id="y" component="y"/>
        <player-location id="z" component="z"/>
</variables>
```