### PR TITLE
fix: avoid loading 1.13+ maps in legacy versions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.api.map;
 
+import com.google.common.collect.Range;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Map;
@@ -33,6 +34,14 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
    * @return a map of variants by their variant id
    */
   Map<String, VariantInfo> getVariants();
+
+  /**
+   * Get what servers versions should load this map, servers outside the range should ignore the
+   * map.
+   *
+   * @return range of the server versions that can load this map
+   */
+  Range<Version> getServerVersion();
 
   /** @return the subfolder in which the world is in, or null for the parent folder */
   @Nullable
@@ -203,5 +212,7 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
     String getMapName();
 
     String getWorld();
+
+    Range<Version> getServerVersions();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -5,6 +5,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,6 +36,7 @@ import tc.oc.pgm.regions.LegacyRegionParser;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.ClassLogger;
 import tc.oc.pgm.util.Version;
+import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.xml.DocumentWrapper;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
@@ -55,7 +57,8 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
 
   public MapFactoryImpl(Logger logger, MapSource source, MapIncludeProcessor includes) {
     super(Modules.MAP, Modules.MAP_DEPENDENCY_ONLY); // Don't copy, avoid N factory copies
-    this.logger = ClassLogger.get(assertNotNull(logger), getClass(), assertNotNull(source).getId());
+    this.logger =
+        ClassLogger.get(assertNotNull(logger), getClass(), assertNotNull(source).getId());
     this.source = source;
     this.includes = includes;
   }
@@ -75,6 +78,12 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
       document = MapFilePreprocessor.getDocument(source, includes);
 
       info = new MapInfoImpl(source, document.getRootElement());
+
+      // We're not loading this map, return a dummy map context to allow variants to load, if needed
+      if (!info.getServerVersion().contains(Platform.MINECRAFT_VERSION)) {
+        return new MapContextImpl(info, List.of());
+      }
+
       try {
         loadAll();
       } catch (ModuleLoadException e) {

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernMiscUtil.java
@@ -3,7 +3,11 @@ package tc.oc.pgm.platform.modern;
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
 import com.google.gson.JsonObject;
+import java.nio.file.Path;
 import java.util.List;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.NbtUtils;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.CraftWorld;
@@ -84,5 +88,16 @@ public class ModernMiscUtil implements MiscUtils {
   @Override
   public double getArrowDamage(Arrow arrow) {
     return arrow.getDamage();
+  }
+
+  @Override
+  public int getWorldDataVersion(Path levelDatPath) {
+    try {
+      var rootLevelTag = NbtIo.readCompressed(levelDatPath, NbtAccounter.unlimitedHeap());
+      return NbtUtils.getDataVersion(rootLevelTag.getCompound("Data"), -1);
+    } catch (Exception ignored) {
+      // In case we cannot read the level.dat file, return a constant
+      return -1;
+    }
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpMiscUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpMiscUtil.java
@@ -4,8 +4,12 @@ import static tc.oc.pgm.util.platform.Supports.Priority.HIGH;
 import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
 
 import com.google.gson.JsonObject;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import net.minecraft.server.v1_8_R3.EntityPotion;
+import net.minecraft.server.v1_8_R3.NBTCompressedStreamTools;
 import net.minecraft.server.v1_8_R3.World;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -31,6 +35,8 @@ import tc.oc.pgm.util.platform.Supports;
 
 @Supports(value = SPORTPAPER, priority = HIGH)
 public class SpMiscUtil implements MiscUtils {
+  private static final byte NBT_TAG_ANY_NUMERIC = 99;
+
   @Override
   public boolean yield(Event event) {
     event.yield();
@@ -82,5 +88,20 @@ public class SpMiscUtil implements MiscUtils {
   @Override
   public double getArrowDamage(Arrow arrow) {
     return arrow.spigot().getDamage();
+  }
+
+  @Override
+  public int getWorldDataVersion(Path levelDatPath) {
+    try {
+      var compoundTag =
+          NBTCompressedStreamTools.a(Files.newInputStream(levelDatPath, StandardOpenOption.READ));
+      var dataTag = compoundTag.getCompound("Data");
+      return dataTag.hasKeyOfType("DataVersion", NBT_TAG_ANY_NUMERIC)
+          ? dataTag.getInt("DataVersion")
+          : -1;
+    } catch (Exception ignored) {
+      // In case we cannot read the level.dat file, return a constant
+      return -1;
+    }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.util.bukkit;
 
 import com.google.gson.JsonObject;
+import java.nio.file.Path;
 import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -48,4 +49,6 @@ public interface MiscUtils {
   ThrownPotion spawnPotion(Location loc, ItemStack item);
 
   double getArrowDamage(Arrow arrow);
+
+  int getWorldDataVersion(Path levelDatPath);
 }

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -468,6 +468,17 @@ public final class XMLUtils {
         lowStr == null || lowStr.equals("-oo") ? null : parseNumber(node, lowStr, type, false);
     T upper = uppStr == null || uppStr.equals("oo") ? null : parseNumber(node, uppStr, type, false);
 
+    return parseRange(node, lower, lowerBound, upper, upperBound);
+  }
+
+  public static <T extends Comparable<T>> Range<T> parseClosedRange(
+      Node node, @Nullable T lower, @Nullable T upper) throws InvalidXMLException {
+    return parseRange(node, lower, BoundType.CLOSED, upper, BoundType.CLOSED);
+  }
+
+  public static <T extends Comparable<T>> Range<T> parseRange(
+      Node node, @Nullable T lower, BoundType lowerBound, @Nullable T upper, BoundType upperBound)
+      throws InvalidXMLException {
     if (lower != null && upper != null) {
       if (lower.compareTo(upper) > 0) {
         throw new InvalidXMLException(
@@ -476,7 +487,6 @@ public final class XMLUtils {
       }
 
       return Range.range(lower, lowerBound, upper, upperBound);
-
     } else if (lower != null) {
       return Range.downTo(lower, lowerBound);
     } else if (upper != null) {


### PR DESCRIPTION
This patch (based on #1356) adds the ability to prevent 1.13+ maps without a specified minimum version in `map.xml` from accidentally being loaded into legacy servers, causing undefined behavior including server crashes when cycled to.

This is achieved by reading the data version (an integer increased with any Minecraft version, including snapshots [^1]) from `level.dat` bundled with the map and inferring whether the map is a 1.13+ map.

The patch is in a preliminary state, some things might need to be moved around as the version-gating PR develops.

[^1]: See https://minecraft.wiki/w/Data_version for more information.