### PR TITLE
Add disguise check and fix nicked user bug

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/integration/Integration.java
+++ b/core/src/main/java/tc/oc/pgm/api/integration/Integration.java
@@ -79,6 +79,10 @@ public final class Integration {
     return VANISH.get().setVanished(player, vanish, quiet);
   }
 
+  public static boolean isDisguised(Player player) {
+    return isVanished(player) || getNick(player) != null;
+  }
+
   // No-op Implementations
 
   private static class NoopFriendIntegration implements FriendIntegration {


### PR DESCRIPTION
This PR introduces a new method to the `Integration` class that determines if a player is disguised (either vanished or nicked). Additionally, it addresses a minor bug where nicked users were not correctly hidden from the multiplayer server list ping.

I reviewed all instances where `Integration#isVanished` is used, and only the one fixed below needed to be changed. If you think there are other places where this check should be applied, please let me know 👍 Otherwise, this should be ready to go. 