### PR TITLE
Proactively remove players from location on disconnect

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/listener/PlayerMoveListener.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/PlayerMoveListener.java
@@ -170,6 +170,12 @@ public class PlayerMoveListener implements Listener {
     this.handleMovementMonitor(event);
   }
 
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerQuit(final PlayerQuitEvent event) {
+    // Faster & predictable cleanup even if player object fails to GC
+    this.lastToLocation.remove(event.getPlayer());
+  }
+
   private void handleMovementMonitor(PlayerMoveEvent event) {
     // It's possible for a PlayerMoveEvent to be modified by another
     // HIGHEST handler after we handle it, so we also check it at MONITOR


### PR DESCRIPTION
lastToLocation is a weak hash map of Player -> Location, issue is if player is slow to get GCed, it also drags along the location (which contains the world). This more proactively cleans up the map