### PR TITLE
Fix player target variables & make score optional

### DIFF
--- a/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/PlayerLocationVariable.java
@@ -81,7 +81,7 @@ public class PlayerLocationVariable extends AbstractVariable<MatchPlayer> {
 
   private static RayBlockIntersection intersection(MatchPlayer player) {
     RayCastCache cache = lastRaytrace;
-    if (player.getLocation().equals(cache.location)) {
+    if (cache != null && player.getLocation().equals(cache.location)) {
       return cache.rayCast;
     }
     lastRaytrace = cache = new RayCastCache(

--- a/core/src/main/java/tc/oc/pgm/variables/types/ScoreVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/ScoreVariable.java
@@ -13,14 +13,17 @@ public class ScoreVariable extends AbstractVariable<Party> {
 
   @Override
   protected double getValueImpl(Party party) {
-    if (party instanceof Competitor)
-      return party.moduleRequire(ScoreMatchModule.class).getScore((Competitor) party);
-    return 0;
+    if (party instanceof Competitor c)
+      return party
+          .moduleOptional(ScoreMatchModule.class)
+          .map(smm -> smm.getScore(c))
+          .orElse(-1d);
+    return -1;
   }
 
   @Override
   protected void setValueImpl(Party party, double value) {
-    if (party instanceof Competitor)
-      party.moduleRequire(ScoreMatchModule.class).setScore((Competitor) party, value);
+    if (party instanceof Competitor c)
+      party.moduleOptional(ScoreMatchModule.class).ifPresent(smm -> smm.setScore(c, value));
   }
 }


### PR DESCRIPTION
Score variable will now return `-1` for maps with no score, instead of throwing an error

Player target-related variables were throwing a NPE, that has been fixed now