### PR TITLE
Fix objective event performance issues

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/match/Match.java
+++ b/core/src/main/java/tc/oc/pgm/api/match/Match.java
@@ -38,8 +38,8 @@ import tc.oc.pgm.util.Audience;
  *
  * <p>Each {@link Match} should operate like an independent {@link org.bukkit.Server}, and ensure
  * its resources, such as {@link MatchPlayer}s, can only interact with other resources in the same
- * {@link Match}. This should allow multiple {@link Match}es to run concurrently on the same {@link
- * org.bukkit.Server}, as long as resources are cleaned up after {@link #unload()}.
+ * {@link Match}. This should allow multiple {@link Match}es to run concurrently on the same
+ * {@link org.bukkit.Server}, as long as resources are cleaned up after {@link #unload()}.
  */
 public interface Match
     extends MatchPlayerResolver,
@@ -254,8 +254,8 @@ public interface Match
   /**
    * Get the {@link CountdownContext} for the {@link Match}.
    *
-   * <p>There are several places in the code that assume this should be a {@link
-   * tc.oc.pgm.countdowns.SingleCountdownContext}. Will need to be fixed later.
+   * <p>There are several places in the code that assume this should be a
+   * {@link tc.oc.pgm.countdowns.SingleCountdownContext}. Will need to be fixed later.
    *
    * @return The {@link CountdownContext}.
    */
@@ -420,12 +420,15 @@ public interface Match
   Collection<VictoryCondition> getVictoryConditions();
 
   /**
-   * Calculate whether a {@link VictoryCondition} has been meet, and if so, transition the {@link
-   * Match} to {@link MatchPhase#FINISHED}.
+   * Calculate whether a {@link VictoryCondition} has been meet, and if so, transition the
+   * {@link Match} to {@link MatchPhase#FINISHED}.
    *
    * @return If the {@link Match} was just ended.
    */
   boolean calculateVictory();
+
+  /** Invalidates the ranking of participating competitors. */
+  void invalidateRanking();
 
   /**
    * Get whether friendly fire should be on or off.

--- a/core/src/main/java/tc/oc/pgm/goals/GoalMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/goals/GoalMatchModule.java
@@ -144,13 +144,11 @@ public class GoalMatchModule implements MatchModule, Listener {
     return progress;
   }
 
-  protected void updateProgress(Goal goal) {
+  protected void updateProgress(Goal<?> goal) {
     for (Competitor competitor : competitorsByGoal.get(goal)) {
       progressByCompetitor.put(competitor, new GoalProgress(competitor));
     }
-
-    // Forces team rankings to be invalidated
-    match.getWinners();
+    match.invalidateRanking();
   }
 
   // TODO: These events will often be fired together.. debounce them somehow?

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -132,8 +132,8 @@ public class MatchImpl implements Match {
     this.state = new AtomicReference<>(MatchPhase.IDLE);
     this.start = new AtomicLong(0);
     this.end = new AtomicLong(0);
-    this.capacity =
-        new AtomicInteger(map.getInfo().getMaxPlayers().stream().mapToInt(i -> i).sum());
+    this.capacity = new AtomicInteger(
+        map.getInfo().getMaxPlayers().stream().mapToInt(i -> i).sum());
     this.executors = new EnumMap<>(MatchScope.class);
     this.listeners = new EnumMap<>(MatchScope.class);
     this.tickables = new EnumMap<>(MatchScope.class);
@@ -147,21 +147,17 @@ public class MatchImpl implements Match {
     this.players = new ConcurrentHashMap<>();
     this.partyChanges = new WeakHashMap<>();
     this.parties = new LinkedHashSet<>();
-    this.victory =
-        new RankedSet<>(
-            Comparator.<VictoryCondition, Boolean>comparing(
-                    vc -> !vc.isCompleted(this), Boolean::compare)
-                .thenComparing(VictoryCondition::getPriority));
+    this.victory = new RankedSet<>(Comparator.<VictoryCondition, Boolean>comparing(
+            vc -> !vc.isCompleted(this), Boolean::compare)
+        .thenComparing(VictoryCondition::getPriority));
     this.competitors = new HashSet<>();
-    this.winners =
-        new RankedSet<>(
-            (Competitor a, Competitor b) -> {
-              for (VictoryCondition condition : getVictoryConditions()) {
-                int result = condition.compare(a, b);
-                if (result != 0 || condition.isFinal(this)) return result;
-              }
-              return 0;
-            });
+    this.winners = new RankedSet<>((Competitor a, Competitor b) -> {
+      for (VictoryCondition condition : getVictoryConditions()) {
+        int result = condition.compare(a, b);
+        if (result != 0 || condition.isFinal(this)) return result;
+      }
+      return 0;
+    });
     this.queuedParticipants = new AtomicReference<>();
     this.observers = new ObserverParty(this);
     this.features = new MatchFeatureContext();
@@ -340,8 +336,10 @@ public class MatchImpl implements Match {
   }
 
   private void startListener(Listener listener) {
-    for (Map.Entry<Class<? extends Event>, Set<RegisteredListener>> entry :
-        PGM.get().getPluginLoader().createRegisteredListeners(listener, PGM.get()).entrySet()) {
+    for (Map.Entry<Class<? extends Event>, Set<RegisteredListener>> entry : PGM.get()
+        .getPluginLoader()
+        .createRegisteredListeners(listener, PGM.get())
+        .entrySet()) {
       Class<? extends Event> eventClass = entry.getKey();
       HandlerList handlerList = Events.getEventListeners(eventClass);
 
@@ -464,10 +462,9 @@ public class MatchImpl implements Match {
   @Override
   public boolean setParty(MatchPlayer player, Party party, @Nullable JoinRequest request) {
     if (request == null)
-      request =
-          party instanceof Team
-              ? JoinRequest.of((Team) party, JoinRequest.Flag.FORCE)
-              : JoinRequest.force();
+      request = party instanceof Team
+          ? JoinRequest.of((Team) party, JoinRequest.Flag.FORCE)
+          : JoinRequest.force();
     return setOrClearPlayerParty(player, assertNotNull(party), request);
   }
 
@@ -510,13 +507,12 @@ public class MatchImpl implements Match {
       // to detect nested calls for the same player, which we definitely do not want.
       Party nested = partyChanges.put(player, newParty);
       if (nested != null) {
-        throw new IllegalStateException(
-            "Nested party change: "
-                + player
-                + " tried to join "
-                + newParty
-                + " in the middle of joining "
-                + nested);
+        throw new IllegalStateException("Nested party change: "
+            + player
+            + " tried to join "
+            + newParty
+            + " in the middle of joining "
+            + nested);
       }
 
       if (oldParty instanceof Competitor) {
@@ -661,6 +657,11 @@ public class MatchImpl implements Match {
   @Override
   public Collection<Competitor> getSortedCompetitors() {
     return ImmutableList.copyOf(winners);
+  }
+
+  @Override
+  public void invalidateRanking() {
+    winners.invalidateRanking();
   }
 
   @Override
@@ -811,9 +812,8 @@ public class MatchImpl implements Match {
       matchModules.put(module.getClass(), module);
 
       if (module instanceof Listener && getListenerScope((Listener) module) == null) {
-        logger.warning(
-            module.getClass().getSimpleName()
-                + " implements Listener but is not annotated with @ListenerScope");
+        logger.warning(module.getClass().getSimpleName()
+            + " implements Listener but is not annotated with @ListenerScope");
       }
 
       if (module instanceof Listener) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a3b23508-603e-49ef-965c-5d05e14577b0)

In an FFA map with a ton of hills being captured by a ton of players, re-sorting the list of competitors every time a hill is captured is a real performance issue.