### PR TITLE
Avoid exceptions using lives on non-blitz matches

### DIFF
--- a/core/src/main/java/tc/oc/pgm/variables/types/LivesVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/LivesVariable.java
@@ -12,11 +12,15 @@ public class LivesVariable extends AbstractVariable<MatchPlayer> {
 
   @Override
   protected double getValueImpl(MatchPlayer player) {
-    return player.moduleRequire(BlitzMatchModule.class).getNumOfLives(player.getId());
+    return player
+        .moduleOptional(BlitzMatchModule.class)
+        .map(bmm -> bmm.getNumOfLives(player.getId()))
+        .orElse(-1);
   }
 
   @Override
   protected void setValueImpl(MatchPlayer player, double value) {
-    player.moduleRequire(BlitzMatchModule.class).setLives(player, Math.max((int) value, 0));
+    int amt = Math.max((int) value, 0);
+    player.moduleOptional(BlitzMatchModule.class).ifPresent(bmm -> bmm.setLives(player, amt));
   }
 }


### PR DESCRIPTION
Given this variable is a default, it makes the `/variables` command throw an exception when trying to use it. Similar to what we did with score variables, we're defaulting blitz to -1 and ignoring changes to it if blitz isn't enabled