### PR TITLE
Cleanup last damage cause on reset

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -282,6 +282,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     bukkit.setSprinting(false);
     bukkit.setFlySpeed(0.1f);
     bukkit.setWalkSpeed(WalkSpeedKit.BUKKIT_DEFAULT);
+    bukkit.setLastDamageCause(null);
     PLAYER_UTILS.clearArrowsInPlayer(bukkit);
     PLAYER_UTILS.setKnockbackReduction(bukkit, 0);
     bukkit.setVelocity(new Vector());


### PR DESCRIPTION
This is also a cause for memory leaks, since an still online player can have a reference to a damage from an older player/world, and this can create quite a chain that keeps lots of stuff loaded. By cleaning this up on reset we cut down alot on the problematic nature of the lastDamageCause field.