### PR TITLE
Make ticking start only after load

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import org.bukkit.entity.Player;
@@ -75,7 +74,6 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
   private final Match match;
   private final ContextStore<? super Filter> filterContext;
   private final Set<Class<? extends Event>> listeningFor = new HashSet<>();
-  private final AtomicBoolean loaded = new AtomicBoolean(false);
 
   private final DummyListener dummyListener = new DummyListener();
 
@@ -155,8 +153,6 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
         });
       }
     }
-
-    loaded.set(true);
   }
 
   private void findAndCreateReactorFactories(Filter filter) {
@@ -361,9 +357,6 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
   }
 
   public void tick() {
-    // Tried to tick while haven't finished loading!
-    if (!loaded.get()) return;
-
     final Set<Filterable<?>> checked = new HashSet<>();
     Set<Filterable<?>> checking;
     // Collect Filterables that are dirty, and have not already been checked in this tick

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -845,11 +845,11 @@ public class MatchImpl implements Match {
       }
 
       startListeners(MatchScope.LOADED);
-      startTickables(MatchScope.LOADED);
       addParty(observers);
-
       loaded.set(true);
       callEvent(new MatchLoadEvent(this));
+      // Start ticking after match load event ocurred
+      startTickables(MatchScope.LOADED);
     } catch (Throwable e) {
       e.printStackTrace();
       unload();


### PR DESCRIPTION
State is initialized by variables or filters during the match load event. At the moment, tickables are started alongside this event, and has caused some race conditions like:
```
[12:13:27 ERROR]: [MatchImpl] Could not tick tc.oc.pgm.filters.FilterMatchModule@57ba9999
java.lang.NullPointerException: state
        at tc.oc.pgm.util.Assert.assertNotNull(Assert.java:19) ~[?:?]
        at tc.oc.pgm.features.MatchFeatureContext.getState(MatchFeatureContext.java:33) ~[?:?]
        at tc.oc.pgm.api.filter.query.MatchQuery.state(MatchQuery.java:30) ~[?:?]
        at tc.oc.pgm.variables.types.DummyVariable.getValueImpl(DummyVariable.java:40) ~[?:?]
[...]
        at tc.oc.pgm.filters.operator.AllFilter.query(AllFilter.java:18) ~[?:?]
        at tc.oc.pgm.api.filter.Filter.response(Filter.java:37) ~[?:?]
        at tc.oc.pgm.filters.FilterMatchModule.lambda$check$8(FilterMatchModule.java:330) ~[?:?]
        at java.util.Map.forEach(Map.java:733) ~[?:?]
        at tc.oc.pgm.filters.FilterMatchModule.lambda$check$9(FilterMatchModule.java:318) ~[?:?]
        at java.util.Map.forEach(Map.java:733) ~[?:?]
        at tc.oc.pgm.filters.FilterMatchModule.check(FilterMatchModule.java:315) ~[?:?]
        at tc.oc.pgm.filters.FilterMatchModule.lambda$tick$10(FilterMatchModule.java:379) ~[?:?]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at tc.oc.pgm.filters.FilterMatchModule.tick(FilterMatchModule.java:379) ~[?:?]
        at tc.oc.pgm.filters.FilterMatchModule.tick(FilterMatchModule.java:360) ~[?:?]
        at tc.oc.pgm.match.MatchImpl$TickableTask.run(MatchImpl.java:752) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
[...]
```