### PR TITLE
Fix NPE on inventory interact

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
@@ -137,8 +137,9 @@ public class Observing extends State {
   public void onEvent(InventoryClickEvent event) {
     super.onEvent(event);
 
-    if (!(event.getClickedInventory() instanceof PlayerInventory
-            || event.getClickedInventory().getType() == InventoryType.CRAFTING)
+    var inv = event.getInventory();
+    if (inv == null
+        || !(inv instanceof PlayerInventory || inv.getType() == InventoryType.CRAFTING)
         || event.getCursor() == null) return;
 
     ItemStack item = event.getCursor();


### PR DESCRIPTION
The clicked inventory can be null, and checking for type=crafting causes a npe