### PR TITLE
Implement fluent parser & start migration

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionModule.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionModule.java
@@ -57,7 +57,7 @@ public class ActionModule implements MapModule<ActionMatchModule> {
     @Override
     public ActionModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
-      ActionParser parser = new ActionParser(factory);
+      ActionParser parser = factory.getParser().getActionParser();
 
       for (Element action :
           XMLUtils.flattenElements(doc.getRootElement(), Set.of("actions"), parser.actionTypes())) {

--- a/core/src/main/java/tc/oc/pgm/api/filter/Filterables.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/Filterables.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.api.filter;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
@@ -10,9 +9,12 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 
 public interface Filterables {
+  Class<Match> MATCH = Match.class;
+  Class<Party> PARTY = Party.class;
+  Class<MatchPlayer> PLAYER = MatchPlayer.class;
+
   /** {@link Filterable}s ordered from general to specific */
-  List<Class<? extends Filterable<?>>> SCOPES =
-      ImmutableList.of(Match.class, Party.class, MatchPlayer.class);
+  List<Class<? extends Filterable<?>>> SCOPES = List.of(MATCH, PARTY, PLAYER);
 
   /**
    * Return the "scope" of the given filter, which is the most general {@link Filterable} type that
@@ -46,15 +48,13 @@ public interface Filterables {
   // pgm classes
   @SuppressWarnings("unchecked")
   static <T extends Filterable<?>> Class<T> parse(Node node) throws InvalidXMLException {
-    switch (node.getValueNormalize()) {
-      case "player":
-        return (Class<T>) MatchPlayer.class;
-      case "team":
-        return (Class<T>) Party.class;
-      case "match":
-        return (Class<T>) Match.class;
-      default:
-        throw new InvalidXMLException("Unknown scope, must be one of: player, team, match", node);
-    }
+    return (Class<T>)
+        switch (node.getValueNormalize()) {
+          case "player" -> PLAYER;
+          case "team" -> PARTY;
+          case "match" -> MATCH;
+          default -> throw new InvalidXMLException(
+              "Unknown scope, must be one of: player, team, match", node);
+        };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/map/factory/MapFactory.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/factory/MapFactory.java
@@ -10,9 +10,17 @@ import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.Version;
+import tc.oc.pgm.util.xml.XMLFluentParser;
 
 /** A factory for creating {@link MapInfo}s and {@link MapContext}s. */
 public interface MapFactory extends ModuleContext<MapModule<?>>, AutoCloseable {
+
+  /**
+   * A parser able to parse most commonly required things, with a fluent interface.
+   *
+   * @return A {@link XMLFluentParser}
+   */
+  XMLFluentParser getParser();
 
   /**
    * Get the {@link RegionParser} for parsing region references.

--- a/core/src/main/java/tc/oc/pgm/damage/DamageModule.java
+++ b/core/src/main/java/tc/oc/pgm/damage/DamageModule.java
@@ -9,16 +9,13 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import tc.oc.pgm.action.Action;
 import tc.oc.pgm.action.ActionModule;
-import tc.oc.pgm.action.ActionParser;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.filters.parse.FilterParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
-import tc.oc.pgm.util.xml.Node;
 
 public class DamageModule implements MapModule<DamageMatchModule> {
 
@@ -50,22 +47,24 @@ public class DamageModule implements MapModule<DamageMatchModule> {
     @Override
     public DamageModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
-      FilterParser filterParser = factory.getFilters();
-      ActionParser actionParser = new ActionParser(factory);
+      var parser = factory.getParser();
 
       List<Filter> filters = new ArrayList<>();
       Action<? super MatchPlayer> attackerAction = null;
       Action<? super MatchPlayer> victimAction = null;
 
       for (Element elDamage : doc.getRootElement().getChildren("damage")) {
-        attackerAction = actionParser.parseProperty(
-            Node.fromAttr(elDamage, "attacker-action"), MatchPlayer.class, attackerAction);
-
-        victimAction = actionParser.parseProperty(
-            Node.fromAttr(elDamage, "victim-action"), MatchPlayer.class, victimAction);
+        attackerAction = parser
+            .action(MatchPlayer.class, elDamage, "attacker-action")
+            .attr()
+            .optional(attackerAction);
+        victimAction = parser
+            .action(MatchPlayer.class, elDamage, "victim-action")
+            .attr()
+            .optional(victimAction);
 
         for (Element elFilter : elDamage.getChildren()) {
-          filters.add(filterParser.parse(elFilter));
+          filters.add(parser.filter(elFilter).required());
         }
       }
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -44,7 +44,6 @@ import org.bukkit.potion.PotionEffect;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.action.Action;
-import tc.oc.pgm.action.ActionParser;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -812,10 +811,10 @@ public abstract class KitParser {
   public ActionKit parseActionKit(Element parent) throws InvalidXMLException {
     if (parent.getChildren("action").isEmpty()) return null;
 
-    ActionParser parser = new ActionParser(factory);
+    var parser = factory.getParser();
     ImmutableList.Builder<Action<? super MatchPlayer>> builder = ImmutableList.builder();
     for (Element action : parent.getChildren("action")) {
-      builder.add(parser.parse(action, MatchPlayer.class));
+      builder.add(parser.action(MatchPlayer.class, action).required());
     }
 
     return new ActionKit(builder.build());

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -37,6 +37,7 @@ import tc.oc.pgm.util.Version;
 import tc.oc.pgm.util.xml.DocumentWrapper;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLFluentParser;
 
 public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?>>
     implements MapFactory {
@@ -51,6 +52,7 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
   private FilterParser filters;
   private KitParser kits;
   private FeatureDefinitionContext features;
+  private XMLFluentParser parser;
 
   public MapFactoryImpl(
       Logger logger,
@@ -146,6 +148,16 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
 
   private boolean isLegacy() {
     return getProto().isOlderThan(MapProtos.FILTER_FEATURES);
+  }
+
+  @Override
+  public XMLFluentParser getParser() {
+    if (parser == null) {
+      parser = new XMLFluentParser(this);
+      // Calling init will cause more calls to getParser, that's why we need them separate
+      parser.init();
+    }
+    return parser;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -1,0 +1,118 @@
+package tc.oc.pgm.util.xml;
+
+import org.jdom2.Element;
+import tc.oc.pgm.action.Action;
+import tc.oc.pgm.action.ActionParser;
+import tc.oc.pgm.api.feature.FeatureDefinition;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.features.FeatureDefinitionContext;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.filters.parse.FilterParser;
+import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.kits.KitParser;
+import tc.oc.pgm.regions.RegionParser;
+import tc.oc.pgm.util.math.Formula;
+import tc.oc.pgm.util.text.TextException;
+import tc.oc.pgm.util.text.TextParser;
+import tc.oc.pgm.util.xml.parsers.BoolBuilder;
+import tc.oc.pgm.util.xml.parsers.Builder;
+import tc.oc.pgm.util.xml.parsers.FilterBuilder;
+import tc.oc.pgm.util.xml.parsers.ItemBuilder;
+import tc.oc.pgm.util.xml.parsers.PrimitiveBuilder;
+import tc.oc.pgm.util.xml.parsers.ReferenceBuilder;
+import tc.oc.pgm.util.xml.parsers.RegionBuilder;
+import tc.oc.pgm.variables.VariablesModule;
+
+public class XMLFluentParser {
+
+  private final MapFactory factory;
+  private FeatureDefinitionContext features;
+  private ActionParser actions;
+  private FilterParser filters;
+  private RegionParser regions;
+  private KitParser kits;
+  private VariablesModule variables;
+
+  public XMLFluentParser(MapFactory factory) {
+    this.factory = factory;
+  }
+
+  // This is required to avoid recursive initialization
+  // ie: fluent parser -> action parser -> fluent parser
+  public void init() {
+    this.features = factory.getFeatures();
+    this.actions = new ActionParser(factory);
+    this.filters = factory.getFilters();
+    this.regions = factory.getRegions();
+    this.kits = factory.getKits();
+    this.variables = factory.needModule(VariablesModule.class);
+  }
+
+  public BoolBuilder parseBool(Element el, String... prop) {
+    return new BoolBuilder(el, prop);
+  }
+
+  public <T extends Enum<T>> PrimitiveBuilder.Generic<T> parseEnum(
+      Class<T> type, Element el, String... prop) {
+    return new PrimitiveBuilder.Generic<T>(el, prop) {
+      @Override
+      protected T parse(String text) throws TextException {
+        return TextParser.parseEnum(text, type);
+      }
+    };
+  }
+
+  public FilterBuilder filter(Element el, String... prop) throws InvalidXMLException {
+    return new FilterBuilder(filters, el, prop);
+  }
+
+  public RegionBuilder region(Element el, String... prop) throws InvalidXMLException {
+    return new RegionBuilder(regions, el, prop);
+  }
+
+  public ItemBuilder item(Element el, String... prop) throws InvalidXMLException {
+    return new ItemBuilder(kits, el, prop);
+  }
+
+  public Builder.Generic<Kit> kit(Element el, String... prop) throws InvalidXMLException {
+    return new Builder.Generic<>(el, prop) {
+      @Override
+      protected Kit parse(Node node) throws InvalidXMLException {
+        return node.isAttribute()
+            ? kits.parseReference(node, node.getValue())
+            : kits.parse(node.getElement());
+      }
+    };
+  }
+
+  public <T extends FeatureDefinition> ReferenceBuilder<T> reference(
+      Class<T> clazz, Element el, String... prop) throws InvalidXMLException {
+    return new ReferenceBuilder<T>(features, clazz, el, prop);
+  }
+
+  public <T extends Filterable<?>> Builder.Generic<Action<? super T>> action(
+      Class<T> clazz, Element el, String... prop) throws InvalidXMLException {
+    return new Builder.Generic<>(el, prop) {
+      @Override
+      protected Action<? super T> parse(Node node) throws InvalidXMLException {
+        return node.isAttribute()
+            ? actions.parseReference(node, clazz)
+            : actions.parse(node.getElement(), clazz);
+      }
+    };
+  }
+
+  public ActionParser getActionParser() {
+    return actions;
+  }
+
+  public <T extends Filterable<?>> Builder<Formula<T>, ?> formula(
+      Class<T> clazz, Element el, String... prop) throws InvalidXMLException {
+    return new Builder.Generic<>(el, prop) {
+      @Override
+      protected Formula<T> parse(Node node) {
+        return Formula.of(node.getValue(), variables.getContext(clazz));
+      }
+    };
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/BoolBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/BoolBuilder.java
@@ -1,0 +1,30 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.jdom2.Element;
+import tc.oc.pgm.util.text.TextException;
+import tc.oc.pgm.util.text.TextParser;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+
+public class BoolBuilder extends PrimitiveBuilder<Boolean, BoolBuilder> {
+  public BoolBuilder(Element el, String... prop) {
+    super(el, prop);
+  }
+
+  public boolean orTrue() throws InvalidXMLException {
+    return optional(true);
+  }
+
+  public boolean orFalse() throws InvalidXMLException {
+    return optional(false);
+  }
+
+  @Override
+  protected Boolean parse(String text) throws TextException {
+    return TextParser.parseBoolean(text);
+  }
+
+  @Override
+  protected BoolBuilder getThis() {
+    return this;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/Builder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/Builder.java
@@ -1,0 +1,114 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.function.ThrowingSupplier;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+
+public abstract class Builder<T, B extends Builder<T, B>> {
+  protected final @Nullable Element el;
+  protected final String[] prop;
+
+  protected List<Validator<T>> validators;
+  protected boolean attr;
+  protected boolean child;
+  protected boolean self;
+
+  public Builder(@Nullable Element el, String... prop) {
+    this.el = el;
+    this.prop = prop;
+    this.attr = prop.length > 0;
+    this.child = prop.length > 0;
+    this.self = prop.length == 0;
+  }
+
+  /** Make it so this parser will only run on attributes, ignoring child elements */
+  public B attr() {
+    assert prop.length != 0;
+    attr = true;
+    child = false;
+    return getThis();
+  }
+
+  /** Make it so this parser will only run on child elements, ignoring attributes */
+  public B child() {
+    assert prop.length != 0;
+    attr = false;
+    child = true;
+    return getThis();
+  }
+
+  public B validate(Validator<T> validator) {
+    if (validators == null) validators = new ArrayList<>();
+    validators.add(validator);
+    return getThis();
+  }
+
+  public T required() throws InvalidXMLException {
+    return handleParse(getNode(true));
+  }
+
+  public T optional(T defaultValue) throws InvalidXMLException {
+    Node node = getNode(false);
+    return node == null ? defaultValue : handleParse(node);
+  }
+
+  public T optional(ThrowingSupplier<T, InvalidXMLException> defaultValue)
+      throws InvalidXMLException {
+    Node node = getNode(false);
+    return node == null ? defaultValue.get() : handleParse(node);
+  }
+
+  public Optional<T> optional() throws InvalidXMLException {
+    Node node = getNode(false);
+    return node == null ? Optional.empty() : Optional.of(handleParse(node));
+  }
+
+  public T orNull() throws InvalidXMLException {
+    return optional((T) null);
+  }
+
+  public T orSelf() throws InvalidXMLException {
+    attr = true;
+    child = false;
+    self = true;
+    return handleParse(getNode(true));
+  }
+
+  protected Node getNode(boolean required) throws InvalidXMLException {
+    return Node.from(attr, child, self, required, el, prop);
+  }
+
+  T handleParse(Node node) throws InvalidXMLException {
+    T value = parse(node);
+    if (validators != null) {
+      for (Validator<T> validator : validators) {
+        validator.validate(value, node);
+      }
+    }
+    return value;
+  }
+
+  protected abstract T parse(Node node) throws InvalidXMLException;
+
+  protected abstract B getThis();
+
+  public interface Validator<T> {
+    void validate(T t, Node node) throws InvalidXMLException;
+  }
+
+  public abstract static class Generic<T> extends Builder<T, Generic<T>> {
+    public Generic(@Nullable Element el, String... prop) {
+      super(el, prop);
+    }
+
+    @Override
+    protected Generic<T> getThis() {
+      return this;
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/FilterBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/FilterBuilder.java
@@ -1,0 +1,48 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.jdom2.Element;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.filters.matcher.StaticFilter;
+import tc.oc.pgm.filters.parse.DynamicFilterValidation;
+import tc.oc.pgm.filters.parse.FilterParser;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+
+public class FilterBuilder extends Builder<Filter, FilterBuilder> {
+  private final FilterParser filters;
+
+  public FilterBuilder(FilterParser filters, Element el, String... prop) {
+    super(el, prop);
+    this.filters = filters;
+  }
+
+  public FilterBuilder dynamic() {
+    validate((f, n) -> filters.validate(f, DynamicFilterValidation.ANY, n));
+    return this;
+  }
+
+  public FilterBuilder dynamic(Class<? extends Filterable<?>> type) {
+    validate((f, n) -> filters.validate(f, DynamicFilterValidation.of(type), n));
+    return this;
+  }
+
+  public Filter orAllow() throws InvalidXMLException {
+    return optional(StaticFilter.ALLOW);
+  }
+
+  public Filter orDeny() throws InvalidXMLException {
+    return optional(StaticFilter.DENY);
+  }
+
+  @Override
+  protected Filter parse(Node node) throws InvalidXMLException {
+    if (prop.length == 0) return filters.parse(el);
+    return filters.parseProperty(node);
+  }
+
+  @Override
+  protected FilterBuilder getThis() {
+    return this;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/ItemBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/ItemBuilder.java
@@ -1,0 +1,38 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.bukkit.inventory.ItemStack;
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.kits.KitParser;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+
+public class ItemBuilder extends Builder<ItemStack, ItemBuilder> {
+  private final KitParser kits;
+  boolean allowAir = false;
+
+  public ItemBuilder(KitParser kits, @Nullable Element el, String... prop) {
+    super(el, prop);
+    this.kits = kits;
+  }
+
+  public ItemBuilder allowAir() {
+    allowAir = true;
+    return this;
+  }
+
+  @Override
+  protected Node getNode(boolean required) throws InvalidXMLException {
+    return Node.from(false, child, self, required, el, prop);
+  }
+
+  @Override
+  protected ItemStack parse(Node node) throws InvalidXMLException {
+    return kits.parseItem(node.getElement(), allowAir);
+  }
+
+  @Override
+  protected ItemBuilder getThis() {
+    return this;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/PrimitiveBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/PrimitiveBuilder.java
@@ -1,0 +1,36 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.text.TextException;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+
+public abstract class PrimitiveBuilder<T, B extends PrimitiveBuilder<T, B>> extends Builder<T, B> {
+
+  public PrimitiveBuilder(Element el, String... prop) {
+    super(el, prop);
+  }
+
+  @Override
+  protected T parse(Node node) throws InvalidXMLException {
+    try {
+      return parse(node.getValueNormalize());
+    } catch (TextException e) {
+      throw new InvalidXMLException(node, e);
+    }
+  }
+
+  protected abstract T parse(String text) throws TextException;
+
+  public abstract static class Generic<T> extends PrimitiveBuilder<T, PrimitiveBuilder.Generic<T>> {
+    public Generic(@Nullable Element el, String... prop) {
+      super(el, prop);
+    }
+
+    @Override
+    protected PrimitiveBuilder.Generic<T> getThis() {
+      return this;
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/ReferenceBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/ReferenceBuilder.java
@@ -1,0 +1,36 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.jdom2.Element;
+import tc.oc.pgm.api.feature.FeatureDefinition;
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.api.feature.FeatureValidation;
+import tc.oc.pgm.features.FeatureDefinitionContext;
+import tc.oc.pgm.util.xml.Node;
+
+public class ReferenceBuilder<T extends FeatureDefinition>
+    extends Builder<FeatureReference<T>, ReferenceBuilder<T>> {
+  private final FeatureDefinitionContext features;
+  private final Class<T> type;
+
+  public ReferenceBuilder(
+      FeatureDefinitionContext features, Class<T> type, Element el, String... prop) {
+    super(el, prop);
+    this.features = features;
+    this.type = type;
+  }
+
+  @Override
+  protected FeatureReference<T> parse(Node node) {
+    return features.createReference(node, type);
+  }
+
+  public ReferenceBuilder<T> validate(FeatureValidation<T> fv) {
+    super.validate((ref, node) -> features.validate(ref, fv));
+    return this;
+  }
+
+  @Override
+  protected ReferenceBuilder<T> getThis() {
+    return this;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/RegionBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/RegionBuilder.java
@@ -1,0 +1,39 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.jdom2.Element;
+import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.regions.BlockBoundedValidation;
+import tc.oc.pgm.regions.RandomPointsValidation;
+import tc.oc.pgm.regions.RegionParser;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+
+public class RegionBuilder extends Builder<Region, RegionBuilder> {
+  private final RegionParser regions;
+
+  public RegionBuilder(RegionParser regions, Element el, String... prop) {
+    super(el, prop);
+    this.regions = regions;
+  }
+
+  public RegionBuilder blockBounded() {
+    validate((r, n) -> regions.validate(r, BlockBoundedValidation.INSTANCE, n));
+    return this;
+  }
+
+  public RegionBuilder randomPoints() {
+    validate((r, n) -> regions.validate(r, RandomPointsValidation.INSTANCE, n));
+    return this;
+  }
+
+  @Override
+  protected Region parse(Node node) throws InvalidXMLException {
+    if (prop.length == 0) return regions.parse(el);
+    return regions.parseProperty(node);
+  }
+
+  @Override
+  protected RegionBuilder getThis() {
+    return this;
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/function/ThrowingSupplier.java
+++ b/util/src/main/java/tc/oc/pgm/util/function/ThrowingSupplier.java
@@ -1,0 +1,6 @@
+package tc.oc.pgm.util.function;
+
+@FunctionalInterface
+public interface ThrowingSupplier<T, E extends Throwable> {
+  T get() throws E;
+}


### PR DESCRIPTION
For a long while, PGM has had an explosion of parsing methods to support the different ways in which we can parse. Overloads upon overloads for parsing a node, an element, an attribute, required or with a default, maybe with a validation in there too.

That doesn't create the cleanest programming model, and it's why i want to move away from it. Welcome fluent parsing api:

```java
// Before (yes, all diff 10  overloads exist for filters):
var a1 = parseProperty(el, "filter"); // Defaults to null, non-obvious
var b1 = parseProperty(el, "filter", StaticFilter.ALLOW); // Defaults to ALLOW
var c1 = parseProperty(el, "filter", DynamicFilterValidation.ANY); // Defaults to null, non-obvious
var d1 = parseProperty(el, "filter", StaticFilter.ALLOW, DynamicFilterValidation.ANY);

var a2 = parseProperty(Node.fromChildOrAttr(el, "filter", "trigger"));
var b2 = parseProperty(Node.fromChildOrAttr(el, "filter", "trigger"), StaticFilter.ALLOW);
var c2 = parseProperty(Node.fromChildOrAttr(el, "filter", "trigger"), DynamicFilterValidation.ANY);
var d2 = parseProperty(Node.fromChildOrAttr(el, "filter", "trigger"), StaticFilter.ALLOW, DynamicFilterValidation.ANY);

var a3 = parseRequiredProperty(el, "filter");
var b3 = parseRequiredProperty(el, "filter", DynamicFilterValidation.ANY);

// After
var a1 = parser.filter(el, "filter").orNull();
var b1 = parser.filter(el, "filter").orAllow();
var c1 = parser.filter(el, "filter").dynamic().orNull();
var d1 = parser.filter(el, "filter").dynamic().orAllow();

var a2 = parser.filter(el, "filter", "trigger").orNull();
var b2 = parser.filter(el, "filter", "trigger").orAllow();
var c2 = parser.filter(el, "filter", "trigger").dynamic().orNull();
var d2 = parser.filter(el, "filter", "trigger").dynamic().orAllow();

var a3 = parser.filter(el, "filter").required();
var b3 = parser.filter(el, "filter").dynamic().required();
```
This is just a specific example for filters (listing all 10 former methods) but the new api also comes with more methods  like `optional(defaultValue)` of which `orAllow` is just an overload specifically for filters. The beauty is we can compose these calls without having an explosion in method overloads.