### PR TITLE
Fix incorrectly excluding obs in match scope

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -200,7 +200,7 @@ public class ActionParser {
 
   private <B extends Filterable<?>> boolean includeObs(Element el, Class<B> scope)
       throws InvalidXMLException {
-    return PartyQuery.class.isAssignableFrom(scope)
+    return !PartyQuery.class.isAssignableFrom(scope)
         || XMLUtils.parseBoolean(el.getAttribute("observers"), legacy);
   }
 

--- a/core/src/main/java/tc/oc/pgm/command/ShowXmlCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ShowXmlCommand.java
@@ -116,7 +116,7 @@ public final class ShowXmlCommand {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent e) {
-      server.getScheduler().runTaskLater(PGM.get(), () -> usePlayer(e.getPlayer()), 10L);
+      server.getScheduler().runTaskLater(PGM.get(), () -> usePlayer(e.getPlayer()), 25L);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1401 

Additionally increases the delay for checking showxml local ip, makes race conditions where it won't register properly more rare.