### PR TITLE
Implement player replacements in message actions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -55,6 +55,7 @@ import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
 import tc.oc.pgm.util.inventory.ItemMatcher;
 import tc.oc.pgm.util.math.Formula;
+import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLFluentParser;
@@ -290,9 +291,10 @@ public class ActionParser {
       case "player":
         var variable = parser.variable(el, "var").scope(MatchPlayer.class).singleExclusive();
         var fallback = XMLUtils.parseFormattedText(el, "fallback", empty());
+        var nameStyle = parser.parseEnum(NameStyle.class, el, "style").optional(NameStyle.VERBOSE);
 
         return (T filterable) ->
-            variable.getHolder(filterable).map(MatchPlayer::getName).orElse(fallback);
+            variable.getHolder(filterable).map(mp -> mp.getName(nameStyle)).orElse(fallback);
       default:
         throw new InvalidXMLException("Unknown replacement type", el);
     }

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -21,6 +21,7 @@ import tc.oc.pgm.util.xml.parsers.ItemBuilder;
 import tc.oc.pgm.util.xml.parsers.PrimitiveBuilder;
 import tc.oc.pgm.util.xml.parsers.ReferenceBuilder;
 import tc.oc.pgm.util.xml.parsers.RegionBuilder;
+import tc.oc.pgm.util.xml.parsers.VariableBuilder;
 import tc.oc.pgm.variables.VariablesModule;
 
 public class XMLFluentParser {
@@ -88,6 +89,10 @@ public class XMLFluentParser {
   public <T extends FeatureDefinition> ReferenceBuilder<T> reference(
       Class<T> clazz, Element el, String... prop) throws InvalidXMLException {
     return new ReferenceBuilder<T>(features, clazz, el, prop);
+  }
+
+  public VariableBuilder<?> variable(Element el, String... prop) throws InvalidXMLException {
+    return new VariableBuilder<>(features, el, prop);
   }
 
   public <T extends Filterable<?>> Builder.Generic<Action<? super T>> action(

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/VariableBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/VariableBuilder.java
@@ -1,0 +1,82 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.jdom2.Element;
+import tc.oc.pgm.api.filter.Filterables;
+import tc.oc.pgm.features.FeatureDefinitionContext;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.variables.Variable;
+
+public class VariableBuilder<T extends Filterable<?>>
+    extends Builder<Variable<T>, VariableBuilder<T>> {
+  private final FeatureDefinitionContext features;
+
+  public VariableBuilder(FeatureDefinitionContext features, Element el, String... prop) {
+    super(el, prop);
+    this.features = features;
+  }
+
+  public VariableBuilder<T> bound(Class<? extends Filterable<?>> scope) {
+    validate((var, n) -> {
+      if (!Filterables.isAssignable(scope, var.getScope()))
+        throw new InvalidXMLException(
+            "Wrong variable scope for '"
+                + n.getValue()
+                + "', required "
+                + scope.getSimpleName()
+                + " or higher, but was "
+                + var.getScope().getSimpleName(),
+            el);
+    });
+    return this;
+  }
+
+  public <S extends Filterable<?>> VariableBuilder<S> scope(Class<S> scope) {
+    validate((var, n) -> {
+      if (scope != var.getScope())
+        throw new InvalidXMLException(
+            "Wrong variable scope for '"
+                + n.getValue()
+                + "', required "
+                + scope.getSimpleName()
+                + " but variable was "
+                + var.getScope().getSimpleName(),
+            n);
+    });
+    return (VariableBuilder<S>) this;
+  }
+
+  public VariableBuilder<T> writtable() {
+    validate((var, n) -> {
+      if (var.isReadonly())
+        throw new InvalidXMLException("Variable was readonly when write access is required", n);
+    });
+    return this;
+  }
+
+  public Variable.Exclusive<T> singleExclusive() throws InvalidXMLException {
+    validate((var, n) -> {
+      if (!var.isExclusive() || ((Variable.Exclusive<T>) var).getCardinality() != 1)
+        throw new InvalidXMLException("Variable with exclusive=1 required", n);
+    });
+    return (Variable.Exclusive<T>) required();
+  }
+
+  public Variable.Exclusive<T> exclusive() throws InvalidXMLException {
+    validate((var, n) -> {
+      if (!var.isExclusive()) throw new InvalidXMLException("Variable with exclusive required", n);
+    });
+    return (Variable.Exclusive<T>) required();
+  }
+
+  @Override
+  protected Variable<T> parse(Node node) throws InvalidXMLException {
+    return features.resolve(node, Variable.class);
+  }
+
+  @Override
+  protected VariableBuilder<T> getThis() {
+    return this;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/variables/Variable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/Variable.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.variables;
 
+import java.util.Collection;
+import java.util.Optional;
 import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.filters.Filterable;
@@ -24,6 +26,10 @@ public interface Variable<T extends Filterable<?>> extends FeatureDefinition {
     return false;
   }
 
+  default boolean isExclusive() {
+    return false;
+  }
+
   default void load(Match match) {}
 
   /**
@@ -44,5 +50,18 @@ public interface Variable<T extends Filterable<?>> extends FeatureDefinition {
     void setValue(Filterable<?> context, int idx, double value);
 
     int size();
+  }
+
+  interface Exclusive<T extends Filterable<?>> extends Variable<T> {
+    @Override
+    default boolean isExclusive() {
+      return getCardinality() != null;
+    }
+
+    Integer getCardinality();
+
+    Optional<T> getHolder(Filterable<?> context);
+
+    Collection<T> getHolders(Filterable<?> context);
   }
 }


### PR DESCRIPTION
Adds a `<player>` replacement to the message action, which takes in an exclusive variable:


```xml
<variables
    <variable id="last_scorer" scope="player" exclusive="1"/>
</variables>
<actions>
    <action id="the-player-scored" scope="player">
        <set var="last_scorer" value="1"/>
        <switch-scope outer="player" inner="match">
            <message text="{pl} scored a goal!">
                <replacements>
                    <player id="pl" var="last_scorer"/>
                </replacements>
            </message>
        </switch-scope>
    </action>
</actions>
```
![image](https://github.com/user-attachments/assets/7aa397d4-d7de-4341-914c-b2aadeb37c86)


Attributes:
- `id` required, the id to use as  replacement inside the text
- `var` required, the variable to check for. Must be player-scoped and exclusive=1 variable.
- `style` optional, the style to show the player name in. Defaults to `verbose`
  - `plain` no formatting at all
  - ~`simple_color`~  (discouraged) Simple formatting, just team color. Used for non-clickable places
  - `color` the name with color, and the typical hover with click to teleport to the player
  - `fancy` Fancy formatting, flairs, color, click to teleport, italic for friends, crossed for vanish/nicked
  - ~`tab`~ (discouraged) Tab list format, flairs, color, death status, self, etc
  - `verbose` **DEFAULT** like fancy,  but includes full nickname for nicked
  - Note that these all depend on who's seeing it, you won't be revealing anyone's nick by using them.
- `fallback` optional, if no player has been assigned that variable, what text to show. Defaults to empty text.


Here's how the different formats show for an unnicked player:
![image](https://github.com/user-attachments/assets/dd16dbee-8968-4e59-b7c0-9f90ccd2f5ca)

And then for completeness when nicked, first seen as someone with perms, and a 3rd party too:
![image](https://github.com/user-attachments/assets/3997e3de-efc2-480a-b018-9d0d312db40c)
![image](https://github.com/user-attachments/assets/f22d4c6c-a5b2-4ba9-a635-1392b3e41528)




