### PR TITLE
Add squad death message setting

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -31,7 +31,8 @@ public enum SettingKey implements Aliased {
       Materials.SKULL,
       DEATH_ALL,
       DEATH_OWN,
-      DEATH_FRIENDS), // Changes which death messages are seen
+      DEATH_FRIENDS,
+      DEATH_SQUAD), // Changes which death messages are seen
   PICKER(
       "picker",
       Material.LEATHER_HELMET,

--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -53,7 +53,11 @@ public enum SettingValue {
   TIME_LIGHT("time", "light", DyeColor.WHITE), // Player time is always set to midnight
 
   PICKER_MANUAL("picker", "manual", DyeColor.WHITE), // Only display the picker GUI if right clicked
-  SOUNDS_CHAT("sounds", "chat", DyeColor.ORANGE); // Only play DM and admin sounds
+  SOUNDS_CHAT("sounds", "chat", DyeColor.ORANGE), // Only play DM and admin sounds
+  DEATH_SQUAD(
+      "death",
+      "squad",
+      DyeColor.YELLOW); // Only send death messages involving yourself, friends, or squad members
 
   private final String key;
   private final String name;

--- a/util/src/main/i18n/templates/ui.properties
+++ b/util/src/main/i18n/templates/ui.properties
@@ -77,6 +77,8 @@ settings.death.own = View own death messages only
 
 settings.death.friends = Only view death messages from friends
 
+settings.death.squad = Only view death messages from your friends and squad
+
 settings.picker = Changes when the picker is displayed
 
 settings.picker.auto = Automatically display picker based on match


### PR DESCRIPTION
This PR adds squad support to death messages, resolving issue #1352. Additionally, it includes a cleanup of the death message logic for better readability and maintainability. As always, I've tested all changes and everything is in working order 👍 Please let me know if there's any additional feedback/changes you'd like to see made.

Thanks!


<img width="548" alt="2" src="https://github.com/PGMDev/PGM/assets/3377659/5f84d5f3-1396-4194-8540-307044fed5a5">
<img width="1056" alt="1" src="https://github.com/PGMDev/PGM/assets/3377659/a6e9ac68-96b4-4970-a0bd-7e656ed55715">
