### PR TITLE
Implement time penalties for switching

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -81,6 +82,7 @@ public final class PGMConfig implements Config {
   private final boolean woolRefill;
   private final int griefScore;
   private final float assistPercent;
+  private final Map<TimePenalty, Duration> timePenalties;
 
   // votes.*
   private final boolean allowExtraVotes;
@@ -183,6 +185,12 @@ public final class PGMConfig implements Config {
         parseInteger(config.getString("gameplay.grief-score", "-10"), Range.atMost(0));
     this.assistPercent =
         parseFloat(config.getString("gameplay.assist-percent", "0.3"), Range.openClosed(0f, 1f));
+    this.timePenalties = new EnumMap<>(TimePenalty.class);
+    for (TimePenalty penalty : TimePenalty.values()) {
+      String key = penalty.name().toLowerCase(Locale.ROOT).replace('_', '-');
+      timePenalties.put(
+          penalty, parseDuration(config.getString("gameplay.time-penalties." + key, "0")));
+    }
 
     this.allowExtraVotes = parseBoolean(config.getString("votes.allow-extra-votes", "true"));
     this.maxExtraVotes = parseInteger(config.getString("votes.max-extra-votes", "5"));
@@ -567,6 +575,11 @@ public final class PGMConfig implements Config {
   @Override
   public float getAssistPercent() {
     return assistPercent;
+  }
+
+  @Override
+  public Duration getTimePenalty(TimePenalty penalty) {
+    return timePenalties.get(penalty);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -305,6 +305,22 @@ public interface Config {
   float getAssistPercent();
 
   /**
+   * Gets how long to penalize players for certain actions
+   *
+   * @return time to make them sit out for
+   */
+  Duration getTimePenalty(TimePenalty penalty);
+
+  enum TimePenalty {
+    FFA_FULL_REJOIN,
+    STACKED,
+    FULL_REJOIN,
+    REJOIN_MULTIPLIER,
+    REJOIN_MAX,
+    SWITCH
+  }
+
+  /**
    * Gets if extra votes are allowed based on the "pgm.vote.extra.#" permission.
    *
    * @return {@code true} if extra votes are enabled, {@code false} otherwise.

--- a/core/src/main/java/tc/oc/pgm/spawns/ParticipationData.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/ParticipationData.java
@@ -1,0 +1,64 @@
+package tc.oc.pgm.spawns;
+
+import java.time.Duration;
+import tc.oc.pgm.api.Config.TimePenalty;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.util.TimeUtils;
+
+class ParticipationData {
+  private Team lastTeam;
+  private long lastLeaveTick;
+  private boolean wasFull;
+  private boolean wasStacked;
+  private int rejoins;
+
+  public void trackLeave(Match match, Competitor competitor) {
+    if (competitor instanceof Team team) {
+      if (lastTeam == team) rejoins++;
+      lastTeam = team;
+      wasFull = team.getSize() >= team.getMaxPlayers() - 1;
+      wasStacked = team.isStacked();
+    } else {
+      lastTeam = null;
+      wasFull = match.getParticipants().size() >= match.getMaxPlayers();
+      wasStacked = false;
+    }
+    lastLeaveTick = match.getTick().tick;
+  }
+
+  public long getJoinTick(Team newTeam) {
+    TimePenalty penalty = getPenalty(newTeam);
+    Duration timeOff = getDuration(penalty);
+    if (penalty == TimePenalty.REJOIN_MULTIPLIER) {
+      timeOff = TimeUtils.min(timeOff.multipliedBy(rejoins), getDuration(TimePenalty.REJOIN_MAX));
+    }
+    return lastLeaveTick + TimeUtils.toTicks(timeOff);
+  }
+
+  static Duration getDuration(TimePenalty penalty) {
+    return penalty == null ? Duration.ZERO : PGM.get().getConfiguration().getTimePenalty(penalty);
+  }
+
+  private TimePenalty getPenalty(Team newTeam) {
+    if (lastTeam == null || newTeam == null) { // FFA
+      return wasFull ? TimePenalty.FFA_FULL_REJOIN : null;
+    }
+    // Left and rejoined to get the team stacked
+    if (newTeam.isStacked()) return TimePenalty.STACKED;
+
+    if (lastTeam == newTeam) { // Team rejoin
+      // Making space for someone else to join
+      if (wasFull && newTeam.getSize() >= newTeam.getMaxPlayers()) return TimePenalty.FULL_REJOIN;
+      // Rejoin spam for resources
+      return TimePenalty.REJOIN_MULTIPLIER;
+    } else {
+      // Explicitly forgive switching to un-stack
+      if (wasStacked && !newTeam.isStacked()) return null;
+
+      return TimePenalty.STACKED;
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
@@ -105,7 +105,7 @@ public class Alive extends Participating {
     super.onEvent(event);
 
     if (event.getNewParty() instanceof Competitor) {
-      transition(new Joining(smm, player));
+      transition(new Joining(smm, player, smm.getJoinPenalty(event)));
     } else {
       transition(new Observing(smm, player, true, true));
     }

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
@@ -36,7 +36,7 @@ public class Dead extends Spawning {
   private boolean kitted, rotted;
 
   public Dead(SpawnMatchModule smm, MatchPlayer player) {
-    super(smm, player, player.getMatch().getTick().tick);
+    super(smm, player, player.getMatch().getTick().tick, 0);
   }
 
   @Override
@@ -55,15 +55,12 @@ public class Dead extends Spawning {
     // Flash/wobble the screen. If we don't delay this then the client glitches out
     // when the player dies from a potion effect. I have no idea why it happens,
     // but this fixes it. We could investigate a better fix at some point.
-    smm.getMatch()
-        .getExecutor(MatchScope.LOADED)
-        .execute(
-            () -> {
-              if (isCurrent() && bukkit.isOnline()) {
-                bukkit.addPotionEffect(options.blackout ? BLINDNESS_LONG : BLINDNESS_SHORT, true);
-                bukkit.addPotionEffect(CONFUSION, true);
-              }
-            });
+    smm.getMatch().getExecutor(MatchScope.LOADED).execute(() -> {
+      if (isCurrent() && bukkit.isOnline()) {
+        bukkit.addPotionEffect(options.blackout ? BLINDNESS_LONG : BLINDNESS_SHORT, true);
+        bukkit.addPotionEffect(CONFUSION, true);
+      }
+    });
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Joining.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Joining.java
@@ -15,8 +15,8 @@ public class Joining extends Spawning {
     this(smm, player, 0);
   }
 
-  public Joining(SpawnMatchModule smm, MatchPlayer player, long deathTick) {
-    super(smm, player, deathTick);
+  public Joining(SpawnMatchModule smm, MatchPlayer player, long minSpawnTick) {
+    super(smm, player, smm.getDeathTick(player), minSpawnTick);
     this.spawnRequested = true;
   }
 

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
@@ -123,7 +123,7 @@ public class Observing extends State {
   @Override
   public void onEvent(PlayerJoinPartyEvent event) {
     if (event.getNewParty() instanceof Competitor && event.getMatch().isRunning()) {
-      transition(new Joining(smm, player, smm.getDeathTick(event.getPlayer())));
+      transition(new Joining(smm, player, smm.getJoinPenalty(event)));
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Spawning.java
@@ -25,13 +25,15 @@ public abstract class Spawning extends Participating {
 
   protected final RespawnOptions options;
   protected boolean spawnRequested;
-  protected final long deathTick;
+  protected final long startTick;
+  protected final long spawnAtTick;
 
-  public Spawning(SpawnMatchModule smm, MatchPlayer player, long deathTick) {
+  public Spawning(SpawnMatchModule smm, MatchPlayer player, long deathTick, long minSpawnTick) {
     super(smm, player);
     this.options = smm.getRespawnOptions(player);
     this.spawnRequested = options.auto;
-    this.deathTick = deathTick;
+    this.startTick = player.getMatch().getTick().tick;
+    this.spawnAtTick = Math.max(deathTick + options.delayTicks, minSpawnTick);
   }
 
   @Override
@@ -73,7 +75,7 @@ public abstract class Spawning extends Participating {
   }
 
   protected long age() {
-    return player.getMatch().getTick().tick - deathTick;
+    return player.getMatch().getTick().tick - startTick;
   }
 
   @Override
@@ -100,7 +102,7 @@ public abstract class Spawning extends Participating {
   }
 
   protected long ticksUntilRespawn() {
-    return Math.max(0, options.delayTicks - age());
+    return spawnAtTick - player.getMatch().getTick().tick;
   }
 
   public @Nullable Spawn chooseSpawn() {
@@ -144,7 +146,7 @@ public abstract class Spawning extends Participating {
   }
 
   public void sendMessage() {
-    long ticks = options.delayTicks - age();
+    long ticks = ticksUntilRespawn();
     if (ticks % (ticks > 0 ? 20 : 100) == 0) {
       player.sendMessage(getSubtitle(false));
     }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -74,9 +74,16 @@ join:
 
 # Changes various gameplay mechanics.
 gameplay:
-  refill-wool: true # Should wool in wool rooms be automatically refilled?
-  grief-score: -10 # Score under which players should be kept out of the match
+  refill-wool: true   # Should wool in wool rooms be automatically refilled?
+  grief-score: -10    # Score under which players should be kept out of the match
   assist-percent: 0.3 # What percent of the damage is required for an assist 0.3 = 30% of max hp
+  time-penalties:
+    ffa-full-rejoin: 10s   # Rejoining on ffa when it's full
+    stacked: 30s           # Rejoining into a stacked team
+    full-rejoin: 30s       # Rejoining when your team was full and is still full
+    rejoin-multiplier: 10s # Increased penalty for every additional rejoin, up to max
+    rejoin-max: 30s        # Max time penalty for repeated rejoins
+    switch: 30s            # Plainly switching teams
   
 # Changes map voting mechanics.
 votes:

--- a/util/src/main/java/tc/oc/pgm/util/TimeUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/TimeUtils.java
@@ -42,4 +42,12 @@ public final class TimeUtils {
   public static boolean isLongerThan(Duration a, Duration b) {
     return a.compareTo(b) > 0;
   }
+
+  public static Duration max(Duration a, Duration b) {
+    return a.compareTo(b) > 0 ? a : b;
+  }
+
+  public static Duration min(Duration a, Duration b) {
+    return a.compareTo(b) < 0 ? a : b;
+  }
 }


### PR DESCRIPTION
Adds options for PGM to penalize certain team-switches or rejoins. Aims to nerf certain kinds of unwanted behaviors on players:
1) team switching to stack (ie: switching team right after match start)
2) team swapping for your own benefit (ie: get wool from one team to another, or switching to the winning team)
3) rejoin spam to gather resources
4) rejoining to get your team over max (ie: join obs to make room for a non-premium user)

Some safeguards exist to avoid punishing legitimate switches, like switching to un-stack teams will avoid penalizing or a single rejoin to the same team wont penalize either.

Additionally what is considered a "stacked" team has been lowered from 20% to 10% for cased where all teams are equally sized (and increased to 25% when differing sizes)