### PR TITLE
fix(ModernParticles): correct spawnParticle argument list for spawnFlame, explosion

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernEffects.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernEffects.java
@@ -62,11 +62,11 @@ public class ModernEffects implements Effects {
 
   @Override
   public void spawnFlame(World world, Location location) {
-    world.spawnParticle(Particle.FLAME, location, 40, 0, 0.15f, 0, 0, true);
+    world.spawnParticle(Particle.FLAME, location, 40, 0, 0.15f, 0, 0, null, true);
   }
 
   @Override
   public void explosion(Player player, Location location) {
-    player.spawnParticle(Particle.EXPLOSION, location, 1, 0d, 0d, 0d, 0, true);
+    player.spawnParticle(Particle.EXPLOSION, location, 1, 0d, 0d, 0d, 0, null, true);
   }
 }


### PR DESCRIPTION
This patch corrects the argument list for FLAME/EXPLOSION data types, where the boolean was supposed to force the client to show the particle but was incorrectly passed as particle data, resulting in an exception being thrown.

This solves the issue with spawners spam-spawning items as fast as the server can.