### PR TITLE
Fix block data encoding in modern

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernEffects.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernEffects.java
@@ -5,12 +5,15 @@ import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
+import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import tc.oc.pgm.platform.modern.material.ModernBlockMaterialData;
 import tc.oc.pgm.util.bukkit.Effects;
+import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Supports;
 
 @Supports(value = PAPER, minVersion = "1.20.6")
@@ -68,5 +71,12 @@ public class ModernEffects implements Effects {
   @Override
   public void explosion(Player player, Location location) {
     player.spawnParticle(Particle.EXPLOSION, location, 1, 0d, 0d, 0d, 0, null, true);
+  }
+
+  @Override
+  public void blockBreak(Location location, BlockMaterialData material) {
+    location
+        .getWorld()
+        .playEffect(location, Effect.STEP_SOUND, ((ModernBlockMaterialData) material).getBlock());
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernBlockMaterialData.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernBlockMaterialData.java
@@ -11,6 +11,7 @@ import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
 public interface ModernBlockMaterialData extends BlockMaterialData {
+
   BlockData getBlock();
 
   @Override
@@ -30,7 +31,7 @@ public interface ModernBlockMaterialData extends BlockMaterialData {
 
   @Override
   default int encoded() {
-    return getItemType().ordinal();
+    return ModernEncodeUtil.encode(getBlock());
   }
 
   @Override

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernEncodeUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernEncodeUtil.java
@@ -1,0 +1,20 @@
+package tc.oc.pgm.platform.modern.material;
+
+import net.minecraft.world.level.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.craftbukkit.block.data.CraftBlockData;
+
+class ModernEncodeUtil {
+  private static final int ENCODED_NULL_MATERIAL = -1;
+
+  static int encode(BlockData blockData) {
+    return Block.BLOCK_STATE_REGISTRY.getId(((CraftBlockData) blockData).getState());
+  }
+
+  static ModernBlockData decode(int encoded) {
+    if (encoded == ENCODED_NULL_MATERIAL) return null;
+    var vanillaBlockstate = Block.BLOCK_STATE_REGISTRY.byId(encoded);
+    if (vanillaBlockstate == null) return null;
+    return new ModernBlockData(vanillaBlockstate.createCraftBlockData());
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
@@ -33,7 +33,6 @@ import tc.oc.pgm.util.xml.Node;
 @Supports(value = PAPER, minVersion = "1.20.6")
 @SuppressWarnings("deprecation")
 public class ModernMaterialUtils implements MaterialUtils {
-  private static final int ENCODED_NULL_MATERIAL = -1;
 
   @Override
   public BlockMaterialData createBlockData(Material material) {
@@ -83,8 +82,7 @@ public class ModernMaterialUtils implements MaterialUtils {
 
   @Override
   public BlockMaterialData decode(int encoded) {
-    if (encoded == ENCODED_NULL_MATERIAL) return null;
-    return new ModernBlockData(Material.values()[encoded].createBlockData());
+    return ModernEncodeUtil.decode(encoded);
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpEffects.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpEffects.java
@@ -10,6 +10,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.util.bukkit.Effects;
+import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Supports;
 
 @Supports(SPORTPAPER)
@@ -96,6 +97,11 @@ public class SpEffects implements Effects {
   @Override
   public void explosion(Player player, Location location) {
     player.spigot().playEffect(location, Effect.EXPLOSION_HUGE, 0, 0, 0f, 0f, 0f, 1f, 1, 256);
+  }
+
+  @Override
+  public void blockBreak(Location location, BlockMaterialData material) {
+    location.getWorld().playEffect(location, Effect.STEP_SOUND, material.encoded());
   }
 
   private float rgbToParticle(int rgb) {

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/BlockDataIterator.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/BlockDataIterator.java
@@ -100,7 +100,7 @@ class BlockDataIterator implements Iterator<BlockData>, BlockData, LegacyMateria
 
   @Override
   public int encoded() {
-    throw new UnsupportedOperationException();
+    return SpEncodeUtil.encode(materialId, data);
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpEncodeUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpEncodeUtil.java
@@ -1,0 +1,29 @@
+package tc.oc.pgm.platform.sportpaper.material;
+
+import org.bukkit.Material;
+
+@SuppressWarnings("deprecation")
+class SpEncodeUtil {
+  private static final int ENCODED_NULL_MATERIAL = -1;
+
+  static int encode(Material mat, int data) {
+    return encode(mat.getId(), data);
+  }
+
+  static int encode(int typeId, int data) {
+    return typeId + (data << 12);
+  }
+
+  static SpMaterialData decode(int encoded) {
+    if (encoded == ENCODED_NULL_MATERIAL) return null;
+    return new SpMaterialData(decodeMaterial(encoded), decodeData(encoded));
+  }
+
+  static Material decodeMaterial(int encoded) {
+    return Material.getMaterial(encoded & 0xfff);
+  }
+
+  static byte decodeData(int encoded) {
+    return (byte) (encoded >> 12);
+  }
+}

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialData.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialData.java
@@ -66,7 +66,7 @@ class SpMaterialData implements LegacyMaterialData, ItemMaterialData, BlockMater
 
   @Override
   public int encoded() {
-    return material.getId() + (((int) damage) << 12);
+    return SpEncodeUtil.encode(material, damage);
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
@@ -82,17 +82,7 @@ public class SpMaterialUtils implements MaterialUtils {
 
   @Override
   public BlockMaterialData decode(int encoded) {
-    if (encoded == ENCODED_NULL_MATERIAL) return null;
-    Material material = Material.getMaterial(decodeTypeId(encoded));
-    return new SpMaterialData(material, decodeMetadata(encoded));
-  }
-
-  static int decodeTypeId(int encoded) {
-    return encoded & 0xfff;
-  }
-
-  static byte decodeMetadata(int encoded) {
-    return (byte) (encoded >> 12);
+    return SpEncodeUtil.decode(encoded);
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/Effects.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/Effects.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.util.bukkit;
 
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -26,7 +25,5 @@ public interface Effects {
 
   void explosion(Player player, Location location);
 
-  default void blockBreak(Location location, BlockMaterialData material) {
-    location.getWorld().playEffect(location, Effect.STEP_SOUND, material.encoded());
-  }
+  void blockBreak(Location location, BlockMaterialData material);
 }

--- a/util/src/main/java/tc/oc/pgm/util/material/MaterialCounter.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/MaterialCounter.java
@@ -6,7 +6,7 @@ import it.unimi.dsi.fastutil.ints.IntIterator;
 import java.util.Iterator;
 import org.bukkit.block.BlockState;
 
-/** Efficiently counts distinct {@link MaterialData}s */
+/** Efficiently counts distinct {@link BlockMaterialData}s */
 public class MaterialCounter {
   private final Int2IntMap counts;
 
@@ -14,28 +14,16 @@ public class MaterialCounter {
     this.counts = new Int2IntOpenHashMap();
   }
 
-  public boolean contains(int encodedMaterial) {
-    return counts.containsKey(encodedMaterial);
-  }
-
   public boolean contains(BlockMaterialData material) {
-    return contains(material.encoded());
-  }
-
-  public int get(int encodedMaterial) {
-    return counts.get(encodedMaterial);
+    return counts.containsKey(material.encoded());
   }
 
   public int get(BlockMaterialData material) {
-    return get(material.encoded());
+    return counts.get(material.encoded());
   }
 
-  public int increment(int encodedMaterial, int count) {
-    return counts.merge(encodedMaterial, count, (key, v) -> v + count);
-  }
-
-  public int increment(BlockState block, int count) {
-    return increment(MaterialData.block(block).encoded(), count);
+  public void increment(BlockState block, int count) {
+    counts.merge(MaterialData.block(block).encoded(), count, (key, v) -> v + count);
   }
 
   public void clear() {


### PR DESCRIPTION
Simplifies the MaterialCounter and makes modern use relevant ids for the blockstates from the vanilla blockstate registry, instead of a hacky workaround of using just the material id as a stopgap.