### PR TITLE
Cleanup more fields on player & world

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.match;
 
 import static tc.oc.pgm.util.Assert.assertNotNull;
 import static tc.oc.pgm.util.Assert.assertTrue;
+import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -909,6 +910,7 @@ public class MatchImpl implements Match {
     if (world == null) return;
 
     final String worldName = world.getName();
+    NMS_HACKS.cleanupWorld(world);
     if (PGM.get().getServer().unloadWorld(worldName, false)) {
       logger.fine("Successfully unloaded " + worldName);
     } else {

--- a/core/src/main/java/tc/oc/pgm/match/MatchManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchManagerImpl.java
@@ -104,6 +104,7 @@ public class MatchManagerImpl implements MatchManager, Listener {
     if (name.startsWith("match")) return;
 
     NMS_HACKS.resetDimension(world);
+    NMS_HACKS.cleanupWorld(world);
 
     if (PGM.get().getServer().unloadWorld(name, false)) {
       logger.info("Unloaded non-match " + name);

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -283,6 +283,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
     bukkit.setFlySpeed(0.1f);
     bukkit.setWalkSpeed(WalkSpeedKit.BUKKIT_DEFAULT);
     bukkit.setLastDamageCause(null);
+    NMS_HACKS.cleanupPlayer(bukkit);
     PLAYER_UTILS.clearArrowsInPlayer(bukkit);
     PLAYER_UTILS.setKnockbackReduction(bukkit, 0);
     bukkit.setVelocity(new Vector());

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernNMSHacks.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernNMSHacks.java
@@ -157,6 +157,16 @@ public class ModernNMSHacks implements NMSHacks {
   }
 
   @Override
+  public void cleanupWorld(World world) {
+    // no-op
+  }
+
+  @Override
+  public void cleanupPlayer(Player player) {
+    // no-op
+  }
+
+  @Override
   public double getTPS() {
     return Bukkit.getServer().getTPS()[0];
   }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/NMSHacksSportPaper.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/NMSHacksSportPaper.java
@@ -30,6 +30,7 @@ import org.bukkit.craftbukkit.v1_8_R3.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftFireball;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftFirework;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftItem;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_8_R3.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fireball;
@@ -183,8 +184,20 @@ public class NMSHacksSportPaper implements NMSHacks {
         // No-op, newer version of Java have disabled modifying final fields
       }
     }
+  }
 
+  @Override
+  public void cleanupWorld(World world) {
+    var nmsWorld = ((CraftWorld) world).getHandle();
     nmsWorld.craftingManager.lastCraftView = null;
+    world.setKeepSpawnInMemory(false);
+  }
+
+  @Override
+  public void cleanupPlayer(Player player) {
+    var nmsPlayer = ((CraftPlayer) player).getHandle();
+    nmsPlayer.killer = null;
+    nmsPlayer.p(null); // Resets who last hit the entityLiving
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpPlayerUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpPlayerUtils.java
@@ -93,7 +93,7 @@ public class SpPlayerUtils implements PlayerUtils {
 
   @Override
   public void clearArrowsInPlayer(Player player) {
-    ((CraftPlayer) player).getHandle().o(0);
+    player.setArrowsStuck(0);
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -47,6 +47,10 @@ public interface NMSHacks {
 
   void resetDimension(World world);
 
+  void cleanupWorld(World world);
+
+  void cleanupPlayer(Player player);
+
   double getTPS();
 
   void postToMainThread(Plugin plugin, boolean priority, Runnable task);


### PR DESCRIPTION
Player's last killer & last who hit them is cleared on reset, which avoids online players in new matches who may be in obs retaining who hit them in a past match (and maybe went offline) keeping a reference to older worlds

lastCraftView was only being cleared for non-match worlds, made it cleanup on all worlds when we stop using them

Also cleans up spigot-only nms usage replacing it with `setArrowsStuck`