### PR TITLE
Destroyable - Add sparks-match parameter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -356,12 +356,15 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
             NMS_HACKS.skipFireworksLaunch(firework);
           }
 
-          // Players more than 64m away will not see or hear the fireworks, so just play the sound
-          // for them
-          for (MatchPlayer listener : this.getOwner().getMatch().getPlayers()) {
-            if (listener.getBukkit().getLocation().distance(blockLocation) > 64) {
-              listener.playSound(Sounds.OBJECTIVE_FIREWORKS_FAR);
-              listener.playSound(Sounds.OBJECTIVE_FIREWORKS_TWINKLE);
+          if (this.definition.hasSparksMatch()) {
+            // Players more than 64m away will not see or hear the fireworks, so play sound for them
+            for (MatchPlayer listener : this.getOwner().getMatch().getPlayers()) {
+              if (listener.getBukkit().getLocation().distance(blockLocation) > 64) {
+                listener.playSound(
+                    sound(key("fireworks.blast_far"), Sound.Source.MASTER, 0.75f, 1f));
+                listener.playSound(
+                    sound(key("fireworks.twinkle_far"), Sound.Source.MASTER, 0.75f, 1f));
+              }
             }
           }
         }

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -19,6 +19,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   protected final ImmutableSet<Mode> modeList;
   protected final boolean showProgress;
   protected final boolean sparks;
+  protected final boolean sparksMatch;
   protected final boolean repairable;
 
   public DestroyableFactory(
@@ -34,6 +35,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       @Nullable ImmutableSet<Mode> modeList,
       boolean showProgress,
       boolean sparks,
+      boolean sparksMatch,
       boolean repairable) {
     super(id, name, required, showOptions, owner, proximityMetric);
     this.region = region;
@@ -42,6 +44,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     this.modeList = modeList;
     this.showProgress = showProgress;
     this.sparks = sparks;
+    this.sparksMatch = sparksMatch;
     this.repairable = repairable;
   }
 
@@ -67,6 +70,10 @@ public class DestroyableFactory extends ProximityGoalDefinition {
 
   public boolean hasSparks() {
     return this.sparks;
+  }
+
+  public boolean hasSparksMatch() {
+    return this.sparksMatch;
   }
 
   public boolean isRepairable() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -128,6 +128,8 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
         boolean showProgress =
             XMLUtils.parseBoolean(destroyableEl.getAttribute("show-progress"), false);
         boolean sparks = XMLUtils.parseBoolean(destroyableEl.getAttribute("sparks"), false);
+        boolean sparksMatch =
+            XMLUtils.parseBoolean(destroyableEl.getAttribute("sparks-match"), true);
         boolean repairable = XMLUtils.parseBoolean(destroyableEl.getAttribute("repairable"), true);
         ShowOptions options = ShowOptions.parse(context.getFilters(), destroyableEl);
         Boolean required = XMLUtils.parseBoolean(destroyableEl.getAttribute("required"), null);
@@ -147,6 +149,7 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
             modeSet,
             showProgress,
             sparks,
+            sparksMatch,
             repairable);
 
         context.getFeatures().addFeature(destroyableEl, factory);


### PR DESCRIPTION
- Adds a new parameter "sparks-match" to Destroyable

- "sparks" must be active for "sparks-match" to have any effect

- With the default value of "true" there is no change to current behavior for Destroyable sparks.

- With value of "false" PGM will skip the far (+64 blocks away) logic

- Purpose is to reduce the "noise" for players not actually near the action, especially for large Destroyables

- Tested and verified that sound behavior changed for players and observers