### PR TITLE
Destroyable - Add new sparks parameter value of "near"

### DIFF
--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -330,7 +330,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     if (deltaHealth < 0) {
       touch(player);
 
-      if (this.definition.hasSparks()) {
+      if (this.definition.isSparksActive()) {
         Location blockLocation = BlockVectors.center(oldState);
         Instant now = Instant.now();
 
@@ -356,14 +356,12 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
             NMS_HACKS.skipFireworksLaunch(firework);
           }
 
-          if (this.definition.hasSparksMatch()) {
+          if (this.definition.isSparksAll()) {
             // Players more than 64m away will not see or hear the fireworks, so play sound for them
             for (MatchPlayer listener : this.getOwner().getMatch().getPlayers()) {
               if (listener.getBukkit().getLocation().distance(blockLocation) > 64) {
-                listener.playSound(
-                    sound(key("fireworks.blast_far"), Sound.Source.MASTER, 0.75f, 1f));
-                listener.playSound(
-                    sound(key("fireworks.twinkle_far"), Sound.Source.MASTER, 0.75f, 1f));
+                listener.playSound(Sounds.OBJECTIVE_FIREWORKS_FAR);
+                listener.playSound(Sounds.OBJECTIVE_FIREWORKS_TWINKLE);
               }
             }
           }

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -356,12 +356,15 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
             NMS_HACKS.skipFireworksLaunch(firework);
           }
 
-          // Players more than 64m away will not see or hear the fireworks, so just play the sound
-          // for them
-          for (MatchPlayer listener : this.getOwner().getMatch().getPlayers()) {
-            if (listener.getBukkit().getLocation().distance(blockLocation) > 64) {
-              listener.playSound(Sounds.OBJECTIVE_FIREWORKS_FAR);
-              listener.playSound(Sounds.OBJECTIVE_FIREWORKS_TWINKLE);
+          if (this.definition.hasSparksMatch()) {
+            // Players more than 64m away will not see or hear the fireworks, so play sound for them
+            for (MatchPlayer listener : this.getOwner().getMatch().getPlayers()) {
+              if (listener.getBukkit().getLocation().distance(blockLocation) > 64) {
+                listener.playSound(
+                    sound(key("fireworks.blast_far"), Sound.Source.MASTER, 0.75f, 1f));
+                listener.playSound(
+                    sound(key("fireworks.twinkle_far"), Sound.Source.MASTER, 0.75f, 1f));
+              }
             }
           }
         }

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.destroyable;
 
 import com.google.common.collect.ImmutableSet;
+import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
@@ -10,16 +11,37 @@ import tc.oc.pgm.goals.ShowOptions;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.util.material.MaterialMatcher;
+import tc.oc.pgm.util.xml.InvalidXMLException;
 
 @FeatureInfo(name = "destroyable")
 public class DestroyableFactory extends ProximityGoalDefinition {
+  public static enum SparksType {
+    SPARKS_ALL("true"),
+    SPARKS_NONE("false"),
+    SPARKS_NEAR("near");
+
+    private final String name;
+
+    private SparksType(String name) {
+      this.name = name;
+    }
+
+    public static SparksType fromString(String name, Element el) throws InvalidXMLException {
+      for (SparksType i : SparksType.values()) {
+        if (i.name.equalsIgnoreCase(name)) {
+          return i;
+        }
+      }
+      throw new InvalidXMLException("Unknown Destroyable sparks type: " + name, el);
+    }
+  }
+
   protected final Region region;
   protected final MaterialMatcher materials;
   protected final double destructionRequired;
   protected final ImmutableSet<Mode> modeList;
   protected final boolean showProgress;
-  protected final boolean sparks;
-  protected final boolean sparksMatch;
+  protected final SparksType sparks;
   protected final boolean repairable;
 
   public DestroyableFactory(
@@ -34,17 +56,17 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       double destructionRequired,
       @Nullable ImmutableSet<Mode> modeList,
       boolean showProgress,
-      boolean sparks,
-      boolean sparksMatch,
-      boolean repairable) {
+      String sparks,
+      boolean repairable,
+      Element el)
+      throws InvalidXMLException {
     super(id, name, required, showOptions, owner, proximityMetric);
     this.region = region;
     this.materials = materials;
     this.destructionRequired = destructionRequired;
     this.modeList = modeList;
     this.showProgress = showProgress;
-    this.sparks = sparks;
-    this.sparksMatch = sparksMatch;
+    this.sparks = SparksType.fromString(sparks, el);
     this.repairable = repairable;
   }
 
@@ -68,12 +90,12 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     return this.showProgress;
   }
 
-  public boolean hasSparks() {
-    return this.sparks;
+  public boolean isSparksActive() {
+    return this.sparks != SparksType.SPARKS_NONE;
   }
 
-  public boolean hasSparksMatch() {
-    return this.sparksMatch;
+  public boolean isSparksAll() {
+    return this.sparks != SparksType.SPARKS_NEAR;
   }
 
   public boolean isRepairable() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -19,6 +19,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   protected final ImmutableSet<Mode> modeList;
   protected final boolean showProgress;
   protected final boolean sparks;
+  protected final boolean sparksMatch;
   protected final boolean repairable;
 
   public DestroyableFactory(
@@ -34,6 +35,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       @Nullable ImmutableSet<Mode> modeList,
       boolean showProgress,
       boolean sparks,
+      boolean sparksMatch,
       boolean repairable) {
     super(id, name, required, showOptions, owner, proximityMetric);
     this.region = region;
@@ -42,6 +44,7 @@ public class DestroyableFactory extends ProximityGoalDefinition {
     this.modeList = modeList;
     this.showProgress = showProgress;
     this.sparks = sparks;
+    this.sparksMatch = sparksMatch;
     this.repairable = repairable;
   }
 
@@ -67,6 +70,10 @@ public class DestroyableFactory extends ProximityGoalDefinition {
 
   public boolean hasSparks() {
     return this.sparks;
+  }
+
+  public boolean hasSparksMatch() {
+    return this.sparksMatch;
   }
 
   public boolean isRepairable() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -1,6 +1,9 @@
 package tc.oc.pgm.destroyable;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
@@ -9,16 +12,11 @@ import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.goals.ShowOptions;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.teams.TeamFactory;
+import tc.oc.pgm.util.Aliased;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
 @FeatureInfo(name = "destroyable")
 public class DestroyableFactory extends ProximityGoalDefinition {
-  public static enum SparksType {
-    FALSE, // none
-    NEAR, // normal sparks
-    TRUE; // normal/far sparks
-  }
-
   protected final Region region;
   protected final MaterialMatcher materials;
   protected final double destructionRequired;
@@ -72,14 +70,32 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   }
 
   public boolean isSparksActive() {
-    return this.sparks != SparksType.FALSE;
+    return this.sparks != SparksType.NONE;
   }
 
   public boolean isSparksAll() {
-    return this.sparks == SparksType.TRUE;
+    return this.sparks == SparksType.ALL;
   }
 
   public boolean isRepairable() {
     return this.repairable;
+  }
+
+  public enum SparksType implements Aliased {
+    NONE("false", "no", "off"),
+    NEAR("near"),
+    ALL("true", "yes", "on");
+
+    private final String[] names;
+
+    SparksType(String... names) {
+      this.names = names;
+    }
+
+    @NotNull
+    @Override
+    public Iterator<String> iterator() {
+      return Iterators.forArray(names);
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -15,8 +15,8 @@ import tc.oc.pgm.util.material.MaterialMatcher;
 public class DestroyableFactory extends ProximityGoalDefinition {
   public static enum SparksType {
     FALSE, // none
-    NEAR,  // normal sparks
-    TRUE;  // normal/far sparks
+    NEAR, // normal sparks
+    TRUE; // normal/far sparks
   }
 
   protected final Region region;

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableFactory.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.destroyable;
 
 import com.google.common.collect.ImmutableSet;
-import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.region.Region;
@@ -11,29 +10,13 @@ import tc.oc.pgm.goals.ShowOptions;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.util.material.MaterialMatcher;
-import tc.oc.pgm.util.xml.InvalidXMLException;
 
 @FeatureInfo(name = "destroyable")
 public class DestroyableFactory extends ProximityGoalDefinition {
   public static enum SparksType {
-    SPARKS_ALL("true"),
-    SPARKS_NONE("false"),
-    SPARKS_NEAR("near");
-
-    private final String name;
-
-    private SparksType(String name) {
-      this.name = name;
-    }
-
-    public static SparksType fromString(String name, Element el) throws InvalidXMLException {
-      for (SparksType i : SparksType.values()) {
-        if (i.name.equalsIgnoreCase(name)) {
-          return i;
-        }
-      }
-      throw new InvalidXMLException("Unknown Destroyable sparks type: " + name, el);
-    }
+    FALSE, // none
+    NEAR,  // normal sparks
+    TRUE;  // normal/far sparks
   }
 
   protected final Region region;
@@ -56,17 +39,15 @@ public class DestroyableFactory extends ProximityGoalDefinition {
       double destructionRequired,
       @Nullable ImmutableSet<Mode> modeList,
       boolean showProgress,
-      String sparks,
-      boolean repairable,
-      Element el)
-      throws InvalidXMLException {
+      SparksType sparks,
+      boolean repairable) {
     super(id, name, required, showOptions, owner, proximityMetric);
     this.region = region;
     this.materials = materials;
     this.destructionRequired = destructionRequired;
     this.modeList = modeList;
     this.showProgress = showProgress;
-    this.sparks = SparksType.fromString(sparks, el);
+    this.sparks = sparks;
     this.repairable = repairable;
   }
 
@@ -91,11 +72,11 @@ public class DestroyableFactory extends ProximityGoalDefinition {
   }
 
   public boolean isSparksActive() {
-    return this.sparks != SparksType.SPARKS_NONE;
+    return this.sparks != SparksType.FALSE;
   }
 
   public boolean isSparksAll() {
-    return this.sparks != SparksType.SPARKS_NEAR;
+    return this.sparks == SparksType.TRUE;
   }
 
   public boolean isRepairable() {

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -127,9 +127,9 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
 
         boolean showProgress =
             XMLUtils.parseBoolean(destroyableEl.getAttribute("show-progress"), false);
-        boolean sparks = XMLUtils.parseBoolean(destroyableEl.getAttribute("sparks"), false);
-        boolean sparksMatch =
-            XMLUtils.parseBoolean(destroyableEl.getAttribute("sparks-match"), true);
+        String sparks = destroyableEl.getAttributeValue("sparks") != null
+            ? destroyableEl.getAttributeValue("sparks")
+            : "false";
         boolean repairable = XMLUtils.parseBoolean(destroyableEl.getAttribute("repairable"), true);
         ShowOptions options = ShowOptions.parse(context.getFilters(), destroyableEl);
         Boolean required = XMLUtils.parseBoolean(destroyableEl.getAttribute("required"), null);
@@ -149,8 +149,8 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
             modeSet,
             showProgress,
             sparks,
-            sparksMatch,
-            repairable);
+            repairable,
+            destroyableEl);
 
         context.getFeatures().addFeature(destroyableEl, factory);
         destroyables.add(factory);

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -129,7 +129,7 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
         boolean showProgress =
             XMLUtils.parseBoolean(destroyableEl.getAttribute("show-progress"), false);
         SparksType sparks = XMLUtils.parseEnum(
-            Node.fromAttr(destroyableEl, "sparks"), SparksType.class, SparksType.FALSE);
+            Node.fromAttr(destroyableEl, "sparks"), SparksType.class, SparksType.NONE);
         boolean repairable = XMLUtils.parseBoolean(destroyableEl.getAttribute("repairable"), true);
         ShowOptions options = ShowOptions.parse(context.getFilters(), destroyableEl);
         Boolean required = XMLUtils.parseBoolean(destroyableEl.getAttribute("required"), null);

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -128,6 +128,8 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
         boolean showProgress =
             XMLUtils.parseBoolean(destroyableEl.getAttribute("show-progress"), false);
         boolean sparks = XMLUtils.parseBoolean(destroyableEl.getAttribute("sparks"), false);
+        boolean sparksMatch =
+            XMLUtils.parseBoolean(destroyableEl.getAttribute("sparks-match"), true);
         boolean repairable = XMLUtils.parseBoolean(destroyableEl.getAttribute("repairable"), true);
         ShowOptions options = ShowOptions.parse(context.getFilters(), destroyableEl);
         Boolean required = XMLUtils.parseBoolean(destroyableEl.getAttribute("required"), null);
@@ -147,6 +149,7 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
             modeSet,
             showProgress,
             sparks,
+            sparksMatch,
             repairable);
 
         context.getFeatures().addFeature(destroyableEl, factory);

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -18,6 +18,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.blockdrops.BlockDropsModule;
+import tc.oc.pgm.destroyable.DestroyableFactory.SparksType;
 import tc.oc.pgm.goals.GoalMatchModule;
 import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.goals.ShowOptions;
@@ -127,9 +128,8 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
 
         boolean showProgress =
             XMLUtils.parseBoolean(destroyableEl.getAttribute("show-progress"), false);
-        String sparks = destroyableEl.getAttributeValue("sparks") != null
-            ? destroyableEl.getAttributeValue("sparks")
-            : "false";
+        SparksType sparks = XMLUtils.parseEnum(
+            Node.fromAttr(destroyableEl, "sparks"), SparksType.class, SparksType.FALSE);
         boolean repairable = XMLUtils.parseBoolean(destroyableEl.getAttribute("repairable"), true);
         ShowOptions options = ShowOptions.parse(context.getFilters(), destroyableEl);
         Boolean required = XMLUtils.parseBoolean(destroyableEl.getAttribute("required"), null);
@@ -149,8 +149,7 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
             modeSet,
             showProgress,
             sparks,
-            repairable,
-            destroyableEl);
+            repairable);
 
         context.getFeatures().addFeature(destroyableEl, factory);
         destroyables.add(factory);

--- a/util/src/main/java/tc/oc/pgm/util/text/TextParser.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextParser.java
@@ -29,6 +29,7 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Chunk;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
+import tc.oc.pgm.util.Aliased;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.Version;
@@ -343,7 +344,7 @@ public final class TextParser {
     String name = text.replace(' ', '_');
     E value = StringUtils.bestFuzzyMatch(name, type);
 
-    if (value == null || (!fuzzyMatch && !name.equalsIgnoreCase(value.name()))) {
+    if (value == null || (!fuzzyMatch && !isExactMatch(name, value))) {
       throw invalidFormat(text, type, value != null ? value.name().toLowerCase() : null, null);
     }
 
@@ -352,6 +353,17 @@ public final class TextParser {
     }
 
     return value;
+  }
+
+  private static <E extends Enum<E>> boolean isExactMatch(String text, E value) {
+    if (value instanceof Aliased aliased) {
+      for (String aliases : aliased) {
+        if (text.equalsIgnoreCase(aliases)) return true;
+      }
+      return false;
+    } else {
+      return text.equalsIgnoreCase(value.name());
+    }
   }
 
   /**
@@ -434,11 +446,11 @@ public final class TextParser {
    *
    * <p>Accepts full qualified json strings as components.
    *
-   * <p>This method is mainly for backwards compatability for {@link
-   * XMLUtils#parseFormattedText(Node, Component)}. Previously using {@link #parseComponent(String)}
-   * with the result from {@code parseFormattedText} would bug out when sent to older clients, since
-   * the LegacyComponentSerializer expects "&" but {@link BukkitUtils#colorize(String)}(Used in the
-   * XMLUtils method) results in using "§".
+   * <p>This method is mainly for backwards compatability for
+   * {@link XMLUtils#parseFormattedText(Node, Component)}. Previously using
+   * {@link #parseComponent(String)} with the result from {@code parseFormattedText} would bug out
+   * when sent to older clients, since the LegacyComponentSerializer expects "&" but
+   * {@link BukkitUtils#colorize(String)}(Used in the XMLUtils method) results in using "§".
    *
    * @param text The text.
    * @return a Component.


### PR DESCRIPTION
Adds a new parameter "sparks-match" to Destroyable

"sparks" must be active for "sparks-match" to have any effect

With the default value of "true" there is no change to current behavior for Destroyable sparks.

 With value of "false" PGM will skip the far (+64 blocks away) logic

 Purpose is to reduce the "noise" for players not actually near the action, especially for large Destroyables

 Tested and verified that sound behavior changed for players and observers

