### PR TITLE
Add "5CP" to the list of gamemodes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -1,31 +1,31 @@
 package tc.oc.pgm.api.map;
 
 public enum Gamemode {
-  FIVE_CONTROL_POINT("5cp", "5 Control Points", "5CP"),
-  ATTACK_DEFEND("ad", "Attack/Defend", "A/D"),
   ARCADE("arcade", "Arcade", "Arcade"),
+  ATTACK_DEFEND("ad", "Attack/Defend", "A/D"),
   BEDWARS("bedwars", "Bed Wars", "Bed Wars"),
   BLITZ("blitz", "Blitz", "Blitz"),
   BLITZ_RAGE("br", "Blitz: Rage", "Blitz: Rage"),
   BRIDGE("bridge", "Bridge", "Bridge"),
   CAPTURE_THE_FLAG("ctf", "Capture the Flag", "CTF"),
-  CONTROL_THE_POINT("cp", "Control the Point", "CP"),
   CAPTURE_THE_WOOL("ctw", "Capture the Wool", "CTW"),
+  CONTROL_THE_POINT("cp", "Control the Point", "CP"),
+  DEATHMATCH("tdm", "Deathmatch", "TDM"),
   DESTROY_THE_CORE("dtc", "Destroy the Core", "DTC"),
   DESTROY_THE_MONUMENT("dtm", "Destroy the Monument", "DTM"),
-  FREE_FOR_ALL("ffa", "Free for All", "FFA"),
+  FIVE_CONTROL_POINT("5cp", "5 Control Points", "5CP"),
   FLAG_FOOTBALL("ffb", "Flag Football", "FFB"),
+  FREE_FOR_ALL("ffa", "Free for All", "FFA"),
   INFECTION("infection", "Infection", "Infection"),
-  KING_OF_THE_HILL("koth", "King of the Hill", "KotH"),
   KING_OF_THE_FLAG("kotf", "King of the Flag", "KotF"),
+  KING_OF_THE_HILL("koth", "King of the Hill", "KotH"),
   MIXED("mixed", "Mixed", "Mixed"),
   PAYLOAD("payload", "Payload", "Payload"),
-  RAGE("rage", "Rage", "Rage"),
   RACE_FOR_WOOL("rfw", "Race for Wool", "RFW"),
+  RAGE("rage", "Rage", "Rage"),
   SCOREBOX("scorebox", "Scorebox", "Scorebox"),
   SKYWARS("skywars", "Skywars", "Skywars"),
-  SURVIVAL_GAMES("sg", "Survival Games", "SG"),
-  DEATHMATCH("tdm", "Deathmatch", "TDM");
+  SURVIVAL_GAMES("sg", "Survival Games", "SG");
 
   private final String id;
 

--- a/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/Gamemode.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.api.map;
 
 public enum Gamemode {
+  FIVE_CONTROL_POINT("5cp", "5 Control Points", "5CP"),
   ATTACK_DEFEND("ad", "Attack/Defend", "A/D"),
   ARCADE("arcade", "Arcade", "Arcade"),
   BEDWARS("bedwars", "Bed Wars", "Bed Wars"),


### PR DESCRIPTION
This PR adds 5CP (5 Control Points) to the list of gamemodes. From searching through some discords, it seems that `Points` is always plural, which makes sense but for some reason isn't what I expected.

This is following [discussion in the discord](https://discord.com/channels/730855489767997511/730855489767997515/1259601301994733568).

I alphabetically sorted `5` as coming before `a`, since I've never seen `five` spelled out in 5cp.

