### PR TITLE
Update dependencies to 1.21.1

### DIFF
--- a/platform/platform-modern/pom.xml
+++ b/platform/platform-modern/pom.xml
@@ -17,13 +17,13 @@
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.21-R0.1-SNAPSHOT</version>
+      <version>1.21.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper</artifactId>
-      <version>1.21-R0.1-SNAPSHOT</version>
+      <version>1.21.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernInventoryUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernInventoryUtil.java
@@ -23,7 +23,7 @@ import org.bukkit.potion.PotionEffect;
 import tc.oc.pgm.util.inventory.InventoryUtils;
 import tc.oc.pgm.util.platform.Supports;
 
-@Supports(value = PAPER, minVersion = "1.20.6")
+@Supports(value = PAPER, minVersion = "1.21.1")
 public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatform {
 
   @Override
@@ -80,24 +80,26 @@ public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatfor
   }
 
   @Override
-  public void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials) {
-    // TODO: PLATFORM 1.20 no support for can place/destroy
+  @SuppressWarnings("removal")
+  public void setCanDestroy(ItemMeta itemMeta, Set<Material> materials) {
+    itemMeta.setCanDestroy(materials);
   }
 
   @Override
+  @SuppressWarnings("removal")
   public Set<Material> getCanDestroy(ItemMeta itemMeta) {
-    // TODO: PLATFORM 1.20 no support for can place/destroy
-    return Collections.emptySet();
+    return itemMeta.getCanDestroy();
   }
 
   @Override
-  public void setCanPlaceOn(ItemMeta itemMeta, Collection<Material> materials) {
-    // TODO: PLATFORM 1.20 no support for can place/destroy
+  @SuppressWarnings("removal")
+  public void setCanPlaceOn(ItemMeta itemMeta, Set<Material> materials) {
+    itemMeta.setCanPlaceOn(materials);
   }
 
   @Override
+  @SuppressWarnings("removal")
   public Set<Material> getCanPlaceOn(ItemMeta itemMeta) {
-    // TODO: PLATFORM 1.20 no support for can place/destroy
-    return Collections.emptySet();
+    return itemMeta.getCanPlaceOn();
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpInventoryUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpInventoryUtil.java
@@ -73,7 +73,7 @@ public class SpInventoryUtil implements InventoryUtils.InventoryUtilsPlatform {
   }
 
   @Override
-  public void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials) {
+  public void setCanDestroy(ItemMeta itemMeta, Set<Material> materials) {
     itemMeta.setCanDestroy(materials);
   }
 
@@ -83,7 +83,7 @@ public class SpInventoryUtil implements InventoryUtils.InventoryUtilsPlatform {
   }
 
   @Override
-  public void setCanPlaceOn(ItemMeta itemMeta, Collection<Material> materials) {
+  public void setCanPlaceOn(ItemMeta itemMeta, Set<Material> materials) {
     itemMeta.setCanPlaceOn(materials);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>dev.pgm.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.8_1.21-SNAPSHOT</version>
+            <version>1.8_1.21.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.3.3</version>
+            <version>4.3.4</version>
             <scope>compile</scope>
             <!-- Exclude Spigot APIs since we already provide Bukkit -->
             <exclusions>

--- a/util/src/main/java/tc/oc/pgm/util/collection/DefaultMapAdapter.java
+++ b/util/src/main/java/tc/oc/pgm/util/collection/DefaultMapAdapter.java
@@ -58,29 +58,16 @@ public class DefaultMapAdapter<K, V> implements Map<K, V> {
 
   @Override
   public V get(Object key) {
-    V value = this.map.get(key);
-    if (value == null) {
-      value = this.defaultProvider.apply((K) key);
-      if (this.putDefault) this.map.put((K) key, value);
-    }
-    return value;
+    return this.putDefault ? getOrCreate((K) key) : getOrDefault((K) key);
   }
 
   public V getOrDefault(K key) {
     V value = this.map.get(key);
-    if (value == null) {
-      value = this.defaultProvider.apply(key);
-    }
-    return value;
+    return value != null ? value : this.defaultProvider.apply((K) key);
   }
 
   public V getOrCreate(K key) {
-    V value = this.map.get(key);
-    if (value == null) {
-      value = this.defaultProvider.apply(key);
-      this.map.put(key, value);
-    }
-    return value;
+    return this.map.computeIfAbsent(key, this.defaultProvider);
   }
 
   public V getOrNull(K key) {

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -171,10 +171,6 @@ public final class InventoryUtils {
   public interface InventoryUtilsPlatform {
     Collection<PotionEffect> getPotionEffects(ItemStack item);
 
-    default boolean isUnbreakable(ItemStack item) {
-      return isUnbreakable(item.getItemMeta());
-    }
-
     boolean isUnbreakable(ItemMeta item);
 
     default void setUnbreakable(ItemStack item, boolean unbreakable) {
@@ -194,11 +190,11 @@ public final class InventoryUtils {
 
     EquipmentSlot getUsedHand(PlayerEvent event);
 
-    void setCanDestroy(ItemMeta itemMeta, Collection<Material> materials);
+    void setCanDestroy(ItemMeta itemMeta, Set<Material> materials);
 
     Set<Material> getCanDestroy(ItemMeta itemMeta);
 
-    void setCanPlaceOn(ItemMeta itemMeta, Collection<Material> materials);
+    void setCanPlaceOn(ItemMeta itemMeta, Set<Material> materials);
 
     Set<Material> getCanPlaceOn(ItemMeta itemMeta);
   }

--- a/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
+++ b/util/src/main/java/tc/oc/pgm/util/listener/ItemTransferListener.java
@@ -36,17 +36,16 @@ public class ItemTransferListener implements Listener {
     // from inside the event, so instead we replace the entire stack.
 
     int initialQuantity = event.getItem().getItemStack().getAmount();
-    PlayerItemTransferEvent transferEvent =
-        new PlayerItemTransferEvent(
-            event,
-            ItemTransferEvent.Reason.PICKUP,
-            event.getPlayer(),
-            null,
-            event.getPlayer().getInventory(),
-            event.getItem().getItemStack(),
-            event.getItem(),
-            initialQuantity,
-            event.getPlayer().getOpenInventory().getCursor());
+    PlayerItemTransferEvent transferEvent = new PlayerItemTransferEvent(
+        event,
+        ItemTransferEvent.Reason.PICKUP,
+        event.getPlayer(),
+        null,
+        event.getPlayer().getInventory(),
+        event.getItem().getItemStack(),
+        event.getItem(),
+        initialQuantity,
+        event.getPlayer().getOpenInventory().getCursor());
 
     callEvent(transferEvent);
 
@@ -71,15 +70,14 @@ public class ItemTransferListener implements Listener {
   public void onBlockPickupItem(final InventoryPickupItemEvent event) {
     int initialQuantity =
         getQuantityPlaceable(event.getItem().getItemStack(), event.getInventory());
-    ItemTransferEvent transferEvent =
-        new ItemTransferEvent(
-            event,
-            ItemTransferEvent.Reason.PICKUP,
-            null,
-            event.getInventory(),
-            event.getItem().getItemStack(),
-            event.getItem(),
-            initialQuantity);
+    ItemTransferEvent transferEvent = new ItemTransferEvent(
+        event,
+        ItemTransferEvent.Reason.PICKUP,
+        null,
+        event.getInventory(),
+        event.getItem().getItemStack(),
+        event.getItem(),
+        initialQuantity);
 
     callEvent(transferEvent);
 
@@ -128,17 +126,16 @@ public class ItemTransferListener implements Listener {
       int quantity = event.getCurrentItem().getAmount();
 
       // The take event has no items on the cursor, because those will be placed by the second event
-      PlayerItemTransferEvent transferEvent =
-          new PlayerItemTransferEvent(
-              event,
-              ItemTransferEvent.Reason.TAKE,
-              player,
-              inventory,
-              null,
-              event.getCurrentItem(),
-              null,
-              quantity,
-              null);
+      PlayerItemTransferEvent transferEvent = new PlayerItemTransferEvent(
+          event,
+          ItemTransferEvent.Reason.TAKE,
+          player,
+          inventory,
+          null,
+          event.getCurrentItem(),
+          null,
+          quantity,
+          null);
       this.callEvent(transferEvent);
       cancelled = cancelled | event.isCancelled() | quantity != transferEvent.getQuantity();
 
@@ -147,17 +144,16 @@ public class ItemTransferListener implements Listener {
       event.setCurrentItem(null);
 
       quantity = event.getCursor().getAmount();
-      transferEvent =
-          new PlayerItemTransferEvent(
-              event,
-              ItemTransferEvent.Reason.PLACE,
-              player,
-              null,
-              inventory,
-              event.getCursor(),
-              null,
-              event.getCursor().getAmount(),
-              event.getCursor());
+      transferEvent = new PlayerItemTransferEvent(
+          event,
+          ItemTransferEvent.Reason.PLACE,
+          player,
+          null,
+          inventory,
+          event.getCursor(),
+          null,
+          event.getCursor().getAmount(),
+          event.getCursor());
       event.setCancelled(cancelled | event.isCancelled() | quantity != transferEvent.getQuantity());
 
       // Replace the old item in the inventory
@@ -288,11 +284,9 @@ public class ItemTransferListener implements Listener {
 
       case PLACE_SOME: // left-click with cursor stack on undersized-slot (e.g. beacon) or matching
         // stack without enough space
-        initialQuantity =
-            Math.min(
-                event.getCursor().getAmount(),
-                Math.min(
-                    event.getCursor().getMaxStackSize(), event.getInventory().getMaxStackSize()));
+        initialQuantity = Math.min(
+            event.getCursor().getAmount(),
+            Math.min(event.getCursor().getMaxStackSize(), event.getInventory().getMaxStackSize()));
         ItemStack existingStack = event.getCurrentItem();
         if (existingStack != null) {
           initialQuantity -= existingStack.getAmount();
@@ -319,17 +313,16 @@ public class ItemTransferListener implements Listener {
       return;
     }
 
-    PlayerItemTransferEvent transferEvent =
-        new PlayerItemTransferEvent(
-            event,
-            type,
-            player,
-            fromInventory,
-            toInventory,
-            itemStack,
-            null,
-            initialQuantity,
-            event.getCursor());
+    PlayerItemTransferEvent transferEvent = new PlayerItemTransferEvent(
+        event,
+        type,
+        player,
+        fromInventory,
+        toInventory,
+        itemStack,
+        null,
+        initialQuantity,
+        event.getCursor());
 
     callEvent(transferEvent);
     int quantity = Math.min(transferEvent.getQuantity(), initialQuantity);
@@ -453,17 +446,16 @@ public class ItemTransferListener implements Listener {
       // an inventory click (e.g. drop key, death, etc), so an event has not yet been fired
       int initialQuantity = event.getItemDrop().getItemStack().getAmount();
       ItemStack stack = event.getItemDrop().getItemStack();
-      PlayerItemTransferEvent transferEvent =
-          new PlayerItemTransferEvent(
-              event,
-              ItemTransferEvent.Reason.DROP,
-              event.getPlayer(),
-              event.getPlayer().getInventory(),
-              null,
-              stack,
-              event.getItemDrop(),
-              initialQuantity,
-              event.getPlayer().getOpenInventory().getCursor());
+      PlayerItemTransferEvent transferEvent = new PlayerItemTransferEvent(
+          event,
+          ItemTransferEvent.Reason.DROP,
+          event.getPlayer(),
+          event.getPlayer().getInventory(),
+          null,
+          stack,
+          event.getItemDrop(),
+          initialQuantity,
+          event.getPlayer().getOpenInventory().getCursor());
       callEvent(transferEvent);
 
       if (!transferEvent.isCancelled() && transferEvent.getQuantity() < initialQuantity) {
@@ -493,48 +485,45 @@ public class ItemTransferListener implements Listener {
     if (this.collectToCursor) {
       this.collectToCursor = false;
 
-      if (!(event.getWhoClicked() instanceof Player)) {
-        return;
-      }
-      Player player = (Player) event.getWhoClicked();
+      if (!(event.getWhoClicked() instanceof Player player)) return;
 
       ItemStack cursor = event.getCursor().clone();
+      var view = event.getView();
+      int totalSize = getViewSize(view);
 
       for (int pass = 0; pass < 2; pass++) {
-        for (int rawSlot = 0; rawSlot < event.getView().countSlots(); rawSlot++) {
+        for (int rawSlot = 0; rawSlot < totalSize; rawSlot++) {
           if (cursor.getAmount() >= cursor.getMaxStackSize()) {
             // If the gathered stack is full, we're done
             break;
           }
 
-          ItemStack stack = event.getView().getItem(rawSlot);
+          ItemStack stack = view.getItem(rawSlot);
           // First pass takes incomplete stacks, second pass takes complete ones
           if (cursor.isSimilar(stack)
               && ((pass == 0 && stack.getAmount() < stack.getMaxStackSize())
                   || (pass == 1 && stack.getAmount() >= stack.getMaxStackSize()))) {
             // Calculate how much can be collected from this stack
             // If it is the output slot of a transaction preview, 0
-            int quantity =
-                event.getView().getTopInventory() instanceof CraftingInventory
-                            && event.getView().convertSlot(rawSlot) == 0
-                        || event.getView().getTopInventory() instanceof MerchantInventory
-                            && event.getView().convertSlot(rawSlot) == 2
-                    ? 0
-                    : Math.min(stack.getAmount(), cursor.getMaxStackSize() - cursor.getAmount());
-            Inventory localInventory = getLocalInventory(event.getView(), rawSlot);
+            int quantity = view.getTopInventory() instanceof CraftingInventory
+                        && view.convertSlot(rawSlot) == 0
+                    || view.getTopInventory() instanceof MerchantInventory
+                        && view.convertSlot(rawSlot) == 2
+                ? 0
+                : Math.min(stack.getAmount(), cursor.getMaxStackSize() - cursor.getAmount());
+            Inventory localInventory = getLocalInventory(view, rawSlot);
             if (localInventory.getHolder() != player) {
               // If stack comes from an external inventory, fire a transfer event
-              PlayerItemTransferEvent transferEvent =
-                  new PlayerItemTransferEvent(
-                      event,
-                      ItemTransferEvent.Reason.TAKE,
-                      player,
-                      localInventory,
-                      null,
-                      stack,
-                      null,
-                      quantity,
-                      cursor);
+              PlayerItemTransferEvent transferEvent = new PlayerItemTransferEvent(
+                  event,
+                  ItemTransferEvent.Reason.TAKE,
+                  player,
+                  localInventory,
+                  null,
+                  stack,
+                  null,
+                  quantity,
+                  cursor);
               callEvent(transferEvent);
               if (transferEvent.isCancelled()) {
                 // If the event is cancelled, don't transfer from this slot
@@ -548,7 +537,7 @@ public class ItemTransferListener implements Listener {
               // Collect items from this stack to the cursor
               cursor.setAmount(cursor.getAmount() + quantity);
               if (quantity == stack.getAmount()) {
-                event.getView().setItem(rawSlot, null);
+                view.setItem(rawSlot, null);
               } else {
                 stack.setAmount(stack.getAmount() - quantity);
               }
@@ -557,9 +546,18 @@ public class ItemTransferListener implements Listener {
         }
       }
 
-      event.getView().setCursor(cursor);
+      view.setCursor(cursor);
       player.updateInventory();
     }
+  }
+
+  private int getViewSize(InventoryView view) {
+    // Modern view.countSlots() sums all slots (including armor & offhand), which out-of-bounds if
+    // you try to later try to view.getItem(slot) with the highest numbers as they're not part of
+    // the view. As a workaround, only use countSlots() when in the player's view (ie: the 2x2
+    // Crafting view), otherwise hard-code the 36 slots of 9x4.
+    if (view.getTopInventory().getType().equals(InventoryType.CRAFTING)) return view.countSlots();
+    return view.getTopInventory().getSize() + 36;
   }
 
   @EventHandler(ignoreCancelled = true)
@@ -585,17 +583,16 @@ public class ItemTransferListener implements Listener {
 
     if (externalInventory != null) {
       int initialQuantity = transferred.getAmount();
-      PlayerItemTransferEvent transferEvent =
-          new PlayerItemTransferEvent(
-              event,
-              ItemTransferEvent.Reason.PLACE,
-              player,
-              null,
-              externalInventory,
-              transferred,
-              null,
-              initialQuantity,
-              event.getOldCursor());
+      PlayerItemTransferEvent transferEvent = new PlayerItemTransferEvent(
+          event,
+          ItemTransferEvent.Reason.PLACE,
+          player,
+          null,
+          externalInventory,
+          transferred,
+          null,
+          initialQuantity,
+          event.getOldCursor());
 
       callEvent(transferEvent);
 


### PR DESCRIPTION
Pushes modern dependencies to 1.21.1, also re-adds can-place-on and can-destroy functionality (allows players in adventure mode to break certain blocks or place against certain blocks, some maps used this and were non-functional in modern pgm prior to this)