### PR TITLE
Add variant support for slugs & server version limitation

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -9,6 +9,7 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.Version;
 import tc.oc.pgm.util.named.MapNameStyle;
+import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.text.TextTranslations;
 
 /** Essential information about a map. */
@@ -42,6 +43,10 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
    * @return range of the server versions that can load this map
    */
   Range<Version> getServerVersion();
+
+  default boolean isServerSupported() {
+    return getServerVersion().contains(Platform.MINECRAFT_VERSION);
+  }
 
   /** @return the subfolder in which the world is in, or null for the parent folder */
   @Nullable
@@ -214,5 +219,9 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
     String getWorld();
 
     Range<Version> getServerVersions();
+
+    default boolean isServerSupported() {
+      return getServerVersions().contains(Platform.MINECRAFT_VERSION);
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.api.map;
 
+import com.google.common.collect.Range;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Map;
@@ -33,6 +34,14 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
    * @return a map of variants by their variant id
    */
   Map<String, VariantInfo> getVariants();
+
+  /**
+   * Get what servers versions should load this map, servers outside the range should ignore the
+   * map.
+   *
+   * @return range of the server versions that can load this map
+   */
+  Range<Version> getServerVersion();
 
   /** @return the subfolder in which the world is in, or null for the parent folder */
   @Nullable
@@ -203,5 +212,7 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
     String getMapName();
 
     String getWorld();
+
+    Range<Version> getServerVersions();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/factory/MapFactory.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/factory/MapFactory.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.api.map.factory;
 
-import java.util.Collection;
 import tc.oc.pgm.api.map.MapContext;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapModule;
@@ -11,7 +10,6 @@ import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.Version;
-import tc.oc.pgm.util.xml.InvalidXMLException;
 
 /** A factory for creating {@link MapInfo}s and {@link MapContext}s. */
 public interface MapFactory extends ModuleContext<MapModule<?>>, AutoCloseable {
@@ -59,11 +57,4 @@ public interface MapFactory extends ModuleContext<MapModule<?>>, AutoCloseable {
    * @throws MapException If there was an error loading the context.
    */
   MapContext load() throws MapException;
-
-  /**
-   * Get the map variants found in the map
-   *
-   * @return a collection of map variants, empty if no variants exist
-   */
-  Collection<String> getVariants() throws InvalidXMLException;
 }

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -357,13 +357,19 @@ public final class MapCommand {
       if (map.getVariantId().equals(variant.getVariantId())) {
         variantComp = text(variant.getVariantId(), null, TextDecoration.UNDERLINED)
             .hoverEvent(showText(translatable("map.info.variants.current", NamedTextColor.GRAY)));
-      } else {
+      } else if (variant.isServerSupported()) {
         variantComp = text(variant.getVariantId())
             .hoverEvent(showText(translatable(
                 "command.maps.hover",
                 NamedTextColor.GRAY,
                 text(variant.getMapName(), NamedTextColor.GOLD))))
             .clickEvent(runCommand("/map " + variant.getMapName()));
+      } else {
+        variantComp = text(variant.getVariantId(), NamedTextColor.RED)
+            .hoverEvent(showText(translatable(
+                "command.maps.unsupported",
+                NamedTextColor.GRAY,
+                text(variant.getMapName(), NamedTextColor.GOLD))));
       }
       text.append(variantComp).append(text(" "));
     }

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -5,6 +5,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,6 +36,7 @@ import tc.oc.pgm.regions.LegacyRegionParser;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.ClassLogger;
 import tc.oc.pgm.util.Version;
+import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.xml.DocumentWrapper;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
@@ -55,7 +57,8 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
 
   public MapFactoryImpl(Logger logger, MapSource source, MapIncludeProcessor includes) {
     super(Modules.MAP, Modules.MAP_DEPENDENCY_ONLY); // Don't copy, avoid N factory copies
-    this.logger = ClassLogger.get(assertNotNull(logger), getClass(), assertNotNull(source).getId());
+    this.logger =
+        ClassLogger.get(assertNotNull(logger), getClass(), assertNotNull(source).getId());
     this.source = source;
     this.includes = includes;
   }
@@ -75,6 +78,12 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
       document = MapFilePreprocessor.getDocument(source, includes);
 
       info = new MapInfoImpl(source, document.getRootElement());
+
+      // We're not loading this map, return a dummy map context to allow variants to load, if needed
+      if (!info.getServerVersion().contains(Platform.MINECRAFT_VERSION)) {
+        return new MapContextImpl(info, List.of());
+      }
+
       try {
         loadAll();
       } catch (ModuleLoadException e) {

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -3,18 +3,16 @@ package tc.oc.pgm.map;
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jdom2.Document;
-import org.jdom2.Element;
 import org.jdom2.input.JDOMParseException;
 import tc.oc.pgm.api.Modules;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapContext;
+import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.MapSource;
@@ -36,17 +34,16 @@ import tc.oc.pgm.regions.LegacyRegionParser;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.ClassLogger;
 import tc.oc.pgm.util.Version;
-import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.xml.DocumentWrapper;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
-import tc.oc.pgm.util.xml.XMLUtils;
 
 public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?>>
     implements MapFactory {
 
   private final Logger logger;
   private final MapSource source;
+  private final Map<String, MapInfo.VariantInfo> variants;
   private final MapIncludeProcessor includes;
   private Document document;
   private MapInfoImpl info;
@@ -55,11 +52,16 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
   private KitParser kits;
   private FeatureDefinitionContext features;
 
-  public MapFactoryImpl(Logger logger, MapSource source, MapIncludeProcessor includes) {
+  public MapFactoryImpl(
+      Logger logger,
+      MapSource source,
+      Map<String, MapInfo.VariantInfo> variants,
+      MapIncludeProcessor includes) {
     super(Modules.MAP, Modules.MAP_DEPENDENCY_ONLY); // Don't copy, avoid N factory copies
     this.logger =
         ClassLogger.get(assertNotNull(logger), getClass(), assertNotNull(source).getId());
     this.source = source;
+    this.variants = variants;
     this.includes = includes;
   }
 
@@ -77,10 +79,10 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
     try {
       document = MapFilePreprocessor.getDocument(source, includes);
 
-      info = new MapInfoImpl(source, document.getRootElement());
+      info = new MapInfoImpl(source, variants, document.getRootElement());
 
       // We're not loading this map, return a dummy map context to allow variants to load, if needed
-      if (!info.getServerVersion().contains(Platform.MINECRAFT_VERSION)) {
+      if (!info.isServerSupported()) {
         return new MapContextImpl(info, List.of());
       }
 
@@ -176,20 +178,6 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
       features = new FeatureDefinitionContext();
     }
     return features;
-  }
-
-  @Override
-  public Collection<String> getVariants() throws InvalidXMLException {
-    Set<String> collect = new HashSet<>();
-    for (Element variant : document.getRootElement().getChildren("variant")) {
-      String id = XMLUtils.parseRequiredId(variant);
-      if ("default".equals(id))
-        throw new InvalidXMLException("Variant id must not be 'default'", variant);
-
-      if (!collect.add(id))
-        throw new InvalidXMLException("Duplicate variant ids are not allowed", variant);
-    }
-    return collect;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -398,6 +398,7 @@ public class MapInfoImpl implements MapInfo {
 
         String variantSlug = variantEl.getAttributeValue("slug");
         if (variantSlug != null) slug = variantSlug;
+        else if (override) slug = null;
         else if (slug != null) slug += "_" + variantId;
 
         minVer = fallback(Node.fromAttr(variantEl, "min-server-version"), minVer);

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -4,6 +4,7 @@ import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.api.map.MapSource.DEFAULT_VARIANT;
 import static tc.oc.pgm.util.Assert.assertNotNull;
+import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -39,7 +40,6 @@ import tc.oc.pgm.teams.TeamModule;
 import tc.oc.pgm.util.StreamUtils;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.Version;
-import tc.oc.pgm.util.bukkit.MiscUtils;
 import tc.oc.pgm.util.named.MapNameStyle;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextFormatter;
@@ -122,9 +122,9 @@ public class MapInfoImpl implements MapInfo {
   @NotNull
   private Map<String, VariantInfo> createVariantMap(Element root) throws InvalidXMLException {
     ImmutableMap.Builder<String, VariantInfo> variants = ImmutableMap.builder();
-    variants.put(DEFAULT_VARIANT, new VariantData(root, this, null));
+    variants.put(DEFAULT_VARIANT, new VariantData(root, null));
     for (Element el : root.getChildren("variant")) {
-      VariantData vd = new VariantData(root, this, el);
+      VariantData vd = new VariantData(root, el);
       variants.put(vd.variantId, vd);
     }
     return variants.build();
@@ -365,7 +365,7 @@ public class MapInfoImpl implements MapInfo {
     this.context = new SoftReference<>(context);
   }
 
-  private static class VariantData implements VariantInfo {
+  private class VariantData implements VariantInfo {
     // taken from https://minecraft.wiki/w/Data_version#Java_Edition
     private static final int MAP_DATA_VERSION_1_13 = 1519;
     private static final Version VERSION_1_13 = new Version(1, 13, 0);
@@ -375,8 +375,7 @@ public class MapInfoImpl implements MapInfo {
     private final String world;
     private final Range<Version> serverVersions;
 
-    public VariantData(Element root, MapInfo mapInfo, @Nullable Element variantEl)
-        throws InvalidXMLException {
+    public VariantData(Element root, @Nullable Element variantEl) throws InvalidXMLException {
       String name = assertNotNull(Node.fromRequiredChildOrAttr(root, "name").getValueNormalize());
       String slug = assertNotNull(root).getChildTextNormalize("slug");
       Node minVer = Node.fromAttr(root, "min-server-version");
@@ -409,7 +408,7 @@ public class MapInfoImpl implements MapInfo {
 
       this.serverVersions = XMLUtils.parseClosedRange(
           minVer,
-          parseOrInferMinimumVersion(mapInfo, minVer),
+          parseOrInferMinimumVersion(source, minVer),
           XMLUtils.parseSemanticVersion(maxVer));
     }
 
@@ -439,27 +438,17 @@ public class MapInfoImpl implements MapInfo {
     }
 
     @Nullable
-    private Version parseOrInferMinimumVersion(MapInfo mapInfo, @Nullable Node minVer)
+    private Version parseOrInferMinimumVersion(MapSource source, @Nullable Node minVer)
         throws InvalidXMLException {
-      if (minVer != null) {
-        return XMLUtils.parseSemanticVersion(minVer);
-      } else {
-        /*
-         * Infer the map version from the DataVersion field in level.dat. We only need to know
-         * if the world is 1.13+ to avoid server crashes in legacy versions due to changes
-         * in chunk formatting.
-         */
-        var sourceDir = mapInfo.getSource().getAbsoluteDir();
-        var levelDatPath =
-            (world != null ? sourceDir.resolve(world) : sourceDir).resolve("level.dat");
+      if (minVer != null) return XMLUtils.parseSemanticVersion(minVer);
+      /* Infer the map version from the DataVersion field in level.dat. If 1.13+, set that as
+      the min version to avoid legacy servers crashing when loading the chunks. */
+      var sourceDir = source.getAbsoluteDir();
+      var levelDat = (world != null ? sourceDir.resolve(world) : sourceDir).resolve("level.dat");
 
-        var mapDataVersion = MiscUtils.MISC_UTILS.getWorldDataVersion(levelDatPath);
-        if (mapDataVersion >= MAP_DATA_VERSION_1_13) {
-          return VERSION_1_13;
-        } else {
-          return null;
-        }
-      }
+      var mapDataVersion = MISC_UTILS.getWorldDataVersion(levelDat);
+      if (mapDataVersion >= MAP_DATA_VERSION_1_13) return VERSION_1_13;
+      return null;
     }
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernMiscUtil.java
@@ -91,11 +91,11 @@ public class ModernMiscUtil implements MiscUtils {
   }
 
   @Override
-  public int getWorldDataVersion(Path levelDatPath) {
+  public int getWorldDataVersion(Path levelDat) {
     // Constant from LevelStorageSource, sounds way too high (104mb) but better than unbounded
     long MAX_HEAP = 104857600L;
     try {
-      var root = NbtIo.readCompressed(levelDatPath, NbtAccounter.create(MAX_HEAP));
+      var root = NbtIo.readCompressed(levelDat, NbtAccounter.create(MAX_HEAP));
       return NbtUtils.getDataVersion(root.getCompound("Data"), -1);
     } catch (Throwable ignored) {
       // In case we cannot read the level.dat file, return a constant

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernMiscUtil.java
@@ -3,7 +3,11 @@ package tc.oc.pgm.platform.modern;
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
 import com.google.gson.JsonObject;
+import java.nio.file.Path;
 import java.util.List;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.NbtUtils;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.CraftWorld;
@@ -84,5 +88,16 @@ public class ModernMiscUtil implements MiscUtils {
   @Override
   public double getArrowDamage(Arrow arrow) {
     return arrow.getDamage();
+  }
+
+  @Override
+  public int getWorldDataVersion(Path levelDatPath) {
+    try {
+      var rootLevelTag = NbtIo.readCompressed(levelDatPath, NbtAccounter.unlimitedHeap());
+      return NbtUtils.getDataVersion(rootLevelTag.getCompound("Data"), -1);
+    } catch (Exception ignored) {
+      // In case we cannot read the level.dat file, return a constant
+      return -1;
+    }
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernMiscUtil.java
@@ -92,10 +92,12 @@ public class ModernMiscUtil implements MiscUtils {
 
   @Override
   public int getWorldDataVersion(Path levelDatPath) {
+    // Constant from LevelStorageSource, sounds way too high (104mb) but better than unbounded
+    long MAX_HEAP = 104857600L;
     try {
-      var rootLevelTag = NbtIo.readCompressed(levelDatPath, NbtAccounter.unlimitedHeap());
-      return NbtUtils.getDataVersion(rootLevelTag.getCompound("Data"), -1);
-    } catch (Exception ignored) {
+      var root = NbtIo.readCompressed(levelDatPath, NbtAccounter.create(MAX_HEAP));
+      return NbtUtils.getDataVersion(root.getCompound("Data"), -1);
+    } catch (Throwable ignored) {
       // In case we cannot read the level.dat file, return a constant
       return -1;
     }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpMiscUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpMiscUtil.java
@@ -6,7 +6,6 @@ import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
 import com.google.gson.JsonObject;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.List;
 import net.minecraft.server.v1_8_R3.EntityPotion;
 import net.minecraft.server.v1_8_R3.NBTCompressedStreamTools;
@@ -91,15 +90,13 @@ public class SpMiscUtil implements MiscUtils {
   }
 
   @Override
-  public int getWorldDataVersion(Path levelDatPath) {
+  public int getWorldDataVersion(Path levelDat) {
     try {
-      var compoundTag =
-          NBTCompressedStreamTools.a(Files.newInputStream(levelDatPath, StandardOpenOption.READ));
-      var dataTag = compoundTag.getCompound("Data");
+      var dataTag = NBTCompressedStreamTools.a(Files.newInputStream(levelDat)).getCompound("Data");
       return dataTag.hasKeyOfType("DataVersion", NBT_TAG_ANY_NUMERIC)
           ? dataTag.getInt("DataVersion")
           : -1;
-    } catch (Exception ignored) {
+    } catch (Throwable ignored) {
       // In case we cannot read the level.dat file, return a constant
       return -1;
     }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpMiscUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpMiscUtil.java
@@ -4,8 +4,12 @@ import static tc.oc.pgm.util.platform.Supports.Priority.HIGH;
 import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
 
 import com.google.gson.JsonObject;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import net.minecraft.server.v1_8_R3.EntityPotion;
+import net.minecraft.server.v1_8_R3.NBTCompressedStreamTools;
 import net.minecraft.server.v1_8_R3.World;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -31,6 +35,8 @@ import tc.oc.pgm.util.platform.Supports;
 
 @Supports(value = SPORTPAPER, priority = HIGH)
 public class SpMiscUtil implements MiscUtils {
+  private static final byte NBT_TAG_ANY_NUMERIC = 99;
+
   @Override
   public boolean yield(Event event) {
     event.yield();
@@ -82,5 +88,20 @@ public class SpMiscUtil implements MiscUtils {
   @Override
   public double getArrowDamage(Arrow arrow) {
     return arrow.spigot().getDamage();
+  }
+
+  @Override
+  public int getWorldDataVersion(Path levelDatPath) {
+    try {
+      var compoundTag =
+          NBTCompressedStreamTools.a(Files.newInputStream(levelDatPath, StandardOpenOption.READ));
+      var dataTag = compoundTag.getCompound("Data");
+      return dataTag.hasKeyOfType("DataVersion", NBT_TAG_ANY_NUMERIC)
+          ? dataTag.getInt("DataVersion")
+          : -1;
+    } catch (Exception ignored) {
+      // In case we cannot read the level.dat file, return a constant
+      return -1;
+    }
   }
 }

--- a/util/src/main/i18n/templates/command.properties
+++ b/util/src/main/i18n/templates/command.properties
@@ -113,6 +113,9 @@ command.message.self = You may not message yourself!
 # {0} = map name
 command.maps.hover = Click to view {0}
 
+# {0} = map name
+command.maps.unsupported = {0} is unsupported in the current server version
+
 command.noResults = No results found!
 
 # {0} = player name

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.util.bukkit;
 
 import com.google.gson.JsonObject;
+import java.nio.file.Path;
 import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -48,4 +49,6 @@ public interface MiscUtils {
   ThrownPotion spawnPotion(Location loc, ItemStack item);
 
   double getArrowDamage(Arrow arrow);
+
+  int getWorldDataVersion(Path levelDatPath);
 }

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
@@ -50,5 +50,5 @@ public interface MiscUtils {
 
   double getArrowDamage(Arrow arrow);
 
-  int getWorldDataVersion(Path levelDatPath);
+  int getWorldDataVersion(Path levelDat);
 }

--- a/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
@@ -12,7 +12,8 @@ import org.jdom2.Namespace;
 
 public class DocumentWrapper extends Document {
 
-  private static final Set<String> IGNORED = Sets.newHashSet("variant", "tutorial", "edition");
+  private static final Set<String> IGNORED =
+      Sets.newHashSet("name", "variant", "tutorial", "edition");
 
   private boolean visitingAllowed = true;
 
@@ -57,15 +58,16 @@ public class DocumentWrapper extends Document {
         unvisited.accept(Node.fromNullable(attribute));
     }
 
+    boolean canIgnore = el == getRootElement();
+
     for (int i = 0; i < el.getContentSize(); i++) {
       Content c = el.getContent(i);
-      if (!(c instanceof InheritingElement)) continue;
-      InheritingElement child = (InheritingElement) c;
+      if (!(c instanceof InheritingElement child)) continue;
+      if (child.getNamespace() != Namespace.NO_NAMESPACE) continue;
+      if (canIgnore && IGNORED.contains(child.getName())) continue;
 
-      if (child.getNamespace() == Namespace.NO_NAMESPACE && !IGNORED.contains(child.getName())) {
-        if (!child.wasVisited()) unvisited.accept(Node.fromNullable(child));
-        else checkVisited(child, unvisited);
-      }
+      if (!child.wasVisited()) unvisited.accept(Node.fromNullable(child));
+      else checkVisited(child, unvisited);
     }
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -468,6 +468,17 @@ public final class XMLUtils {
         lowStr == null || lowStr.equals("-oo") ? null : parseNumber(node, lowStr, type, false);
     T upper = uppStr == null || uppStr.equals("oo") ? null : parseNumber(node, uppStr, type, false);
 
+    return parseRange(node, lower, lowerBound, upper, upperBound);
+  }
+
+  public static <T extends Comparable<T>> Range<T> parseClosedRange(
+      Node node, @Nullable T lower, @Nullable T upper) throws InvalidXMLException {
+    return parseRange(node, lower, BoundType.CLOSED, upper, BoundType.CLOSED);
+  }
+
+  public static <T extends Comparable<T>> Range<T> parseRange(
+      Node node, @Nullable T lower, BoundType lowerBound, @Nullable T upper, BoundType upperBound)
+      throws InvalidXMLException {
     if (lower != null && upper != null) {
       if (lower.compareTo(upper) > 0) {
         throw new InvalidXMLException(
@@ -476,7 +487,6 @@ public final class XMLUtils {
       }
 
       return Range.range(lower, lowerBound, upper, upperBound);
-
     } else if (lower != null) {
       return Range.downTo(lower, lowerBound);
     } else if (upper != null) {


### PR DESCRIPTION
```xml
<map min-server-version="1.21">
    <name>New map</name>
    <variant id="old" min-server-version="1.8" max-server-version="1.17" world="legacy">Old map</variant>
</map>
```

The map itself can have `min-server-version` and `max-server-version` and individual variants can also override this

# Slugs
Currently slugs are broken in variants, as one variant can't know the slug of other variants, since it's not part of the XML it sees (part of conditionals)
This PR fixes that by adding slug as an attribute in variants:

```xml
<map>
  <name>New map</name>
  <variant id="old" slug="map_old">Old map</variant>
</map>
```
If a slug is defined in the variant, that slug is used, otherwise:
For variants `override=true`: the slug defaults to the variant name slugified
For variants `override=false` & no default `<slug>`: the slug will be the full variant name slugified
For variants `override=false` & and default `<slug>`: the slug will be `defaultslug + "_" + variantId`

This aligns closely with what the behavior would usually be if it went thru the old rules, but won't always be the same

