### PR TITLE
Make map search prefer name over slug

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.api.map;
 
-import com.google.common.collect.Range;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Map;
@@ -9,25 +8,13 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.Version;
 import tc.oc.pgm.util.named.MapNameStyle;
-import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.text.TextTranslations;
 
-/** Essential information about a map. */
-public interface MapInfo extends Comparable<MapInfo>, Cloneable {
+/** Basic information about a map. The most bare-bones part is in {@link VariantInfo} */
+public interface MapInfo extends VariantInfo.Forwarding, Comparable<MapInfo>, Cloneable {
 
-  /**
-   * Get a unique id for the map.
-   *
-   * @return A unique id.
-   */
-  String getId();
-
-  /**
-   * The map variant this info represents
-   *
-   * @return A variant for the map, if any.
-   */
-  String getVariantId();
+  /** @return The map variant info for this map */
+  VariantInfo getVariant();
 
   /**
    * Get all the variants available for the map
@@ -35,22 +22,6 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
    * @return a map of variants by their variant id
    */
   Map<String, VariantInfo> getVariants();
-
-  /**
-   * Get what servers versions should load this map, servers outside the range should ignore the
-   * map.
-   *
-   * @return range of the server versions that can load this map
-   */
-  Range<Version> getServerVersion();
-
-  default boolean isServerSupported() {
-    return getServerVersion().contains(Platform.MINECRAFT_VERSION);
-  }
-
-  /** @return the subfolder in which the world is in, or null for the parent folder */
-  @Nullable
-  String getWorldFolder();
 
   /**
    * Get the proto of the map's {@link org.jdom2.Document}.
@@ -66,13 +37,6 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
    * @return The version.
    */
   Version getVersion();
-
-  /**
-   * Get a unique, human-readable name for the map.
-   *
-   * @return A name, alphanumeric with spaces allowed.
-   */
-  String getName();
 
   /**
    * Get the maps' name, but normalized to standard english characters and lower case.
@@ -207,21 +171,5 @@ public interface MapInfo extends Comparable<MapInfo>, Cloneable {
   @Override
   default int compareTo(MapInfo o) {
     return getId().compareTo(o.getId());
-  }
-
-  interface VariantInfo {
-    String getVariantId();
-
-    String getMapId();
-
-    String getMapName();
-
-    String getWorld();
-
-    Range<Version> getServerVersions();
-
-    default boolean isServerSupported() {
-      return getServerVersions().contains(Platform.MINECRAFT_VERSION);
-    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/MapLibrary.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapLibrary.java
@@ -10,13 +10,22 @@ import tc.oc.pgm.api.map.includes.MapIncludeProcessor;
 public interface MapLibrary {
 
   /**
-   * Get the {@link MapInfo} given its id or name.
+   * Get the {@link MapInfo} given its name, or id.
    *
-   * @param idOrName The id or an approximate name of a map.
+   * @param nameOrId The id or an approximate name of a map.
    * @return The best matching {@link MapInfo} or {@code null} if not found.
    */
   @Nullable
-  MapInfo getMap(String idOrName);
+  MapInfo getMap(String nameOrId);
+
+  /**
+   * Get the {@link MapInfo} given its id.
+   *
+   * @param id The id of the map
+   * @return The {@link MapInfo} with that id, or null.
+   */
+  @Nullable
+  MapInfo getMapById(String id);
 
   /**
    * Get all {@link MapInfo}s matching the query.

--- a/core/src/main/java/tc/oc/pgm/api/map/VariantInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/VariantInfo.java
@@ -1,0 +1,90 @@
+package tc.oc.pgm.api.map;
+
+import com.google.common.collect.Range;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.Version;
+import tc.oc.pgm.util.platform.Platform;
+
+/**
+ * Most bare-bones part of a map definition, which is defined as part of its variant. All other data
+ * besides this, resides in {@link MapInfo}
+ */
+public interface VariantInfo {
+  /**
+   * The map variant id this info represents
+   *
+   * @return A variant id for the map, if any.
+   */
+  String getVariantId();
+
+  /**
+   * Get a unique id for the map.
+   *
+   * @return A unique id.
+   */
+  String getId();
+
+  /**
+   * Get a unique, human-readable name for the map.
+   *
+   * @return A name, alphanumeric with spaces allowed.
+   */
+  String getName();
+
+  /**
+   * If the map id has been customized to be something other than the normalized name.
+   *
+   * @return if the map id isn't just the normalized map name
+   */
+  boolean hasCustomId();
+
+  /** @return custom world folder for this variant, if any */
+  @Nullable
+  String getWorldFolder();
+
+  Range<Version> getServerVersions();
+
+  default boolean isServerSupported() {
+    return getServerVersions().contains(Platform.MINECRAFT_VERSION);
+  }
+
+  interface Forwarding extends VariantInfo {
+    VariantInfo getVariant();
+
+    @Override
+    default String getVariantId() {
+      return getVariant().getVariantId();
+    }
+
+    @Override
+    default String getId() {
+      return getVariant().getId();
+    }
+
+    @Override
+    default String getName() {
+      return getVariant().getName();
+    }
+
+    @Override
+    default boolean hasCustomId() {
+      return getVariant().hasCustomId();
+    }
+
+    @Override
+    @Nullable
+    default String getWorldFolder() {
+      return getVariant().getWorldFolder();
+    }
+
+    @Override
+    default Range<Version> getServerVersions() {
+      return getVariant().getServerVersions();
+    }
+
+    @Override
+    default boolean isServerSupported() {
+      return getVariant().isServerSupported();
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -409,7 +409,7 @@ public final class MapCommand {
           .append(text(" ["))
           .append(translatable("map.info.xml.edit"))
           .append(text("]"))
-          .clickEvent(runCommand("/showxml " + map.getId()))
+          .clickEvent(runCommand("/showxml " + map.getName()))
           .hoverEvent(showText(translatable("map.info.xml.edit.tip", NamedTextColor.AQUA))));
     }
     return xmlText;

--- a/core/src/main/java/tc/oc/pgm/command/MapCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapCommand.java
@@ -45,6 +45,7 @@ import tc.oc.pgm.api.map.MapLibrary;
 import tc.oc.pgm.api.map.MapSource;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.Phase;
+import tc.oc.pgm.api.map.VariantInfo;
 import tc.oc.pgm.map.source.MapRoot;
 import tc.oc.pgm.rotation.MapPoolManager;
 import tc.oc.pgm.rotation.pools.MapPool;
@@ -352,7 +353,7 @@ public final class MapCommand {
     TextComponent.Builder text =
         text().append(mapInfoLabel("map.info.variants")).color(NamedTextColor.GOLD);
 
-    for (MapInfo.VariantInfo variant : map.getVariants().values()) {
+    for (VariantInfo variant : map.getVariants().values()) {
       TextComponent variantComp;
       if (map.getVariantId().equals(variant.getVariantId())) {
         variantComp = text(variant.getVariantId(), null, TextDecoration.UNDERLINED)
@@ -362,14 +363,14 @@ public final class MapCommand {
             .hoverEvent(showText(translatable(
                 "command.maps.hover",
                 NamedTextColor.GRAY,
-                text(variant.getMapName(), NamedTextColor.GOLD))))
-            .clickEvent(runCommand("/map " + variant.getMapName()));
+                text(variant.getName(), NamedTextColor.GOLD))))
+            .clickEvent(runCommand("/map " + variant.getName()));
       } else {
         variantComp = text(variant.getVariantId(), NamedTextColor.RED)
             .hoverEvent(showText(translatable(
                 "command.maps.unsupported",
                 NamedTextColor.GRAY,
-                text(variant.getMapName(), NamedTextColor.GOLD))));
+                text(variant.getName(), NamedTextColor.GOLD))));
       }
       text.append(variantComp).append(text(" "));
     }

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -12,10 +12,10 @@ import org.jdom2.input.JDOMParseException;
 import tc.oc.pgm.api.Modules;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapContext;
-import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.MapSource;
+import tc.oc.pgm.api.map.VariantInfo;
 import tc.oc.pgm.api.map.exception.MapException;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
@@ -43,7 +43,7 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
 
   private final Logger logger;
   private final MapSource source;
-  private final Map<String, MapInfo.VariantInfo> variants;
+  private final Map<String, VariantInfo> variants;
   private final MapIncludeProcessor includes;
   private Document document;
   private MapInfoImpl info;
@@ -55,7 +55,7 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
   public MapFactoryImpl(
       Logger logger,
       MapSource source,
-      Map<String, MapInfo.VariantInfo> variants,
+      Map<String, VariantInfo> variants,
       MapIncludeProcessor includes) {
     super(Modules.MAP, Modules.MAP_DEPENDENCY_ONLY); // Don't copy, avoid N factory copies
     this.logger =

--- a/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapLibraryImpl.java
@@ -53,7 +53,7 @@ public class MapLibraryImpl implements MapLibrary {
   @Override
   public MapInfo getMap(String idOrName) {
     // Exact match
-    MapInfo bySlug = maps.get(StringUtils.slugify(idOrName));
+    MapInfo bySlug = getMapById(StringUtils.slugify(idOrName));
     if (bySlug != null && !bySlug.hasCustomId()) return bySlug;
 
     // Fuzzy match
@@ -61,6 +61,11 @@ public class MapLibraryImpl implements MapLibrary {
         StringUtils.normalize(idOrName), maps.values(), MapInfo::getNormalizedName);
 
     return byName != null ? byName : bySlug;
+  }
+
+  @Override
+  public @Nullable MapInfo getMapById(String id) {
+    return maps.get(id);
   }
 
   @Override
@@ -169,7 +174,7 @@ public class MapLibraryImpl implements MapLibrary {
   @Override
   public CompletableFuture<MapContext> loadExistingMap(String id) {
     return CompletableFuture.supplyAsync(() -> {
-      final MapInfo info = maps.get(id);
+      final MapInfo info = getMapById(id);
       if (info == null) {
         throw new RuntimeException(
             new MapMissingException(id, "Unable to find map from id (was it deleted?)"));

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/MapPool.java
@@ -95,7 +95,7 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
     for (String varId : variantIds) {
       VariantInfo variant = variants.get(varId);
       if (variant == null) continue;
-      MapInfo variantMap = maps.getMap(variant.getId());
+      MapInfo variantMap = maps.getMapById(variant.getId());
       if (variantMap != null) {
         return variantMap;
       } else {
@@ -154,7 +154,6 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
    * @param match The match that is currently ending
    */
   public void unloadPool(Match match) {}
-  ;
 
   @Override
   public int compareTo(MapPool o) {

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/MapPool.java
@@ -13,6 +13,7 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapLibrary;
 import tc.oc.pgm.api.map.MapOrder;
+import tc.oc.pgm.api.map.VariantInfo;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.rotation.MapPoolManager;
 
@@ -90,17 +91,17 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
   private static MapInfo getVariant(MapLibrary maps, MapInfo map, List<String> variantIds) {
     if (variantIds == null || !map.getVariantId().equals(DEFAULT_VARIANT)) return map;
 
-    Map<String, ? extends MapInfo.VariantInfo> variants = map.getVariants();
+    Map<String, ? extends VariantInfo> variants = map.getVariants();
     for (String varId : variantIds) {
-      MapInfo.VariantInfo variant = variants.get(varId);
+      VariantInfo variant = variants.get(varId);
       if (variant == null) continue;
-      MapInfo variantMap = maps.getMap(variant.getMapId());
+      MapInfo variantMap = maps.getMap(variant.getId());
       if (variantMap != null) {
         return variantMap;
       } else {
         PGM.get()
             .getLogger()
-            .warning("[MapPool] Failed to get map " + variant.getMapId() + ". Moving on...");
+            .warning("[MapPool] Failed to get map " + variant.getId() + ". Moving on...");
       }
     }
     return map;
@@ -152,7 +153,8 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
    *
    * @param match The match that is currently ending
    */
-  public void unloadPool(Match match) {};
+  public void unloadPool(Match match) {}
+  ;
 
   @Override
   public int compareTo(MapPool o) {

--- a/util/src/main/java/tc/oc/pgm/util/LiquidMetal.java
+++ b/util/src/main/java/tc/oc/pgm/util/LiquidMetal.java
@@ -44,7 +44,7 @@ public final class LiquidMetal {
    * @return the last index in {@param string} matches, or -1 if there's no match
    */
   public static int getIndexOf(String string, String abbreviation) {
-    if (abbreviation == null || abbreviation.length() == 0) return 0;
+    if (abbreviation == null || abbreviation.isEmpty()) return 0;
     if (abbreviation.length() > string.length()) return -1;
     Score score = new Score();
     int result = matchString(score, string, abbreviation);
@@ -59,7 +59,7 @@ public final class LiquidMetal {
    * @return a number between 0.0 and 1.0, 0 being no match and 1 being perfect match.
    */
   public static double score(String string, String abbreviation) {
-    if (abbreviation == null || abbreviation.length() == 0) return SCORE_TRAILING;
+    if (abbreviation == null || abbreviation.isEmpty()) return SCORE_TRAILING;
     if (abbreviation.length() > string.length()) return SCORE_NO_MATCH;
     Score score = new Score();
     int result = matchString(score, string, abbreviation);


### PR DESCRIPTION
Fixes #1377 

Modifies map search to prefer matching a name, and only if multiple (or no) matches by name, it falls back to slug. Note that for maps where slug is just the normalized name, it will still stick to the result of the search by slug since it's a faster match.