### PR TITLE
fix(wool): use platform-specific ColorUtils for wool matching

### DIFF
--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
@@ -102,7 +102,7 @@ public class MonumentWool extends TouchableGoal<MonumentWoolFactory>
   @Override
   protected boolean canBlockUpdateProximity(BlockState oldState, BlockState newState) {
     // If monument proximity metric is closest block, make it only the wool
-    return !hasTouched(getOwner()) || this.getDefinition().isObjectiveWool(newState.getData());
+    return !hasTouched(getOwner()) || this.getDefinition().isObjectiveWool(newState);
   }
 
   public void handleWoolAcquisition(Player player, ItemStack item) {
@@ -129,7 +129,8 @@ public class MonumentWool extends TouchableGoal<MonumentWoolFactory>
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onArmorKitApplication(ApplyKitEvent event) {
     if (event.getKit() instanceof ArmorKit) {
-      for (ArmorKit.ArmorItem armorPiece : ((ArmorKit) event.getKit()).getArmor().values()) {
+      for (ArmorKit.ArmorItem armorPiece :
+          ((ArmorKit) event.getKit()).getArmor().values()) {
         handleWoolAcquisition(event.getPlayer().getBukkit(), armorPiece.stack);
       }
     }

--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
@@ -28,6 +28,7 @@ import tc.oc.pgm.kits.ArmorKit;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
+import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextFormatter;
 
@@ -102,11 +103,12 @@ public class MonumentWool extends TouchableGoal<MonumentWoolFactory>
   @Override
   protected boolean canBlockUpdateProximity(BlockState oldState, BlockState newState) {
     // If monument proximity metric is closest block, make it only the wool
-    return !hasTouched(getOwner()) || this.getDefinition().isObjectiveWool(newState);
+    return !hasTouched(getOwner())
+        || this.getDefinition().isObjectiveWool(MaterialData.block(newState));
   }
 
   public void handleWoolAcquisition(Player player, ItemStack item) {
-    if (!this.isPlaced() && this.getDefinition().isObjectiveWool(item)) {
+    if (!this.isPlaced() && this.getDefinition().isObjectiveWool(MaterialData.item(item))) {
       ParticipantState participant = this.getMatch().getParticipantState(player);
       if (participant != null && this.canComplete(participant.getParty())) {
         touch(participant);

--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWoolFactory.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWoolFactory.java
@@ -8,7 +8,6 @@ import org.bukkit.DyeColor;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.Wool;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
@@ -18,6 +17,7 @@ import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.goals.ShowOptions;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.text.TextFormatter;
 
 @FeatureInfo(name = "wool")
@@ -123,7 +123,10 @@ public class MonumentWoolFactory extends ProximityGoalDefinition {
   }
 
   public boolean isObjectiveWool(org.bukkit.material.MaterialData material) {
-    return material instanceof Wool && ((Wool) material).getColor() == this.color;
+    // On 1.21, CraftItemStack#getData() on wool item stacks returns unsubclassed MaterialData,
+    // hence we're comparing the item type and color manually
+    return material.getItemType() == Materials.WOOL
+        && DyeColor.getByWoolData(material.getData()) == color;
   }
 
   public boolean isHolding(InventoryHolder holder) {

--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWoolFactory.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWoolFactory.java
@@ -6,7 +6,6 @@ import static tc.oc.pgm.wool.WoolModule.WOOL;
 import net.kyori.adventure.text.Component;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.DyeColor;
-import org.bukkit.block.BlockState;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -20,6 +19,7 @@ import tc.oc.pgm.goals.ShowOptions;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.material.ColorUtils;
+import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.text.TextFormatter;
 
 @FeatureInfo(name = "wool")
@@ -120,12 +120,10 @@ public class MonumentWoolFactory extends ProximityGoalDefinition {
     return this.craftable;
   }
 
-  public boolean isObjectiveWool(ItemStack stack) {
-    return stack != null && WOOL.matches(stack) && ColorUtils.COLOR_UTILS.isColor(stack, color);
-  }
-
-  public boolean isObjectiveWool(BlockState state) {
-    return WOOL.matches(state) && ColorUtils.COLOR_UTILS.isColor(state, color);
+  public boolean isObjectiveWool(MaterialData materialData) {
+    return materialData != null
+        && WOOL.matches(materialData)
+        && ColorUtils.COLOR_UTILS.isColor(materialData, color);
   }
 
   public boolean isHolding(InventoryHolder holder) {
@@ -134,7 +132,7 @@ public class MonumentWoolFactory extends ProximityGoalDefinition {
 
   public boolean isHolding(Inventory inv) {
     for (ItemStack stack : inv.getContents()) {
-      if (this.isObjectiveWool(stack)) return true;
+      if (this.isObjectiveWool(MaterialData.item(stack))) return true;
     }
     return false;
   }

--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWoolFactory.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWoolFactory.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.wool;
 
 import static net.kyori.adventure.text.Component.text;
+import static tc.oc.pgm.wool.WoolModule.WOOL;
 
 import net.kyori.adventure.text.Component;
 import org.apache.commons.lang.StringUtils;
@@ -120,13 +121,11 @@ public class MonumentWoolFactory extends ProximityGoalDefinition {
   }
 
   public boolean isObjectiveWool(ItemStack stack) {
-    return stack != null
-        && WoolModule.WOOL.matches(stack)
-        && ColorUtils.COLOR_UTILS.isColor(stack, color);
+    return stack != null && WOOL.matches(stack) && ColorUtils.COLOR_UTILS.isColor(stack, color);
   }
 
   public boolean isObjectiveWool(BlockState state) {
-    return WoolModule.WOOL.matches(state) && ColorUtils.COLOR_UTILS.isColor(state, color);
+    return WOOL.matches(state) && ColorUtils.COLOR_UTILS.isColor(state, color);
   }
 
   public boolean isHolding(InventoryHolder holder) {

--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWoolFactory.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWoolFactory.java
@@ -5,6 +5,7 @@ import static net.kyori.adventure.text.Component.text;
 import net.kyori.adventure.text.Component;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.DyeColor;
+import org.bukkit.block.BlockState;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -17,7 +18,7 @@ import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.goals.ShowOptions;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
-import tc.oc.pgm.util.material.Materials;
+import tc.oc.pgm.util.material.ColorUtils;
 import tc.oc.pgm.util.text.TextFormatter;
 
 @FeatureInfo(name = "wool")
@@ -119,14 +120,13 @@ public class MonumentWoolFactory extends ProximityGoalDefinition {
   }
 
   public boolean isObjectiveWool(ItemStack stack) {
-    return stack != null && this.isObjectiveWool(stack.getData());
+    return stack != null
+        && WoolModule.WOOL.matches(stack)
+        && ColorUtils.COLOR_UTILS.isColor(stack, color);
   }
 
-  public boolean isObjectiveWool(org.bukkit.material.MaterialData material) {
-    // On 1.21, CraftItemStack#getData() on wool item stacks returns unsubclassed MaterialData,
-    // hence we're comparing the item type and color manually
-    return material.getItemType() == Materials.WOOL
-        && DyeColor.getByWoolData(material.getData()) == color;
+  public boolean isObjectiveWool(BlockState state) {
+    return WoolModule.WOOL.matches(state) && ColorUtils.COLOR_UTILS.isColor(state, color);
   }
 
   public boolean isHolding(InventoryHolder holder) {

--- a/core/src/main/java/tc/oc/pgm/wool/WoolMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/wool/WoolMatchModule.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.wool;
 
 import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.util.material.ColorUtils.COLOR_UTILS;
+import static tc.oc.pgm.wool.WoolModule.WOOL;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -80,7 +81,7 @@ public class WoolMatchModule implements MatchModule, Listener {
   }
 
   private boolean isObjectiveWool(ItemStack stack) {
-    if (WoolModule.WOOL.matches(stack.getType())) {
+    if (WOOL.matches(stack.getType())) {
       for (MonumentWool wool : this.wools.values()) {
         if (wool.getDefinition().isObjectiveWool(stack)) return true;
       }
@@ -215,7 +216,7 @@ public class WoolMatchModule implements MatchModule, Listener {
     if (holder instanceof Player) {
       MatchPlayer playerHolder = this.match.getPlayer((Player) holder);
 
-      if (playerHolder != null && result != null && WoolModule.WOOL.matches(result.getType())) {
+      if (playerHolder != null && result != null && WOOL.matches(result.getType())) {
         for (MonumentWool wool : this.wools.values()) {
           if (wool.getDefinition().isObjectiveWool(result)) {
             if (!wool.getDefinition().isCraftable()) {
@@ -239,6 +240,6 @@ public class WoolMatchModule implements MatchModule, Listener {
   }
 
   private static boolean isValidWool(DyeColor expectedColor, BlockState state) {
-    return WoolModule.WOOL.matches(state.getType()) && COLOR_UTILS.isColor(state, expectedColor);
+    return WOOL.matches(state.getType()) && COLOR_UTILS.isColor(state, expectedColor);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/wool/WoolMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/wool/WoolMatchModule.java
@@ -40,7 +40,6 @@ import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.util.block.BlockVectors;
-import tc.oc.pgm.util.material.MaterialMatcher;
 
 @ListenerScope(MatchScope.RUNNING)
 public class WoolMatchModule implements MatchModule, Listener {
@@ -60,8 +59,6 @@ public class WoolMatchModule implements MatchModule, Listener {
   // the exact
   // layout of the wools in the inventory. This is used to refill the container with wools.
   private final Map<Inventory, Map<Integer, ItemStack>> woolChests = new HashMap<>();
-
-  private static final MaterialMatcher WOOL = MaterialMatcher.of(m -> m.name().endsWith("WOOL"));
 
   private static final int REFILL_INTERVAL = 30; // seconds
 
@@ -83,7 +80,7 @@ public class WoolMatchModule implements MatchModule, Listener {
   }
 
   private boolean isObjectiveWool(ItemStack stack) {
-    if (WOOL.matches(stack.getType())) {
+    if (WoolModule.WOOL.matches(stack.getType())) {
       for (MonumentWool wool : this.wools.values()) {
         if (wool.getDefinition().isObjectiveWool(stack)) return true;
       }
@@ -218,7 +215,7 @@ public class WoolMatchModule implements MatchModule, Listener {
     if (holder instanceof Player) {
       MatchPlayer playerHolder = this.match.getPlayer((Player) holder);
 
-      if (playerHolder != null && result != null && WOOL.matches(result.getType())) {
+      if (playerHolder != null && result != null && WoolModule.WOOL.matches(result.getType())) {
         for (MonumentWool wool : this.wools.values()) {
           if (wool.getDefinition().isObjectiveWool(result)) {
             if (!wool.getDefinition().isCraftable()) {
@@ -242,6 +239,6 @@ public class WoolMatchModule implements MatchModule, Listener {
   }
 
   private static boolean isValidWool(DyeColor expectedColor, BlockState state) {
-    return WOOL.matches(state.getType()) && COLOR_UTILS.isColor(state, expectedColor);
+    return WoolModule.WOOL.matches(state.getType()) && COLOR_UTILS.isColor(state, expectedColor);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/wool/WoolMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/wool/WoolMatchModule.java
@@ -41,6 +41,7 @@ import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.util.block.BlockVectors;
+import tc.oc.pgm.util.material.MaterialData;
 
 @ListenerScope(MatchScope.RUNNING)
 public class WoolMatchModule implements MatchModule, Listener {
@@ -83,7 +84,7 @@ public class WoolMatchModule implements MatchModule, Listener {
   private boolean isObjectiveWool(ItemStack stack) {
     if (WOOL.matches(stack.getType())) {
       for (MonumentWool wool : this.wools.values()) {
-        if (wool.getDefinition().isObjectiveWool(stack)) return true;
+        if (wool.getDefinition().isObjectiveWool(MaterialData.item(stack))) return true;
       }
     }
     return false;
@@ -218,7 +219,7 @@ public class WoolMatchModule implements MatchModule, Listener {
 
       if (playerHolder != null && result != null && WOOL.matches(result.getType())) {
         for (MonumentWool wool : this.wools.values()) {
-          if (wool.getDefinition().isObjectiveWool(result)) {
+          if (wool.getDefinition().isObjectiveWool(MaterialData.item(result))) {
             if (!wool.getDefinition().isCraftable()) {
               playerHolder.sendWarning(
                   translatable("wool.craftingDisabled", wool.getComponentName()));
@@ -240,6 +241,7 @@ public class WoolMatchModule implements MatchModule, Listener {
   }
 
   private static boolean isValidWool(DyeColor expectedColor, BlockState state) {
-    return WOOL.matches(state.getType()) && COLOR_UTILS.isColor(state, expectedColor);
+    return WOOL.matches(state.getType())
+        && COLOR_UTILS.isColor(MaterialData.block(state), expectedColor);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
+++ b/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
@@ -35,7 +35,7 @@ import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class WoolModule implements MapModule<WoolMatchModule> {
-  static final MaterialMatcher WOOL = MaterialMatcher.of(m -> m.name().endsWith("WOOL"));
+  protected static final MaterialMatcher WOOL = MaterialMatcher.of(m -> m.name().endsWith("WOOL"));
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("wool", Gamemode.CAPTURE_THE_WOOL, false));
 

--- a/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
+++ b/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
@@ -29,11 +29,13 @@ import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.teams.TeamModule;
 import tc.oc.pgm.teams.Teams;
+import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class WoolModule implements MapModule<WoolMatchModule> {
+  static final MaterialMatcher WOOL = MaterialMatcher.of(m -> m.name().endsWith("WOOL"));
   private static final Collection<MapTag> TAGS =
       ImmutableList.of(new MapTag("wool", Gamemode.CAPTURE_THE_WOOL, false));
 
@@ -98,36 +100,32 @@ public class WoolModule implements MapModule<WoolMatchModule> {
         ShowOptions options = ShowOptions.parse(factory.getFilters(), woolEl);
         Boolean required = XMLUtils.parseBoolean(woolEl.getAttribute("required"), null);
 
-        ProximityMetric woolProximityMetric =
-            ProximityMetric.parse(
-                woolEl, "wool", new ProximityMetric(ProximityMetric.Type.CLOSEST_KILL, false));
-        ProximityMetric monumentProximityMetric =
-            ProximityMetric.parse(
-                woolEl, "monument", new ProximityMetric(ProximityMetric.Type.CLOSEST_BLOCK, false));
+        ProximityMetric woolProximityMetric = ProximityMetric.parse(
+            woolEl, "wool", new ProximityMetric(ProximityMetric.Type.CLOSEST_KILL, false));
+        ProximityMetric monumentProximityMetric = ProximityMetric.parse(
+            woolEl, "monument", new ProximityMetric(ProximityMetric.Type.CLOSEST_BLOCK, false));
 
         Vector location;
         if (factory.getProto().isOlderThan(MapProtos.WOOL_LOCATIONS)) {
           // The default location is at infinity, so players/blocks are always an infinite distance
           // from it
-          location =
-              new Vector(
-                  Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+          location = new Vector(
+              Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
         } else {
           location = XMLUtils.parseVector(XMLUtils.getRequiredAttribute(woolEl, "location"));
         }
 
-        MonumentWoolFactory wool =
-            new MonumentWoolFactory(
-                id,
-                required,
-                options,
-                team,
-                woolProximityMetric,
-                monumentProximityMetric,
-                color,
-                location,
-                placement,
-                craftable);
+        MonumentWoolFactory wool = new MonumentWoolFactory(
+            id,
+            required,
+            options,
+            team,
+            woolProximityMetric,
+            monumentProximityMetric,
+            color,
+            location,
+            placement,
+            craftable);
         factory.getFeatures().addFeature(woolEl, wool);
         woolFactories.put(team, wool);
       }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernColorUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernColorUtils.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.scoreboard.Team;
 import tc.oc.pgm.util.block.BlockFaces;
 import tc.oc.pgm.util.material.ColorUtils;
+import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.platform.Supports;
 
 @Supports(value = PAPER, minVersion = "1.20.6")
@@ -103,18 +104,9 @@ public class ModernColorUtils implements ColorUtils {
     block.setType(setColor(block.getType(), color));
   }
 
-  private boolean setAndCompare(Material mat, DyeColor color) {
-    return setColor(mat, color) == mat;
-  }
-
   @Override
-  public boolean isColor(BlockState block, DyeColor color) {
-    return setAndCompare(block.getType(), color);
-  }
-
-  @Override
-  public boolean isColor(ItemStack stack, DyeColor color) {
-    return setAndCompare(stack.getType(), color);
+  public boolean isColor(MaterialData data, DyeColor color) {
+    return setColor(data.getItemType(), color) == data.getItemType();
   }
 
   @Override

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernColorUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernColorUtils.java
@@ -103,9 +103,18 @@ public class ModernColorUtils implements ColorUtils {
     block.setType(setColor(block.getType(), color));
   }
 
+  private boolean setAndCompare(Material mat, DyeColor color) {
+    return setColor(mat, color) == mat;
+  }
+
   @Override
   public boolean isColor(BlockState block, DyeColor color) {
-    return setColor(block.getType(), color) == block.getType();
+    return setAndCompare(block.getType(), color);
+  }
+
+  @Override
+  public boolean isColor(ItemStack stack, DyeColor color) {
+    return setAndCompare(stack.getType(), color);
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpColorUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpColorUtils.java
@@ -71,6 +71,11 @@ public class SpColorUtils implements ColorUtils {
     return color.getWoolData() == block.getRawData();
   }
 
+  @Override
+  public boolean isColor(ItemStack stack, DyeColor color) {
+    return color.getWoolData() == stack.getDurability();
+  }
+
   public void setColor(World world, Iterable<BlockVector> positions, DyeColor color) {
     byte blockData = color.getWoolData();
     for (BlockVector pos : positions) {

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpColorUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpColorUtils.java
@@ -20,6 +20,7 @@ import org.bukkit.material.Wool;
 import org.bukkit.util.BlockVector;
 import tc.oc.pgm.util.block.BlockFaces;
 import tc.oc.pgm.util.material.ColorUtils;
+import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.platform.Supports;
 import tc.oc.pgm.util.text.TextTranslations;
 
@@ -67,13 +68,10 @@ public class SpColorUtils implements ColorUtils {
   }
 
   @Override
-  public boolean isColor(BlockState block, DyeColor color) {
-    return color.getWoolData() == block.getRawData();
-  }
-
-  @Override
-  public boolean isColor(ItemStack stack, DyeColor color) {
-    return color.getWoolData() == stack.getDurability();
+  public boolean isColor(MaterialData data, DyeColor color) {
+    return data instanceof LegacyMaterialData legacyData
+        && isColorAffected(data.getItemType())
+        && color.getWoolData() == legacyData.getData();
   }
 
   public void setColor(World world, Iterable<BlockVector> positions, DyeColor color) {

--- a/util/src/main/java/tc/oc/pgm/util/material/ColorUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/ColorUtils.java
@@ -9,7 +9,6 @@ import org.bukkit.World;
 import org.bukkit.block.Banner;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.scoreboard.Team;
@@ -27,9 +26,7 @@ public interface ColorUtils {
 
   void setColor(Block block, DyeColor color);
 
-  boolean isColor(BlockState block, DyeColor color);
-
-  boolean isColor(ItemStack stack, DyeColor color);
+  boolean isColor(MaterialData data, DyeColor color);
 
   default void setColor(World world, Iterable<BlockVector> positions, DyeColor color) {
     for (BlockVector pos : positions) {

--- a/util/src/main/java/tc/oc/pgm/util/material/ColorUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/ColorUtils.java
@@ -29,6 +29,8 @@ public interface ColorUtils {
 
   boolean isColor(BlockState block, DyeColor color);
 
+  boolean isColor(ItemStack stack, DyeColor color);
+
   default void setColor(World world, Iterable<BlockVector> positions, DyeColor color) {
     for (BlockVector pos : positions) {
       setColor(world.getBlockAt(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()), color);


### PR DESCRIPTION
On 1.21 servers, CraftItemStack#getData() returns unsubclassed MaterialData for wool item stacks, hence we cannot check for `instanceof Wool` there. This patch changes the appropriate code to a manual comparison, enabling pickup and proximity tracking to work regardless of whether the material data is correctly subclassed.