### PR TITLE
Add weighted voting pool support

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapPoolCommand.java
@@ -73,19 +73,18 @@ public final class MapPoolCommand {
     int resultsPerPage = all ? maps.size() : 8;
     int pages = all ? 1 : (maps.size() + resultsPerPage - 1) / resultsPerPage;
 
-    Component mapPoolComponent =
-        TextFormatter.paginate(
-            text()
-                .append(translatable("pool.name"))
-                .append(text(" (", NamedTextColor.DARK_AQUA))
-                .append(text(mapPool.getName(), NamedTextColor.AQUA))
-                .append(text(")", NamedTextColor.DARK_AQUA))
-                .build(),
-            page,
-            pages,
-            NamedTextColor.DARK_AQUA,
-            NamedTextColor.AQUA,
-            false);
+    Component mapPoolComponent = TextFormatter.paginate(
+        text()
+            .append(translatable("pool.name"))
+            .append(text(" (", NamedTextColor.DARK_AQUA))
+            .append(text(mapPool.getName(), NamedTextColor.AQUA))
+            .append(text(")", NamedTextColor.DARK_AQUA))
+            .build(),
+        page,
+        pages,
+        NamedTextColor.DARK_AQUA,
+        NamedTextColor.AQUA,
+        false);
 
     Component title =
         TextFormatter.horizontalLineHeading(source, mapPoolComponent, NamedTextColor.BLUE, 250);
@@ -96,7 +95,7 @@ public final class MapPoolCommand {
     if (chance && votes != null) {
       double maxWeight = 0, currWeight;
       for (MapInfo map : votes.getMaps()) {
-        chances.put(map, currWeight = votes.mapPicker.getWeight(null, map, votes.getMapScore(map)));
+        chances.put(map, currWeight = votes.mapPicker.getWeight(null, map, votes.getVoteData(map)));
         maxWeight += currWeight;
       }
       double finalMaxWeight = maxWeight;
@@ -106,23 +105,19 @@ public final class MapPoolCommand {
     int nextPos = mapPool instanceof Rotation ? ((Rotation) mapPool).getNextPosition() : -1;
 
     if (order && votes != null) {
-      maps =
-          maps.stream()
-              .sorted(
-                  Comparator.comparingDouble(chance ? chances::get : votes::getMapScore).reversed())
-              .collect(Collectors.toList());
+      maps = maps.stream()
+          .sorted(Comparator.comparingDouble(chance ? chances::get : votes::getMapScore)
+              .reversed())
+          .collect(Collectors.toList());
     }
 
     new PrettyPaginatedComponentResults<MapInfo>(title, resultsPerPage) {
       @Override
       public Component format(MapInfo map, int index) {
         index++;
-        TextComponent.Builder entry =
-            text()
-                .append(
-                    text(
-                        index + ". ",
-                        nextPos == index ? NamedTextColor.DARK_AQUA : NamedTextColor.WHITE));
+        TextComponent.Builder entry = text()
+            .append(text(
+                index + ". ", nextPos == index ? NamedTextColor.DARK_AQUA : NamedTextColor.WHITE));
         if (votes != null && scores)
           entry.append(
               text(SCORE_FORMAT.format(votes.getMapScore(map)) + " ", NamedTextColor.YELLOW));
@@ -156,14 +151,13 @@ public final class MapPoolCommand {
     int resultsPerPage = 8;
     int pages = (mapPools.size() + resultsPerPage - 1) / resultsPerPage;
 
-    Component paginated =
-        TextFormatter.paginate(
-            translatable("pool.title"),
-            page,
-            pages,
-            NamedTextColor.DARK_AQUA,
-            NamedTextColor.AQUA,
-            true);
+    Component paginated = TextFormatter.paginate(
+        translatable("pool.title"),
+        page,
+        pages,
+        NamedTextColor.DARK_AQUA,
+        NamedTextColor.AQUA,
+        true);
 
     Component formattedTitle =
         TextFormatter.horizontalLineHeading(source, paginated, NamedTextColor.BLUE);
@@ -171,30 +165,27 @@ public final class MapPoolCommand {
     new PrettyPaginatedComponentResults<MapPool>(formattedTitle, resultsPerPage) {
       @Override
       public Component format(MapPool mapPool, int index) {
-        Component arrow =
-            text(
-                "» ",
-                poolManager.getActiveMapPool().equals(mapPool)
-                    ? NamedTextColor.GREEN
-                    : NamedTextColor.WHITE);
+        Component arrow = text(
+            "» ",
+            poolManager.getActiveMapPool().equals(mapPool)
+                ? NamedTextColor.GREEN
+                : NamedTextColor.WHITE);
 
-        Component maps =
-            text()
-                .append(text(" (", NamedTextColor.DARK_AQUA))
-                .append(translatable("map.title", NamedTextColor.DARK_GREEN))
-                .append(text(": ", NamedTextColor.DARK_GREEN))
-                .append(text(mapPool.getMaps().size(), NamedTextColor.WHITE))
-                .append(text(")", NamedTextColor.DARK_AQUA))
-                .build();
+        Component maps = text()
+            .append(text(" (", NamedTextColor.DARK_AQUA))
+            .append(translatable("map.title", NamedTextColor.DARK_GREEN))
+            .append(text(": ", NamedTextColor.DARK_GREEN))
+            .append(text(mapPool.getMaps().size(), NamedTextColor.WHITE))
+            .append(text(")", NamedTextColor.DARK_AQUA))
+            .build();
 
-        Component players =
-            text()
-                .append(text(" (", NamedTextColor.DARK_AQUA))
-                .append(translatable("match.info.players", NamedTextColor.AQUA))
-                .append(text(": ", NamedTextColor.AQUA))
-                .append(text(mapPool.getPlayers(), NamedTextColor.WHITE))
-                .append(text(")", NamedTextColor.DARK_AQUA))
-                .build();
+        Component players = text()
+            .append(text(" (", NamedTextColor.DARK_AQUA))
+            .append(translatable("match.info.players", NamedTextColor.AQUA))
+            .append(text(": ", NamedTextColor.AQUA))
+            .append(text(mapPool.getPlayers(), NamedTextColor.WHITE))
+            .append(text(")", NamedTextColor.DARK_AQUA))
+            .build();
 
         return text()
             .append(arrow)
@@ -223,11 +214,10 @@ public final class MapPoolCommand {
     if (newPool == null) throw exception("pool.noPoolMatch");
 
     if (newPool.equals(poolManager.getActiveMapPool())) {
-      sender.sendMessage(
-          translatable(
-              "pool.matching",
-              NamedTextColor.GRAY,
-              text(newPool.getName(), NamedTextColor.LIGHT_PURPLE)));
+      sender.sendMessage(translatable(
+          "pool.matching",
+          NamedTextColor.GRAY,
+          text(newPool.getName(), NamedTextColor.LIGHT_PURPLE)));
       return;
     }
 
@@ -268,17 +258,15 @@ public final class MapPoolCommand {
 
     ((Rotation) pool).advance(positions);
 
-    Component message =
-        text()
-            .append(text("[", NamedTextColor.WHITE))
-            .append(translatable("pool.name", NamedTextColor.GOLD))
-            .append(text("] [", NamedTextColor.WHITE))
-            .append(text(pool.getName(), NamedTextColor.AQUA))
-            .append(text("]", NamedTextColor.WHITE))
-            .append(
-                translatable(
-                    "pool.skip", NamedTextColor.GREEN, text(positions, NamedTextColor.AQUA)))
-            .build();
+    Component message = text()
+        .append(text("[", NamedTextColor.WHITE))
+        .append(translatable("pool.name", NamedTextColor.GOLD))
+        .append(text("] [", NamedTextColor.WHITE))
+        .append(text(pool.getName(), NamedTextColor.AQUA))
+        .append(text("]", NamedTextColor.WHITE))
+        .append(
+            translatable("pool.skip", NamedTextColor.GREEN, text(positions, NamedTextColor.AQUA)))
+        .build();
 
     sender.sendMessage(message);
   }
@@ -291,11 +279,10 @@ public final class MapPoolCommand {
       @Flag(value = "open", aliases = "o") boolean forceOpen,
       @Argument("map") @FlagYielding MapInfo map) {
     boolean voteResult = poll.toggleVote(map, player);
-    Component voteAction =
-        translatable(
-            voteResult ? "vote.for" : "vote.abstain",
-            voteResult ? NamedTextColor.GREEN : NamedTextColor.RED,
-            map.getStyledName(MapNameStyle.COLOR));
+    Component voteAction = translatable(
+        voteResult ? "vote.for" : "vote.abstain",
+        voteResult ? NamedTextColor.GREEN : NamedTextColor.RED,
+        map.getStyledName(MapNameStyle.COLOR));
     player.sendMessage(voteAction);
     poll.sendBook(player, forceOpen);
   }
@@ -318,26 +305,12 @@ public final class MapPoolCommand {
       @Argument("page") @Default("1") @Range(min = "1") int page,
       @Flag(value = "all", aliases = "a") boolean all,
       String[] rawArgs) {
-    wrapLegacy(
-        "pool",
-        sender,
-        rawArgs,
-        () -> {
-          if (poolManager.getActiveMapPool().getType() != MapPoolType.ORDERED)
-            throw exception("pool.noRotation");
+    wrapLegacy("pool", sender, rawArgs, () -> {
+      if (poolManager.getActiveMapPool().getType() != MapPoolType.ORDERED)
+        throw exception("pool.noRotation");
 
-          pool(
-              sender,
-              source,
-              poolManager,
-              page,
-              MapPoolType.ORDERED,
-              null,
-              false,
-              false,
-              false,
-              all);
-        });
+      pool(sender, source, poolManager, page, MapPoolType.ORDERED, null, false, false, false, all);
+    });
   }
 
   @Command("rots [page]")
@@ -391,14 +364,10 @@ public final class MapPoolCommand {
     MapPool resetRot =
         poolManager.getAppropriateDynamicPool(match).orElseThrow(() -> exception("pool.noDynamic"));
 
-    wrapLegacy(
-        "setpool",
-        sender,
-        rawArgs,
-        () -> {
-          if (resetRot.getType() != MapPoolType.ORDERED) throw exception("pool.noRotation");
-          setPool(sender, source, match, poolManager, resetRot, timeLimit, matchLimit);
-        });
+    wrapLegacy("setpool", sender, rawArgs, () -> {
+      if (resetRot.getType() != MapPoolType.ORDERED) throw exception("pool.noRotation");
+      setPool(sender, source, match, poolManager, resetRot, timeLimit, matchLimit);
+    });
   }
 
   private void wrapLegacy(String replace, Audience sender, String[] rawArgs, Runnable task) {

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/DisabledMapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/DisabledMapPool.java
@@ -5,8 +5,8 @@ import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.rotation.MapPoolManager;
 
 public class DisabledMapPool extends MapPool {
-  DisabledMapPool(MapPoolManager manager, ConfigurationSection section, String name) {
-    super(null, name, manager, section);
+  DisabledMapPool(String name, MapPoolManager manager, ConfigurationSection section) {
+    super(null, name, manager, section, MapParser.parse(name, section));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/MapParser.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/MapParser.java
@@ -1,0 +1,101 @@
+package tc.oc.pgm.rotation.pools;
+
+import static tc.oc.pgm.api.map.MapSource.DEFAULT_VARIANT;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.bukkit.configuration.ConfigurationSection;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.api.map.MapLibrary;
+import tc.oc.pgm.api.map.VariantInfo;
+
+public class MapParser {
+  private final MapLibrary maps = PGM.get().getMapLibrary();
+  private final String poolName;
+  private final List<String> variantIds;
+  private final ArrayList<MapInfo> mapList = new ArrayList<>();
+  private final Map<MapInfo, Double> weights = new HashMap<>();
+
+  public static MapParser parse(String poolName, ConfigurationSection section) {
+    var parser = new MapParser(poolName, section.getStringList("variants"));
+    if (section.contains("maps")) parser.parseSection(section, 1d);
+    return parser;
+  }
+
+  private MapParser(String poolName, List<String> variants) {
+    this.poolName = poolName;
+    if (variants != null) {
+      int def = variants.indexOf(DEFAULT_VARIANT);
+      if (def >= 0) variants = variants.subList(0, def);
+      if (variants.isEmpty()) variants = null;
+    }
+    this.variantIds = variants;
+  }
+
+  public List<MapInfo> getMaps() {
+    return mapList;
+  }
+
+  public double getWeight(MapInfo info) {
+    return weights.getOrDefault(info, 1d);
+  }
+
+  private void parseSection(ConfigurationSection parent, double parentWeight) {
+    Set<String> keys;
+    double weight;
+    if (parent.contains("maps")) {
+      keys = Set.of("maps");
+      weight = parent.getDouble("weight", parentWeight);
+    } else {
+      keys = parent.getKeys(false);
+      weight = parentWeight;
+    }
+    keys.forEach(k -> {
+      if (parent.isConfigurationSection(k)) parseSection(parent.getConfigurationSection(k), weight);
+      else parseMapList(parent.getStringList(k), weight);
+    });
+  }
+
+  private void parseMapList(List<String> mapNames, double weight) {
+    if (mapNames == null) return;
+
+    mapList.ensureCapacity(mapList.size() + mapNames.size());
+
+    for (String mapName : mapNames) {
+      MapInfo map = maps.getMap(mapName);
+      if (map != null) {
+        map = getVariant(map);
+        weights.computeIfAbsent(map, k -> {
+          mapList.add(k);
+          return weight;
+        });
+      } else {
+        PGM.get()
+            .getLogger()
+            .warning(
+                "[MapPool] [" + poolName + "] " + mapName + " not found in map repo. Ignoring...");
+      }
+    }
+  }
+
+  private MapInfo getVariant(MapInfo map) {
+    if (variantIds == null || !map.getVariantId().equals(DEFAULT_VARIANT)) return map;
+
+    Map<String, ? extends VariantInfo> variants = map.getVariants();
+    for (String varId : variantIds) {
+      VariantInfo variant = variants.get(varId);
+      if (variant == null) continue;
+      MapInfo variantMap = maps.getMapById(variant.getId());
+      if (variantMap != null) return variantMap;
+      // Should never happen
+      PGM.get()
+          .getLogger()
+          .warning("[MapPool] Failed to get map " + variant.getId() + ". Moving on...");
+    }
+    return map;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/MapPoolType.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/MapPoolType.java
@@ -40,9 +40,9 @@ public enum MapPoolType implements Aliased {
     MapPoolType type = of(typeStr);
     if (type == null) {
       PGM.get().getLogger().severe("Invalid map pool type for " + key + ": '" + typeStr + "'");
-      return new DisabledMapPool(manager, section, key);
+      return new DisabledMapPool(key, manager, section);
     }
-    return type.factory.build(type, key, manager, section);
+    return type.factory.build(type, key, manager, section, MapParser.parse(key, section));
   }
 
   @NotNull
@@ -53,6 +53,10 @@ public enum MapPoolType implements Aliased {
 
   private interface PoolFactory {
     MapPool build(
-        MapPoolType type, String name, MapPoolManager manager, ConfigurationSection section);
+        MapPoolType type,
+        String name,
+        MapPoolManager manager,
+        ConfigurationSection section,
+        MapParser maps);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/RandomMapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/RandomMapPool.java
@@ -11,9 +11,13 @@ public class RandomMapPool extends MapPool {
   private final RandomMapOrder order;
 
   public RandomMapPool(
-      MapPoolType type, String name, MapPoolManager manager, ConfigurationSection section) {
-    super(type, name, manager, section);
-    this.order = new RandomMapOrder(maps);
+      MapPoolType type,
+      String name,
+      MapPoolManager manager,
+      ConfigurationSection section,
+      MapParser maps) {
+    super(type, name, manager, section, maps);
+    this.order = new RandomMapOrder(this.maps);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/Rotation.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/Rotation.java
@@ -14,8 +14,12 @@ public class Rotation extends MapPool {
   private int position;
 
   public Rotation(
-      MapPoolType type, String name, MapPoolManager manager, ConfigurationSection section) {
-    super(type, name, manager, section);
+      MapPoolType type,
+      String name,
+      MapPoolManager manager,
+      ConfigurationSection section,
+      MapParser maps) {
+    super(type, name, manager, section, maps);
 
     @Nullable MapInfo nextMap = PGM.get().getMapLibrary().getMap(manager.getNextMapForPool(name));
     if (nextMap != null) this.position = getMapPosition(nextMap);

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/VoteData.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/VoteData.java
@@ -1,0 +1,36 @@
+package tc.oc.pgm.rotation.vote;
+
+import tc.oc.pgm.rotation.pools.VotingPool;
+
+public class VoteData {
+  private final double weight;
+  private double score;
+
+  public VoteData(double weight, double score) {
+    this.score = score;
+    this.weight = weight;
+  }
+
+  public void setScore(double score) {
+    this.score = score;
+  }
+
+  public VoteData withScore(double score) {
+    setScore(score);
+    return this;
+  }
+
+  public double getWeight() {
+    return weight;
+  }
+
+  public double getScore() {
+    return score;
+  }
+
+  public void tickScore(VotingPool.VoteConstants constants) {
+    this.score = score > constants.defaultScore()
+        ? Math.max(score - constants.scoreDecay(), constants.defaultScore())
+        : Math.min(score + constants.scoreRise(), constants.defaultScore());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/VotePoolOptions.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/VotePoolOptions.java
@@ -69,8 +69,8 @@ public class VotePoolOptions {
     return Collections.unmodifiableSet(customVoteMaps.keySet());
   }
 
-  public Map<MapInfo, Double> getCustomVoteMapsWeighted() {
+  public Map<MapInfo, VoteData> getCustomVoteMapsWeighted() {
     return customVoteMaps.keySet().stream()
-        .collect(Collectors.toMap(map -> map, score -> VotingPool.DEFAULT_SCORE));
+        .collect(Collectors.toMap(map -> map, score -> new VoteData(1, VotingPool.DEFAULT_SCORE)));
   }
 }


### PR DESCRIPTION
Adds support for map-weighting in voted pools, as well as allowing more flexibility in defining maps in groups in the map-pool config file.

Currently, the pool has simply one `maps` list of strings:
```yml
pools:
  default:
    [...]
    maps:
    - Airship Battle
    - Harb
    - Race for Victory
    - The Fenland
    - Warlock
```
This remains supported, but can now (for all types of pools, not just voted) be extended to be grouped, eg:

```yml
pools:
  default:
    [...]
    maps:
      dtc:
        - Airship Battle
      tdm:
        - Harb
      ctw:
        - Race for Victory
      dtm:
        - The Fenland
        - Warlock
```

These groups, can also be weighted (you can do this for all pools, but weight will have no effect on non-voted pools):
```yml
pools:
  default:
    [...]
    maps:
      dtc:
        - Airship Battle
      tdm:
        - Harb
      ctw:
        - Race for Victory
      dtm:
        weight: 0.5
        maps:
          - The Fenland
          - Warlock
```

Note that you can mix-and-match the above, and even recursively nest stuff:
```yml
pools:
  default:
    [...]
    weight: 0.5
    maps:
      dtc:
        weight: 1
        maps:
          - Airship Battle # weight = 1
      tdm:
        - Harb # weight = 0.5
      ctw:
        - Race for Victory # weight = 0.5
      dtm:
        weight: 0.7
        maps:
          s-tier:
            - The Fenland # weight = 0.7
          overplayed:
            weight: 0.2
            maps:
              - Warlock # weight = 0.2
```

