### PR TITLE
Add repeat action & tweak untrigger filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/actions/RepeatAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/RepeatAction.java
@@ -1,0 +1,24 @@
+package tc.oc.pgm.action.actions;
+
+import tc.oc.pgm.action.Action;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.util.math.Formula;
+
+public class RepeatAction<B extends Filterable<?>> extends AbstractAction<B> {
+
+  protected final Action<? super B> action;
+  protected final Formula<B> formula;
+
+  public RepeatAction(Class<B> scope, Action<? super B> action, Formula<B> formula) {
+    super(scope);
+    this.action = action;
+    this.formula = formula;
+  }
+
+  @Override
+  public void trigger(B t) {
+    for (int i = (int) formula.applyAsDouble(t); i > 0; i--) {
+      action.trigger(t);
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/FilterBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/FilterBuilder.java
@@ -35,6 +35,10 @@ public class FilterBuilder extends Builder<Filter, FilterBuilder> {
     return optional(StaticFilter.DENY);
   }
 
+  public Filter result(boolean result) throws InvalidXMLException {
+    return optional(result ? StaticFilter.ALLOW : StaticFilter.DENY);
+  }
+
   @Override
   protected Filter parse(Node node) throws InvalidXMLException {
     if (prop.length == 0) return filters.parse(el);


### PR DESCRIPTION
Modifies the 1.5 proto default behavior for `untrigger-filter` back to never whenever the action is filtered. This is because we've realized that otherwise recursive actions will cause infinite recursion on untrigger by default, which is undesired behavior.
So now in proto 1.5, when an action has no filter,  it defaults to untrigger-filter="always", but whenever it's filtered or map is in an older proto, it defaults to never.

Additionally a `repeat` action has been introduced. This allows for loops without recursion within actions:

```xml
<actions>
  <repeat times="var * 2" filter="allow">
    <message text="This message is repeating a bunch of times!"/>
  </repeat>
</actions>
```

When `var` is 5, this will send the message 10 times in chat. Note  that `times` takes in a function, so you can do things as simple as `times="5"` or as complex as to mix-in variables, and math operations. Non-whole numbers will be rounded down, negative numbers will cause no iterations (it won't run the inner action).

The `filter` will be run as many times as the loop is ran, for performance reasons if you want the filter to be checked just once move it outside the `repeat` like action filter="x" -> repeat.
Untriggering has no effect whatsoever over the repeat action, it will not propagate any untrigger signal downwards
