### PR TITLE
Fix duplicated countdown filter bossbars

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/filter/ReactorFactory.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/ReactorFactory.java
@@ -16,7 +16,8 @@ public interface ReactorFactory<R extends ReactorFactory.Reactor>
     extends FilterDefinition, StateHolder<R> {
 
   default void register(Match match, FilterMatchModule fmm) {
-    match.getFeatureContext().registerState(this, createReactor(match, fmm));
+    if (!match.getFeatureContext().hasState(this))
+      match.getFeatureContext().registerState(this, createReactor(match, fmm));
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/features/MatchFeatureContext.java
+++ b/core/src/main/java/tc/oc/pgm/features/MatchFeatureContext.java
@@ -8,26 +8,33 @@ import java.util.Map;
 import tc.oc.pgm.api.feature.Feature;
 import tc.oc.pgm.util.collection.ContextStore;
 
-public class MatchFeatureContext extends ContextStore<Feature> {
+public class MatchFeatureContext extends ContextStore<Feature<?>> {
 
   private final Map<StateHolder<?>, Object> states = new IdentityHashMap<>();
 
-  public String add(Feature feature) {
+  public String add(Feature<?> feature) {
     super.add(feature.getId(), feature);
     return feature.getId();
   }
 
-  public <T extends Feature> T get(String id, Class<T> type) {
+  @SuppressWarnings("unchecked")
+  public <T extends Feature<?>> T get(String id, Class<T> type) {
     return (T) this.get(id);
   }
 
   public <T> void registerState(StateHolder<T> stateHolder, T state) {
-    states.put(stateHolder, state);
+    if (states.putIfAbsent(stateHolder, state) != null) {
+      throw new IllegalStateException("State already registered: " + stateHolder);
+    }
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T getState(StateHolder<T> stateHolder) {
-    //noinspection unchecked
     return (T) assertNotNull(states.get(stateHolder), "state");
+  }
+
+  public boolean hasState(StateHolder<?> stateHolder) {
+    return states.containsKey(stateHolder);
   }
 
   public Map<StateHolder<?>, Object> getStates() {


### PR DESCRIPTION
Latest state changes for 1.5 proto have brought up instances where if the same filter is reachable thru multiple references, it can register its state (the bossbar tracking state) multiple times, causing duplicated bossbars. This fixes the issue by ensuring only one state per feature is registered.