### PR TITLE
Avoid string serialization on tab rendering

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernTabPackets.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernTabPackets.java
@@ -12,8 +12,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
-import net.minecraft.core.HolderLookup;
+import net.kyori.adventure.platform.bukkit.MinecraftComponentSerializer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundBundlePacket;
@@ -133,7 +132,7 @@ public class ModernTabPackets implements TabPackets {
         String name,
         int ping,
         @Nullable Skin skin,
-        @Nullable String renderedDisplayName) {
+        @Nullable net.kyori.adventure.text.Component displayName) {
       packet.profileIds().add(uuid);
     }
 
@@ -143,8 +142,11 @@ public class ModernTabPackets implements TabPackets {
     }
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   static class ModernPlayerInfo extends ModernPacket<ClientboundPlayerInfoUpdatePacket>
       implements PlayerInfo {
+    private static final MinecraftComponentSerializer SERIALIZER =
+        MinecraftComponentSerializer.get();
 
     public ModernPlayerInfo(EnumPlayerInfoAction action) {
       super(new ClientboundPlayerInfoUpdatePacket(toNmsAction(action), new ArrayList<Entry>()));
@@ -152,14 +154,16 @@ public class ModernTabPackets implements TabPackets {
 
     @Override
     public void addPlayerInfo(
-        UUID uuid, String name, int ping, @Nullable Skin skin, @Nullable String jsonName) {
+        UUID uuid,
+        String name,
+        int ping,
+        @Nullable Skin skin,
+        @Nullable net.kyori.adventure.text.Component displayName) {
 
       GameProfile profile = new GameProfile(uuid, name);
       if (skin != null) Skins.toProfile(profile, skin);
 
-      Component nmsComponent = jsonName == null
-          ? null
-          : Component.Serializer.fromJson(jsonName, HolderLookup.Provider.create(Stream.of()));
+      var nmsComponent = displayName == null ? null : (Component) SERIALIZER.serialize(displayName);
 
       packet
           .entries()

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/packets/SpTabPackets.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/packets/SpTabPackets.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import net.kyori.adventure.platform.bukkit.MinecraftComponentSerializer;
+import net.kyori.adventure.text.Component;
 import net.minecraft.server.v1_8_R3.DataWatcher;
 import net.minecraft.server.v1_8_R3.EntityPlayer;
 import net.minecraft.server.v1_8_R3.IChatBaseComponent;
@@ -116,27 +118,26 @@ public class SpTabPackets implements TabPackets, PacketSender {
     return copy;
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   class SpPlayerInfo extends SpPacket<PacketPlayOutPlayerInfo> implements PlayerInfo {
+    private static final MinecraftComponentSerializer SERIALIZER =
+        MinecraftComponentSerializer.get();
+
     public SpPlayerInfo(PacketPlayOutPlayerInfo packet) {
       super(packet);
     }
 
     @Override
     public void addPlayerInfo(
-        UUID uuid,
-        String name,
-        int ping,
-        @Nullable Skin skin,
-        @Nullable String renderedDisplayName) {
+        UUID uuid, String name, int ping, @Nullable Skin skin, @Nullable Component displayName) {
       GameProfile profile = new GameProfile(uuid, name);
       if (skin != null) Skins.toProfile(profile, skin);
 
-      IChatBaseComponent iChatBaseComponent = renderedDisplayName == null
-          ? null
-          : IChatBaseComponent.ChatSerializer.a(renderedDisplayName);
+      var nmsComponent =
+          displayName == null ? null : (IChatBaseComponent) SERIALIZER.serialize(displayName);
 
       packet.b.add(packet
-      .new PlayerInfoData(profile, ping, WorldSettings.EnumGamemode.SURVIVAL, iChatBaseComponent));
+      .new PlayerInfoData(profile, ping, WorldSettings.EnumGamemode.SURVIVAL, nmsComponent));
     }
 
     @Override

--- a/util/src/main/java/tc/oc/pgm/util/nms/packets/TabPackets.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/packets/TabPackets.java
@@ -5,6 +5,7 @@ import static tc.oc.pgm.util.nms.packets.TabPackets.TeamPacketOperation.*;
 import com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.UUID;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.NameTagVisibility;
@@ -99,16 +100,12 @@ public interface TabPackets {
       addPlayerInfo(uuid, uuid.toString().substring(0, 16), ping, null, null);
     }
 
-    default void addPlayerInfo(UUID uuid, String renderedDisplayName) {
-      addPlayerInfo(uuid, "|" + uuid.toString().substring(0, 15), 0, null, renderedDisplayName);
+    default void addPlayerInfo(UUID uuid, Component displayName) {
+      addPlayerInfo(uuid, "|" + uuid.toString().substring(0, 15), 0, null, displayName);
     }
 
     void addPlayerInfo(
-        UUID uuid,
-        String name,
-        int ping,
-        @Nullable Skin skin,
-        @Nullable String renderedDisplayName);
+        UUID uuid, String name, int ping, @Nullable Skin skin, @Nullable Component displayName);
 
     boolean isNotEmpty();
   }

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabDisplay.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabDisplay.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.util.tablist;
 
+import static net.kyori.adventure.text.Component.text;
 import static tc.oc.pgm.util.nms.Packets.TAB_PACKETS;
 
 import java.util.Arrays;
@@ -62,7 +63,7 @@ public class TabDisplay {
     SlotBuilder slots = new SlotBuilder();
     for (int slot = 0; slot < this.slots; ++slot) {
       String name = slots.getPlayerName(slot);
-      String renderedPlayerName = "{\"text\":\"" + name + "\"}";
+      var renderedPlayerName = text(name);
 
       String teamName = this.slotTeamName(slot);
       this.teamCreatePackets[slot] = TAB_PACKETS.teamCreatePacket(

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabRender.java
@@ -43,12 +43,12 @@ public class TabRender {
     packet.send(this.view.getViewer());
   }
 
-  private String getJson(TabEntry entry) {
-    return TextTranslations.toMinecraftGson(entry.getContent(this.view), this.view.getViewer());
+  private Component getJson(TabEntry entry) {
+    return TextTranslations.translate(entry.getContent(this.view), this.view.getViewer());
   }
 
   private void appendAddition(TabEntry entry, int index) {
-    String renderedDisplayName = this.getJson(entry);
+    var renderedDisplayName = this.getJson(entry);
     this.addPacket.addPlayerInfo(
         entry.getId(),
         entry.getName(this.view),

--- a/util/src/main/java/tc/oc/pgm/util/text/TextTranslations.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextTranslations.java
@@ -29,7 +29,6 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.translation.Translator;
@@ -52,18 +51,8 @@ public final class TextTranslations {
   private static final UTF8Control SOURCE_CONTROL = new UTF8Control();
 
   // A list of all .properties files to load
-  private static final List<String> SOURCE_NAMES =
-      ImmutableList.of(
-          "command",
-          "death",
-          "error",
-          "gamemode",
-          "join",
-          "map",
-          "match",
-          "misc",
-          "moderation",
-          "ui");
+  private static final List<String> SOURCE_NAMES = ImmutableList.of(
+      "command", "death", "error", "gamemode", "join", "map", "match", "misc", "moderation", "ui");
 
   private static SortedMap<String, Map<Locale, MessageFormat>> getTreeMap() {
     try {
@@ -106,20 +95,18 @@ public final class TextTranslations {
     loadKeys(Locale.getDefault());
     // Add this translator to the global registry (so components are auto-translated by the
     // platform)
-    GlobalTranslator.translator()
-        .addSource(
-            new Translator() {
-              @Override
-              public @NotNull Key name() {
-                return NAMESPACE;
-              }
+    GlobalTranslator.translator().addSource(new Translator() {
+      @Override
+      public @NotNull Key name() {
+        return NAMESPACE;
+      }
 
-              @Override
-              public @Nullable MessageFormat translate(
-                  final @NotNull String key, final @NotNull Locale locale) {
-                return TextTranslations.getNearestKey(locale, key);
-              }
-            });
+      @Override
+      public @Nullable MessageFormat translate(
+          final @NotNull String key, final @NotNull Locale locale) {
+        return TextTranslations.getNearestKey(locale, key);
+      }
+    });
   }
 
   /**
@@ -156,10 +143,9 @@ public final class TextTranslations {
 
     int maxScore = 0;
     for (Locale other : getLocales()) {
-      int score =
-          (locale.getLanguage().equals(other.getLanguage()) ? 3 : 0)
-              + (locale.getCountry().equals(other.getCountry()) ? 2 : 0)
-              + (locale.getVariant().equals(other.getVariant()) ? 1 : 0);
+      int score = (locale.getLanguage().equals(other.getLanguage()) ? 3 : 0)
+          + (locale.getCountry().equals(other.getCountry()) ? 2 : 0)
+          + (locale.getVariant().equals(other.getVariant()) ? 1 : 0);
       if (score > maxScore) {
         maxScore = score;
         nearest = other;
@@ -377,9 +363,8 @@ public final class TextTranslations {
    */
   @Deprecated
   public static String translate(String key, @NotNull Pointered viewer, @NotNull Object... args) {
-    final Component text =
-        translatable(
-            key, Stream.of(args).map(TextTranslations::toComponent).collect(Collectors.toList()));
+    final Component text = translatable(
+        key, Stream.of(args).map(TextTranslations::toComponent).collect(Collectors.toList()));
 
     return LegacyComponentSerializer.legacySection().serialize(translate(text, viewer));
   }
@@ -388,10 +373,5 @@ public final class TextTranslations {
     if (obj instanceof Component) return (Component) obj;
     if (obj instanceof ComponentLike) return (ComponentLike) obj;
     return text(String.valueOf(obj));
-  }
-
-  public static String toMinecraftGson(Component component, @Nullable CommandSender viewer) {
-    Component translated = translate(component, getPointered(viewer));
-    return GsonComponentSerializer.colorDownsamplingGson().serialize(translated);
   }
 }


### PR DESCRIPTION
At the moment we rely on adventure component -> json string -> NMS component, but this process can be optimized using a tree conversion, which will instead use a `JsonElement` tree as intermediate component. This should lower the amount of string allocations when rendering tablist