### PR TITLE
Fix tasks leaking after match end

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
@@ -53,7 +53,7 @@ public class MatchAnnouncer implements Listener {
     final Match match = event.getMatch();
     match
         .getExecutor(MatchScope.LOADED)
-        .scheduleWithFixedDelay(() -> sendCurrentlyPlaying(match), 0, 1, TimeUnit.MINUTES);
+        .scheduleWithFixedDelay(() -> sendCurrentlyPlaying(match), 0, 5, TimeUnit.MINUTES);
   }
 
   @EventHandler(priority = EventPriority.MONITOR)

--- a/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
@@ -34,7 +34,9 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.PlayerJoinMatchEvent;
 import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.LegacyFormatUtils;
+import tc.oc.pgm.util.concurrent.TaskExecutorService;
 import tc.oc.pgm.util.named.MapNameStyle;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextFormatter;
@@ -53,8 +55,7 @@ public class MatchAnnouncer implements Listener {
     final Match match = event.getMatch();
     match
         .getExecutor(MatchScope.LOADED)
-        .scheduleWithFixedDelay(
-            () -> match.getPlayers().forEach(this::sendCurrentlyPlaying), 0, 5, TimeUnit.MINUTES);
+        .scheduleWithFixedDelay(() -> sendCurrentlyPlaying(match), 0, 1, TimeUnit.MINUTES);
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
@@ -173,11 +174,11 @@ public class MatchAnnouncer implements Listener {
     viewer.sendMessage(TextFormatter.horizontalLine(NamedTextColor.WHITE, 200));
   }
 
-  private void sendCurrentlyPlaying(MatchPlayer viewer) {
-    viewer.sendMessage(
+  private void sendCurrentlyPlaying(Match match) {
+    match.sendMessage(
         translatable(
             "misc.playing",
             NamedTextColor.DARK_PURPLE,
-            viewer.getMatch().getMap().getStyledName(MapNameStyle.COLOR_WITH_AUTHORS)));
+            match.getMap().getStyledName(MapNameStyle.COLOR_WITH_AUTHORS)));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
@@ -34,9 +34,7 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.PlayerJoinMatchEvent;
 import tc.oc.pgm.teams.Team;
-import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.LegacyFormatUtils;
-import tc.oc.pgm.util.concurrent.TaskExecutorService;
 import tc.oc.pgm.util.named.MapNameStyle;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextFormatter;
@@ -84,12 +82,11 @@ public class MatchAnnouncer implements Listener {
         title = translatable("broadcast.gameOver");
       } else {
         if (singleWinner) {
-          title =
-              translatable(
-                  Iterables.getOnlyElement(winners).isNamePlural()
-                      ? "broadcast.gameOver.teamWinners"
-                      : "broadcast.gameOver.teamWinner",
-                  TextFormatter.nameList(winners, NameStyle.FANCY, NamedTextColor.WHITE));
+          title = translatable(
+              Iterables.getOnlyElement(winners).isNamePlural()
+                  ? "broadcast.gameOver.teamWinners"
+                  : "broadcast.gameOver.teamWinner",
+              TextFormatter.nameList(winners, NameStyle.FANCY, NamedTextColor.WHITE));
         }
 
         // Use stream here instead of #contains to avoid unchecked cast
@@ -157,13 +154,11 @@ public class MatchAnnouncer implements Listener {
 
     Collection<Contributor> authors = mapInfo.getAuthors();
     if (!authors.isEmpty()) {
-      viewer.sendMessage(
-          space()
-              .append(
-                  translatable(
-                      "misc.createdBy",
-                      NamedTextColor.GRAY,
-                      TextFormatter.nameList(authors, NameStyle.FANCY, NamedTextColor.GRAY))));
+      viewer.sendMessage(space()
+          .append(translatable(
+              "misc.createdBy",
+              NamedTextColor.GRAY,
+              TextFormatter.nameList(authors, NameStyle.FANCY, NamedTextColor.GRAY))));
     }
 
     // Send extra info from other plugins
@@ -175,10 +170,9 @@ public class MatchAnnouncer implements Listener {
   }
 
   private void sendCurrentlyPlaying(Match match) {
-    match.sendMessage(
-        translatable(
-            "misc.playing",
-            NamedTextColor.DARK_PURPLE,
-            match.getMap().getStyledName(MapNameStyle.COLOR_WITH_AUTHORS)));
+    match.sendMessage(translatable(
+        "misc.playing",
+        NamedTextColor.DARK_PURPLE,
+        match.getMap().getStyledName(MapNameStyle.COLOR_WITH_AUTHORS)));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/loot/LootableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/loot/LootableMatchModule.java
@@ -57,18 +57,16 @@ public class LootableMatchModule implements MatchModule, Listener {
     this.fillers = fillers;
     this.match = match;
     this.caches = caches;
-    this.filledAt = new InstantMap<>(new WorldTickClock(match.getWorld()));
+    this.filledAt = new InstantMap<>(match.getClock());
     this.immm = match.getModule(ItemModifyMatchModule.class);
 
     final FilterMatchModule fmm = match.needModule(FilterMatchModule.class);
 
-    fillers.forEach(
-        filler -> {
-          fmm.onRise(
-              Match.class,
-              filler.getRefillTrigger(),
-              m -> this.filledAt.keySet().removeIf(f -> filler.equals(f.getRight())));
-        });
+    fillers.forEach(filler -> {
+      fmm.onRise(Match.class, filler.getRefillTrigger(), m -> this.filledAt
+          .keySet()
+          .removeIf(f -> filler.equals(f.getRight())));
+    });
   }
 
   /**
@@ -78,9 +76,10 @@ public class LootableMatchModule implements MatchModule, Listener {
   private static @Nullable Predicate<Filter> filterPredicate(InventoryHolder holder) {
     if (holder instanceof DoubleChest) {
       final DoubleChest doubleChest = (DoubleChest) holder;
-      return filter ->
-          !filter.query(new BlockQuery((Chest) doubleChest.getLeftSide())).isDenied()
-              || !filter.query(new BlockQuery((Chest) doubleChest.getRightSide())).isDenied();
+      return filter -> !filter
+              .query(new BlockQuery((Chest) doubleChest.getLeftSide()))
+              .isDenied()
+          || !filter.query(new BlockQuery((Chest) doubleChest.getRightSide())).isDenied();
     } else if (holder instanceof BlockState) {
       return filter -> !filter.query(new BlockQuery((BlockState) holder)).isDenied();
     } else if (holder instanceof Player) {
@@ -104,25 +103,17 @@ public class LootableMatchModule implements MatchModule, Listener {
     final Predicate<Filter> filterPredicate = filterPredicate(inventory.getHolder());
     if (filterPredicate == null) return;
 
-    logger.fine(
-        () ->
-            opener.getNameLegacy()
-                + " opened a "
-                + inventory.getHolder().getClass().getSimpleName());
+    logger.fine(() ->
+        opener.getNameLegacy() + " opened a " + inventory.getHolder().getClass().getSimpleName());
 
     // Find all Fillers that apply to the holder of the opened inventory
-    final List<FillerDefinition> fillers =
-        this.fillers.stream()
-            .filter(filler -> filterPredicate.test(filler.getFilter()))
-            .collect(Collectors.toList());
+    final List<FillerDefinition> fillers = this.fillers.stream()
+        .filter(filler -> filterPredicate.test(filler.getFilter()))
+        .collect(Collectors.toList());
     if (fillers.isEmpty()) return;
 
-    logger.fine(
-        () ->
-            "Found fillers "
-                + fillers.stream()
-                    .map(FillerDefinition::toString)
-                    .collect(Collectors.joining(", ")));
+    logger.fine(() -> "Found fillers "
+        + fillers.stream().map(FillerDefinition::toString).collect(Collectors.joining(", ")));
 
     // Find all Caches that the opened inventory is part of
     final List<Fillable> fillables = new ArrayList<>();
@@ -145,67 +136,54 @@ public class LootableMatchModule implements MatchModule, Listener {
 
     void fill(MatchPlayer opener, List<FillerDefinition> fillers) {
       // Build a short list of Fillers that are NOT cooling down from a previous fill
-      final List<FillerDefinition> coolFillers =
-          fillers.stream()
-              .filter(
-                  filler ->
-                      filledAt.putUnlessNewer(new Pair<>(this, filler), filler.getRefillInterval())
-                          == null)
-              .collect(Collectors.toList());
+      final List<FillerDefinition> coolFillers = fillers.stream()
+          .filter(filler ->
+              filledAt.putUnlessNewer(new Pair<>(this, filler), filler.getRefillInterval()) == null)
+          .collect(Collectors.toList());
 
       // Find all the Inventories for this Fillable, and build a map of Fillers to the subset
       // of Inventories that they are allowed to fill, based on the filter of each Filler.
       // Note how duplicate inventories are skipped.
       final SetMultimap<FillerDefinition, Inventory> fillerInventories = HashMultimap.create();
-      inventories()
-          .distinct()
-          .forEach(
-              inventory -> {
-                final Predicate<Filter> passes = filterPredicate(inventory.getHolder());
-                if (passes == null) return;
-                for (FillerDefinition filler : coolFillers) {
-                  if (passes.test(filler.getFilter())) {
-                    fillerInventories.put(filler, inventory);
-                  }
-                }
-              });
+      inventories().distinct().forEach(inventory -> {
+        final Predicate<Filter> passes = filterPredicate(inventory.getHolder());
+        if (passes == null) return;
+        for (FillerDefinition filler : coolFillers) {
+          if (passes.test(filler.getFilter())) {
+            fillerInventories.put(filler, inventory);
+          }
+        }
+      });
 
-      fillerInventories
-          .asMap()
-          .forEach(
-              (filler, inventories) -> {
-                if (filler.cleanBeforeRefill()) {
-                  inventories().forEach(Inventory::clear);
-                }
-              });
+      fillerInventories.asMap().forEach((filler, inventories) -> {
+        if (filler.cleanBeforeRefill()) {
+          inventories().forEach(Inventory::clear);
+        }
+      });
 
       final Random random = new Random();
 
-      fillerInventories
-          .asMap()
-          .forEach(
-              (filler, inventories) -> {
-                // For each Filler, build a mutable list of slots that it can fill.
-                // (27 is the standard size for single chests)
-                final List<InventorySlot> slots = new ArrayList<>(inventories.size() * 27);
-                for (Inventory inv : inventories) {
-                  for (int index = 0; index < inv.getSize(); index++) {
-                    if (inv.getItem(index) == null) {
-                      slots.add(new InventorySlot(index, inv));
-                    }
-                  }
-                }
+      fillerInventories.asMap().forEach((filler, inventories) -> {
+        // For each Filler, build a mutable list of slots that it can fill.
+        // (27 is the standard size for single chests)
+        final List<InventorySlot> slots = new ArrayList<>(inventories.size() * 27);
+        for (Inventory inv : inventories) {
+          for (int index = 0; index < inv.getSize(); index++) {
+            if (inv.getItem(index) == null) {
+              slots.add(new InventorySlot(index, inv));
+            }
+          }
+        }
 
-                filler
-                    .getLoot()
-                    .elements(opener)
-                    .limit(slots.size())
-                    .peek(
-                        i -> {
-                          if (immm != null) immm.applyRules(i);
-                        })
-                    .forEachOrdered(i -> slots.remove(random.nextInt(slots.size())).putItem(i));
-              });
+        filler
+            .getLoot()
+            .elements(opener)
+            .limit(slots.size())
+            .peek(i -> {
+              if (immm != null) immm.applyRules(i);
+            })
+            .forEachOrdered(i -> slots.remove(random.nextInt(slots.size())).putItem(i));
+      });
     }
   }
 
@@ -256,13 +234,11 @@ public class LootableMatchModule implements MatchModule, Listener {
           .region()
           .getChunkPositions()
           .map(cp -> cp.getChunk(match.getWorld()))
-          .<InventoryQuery>flatMap(
-              ch ->
-                  Stream.concat(
-                      Stream.of(ch.getTileEntities()).map(BlockQuery::new),
-                      Stream.of(ch.getEntities())
-                          .filter(e -> !(e instanceof Player))
-                          .map(EntityQuery::new)))
+          .<InventoryQuery>flatMap(ch -> Stream.concat(
+              Stream.of(ch.getTileEntities()).map(BlockQuery::new),
+              Stream.of(ch.getEntities())
+                  .filter(e -> !(e instanceof Player))
+                  .map(EntityQuery::new)))
           .filter(q -> cache.jointFilter().query(q).isAllowed())
           .map(InventoryQuery::getInventory)
           .filter(Objects::nonNull);

--- a/core/src/main/java/tc/oc/pgm/loot/WorldTickClock.java
+++ b/core/src/main/java/tc/oc/pgm/loot/WorldTickClock.java
@@ -5,7 +5,7 @@ import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import org.bukkit.World;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.time.Tick;
 import tc.oc.pgm.util.collection.InstantMap;
 
@@ -18,11 +18,11 @@ import tc.oc.pgm.util.collection.InstantMap;
  */
 public class WorldTickClock extends Clock {
 
-  private final World world;
+  private final Match match;
   private Tick tick;
 
-  public WorldTickClock(World world) {
-    this.world = world;
+  public WorldTickClock(Match match) {
+    this.match = match;
   }
 
   @Override
@@ -45,7 +45,7 @@ public class WorldTickClock extends Clock {
   }
 
   private Tick now() {
-    long tick = NMS_HACKS.getMonotonicTime(this.world);
+    long tick = NMS_HACKS.getMonotonicTime(match.getWorld());
     if (this.tick == null || tick != this.tick.tick) {
       this.tick = new Tick(tick, Instant.now());
     }

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -124,7 +124,7 @@ public class MatchImpl implements Match {
     this.world = new WeakReference<>(assertNotNull(world));
     this.matchModules = new ConcurrentHashMap<>();
 
-    this.clock = new WorldTickClock(world);
+    this.clock = new WorldTickClock(this);
     this.logger = ClassLogger.get(PGM.get().getLogger(), getClass());
     this.random = new Random();
     this.tickRandoms = new HashMap<>();

--- a/util/src/main/java/tc/oc/pgm/util/concurrent/TaskExecutorService.java
+++ b/util/src/main/java/tc/oc/pgm/util/concurrent/TaskExecutorService.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.util.concurrent;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -18,7 +17,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.TimeUtils;
 

--- a/util/src/main/java/tc/oc/pgm/util/concurrent/TaskExecutorService.java
+++ b/util/src/main/java/tc/oc/pgm/util/concurrent/TaskExecutorService.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.util.concurrent;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -17,6 +18,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.TimeUtils;
 
 /** An executor service that is backed by a runnable executor. */
@@ -64,7 +67,7 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
     if (!isShutdown()) shutdown();
     List<Runnable> pending = ImmutableList.copyOf(tasks);
 
-    for (Task<?> task : tasks) {
+    for (var task : tasks) {
       task.cancel(true);
     }
 
@@ -234,49 +237,35 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
 
     @Override
     public boolean complete(V value) {
-      return complete(value, null);
+      return !periodic && cleanup(super.complete(value));
     }
 
     @Override
     public boolean completeExceptionally(Throwable ex) {
-      return complete(null, ex);
+      return cleanup(super.completeExceptionally(ex));
     }
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-      if (super.cancel(mayInterruptIfRunning)) {
-        tasks.remove(this);
-        if (terminated != null) {
-          terminated.countDown();
-        }
-        cancelTask(taskId);
-        return true;
-      }
-
-      return false;
+      return cleanup(super.cancel(mayInterruptIfRunning));
     }
 
     @Override
-    public long getDelay(TimeUnit unit) {
+    public long getDelay(@NotNull TimeUnit unit) {
       return 0;
     }
 
     @Override
-    public int compareTo(Delayed o) {
-      if (!(o instanceof Task)) return 0;
-      return isDone() ? 1 : 0;
+    public int compareTo(@NotNull Delayed other) {
+      if (!(other instanceof Task<?> ot)) return -1;
+      return Integer.compare(taskId, ot.taskId);
     }
 
-    private boolean complete(V value, Throwable ex) {
-      boolean done = false;
-
-      if (!periodic && value != null) {
-        done = super.complete(value);
-      } else if (ex != null) {
-        done = super.completeExceptionally(ex);
-      }
-
-      return !done || cancel(true);
+    private boolean cleanup(boolean triggered) {
+      if (terminated != null) terminated.countDown();
+      cancelTask(taskId);
+      tasks.remove(this);
+      return triggered;
     }
   }
 }


### PR DESCRIPTION
This fixes a pretty critical bug, at the moment the pgm task executor is storing tasks in a skiplist set, that is sorted by natural order of compareTo, however that compareTo of tasks is always 1 or 0 for done/not done, resulting in all tasks but 1 being disregarded as "already in the set".

What this means is at match end (cycling to next match) when it's time to cleanup, it can only cleanup one task, all others are left at mercy of being cleared whenever they next try to run (at which point they see the executor has shutdown and they clean themselves up).

This is in particular bad for one task: the scoreboard rendering one. Because it is intentionally timed out forever so it doesn't render after match end, it leaves a forever lingering task that executes in Integer.MAX_VALUE amount of time, so it is never cleaned, holding a permanent reference to the match object.