### PR TITLE
Fix filter NPEs & improve modern post task

### DIFF
--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/NMSHacksSportPaper.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/NMSHacksSportPaper.java
@@ -191,7 +191,7 @@ public class NMSHacksSportPaper implements NMSHacks {
 
   @Override
   public void postToMainThread(Plugin plugin, boolean priority, Runnable task) {
-    Bukkit.getServer().postToMainThread(plugin, true, task);
+    Bukkit.getServer().postToMainThread(plugin, priority, task);
   }
 
   @Override


### PR DESCRIPTION
Fixes the following NPEs, caused by a race condition between match load and player move events invalidating dynamic filters:

```
java.lang.NullPointerException: reactor
	at tc.oc.pgm.util.Assert.assertNotNull(Assert.java:19) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.getReactor(FilterMatchModule.java:572) ~[?:?]
	at tc.oc.pgm.api.filter.query.MatchQuery.reactor(MatchQuery.java:31) ~[?:?]
	at tc.oc.pgm.filters.matcher.match.MonostableFilter.matches(MonostableFilter.java:68) ~[?:?]
	at tc.oc.pgm.filters.matcher.match.MonostableFilter.matches(MonostableFilter.java:33) ~[?:?]
	at tc.oc.pgm.filters.matcher.TypedFilter.queryTyped(TypedFilter.java:13) ~[?:?]
	at tc.oc.pgm.filters.matcher.WeakTypedFilter.query(WeakTypedFilter.java:21) ~[?:?]
	at tc.oc.pgm.api.filter.Filter.response(Filter.java:37) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.lambda$check$10(FilterMatchModule.java:352) ~[?:?]
	at java.util.Map.forEach(Map.java:733) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.lambda$check$11(FilterMatchModule.java:339) ~[?:?]
	at java.util.Map.forEach(Map.java:733) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.check(FilterMatchModule.java:335) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.lambda$tick$12(FilterMatchModule.java:416) ~[?:?]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.tick(FilterMatchModule.java:416) ~[?:?]
	at org.bukkit.craftbukkit.v1_8_R3.CraftServer$1Wrapped.run(CraftServer.java:1692) ...
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
[...]
	at java.lang.Thread.run(Thread.java:1583) [?:?]
```

Additionally modifies postToMainThread to utilize vanilla's scheduling instead of bukkit's, ensuring it runs on the same tick, even if priority can't be applied in modern