### PR TITLE
Fix dynamic pickup-filter NPE

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/FlagModule.java
+++ b/core/src/main/java/tc/oc/pgm/flag/FlagModule.java
@@ -14,6 +14,7 @@ import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.filters.FilterMatchModule;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.goals.GoalMatchModule;
@@ -35,6 +36,11 @@ public class FlagModule implements MapModule<FlagMatchModule> {
     this.posts = ImmutableList.copyOf(posts);
     this.nets = ImmutableList.copyOf(nets);
     this.flags = ImmutableList.copyOf(flags);
+  }
+
+  @Override
+  public Collection<Class<? extends MatchModule>> getWeakDependencies() {
+    return ImmutableList.of(FilterMatchModule.class);
   }
 
   @Override


### PR DESCRIPTION
Should fix the following NPE:
```
[20:54:27 WARN]: java.lang.NullPointerException: Cannot invoke "tc.oc.pgm.variables.Variable.getValue(tc.oc.pgm.filters.Filterable)" because "variable" is null
[20:54:27 WARN]:        at tc.oc.pgm.filters.matcher.match.VariableFilter.getValue(VariableFilter.java:55)
[20:54:27 WARN]:        at tc.oc.pgm.filters.matcher.match.VariableFilter.queryTyped(VariableFilter.java:51)
[20:54:27 WARN]:        at tc.oc.pgm.filters.matcher.match.VariableFilter$Generic.queryTyped(VariableFilter.java:75)
[20:54:27 WARN]:        at tc.oc.pgm.filters.matcher.WeakTypedFilter.query(WeakTypedFilter.java:21)
[20:54:27 WARN]:        at tc.oc.pgm.filters.operator.AllFilter.query(AllFilter.java:18)
[20:54:27 WARN]:        at tc.oc.pgm.filters.operator.AllFilter.query(AllFilter.java:18)
[20:54:27 WARN]:        at tc.oc.pgm.filters.operator.AllFilter.query(AllFilter.java:18)
[20:54:27 WARN]:        at tc.oc.pgm.flag.FlagDefinition.canPickup(FlagDefinition.java:192)
[20:54:27 WARN]:        at tc.oc.pgm.flag.Flag.<init>(Flag.java:123)
[20:54:27 WARN]:        at tc.oc.pgm.flag.FlagMatchModule.<init>(FlagMatchModule.java:42)
[20:54:27 WARN]:        at tc.oc.pgm.flag.FlagModule.createMatchModule(FlagModule.java:52)
[20:54:27 WARN]:        at tc.oc.pgm.flag.FlagModule.createMatchModule(FlagModule.java:25)
[20:54:27 WARN]:        at tc.oc.pgm.match.MatchImpl$ModuleLoader.createModule(MatchImpl.java:807)
```
