### PR TITLE
Implement conditional constants

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/ConditionalChecker.java
+++ b/core/src/main/java/tc/oc/pgm/map/ConditionalChecker.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jdom2.Element;
+import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
@@ -15,7 +16,9 @@ class ConditionalChecker {
   private static final List<AttributeCheck> ATTRIBUTES = List.of(
       new AttributeCheck("variant", ConditionalChecker::variant),
       new AttributeCheck("has-variant", ConditionalChecker::hasVariant),
-      new AttributeCheck("constant", ConditionalChecker::constant));
+      new AttributeCheck("constant", ConditionalChecker::constant),
+      new AttributeCheck("min-server-version", ConditionalChecker::minServerVersion),
+      new AttributeCheck("max-server-version", ConditionalChecker::maxServerVersion));
   private static final String ALL_ATTRS =
       ATTRIBUTES.stream().map(AttributeCheck::key).collect(Collectors.joining("', '", "'", "'"));
 
@@ -24,7 +27,7 @@ class ConditionalChecker {
    *
    * @param ctx the map's context
    * @param el The conditional element
-   * @return true if the conditional
+   * @return if the conditional passes
    * @throws InvalidXMLException if the element is invalid in any way
    */
   static boolean test(MapFilePreprocessor ctx, Element el) throws InvalidXMLException {
@@ -34,28 +37,39 @@ class ConditionalChecker {
       if (attRes != null) result = result == null ? attRes : result && attRes;
     }
 
-    if (result == null)
-      throw new InvalidXMLException("Expected at least one of " + ALL_ATTRS + " attributes", el);
-
-    return result;
+    if (result != null) return result;
+    throw new InvalidXMLException("Expected at least one of " + ALL_ATTRS + " attributes", el);
   }
 
   private static String[] split(String val) {
     return val.split("[\\s,]+");
   }
 
-  private static boolean variant(MapFilePreprocessor ctx, Element el, String value) {
+  private static boolean variant(MapFilePreprocessor ctx, Element el, Node node) {
+    String value = node.getValue();
     if (value.indexOf(',') == -1) return value.equals(ctx.getVariant());
     return Set.of(split(value)).contains(ctx.getVariant());
   }
 
-  private static boolean hasVariant(MapFilePreprocessor ctx, Element el, String value) {
+  private static boolean hasVariant(MapFilePreprocessor ctx, Element el, Node node) {
+    String value = node.getValue();
     if (value.indexOf(',') == -1) return ctx.getVariantIds().contains(value);
     return Arrays.stream(split(value)).anyMatch(ctx.getVariantIds()::contains);
   }
 
-  private static boolean constant(MapFilePreprocessor ctx, Element el, String id)
+  private static boolean minServerVersion(MapFilePreprocessor ctx, Element el, Node node)
       throws InvalidXMLException {
+    return Platform.MINECRAFT_VERSION.isNoOlderThan(XMLUtils.parseSemanticVersion(node));
+  }
+
+  private static boolean maxServerVersion(MapFilePreprocessor ctx, Element el, Node node)
+      throws InvalidXMLException {
+    return Platform.MINECRAFT_VERSION.isNoNewerThan(XMLUtils.parseSemanticVersion(node));
+  }
+
+  private static boolean constant(MapFilePreprocessor ctx, Element el, Node node)
+      throws InvalidXMLException {
+    var id = node.getValue();
     var value = Node.fromAttr(el, "constant-value");
     var cmp = XMLUtils.parseEnum(
         Node.fromAttr(el, "constant-comparison"),
@@ -63,40 +77,40 @@ class ConditionalChecker {
         value == null ? Cmp.DEFINED : Cmp.EQUALS);
 
     var constants = ctx.getConstants();
+    var isDefined = constants.containsKey(id);
+    var constant = isDefined ? constants.get(id) : null;
 
-    if (!cmp.requireValue) {
-      if (value != null)
-        throw new InvalidXMLException("Comparison type " + cmp + " should not have a value", value);
+    if (!cmp.requireValue && value != null)
+      throw new InvalidXMLException("Comparison type " + cmp + " should not have a value", value);
 
-      if (!constants.containsKey(id)) return cmp == Cmp.UNDEFINED;
-
-      return switch (cmp) {
-        case DEFINED -> true;
-        case DEFINED_DELETE -> constants.get(id) == null;
-        case DEFINED_VALUE -> constants.get(id) != null;
-          // Should never happen
-        default -> throw new IllegalStateException(cmp + " not supported");
-      };
-    } else {
-      String constant = constants.get(id);
-      if (constant == null) {
-        if (!constants.containsKey(id))
-          throw new InvalidXMLException(
-              "Unknown constant '" + id + "'. Only constants before the conditional may be used.",
-              el);
-        return false;
-      }
+    if (cmp.requireValue) {
       if (value == null)
         throw new InvalidXMLException("Required attribute 'constant-value' not set", el);
 
+      if (!isDefined)
+        throw new InvalidXMLException(
+            "Unknown constant '" + id + "'. Only constants before the conditional may be used.",
+            el);
+      if (constant == null) return false;
+    }
+
+    // The only reason these are split is for the IDE to infer nullability
+    if (!cmp.requireValue) {
+      return switch (cmp) {
+        case UNDEFINED -> !isDefined;
+        case DEFINED -> isDefined;
+        case DEFINED_DELETE -> isDefined && constant == null;
+        case DEFINED_VALUE -> isDefined && constant != null;
+        default -> throw new IllegalStateException("Unexpected value: " + cmp);
+      };
+    } else {
       return switch (cmp) {
         case EQUALS -> Objects.equals(value.getValue(), constant);
         case CONTAINS -> Set.of(split(value.getValue())).contains(constant);
         case REGEX -> constant.matches(value.getValue());
         case RANGE -> XMLUtils.parseNumericRange(value, Double.class)
             .contains(XMLUtils.parseNumber(new Node(el), constant, Double.class, true));
-          // Should never happen
-        default -> throw new IllegalStateException(cmp + " not supported");
+        default -> throw new IllegalStateException("Unexpected value: " + cmp);
       };
     }
   }
@@ -118,15 +132,15 @@ class ConditionalChecker {
   }
 
   interface ElementPredicate {
-    boolean test(MapFilePreprocessor ctx, Element el, String value) throws InvalidXMLException;
+    boolean test(MapFilePreprocessor ctx, Element el, Node value) throws InvalidXMLException;
   }
 
   record AttributeCheck(String key, ElementPredicate pred) {
     Boolean apply(MapFilePreprocessor ctx, Element el) throws InvalidXMLException {
-      var attr = el.getAttribute(key);
+      var attr = Node.fromNullable(el.getAttribute(key));
       if (attr == null) return null;
 
-      return pred.test(ctx, el, attr.getValue());
+      return pred.test(ctx, el, attr);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/map/ConditionalChecker.java
+++ b/core/src/main/java/tc/oc/pgm/map/ConditionalChecker.java
@@ -1,0 +1,132 @@
+package tc.oc.pgm.map;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jdom2.Element;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLUtils;
+
+class ConditionalChecker {
+
+  private static final List<AttributeCheck> ATTRIBUTES = List.of(
+      new AttributeCheck("variant", ConditionalChecker::variant),
+      new AttributeCheck("has-variant", ConditionalChecker::hasVariant),
+      new AttributeCheck("constant", ConditionalChecker::constant));
+  private static final String ALL_ATTRS =
+      ATTRIBUTES.stream().map(AttributeCheck::key).collect(Collectors.joining("', '", "'", "'"));
+
+  /**
+   * Test if the current context passes the conditions declared in the element
+   *
+   * @param ctx the map's context
+   * @param el The conditional element
+   * @return true if the conditional
+   * @throws InvalidXMLException if the element is invalid in any way
+   */
+  static boolean test(MapFilePreprocessor ctx, Element el) throws InvalidXMLException {
+    Boolean result = null;
+    for (var check : ATTRIBUTES) {
+      Boolean attRes = check.apply(ctx, el);
+      if (attRes != null) result = result == null ? attRes : result && attRes;
+    }
+
+    if (result == null)
+      throw new InvalidXMLException("Expected at least one of " + ALL_ATTRS + " attributes", el);
+
+    return result;
+  }
+
+  private static String[] split(String val) {
+    return val.split("[\\s,]+");
+  }
+
+  private static boolean variant(MapFilePreprocessor ctx, Element el, String value) {
+    if (value.indexOf(',') == -1) return value.equals(ctx.getVariant());
+    return Set.of(split(value)).contains(ctx.getVariant());
+  }
+
+  private static boolean hasVariant(MapFilePreprocessor ctx, Element el, String value) {
+    if (value.indexOf(',') == -1) return ctx.getVariantIds().contains(value);
+    return Arrays.stream(split(value)).anyMatch(ctx.getVariantIds()::contains);
+  }
+
+  private static boolean constant(MapFilePreprocessor ctx, Element el, String id)
+      throws InvalidXMLException {
+    var value = Node.fromAttr(el, "constant-value");
+    var cmp = XMLUtils.parseEnum(
+        Node.fromAttr(el, "constant-comparison"),
+        Cmp.class,
+        value == null ? Cmp.DEFINED : Cmp.EQUALS);
+
+    var constants = ctx.getConstants();
+
+    if (!cmp.requireValue) {
+      if (value != null)
+        throw new InvalidXMLException("Comparison type " + cmp + " should not have a value", value);
+
+      if (!constants.containsKey(id)) return cmp == Cmp.UNDEFINED;
+
+      return switch (cmp) {
+        case DEFINED -> true;
+        case DEFINED_DELETE -> constants.get(id) == null;
+        case DEFINED_VALUE -> constants.get(id) != null;
+          // Should never happen
+        default -> throw new IllegalStateException(cmp + " not supported");
+      };
+    } else {
+      String constant = constants.get(id);
+      if (constant == null) {
+        if (!constants.containsKey(id))
+          throw new InvalidXMLException(
+              "Unknown constant '" + id + "'. Only constants before the conditional may be used.",
+              el);
+        return false;
+      }
+      if (value == null)
+        throw new InvalidXMLException("Required attribute 'constant-value' not set", el);
+
+      return switch (cmp) {
+        case EQUALS -> Objects.equals(value.getValue(), constant);
+        case CONTAINS -> Set.of(split(value.getValue())).contains(constant);
+        case REGEX -> constant.matches(value.getValue());
+        case RANGE -> XMLUtils.parseNumericRange(value, Double.class)
+            .contains(XMLUtils.parseNumber(new Node(el), constant, Double.class, true));
+          // Should never happen
+        default -> throw new IllegalStateException(cmp + " not supported");
+      };
+    }
+  }
+
+  enum Cmp {
+    UNDEFINED(false),
+    DEFINED(false),
+    DEFINED_DELETE(false),
+    DEFINED_VALUE(false),
+    EQUALS(true),
+    CONTAINS(true),
+    REGEX(true),
+    RANGE(true);
+    private final boolean requireValue;
+
+    Cmp(boolean requireValue) {
+      this.requireValue = requireValue;
+    }
+  }
+
+  interface ElementPredicate {
+    boolean test(MapFilePreprocessor ctx, Element el, String value) throws InvalidXMLException;
+  }
+
+  record AttributeCheck(String key, ElementPredicate pred) {
+    Boolean apply(MapFilePreprocessor ctx, Element el) throws InvalidXMLException {
+      var attr = el.getAttribute(key);
+      if (attr == null) return null;
+
+      return pred.test(ctx, el, attr.getValue());
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
@@ -5,8 +5,6 @@ import static tc.oc.pgm.api.map.MapSource.DEFAULT_VARIANT;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,19 +26,16 @@ import tc.oc.pgm.api.map.includes.MapInclude;
 import tc.oc.pgm.api.map.includes.MapIncludeProcessor;
 import tc.oc.pgm.util.xml.DocumentWrapper;
 import tc.oc.pgm.util.xml.InvalidXMLException;
-import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.SAXHandler;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class MapFilePreprocessor {
 
-  private static final ThreadLocal<SAXBuilder> DOCUMENT_FACTORY =
-      ThreadLocal.withInitial(
-          () -> {
-            final SAXBuilder builder = new SAXBuilder();
-            builder.setSAXHandlerFactory(SAXHandler.FACTORY);
-            return builder;
-          });
+  private static final ThreadLocal<SAXBuilder> DOCUMENT_FACTORY = ThreadLocal.withInitial(() -> {
+    final SAXBuilder builder = new SAXBuilder();
+    builder.setSAXHandlerFactory(SAXHandler.FACTORY);
+    return builder;
+  });
 
   private static final Pattern CONSTANT_PATTERN = Pattern.compile("\\$\\{(.+?)}");
 
@@ -79,27 +74,16 @@ public class MapFilePreprocessor {
       variantIds.add(XMLUtils.parseRequiredId(variant));
     }
 
-    document.runWithoutVisitation(
-        () -> {
-          MapInclude global = includeProcessor.getGlobalInclude();
-          if (global != null) {
-            document.getRootElement().addContent(0, global.getContent());
-            includes.add(global);
-          }
+    document.runWithoutVisitation(() -> {
+      MapInclude global = includeProcessor.getGlobalInclude();
+      if (global != null) {
+        document.getRootElement().addContent(0, global.getContent());
+        includes.add(global);
+      }
 
-          preprocessChildren(document.getRootElement());
-          source.setIncludes(includes);
-        });
-
-    for (Element constant :
-        XMLUtils.flattenElements(document.getRootElement(), "constants", "constant", 0)) {
-      boolean isDelete = XMLUtils.parseBoolean(constant.getAttribute("delete"), false);
-      String text = constant.getText();
-      if ((text == null || text.isEmpty()) != isDelete)
-        throw new InvalidXMLException(
-            "Delete attribute cannot be combined with having an inner text", constant);
-      constants.put(XMLUtils.parseRequiredId(constant), isDelete ? null : constant.getText());
-    }
+      preprocessChildren(document.getRootElement());
+      source.setIncludes(includes);
+    });
 
     // If no constants are set, assume we can skip the step
     if (!constants.isEmpty()) {
@@ -109,25 +93,31 @@ public class MapFilePreprocessor {
     return document;
   }
 
+  String getVariant() {
+    return variant;
+  }
+
+  Set<String> getVariantIds() {
+    return variantIds;
+  }
+
+  Map<String, String> getConstants() {
+    return constants;
+  }
+
   private void preprocessChildren(Element parent) throws InvalidXMLException {
     for (int i = 0; i < parent.getContentSize(); i++) {
       Content content = parent.getContent(i);
-      if (!(content instanceof Element)) continue;
+      if (!(content instanceof Element child)) continue;
 
-      Element child = (Element) content;
-      List<Content> replacement = null;
-
-      switch (child.getName()) {
-        case "include":
-          replacement = processIncludeElement(child);
-          break;
-        case "if":
-          replacement = processConditional(child, true);
-          break;
-        case "unless":
-          replacement = processConditional(child, false);
-          break;
-      }
+      List<Content> replacement =
+          switch (child.getName()) {
+            case "include" -> processIncludeElement(child);
+            case "if" -> processConditional(child, true);
+            case "unless" -> processConditional(child, false);
+            case "constant" -> processConstant(child);
+            default -> null;
+          };
 
       if (replacement != null) {
         parent.removeContent(i);
@@ -141,25 +131,29 @@ public class MapFilePreprocessor {
 
   private List<Content> processIncludeElement(Element element) throws InvalidXMLException {
     MapInclude include = includeProcessor.getMapInclude(element);
-    if (include != null) {
-      includes.add(include);
-      return include.getContent();
-    }
-    return Collections.emptyList();
+    if (include == null) return List.of();
+    includes.add(include);
+    return include.getContent();
   }
 
-  private List<Content> processConditional(Element el, boolean shouldContain)
-      throws InvalidXMLException {
+  private List<Content> processConditional(Element el, boolean expect) throws InvalidXMLException {
+    return ConditionalChecker.test(this, el) == expect ? el.cloneContent() : List.of();
+  }
 
-    Node node = Node.fromRequiredAttr(el, "variant", "has-variant");
-    List<String> filter = Arrays.asList(node.getValue().split("[\\s,]+"));
+  private List<Content> processConstant(Element el) throws InvalidXMLException {
+    boolean isDelete = XMLUtils.parseBoolean(el.getAttribute("delete"), false);
+    String text = el.getTextNormalize();
+    if ((text == null || text.isEmpty()) != isDelete)
+      throw new InvalidXMLException(
+          "Delete attribute cannot be combined with having an inner text", el);
 
-    boolean contains =
-        "variant".equals(node.getName())
-            ? filter.contains(this.variant)
-            : filter.stream().anyMatch(variantIds::contains);
+    var id = XMLUtils.parseRequiredId(el);
+    var value = isDelete ? null : text;
 
-    return contains == shouldContain ? el.cloneContent() : Collections.emptyList();
+    boolean fallback = XMLUtils.parseBoolean(el.getAttribute("fallback"), false);
+    if (!fallback || !constants.containsKey(id)) constants.put(id, value);
+
+    return List.of();
   }
 
   private void postprocessChildren(Element parent) throws InvalidXMLException {
@@ -177,11 +171,9 @@ public class MapFilePreprocessor {
 
     for (int i = 0; i < parent.getContentSize(); i++) {
       Content content = parent.getContent(i);
-      if (content instanceof Element) {
-        postprocessChildren((Element) content);
-      } else if (content instanceof Text) {
-        Text text = (Text) content;
-
+      if (content instanceof Element el) {
+        postprocessChildren(el);
+      } else if (content instanceof Text text) {
         String result = postprocessString(parent, text.getText());
         if (result == null) {
           parent.removeContent(text);
@@ -196,7 +188,7 @@ public class MapFilePreprocessor {
   private @Nullable String postprocessString(Element el, String text) throws InvalidXMLException {
     Matcher matcher = CONSTANT_PATTERN.matcher(text);
 
-    StringBuffer result = new StringBuffer();
+    StringBuilder result = new StringBuilder();
     while (matcher.find()) {
       String constant = matcher.group(1);
       String replacement = constants.get(constant);

--- a/util/src/main/java/tc/oc/pgm/util/Version.java
+++ b/util/src/main/java/tc/oc/pgm/util/Version.java
@@ -43,6 +43,16 @@ public final class Version implements Comparable<Version> {
   }
 
   /**
+   * Gets whether this version is less than or equal to another version.
+   *
+   * @param other Another version.
+   * @return If this version <= other version.
+   */
+  public boolean isNoNewerThan(Version other) {
+    return compareTo(other) <= 0;
+  }
+
+  /**
    * Gets whether this version is less than another version.
    *
    * @param other Another version.
@@ -50,6 +60,16 @@ public final class Version implements Comparable<Version> {
    */
   public boolean isOlderThan(Version other) {
     return compareTo(other) < 0;
+  }
+
+  /**
+   * Gets whether this version is greater than another version.
+   *
+   * @param other Another version.
+   * @return If this version > other version.
+   */
+  public boolean isNewerThan(Version other) {
+    return compareTo(other) > 0;
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.util.xml;
 
-import com.google.common.collect.Sets;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.jdom2.Attribute;
@@ -13,7 +12,7 @@ import org.jdom2.Namespace;
 public class DocumentWrapper extends Document {
 
   private static final Set<String> IGNORED =
-      Sets.newHashSet("name", "variant", "tutorial", "edition");
+      Set.of("constants", "edition", "name", "tutorial", "variant");
 
   private boolean visitingAllowed = true;
 


### PR DESCRIPTION
Implements section 3.2.1 in #1181, in the second bulletpoint way, where constants are processed at the same time as includes. This means that constants can be used in conditionals (`<if> / <unless>`), but only if defined before the conditional.

# TLDR;
- Constants now have a `fallback` attribute, defaults to false. If true, the constant is a fallback (a default) and will NOT override a prior declaration.
  - Consider making all your includes use fallback="true", as you probably do not want to ever override what the map sets
  - You can declare it in the parent `<constants>` tag and it applies to all children
- Conditionals (`<if>` and `<unless>`) can now work on constants, as long as they were defined before the conditional.
 - This is only really useful for includes, in a single-map xml this is pretty useless.
- Also adds `min-server-version` and `max-server-version` attributes to conditionals

# Examples
the-include.xml:
```xml
<map>
  <actions>
    <if constant="compass-time">
      <trigger action="compass-kit">
          <filter><time>${compass-time}</time></filter>
      </trigger>  
    </if>
  </actions>
</map>
```

Map A.xml:
```xml
<map>
  <constant id="compass-time">5m</constant>
  <include id="the-include"/>
</map>
```

Map B:
```xml
<map>
  <include id="the-include"/>
</map>
```

Map C:
```xml
<map>
  <constant id="compass-time">5m</constant>
  <include id="the-include"/>
  <constant id="compass-time" delete="true"/>
</map>
```

This is the most basic usage of the constant in a conditional, this defaults to if anyone has set a value for the constant or not.
- Map A: it would configure the trigger, as the constant was declared
- Map B: it wouldn't configure the trigger, as constant wasn't declared
- Map C: it would configure the trigger as it's "5m" when include and its conditional is checked. However would fail later as the filter would become: `<filter> </filter>` when time is deleted.

**IMPORTANT:** constants in conditionals only work if declared **BEFORE** the conditional is evaluated, and **CAN** be different values.

# Constant fallback attribute
Because of this behavior where defining the constant BEFORE the include is needed, but you likely want your definition to prevail over the includes', it makes sense for all includes to declare their constants as fallback:
```xml
<map>
  <constants fallback="true">
    <constant id="compass-kit">5m</constant>
  </constants>
  <actions>
    <if constant="compass-time" constant-comparison="defined value"> <!-- more on this later -->
      <trigger action="compass-kit">
          <filter><time>${compass-time}</time></filter>
      </trigger>  
    </if>
  </actions>
</map>
```

Now these constants can be overwritten *before* the include (so that they work on conditionals too) without the include imposing them. So all maps using the include by default use 5m, and maps who want to disable it can just set it to delete="true". Note that `fallback` can be specified either on the `constant` or the `constants` parents, similar to many other features in PGM.

# All conditional constant options
Now, can you check more than just the conditional being set? the answer is yes, but it gets a bit complicated:

Attributes:
`constant`: (required) the id of the constant to check against
`constant-value`: (depends on compare) the value to check for, this depends on the type of comparison done
`constant-comparison`: (optional) the type of comparison, like just checking if it is defined, or checking if it matches specific values. If not set, defaults to `defined_value` if no value, or `equals` if there's a value.

(Note: the default changed from `defined` to  `defined_value` in #1381, this comment was updated to reflect it)

All possible constant-comparison possibilities (case-insensitive):

 - UNDEFINED: checks that the constant has not been defined to anything
     - eg: `<if constant="const" constant-comparison="undefined"/>`
 - DEFINED: checks the constant has been defined, to anything (either to delete, or to a value)
    - eg: `<if constant="const" constant-comparison="defined"/>`
 - DEFINED_DELETE: the constant has been defined as a delete
   - eg: `<if constant="const" constant-comparison="defined delete"/>`
 - DEFINED_VALUE: the constant has defined as an actual value (not a delete)
   - eg: `<if constant="const" constant-comparison="defined value"/>`
   - Note: **this is the default if `constant-value` attribute is not defined**
 - EQUALS: the constant equals to the attribute `constant-value`
   - eg: `<if constant="const" constant-value="5m" />`
   - Note: **this is the default if `constant-value` is defined**
 - CONTAINS: the constant is one of the the comma-separated list of values in `constant-value`
   - eg: `<if constant="const" constant-value="a,b,c" constant-comparison="contains"/>`
 - REGEX: checks if the constant matches the regex
   - eg: `<if constant="const" constant-value="[0-9]+" constant-comparison="regex"/>`
 - RANGE: check if the constant, interpreted as a number, is in the range
   - eg: `<if constant="const" constant-value="0..12" constant-comparison="range"/>`
   - checks if `const` is a number between 0 and 12
   - Note: if the constant is not numeric this will be an XML error.

# Last notes

I hope this is enough to understand all the possibilities here, good luck to the documenters.
