### PR TITLE
Fix constant attr inheritance & defined_value conditional default

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/ConditionalChecker.java
+++ b/core/src/main/java/tc/oc/pgm/map/ConditionalChecker.java
@@ -74,7 +74,7 @@ class ConditionalChecker {
     var cmp = XMLUtils.parseEnum(
         Node.fromAttr(el, "constant-comparison"),
         Cmp.class,
-        value == null ? Cmp.DEFINED : Cmp.EQUALS);
+        value == null ? Cmp.DEFINED_VALUE : Cmp.EQUALS);
 
     var constants = ctx.getConstants();
     var isDefined = constants.containsKey(id);

--- a/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
@@ -25,6 +25,7 @@ import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
 import tc.oc.pgm.api.map.includes.MapIncludeProcessor;
 import tc.oc.pgm.util.xml.DocumentWrapper;
+import tc.oc.pgm.util.xml.InheritingElement;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.SAXHandler;
 import tc.oc.pgm.util.xml.XMLUtils;
@@ -141,6 +142,7 @@ public class MapFilePreprocessor {
   }
 
   private List<Content> processConstant(Element el) throws InvalidXMLException {
+    el = new InheritingElement(el);
     boolean isDelete = XMLUtils.parseBoolean(el.getAttribute("delete"), false);
     String text = el.getTextNormalize();
     if ((text == null || text.isEmpty()) != isDelete)


### PR DESCRIPTION
Fixes the fallback attribute not being respected if defined like:
```xml
<constants fallback="true">
  <constant id="a">b</constant>
</constants>
```

Additionally the default constant-comparison will be `defined value` instead of `defined`, as it seems like the more reasonable default as you probably don't want to include a block if it's deleted. This could  be considered a breaking change but it's been in dev for literally a day, so i think it will be fine