### PR TITLE
fix(DeathMessageMatchModule): move message to send into a local variable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/death/DeathMessageMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/death/DeathMessageMatchModule.java
@@ -56,9 +56,10 @@ public class DeathMessageMatchModule implements MatchModule, Listener {
           };
 
       if (show) {
-        if (involved) message = message.decoration(TextDecoration.BOLD, true);
-        else if (isStaff) message = message.decoration(TextDecoration.ITALIC, true);
-        viewer.sendMessage(message);
+        var messageToSend = message;
+        if (involved) messageToSend = message.decoration(TextDecoration.BOLD, true);
+        else if (isStaff) messageToSend = message.decoration(TextDecoration.ITALIC, true);
+        viewer.sendMessage(messageToSend);
       }
     }
   }


### PR DESCRIPTION
This patch moves the message to be sent into a local variable, resolving issues with death messages being randomly bold, although the recipient hadn't any involvement in the death message at all.