### PR TITLE
Add targeted block components to PlayerLocationVariable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
@@ -3,33 +3,29 @@ package tc.oc.pgm.variables.types;
 import static java.lang.Math.toRadians;
 import static tc.oc.pgm.util.nms.PlayerUtils.PLAYER_UTILS;
 
-import java.util.HashMap;
+import org.bukkit.Location;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.util.block.RayBlockIntersection;
-import tc.oc.pgm.util.nms.NMSHacks;
 import tc.oc.pgm.variables.VariableDefinition;
 
 public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
 
   private final Component component;
-  private final HashMap<MatchPlayer, RayBlockIntersection> locationTargetMap;
-  private long tickCached;
+  private Location lastLocation;
+  private RayBlockIntersection lastRayCast;
 
   public PlayerLocationVariable(VariableDefinition<MatchPlayer> definition, Component component) {
     super(definition);
     this.component = component;
-    this.locationTargetMap = new HashMap<>();
-    this.tickCached = -1;
   }
 
   private RayBlockIntersection intersection(MatchPlayer player) {
-    long tick = NMSHacks.NMS_HACKS.getMonotonicTime(player.getWorld());
-    if (tickCached != tick) {
-      tickCached = tick;
-      locationTargetMap.clear();
+    if (player.getLocation().equals(lastLocation)) {
+      return lastRayCast;
     }
-    return locationTargetMap.computeIfAbsent(
-        player, matchPlayer -> PLAYER_UTILS.getTargetedBlock(matchPlayer.getBukkit()));
+    lastLocation = player.getLocation().clone();
+    lastRayCast = PLAYER_UTILS.getTargetedBlock(player.getBukkit());
+    return lastRayCast;
   }
 
   @Override
@@ -54,6 +50,7 @@ public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
       case PLACE_X -> intersection(player).getPlaceAt().getX();
       case PLACE_Y -> intersection(player).getPlaceAt().getY();
       case PLACE_Z -> intersection(player).getPlaceAt().getZ();
+      case HAS_TARGET -> intersection(player) == null ? 0 : 1;
     };
   }
 
@@ -80,5 +77,6 @@ public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
     PLACE_X,
     PLACE_Y,
     PLACE_Z,
+    HAS_TARGET,
   }
 }

--- a/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
@@ -11,7 +11,7 @@ import tc.oc.pgm.variables.VariableDefinition;
 
 public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
 
-  private static final double NULL_VALUE = -1; // negative 1 million
+  private static final double NULL_VALUE = -1;
 
   private final Component component;
   private Location lastLocation;

--- a/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
@@ -1,17 +1,35 @@
 package tc.oc.pgm.variables.types;
 
 import static java.lang.Math.toRadians;
+import static tc.oc.pgm.util.nms.PlayerUtils.PLAYER_UTILS;
 
+import java.util.HashMap;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.util.block.RayBlockIntersection;
+import tc.oc.pgm.util.nms.NMSHacks;
 import tc.oc.pgm.variables.VariableDefinition;
 
 public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
 
   private final Component component;
+  private final HashMap<MatchPlayer, RayBlockIntersection> locationTargetMap;
+  private long tickCached;
 
   public PlayerLocationVariable(VariableDefinition<MatchPlayer> definition, Component component) {
     super(definition);
     this.component = component;
+    this.locationTargetMap = new HashMap<>();
+    this.tickCached = -1;
+  }
+
+  private RayBlockIntersection intersection(MatchPlayer player) {
+    long tick = NMSHacks.NMS_HACKS.getMonotonicTime(player.getWorld());
+    if (tickCached != tick) {
+      tickCached = tick;
+      locationTargetMap.clear();
+    }
+    return locationTargetMap.computeIfAbsent(
+        player, matchPlayer -> PLAYER_UTILS.getTargetedBlock(matchPlayer.getBukkit()));
   }
 
   @Override
@@ -30,6 +48,12 @@ public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
       case VEL_X -> player.getBukkit().getVelocity().getX();
       case VEL_Y -> player.getBukkit().getVelocity().getY();
       case VEL_Z -> player.getBukkit().getVelocity().getZ();
+      case TARGET_X -> intersection(player).getBlock().getX();
+      case TARGET_Y -> intersection(player).getBlock().getY();
+      case TARGET_Z -> intersection(player).getBlock().getZ();
+      case PLACE_X -> intersection(player).getPlaceAt().getX();
+      case PLACE_Y -> intersection(player).getPlaceAt().getY();
+      case PLACE_Z -> intersection(player).getPlaceAt().getZ();
     };
   }
 
@@ -50,5 +74,11 @@ public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
     VEL_X,
     VEL_Y,
     VEL_Z,
+    TARGET_X,
+    TARGET_Y,
+    TARGET_Z,
+    PLACE_X,
+    PLACE_Y,
+    PLACE_Z,
   }
 }

--- a/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
@@ -3,12 +3,15 @@ package tc.oc.pgm.variables.types;
 import static java.lang.Math.toRadians;
 import static tc.oc.pgm.util.nms.PlayerUtils.PLAYER_UTILS;
 
+import java.util.function.ToDoubleFunction;
 import org.bukkit.Location;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.util.block.RayBlockIntersection;
 import tc.oc.pgm.variables.VariableDefinition;
 
 public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
+
+  private static final double NULL_VALUE = -1000000; // negative 1 million
 
   private final Component component;
   private Location lastLocation;
@@ -44,14 +47,19 @@ public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
       case VEL_X -> player.getBukkit().getVelocity().getX();
       case VEL_Y -> player.getBukkit().getVelocity().getY();
       case VEL_Z -> player.getBukkit().getVelocity().getZ();
-      case TARGET_X -> intersection(player).getBlock().getX();
-      case TARGET_Y -> intersection(player).getBlock().getY();
-      case TARGET_Z -> intersection(player).getBlock().getZ();
-      case PLACE_X -> intersection(player).getPlaceAt().getX();
-      case PLACE_Y -> intersection(player).getPlaceAt().getY();
-      case PLACE_Z -> intersection(player).getPlaceAt().getZ();
+      case TARGET_X -> getOrDefault(intersection(player), (i) -> i.getBlock().getX());
+      case TARGET_Y -> getOrDefault(intersection(player), (i) -> i.getBlock().getY());
+      case TARGET_Z -> getOrDefault(intersection(player), (i) -> i.getBlock().getZ());
+      case PLACE_X -> getOrDefault(intersection(player), (i) -> i.getPlaceAt().getX());
+      case PLACE_Y -> getOrDefault(intersection(player), (i) -> i.getPlaceAt().getY());
+      case PLACE_Z -> getOrDefault(intersection(player), (i) -> i.getPlaceAt().getZ());
       case HAS_TARGET -> intersection(player) == null ? 0 : 1;
     };
+  }
+
+  private double getOrDefault(
+      RayBlockIntersection intersection, ToDoubleFunction<RayBlockIntersection> function) {
+    return intersection == null ? NULL_VALUE : function.applyAsDouble(intersection);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
@@ -11,7 +11,7 @@ import tc.oc.pgm.variables.VariableDefinition;
 
 public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
 
-  private static final double NULL_VALUE = -1000000; // negative 1 million
+  private static final double NULL_VALUE = -1; // negative 1 million
 
   private final Component component;
   private Location lastLocation;

--- a/util/src/main/java/tc/oc/pgm/util/block/RayBlockIntersection.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/RayBlockIntersection.java
@@ -26,6 +26,11 @@ public class RayBlockIntersection {
     return face;
   }
 
+  /** @return Where a new blockw would be placed */
+  public Block getPlaceAt() {
+    return block.getRelative(face);
+  }
+
   /** @return The first intersected point on the surface of the block */
   public Vector getPosition() {
     return position;


### PR DESCRIPTION
Adds a few new components to `player-location` variables.

```java
    HAS_TARGET,
    TARGET_X,
    TARGET_Y,
    TARGET_Z,
    PLACE_X,
    PLACE_Y,
    PLACE_Z,
```

not sure whether caching here is worth it.