### PR TITLE
Fix dye showing as ink sacks in modern

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -30,7 +30,7 @@ public interface Materials {
   Material EYE_OF_ENDER = parse("EYE_OF_ENDER", "ENDER_EYE");
   Material FIREWORK = parse("FIREWORK", "FIREWORK_ROCKET");
   Material WATCH = parse("WATCH", "CLOCK");
-  Material DYE = parse("INK_SACK", "LEGACY_INK_SACK");
+  Material DYE = parse("INK_SACK", "BLACK_DYE");
   Material IRON_DOOR = parse("IRON_DOOR_BLOCK", "IRON_DOOR");
   Material RAW_FISH = parse("RAW_FISH", "COD");
   Material WORKBENCH = parse("WORKBENCH", "CRAFTING_TABLE");


### PR DESCRIPTION
Described in #1332, the settings menu was showing ink sacks in modern versions

After the fix they're back to being dye: 
![image](https://github.com/PGMDev/PGM/assets/11789291/ae4da053-b7d4-4384-a911-b496659003d5)
