### PR TITLE
Fix sb filters not working for competitor goals

### DIFF
--- a/core/src/main/java/tc/oc/pgm/scoreboard/RenderContext.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/RenderContext.java
@@ -4,10 +4,8 @@ import static net.kyori.adventure.text.Component.empty;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.match.Match;
@@ -47,12 +45,14 @@ class RenderContext {
 
     // Count the rows used for goals
     for (Goal<?> goal : gmm.getGoals()) {
-      if (goal.hasShowOption(ShowOption.SHOW_SIDEBAR) && goal.getScoreboardFilter().response(match)) {
+      if (goal.hasShowOption(ShowOption.SHOW_SIDEBAR)
+          && goal.getScoreboardFilter().response(match)) {
         if (goal.isShared()) {
           sharedGoals.add(goal);
         } else {
-          gmm.getCompetitors(goal).forEach(competitor ->
-              competitorGoals.computeIfAbsent(competitor, ignored -> new ArrayList<>()).add(goal));
+          gmm.getCompetitors(goal).forEach(competitor -> competitorGoals
+              .computeIfAbsent(competitor, ignored -> new ArrayList<>())
+              .add(goal));
         }
       }
     }

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarRenderer.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarRenderer.java
@@ -28,7 +28,6 @@ import tc.oc.pgm.blitz.BlitzMatchModule;
 import tc.oc.pgm.ffa.Tribute;
 import tc.oc.pgm.goals.Goal;
 import tc.oc.pgm.goals.ProximityGoal;
-import tc.oc.pgm.goals.ShowOption;
 import tc.oc.pgm.score.ScoreMatchModule;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.util.StringUtils;
@@ -66,10 +65,9 @@ class SidebarRenderer {
     final Collection<Gamemode> gamemodes = map.getGamemodes();
     if (!gamemodes.isEmpty()) {
       boolean acronyms = gamemodes.size() > 1;
-      List<Component> gmComponents =
-          gamemodes.stream()
-              .map(gm -> text(acronyms ? gm.getAcronym() : gm.getFullName()))
-              .collect(Collectors.toList());
+      List<Component> gmComponents = gamemodes.stream()
+          .map(gm -> text(acronyms ? gm.getAcronym() : gm.getFullName()))
+          .collect(Collectors.toList());
       return TextFormatter.list(gmComponents, NamedTextColor.AQUA);
     }
 
@@ -199,10 +197,9 @@ class SidebarRenderer {
             spacer = spacer.append(space()).append(space());
           }
           firstWool = false;
-          woolText.append(
-              spacer
-                  .append(wool.renderSidebarStatusText(competitor, context.viewer))
-                  .color(wool.renderSidebarStatusColor(competitor, context.viewer)));
+          woolText.append(spacer
+              .append(wool.renderSidebarStatusText(competitor, context.viewer))
+              .color(wool.renderSidebarStatusColor(competitor, context.viewer)));
         }
       }
       // Add a row for the compact wools
@@ -262,12 +259,11 @@ class SidebarRenderer {
     final TextComponent.Builder line = text();
 
     line.append(space());
-    line.append(
-        goal.renderSidebarStatusText(competitor, viewingParty)
-            .color(
-                blinkTask != null && blinkTask.isDark()
-                    ? NamedTextColor.BLACK
-                    : goal.renderSidebarStatusColor(competitor, viewingParty)));
+    line.append(goal.renderSidebarStatusText(competitor, viewingParty)
+        .color(
+            blinkTask != null && blinkTask.isDark()
+                ? NamedTextColor.BLACK
+                : goal.renderSidebarStatusColor(competitor, viewingParty)));
 
     if (goal instanceof ProximityGoal) {
       final ProximityGoal<?> proximity = (ProximityGoal<?>) goal;
@@ -278,9 +274,8 @@ class SidebarRenderer {
     }
 
     line.append(space());
-    line.append(
-        goal.renderSidebarLabelText(competitor, viewingParty)
-            .color(goal.renderSidebarLabelColor(competitor, viewingParty)));
+    line.append(goal.renderSidebarLabelText(competitor, viewingParty)
+        .color(goal.renderSidebarLabelColor(competitor, viewingParty)));
 
     return line.build();
   }

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarRenderer.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarRenderer.java
@@ -168,7 +168,7 @@ class SidebarRenderer {
 
   private List<Competitor> getSortedCompetitors(RenderContext context, Party viewer) {
     List<Competitor> sortedCompetitors = new ArrayList<>(match.getSortedCompetitors());
-    sortedCompetitors.retainAll(context.competitorsWithGoals);
+    sortedCompetitors.retainAll(context.competitorGoals.keySet());
     // Bump viewing party to the top of the list
     if (viewer instanceof Competitor && sortedCompetitors.remove(viewer)) {
       sortedCompetitors.add(0, (Competitor) viewer);
@@ -185,7 +185,7 @@ class SidebarRenderer {
     if (context.isCompactWool) {
       boolean firstWool = true;
 
-      List<Goal> sortedWools = new ArrayList<>(context.gmm.getGoals(competitor));
+      List<Goal<?>> sortedWools = context.competitorGoals.get(competitor);
       sortedWools.sort((a, b) -> a.getName().compareToIgnoreCase(b.getName()));
 
       // Calculate whether having three spaces between each wool would fit on the scoreboard.
@@ -193,8 +193,7 @@ class SidebarRenderer {
           MAX_LENGTH < (3 * sortedWools.size()) + (3 * (sortedWools.size() - 1)) + 1;
       TextComponent.Builder woolText = text();
       for (Goal<?> goal : sortedWools) {
-        if (goal instanceof MonumentWool && goal.hasShowOption(ShowOption.SHOW_SIDEBAR)) {
-          MonumentWool wool = (MonumentWool) goal;
+        if (goal instanceof MonumentWool wool) {
           TextComponent spacer = space();
           if (!firstWool && !horizontalCompact) {
             spacer = spacer.append(space()).append(space());
@@ -211,12 +210,8 @@ class SidebarRenderer {
 
     } else {
       // Not compact; add a row for each of this team's goals
-      for (Goal<?> goal : context.gmm.getGoals()) {
-        if (!goal.isShared()
-            && goal.canComplete(competitor)
-            && goal.hasShowOption(ShowOption.SHOW_SIDEBAR)) {
-          context.addRow(this.renderGoal(goal, competitor, context.viewer));
-        }
+      for (Goal<?> goal : context.competitorGoals.get(competitor)) {
+        context.addRow(this.renderGoal(goal, competitor, context.viewer));
       }
     }
   }


### PR DESCRIPTION
Currently scoreboard filters are only working correctly for score, blitz and shared goals. Competitor goals were filtered at an initial stage, but would still render afterwards as it iterated thru the original getGoals list without filtering.
To avoid filtering twice, the render context will directly compute the map of competitor -> goals at the time it tests the filters.