### PR TITLE
chore: fold code owners into a single line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,4 @@
 # https://help.github.com/articles/about-codeowners/
 
 * @Electroid
-* @Pablete1234
-* @cswhite2000
+* @Pablete1234 @cswhite2000


### PR DESCRIPTION
Per GitHub's documentation, two or more code owners must be on a single line to be considered "code owners", otherwise only the last entry is taken into account. [^1] This results in review requests currently only being requested only from a single maintainer. As such, this patch folds everyone into a single line so all maintainers get a review request as (probably) intended.

[^1]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax