### PR TITLE
Fix payload beam not being centered

### DIFF
--- a/core/src/main/java/tc/oc/pgm/payload/Payload.java
+++ b/core/src/main/java/tc/oc/pgm/payload/Payload.java
@@ -115,7 +115,7 @@ public class Payload extends ControlPoint {
 
     if (definition.showBeam()) {
       DyeColor dyeColor = display != null ? display.getDyeColor() : DyeColor.WHITE;
-      EFFECTS.beam(match.getWorld(), loc, dyeColor);
+      EFFECTS.beam(match.getWorld(), position.toLocation(match.getWorld()), dyeColor);
     }
   }
 


### PR DESCRIPTION
Payload beam is based off of loc and going in circles around the circle instead of being on the center of the paload, this fixes it