### PR TITLE
Fix NPE on cause filter before tracker load

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/CauseFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/CauseFilter.java
@@ -77,14 +77,12 @@ public class CauseFilter extends TypedFilter.Impl<MatchQuery> {
       event = ((GeneralizedEvent) event).getCause();
     }
 
-    TrackerMatchModule tracker = query.moduleRequire(TrackerMatchModule.class);
-
     EntityDamageEvent.DamageCause damageCause = null;
     DamageInfo damageInfo = null;
     boolean punchDamage = false;
     if (event instanceof EntityDamageEvent damageEvent) {
       damageCause = damageEvent.getCause();
-      damageInfo = tracker.resolveDamage(damageEvent);
+      damageInfo = query.moduleRequire(TrackerMatchModule.class).resolveDamage(damageEvent);
       if (damageInfo instanceof MeleeInfo) {
         PhysicalInfo weapon = ((MeleeInfo) damageInfo).getWeapon();
         if (weapon instanceof ItemInfo && ((ItemInfo) weapon).getItem().getType() == Material.AIR) {


### PR DESCRIPTION
```
Caused by: java.lang.NullPointerException: Cannot invoke "tc.oc.pgm.api.match.Match.needModule(java.lang.Class)" because the return value of "tc.oc.pgm.api.filter.query.MatchQuery.getMatch()" is null
	at tc.oc.pgm.api.filter.query.MatchQuery.moduleRequire(MatchQuery.java:22) ~[?:?]
	at tc.oc.pgm.filters.matcher.CauseFilter.matches(CauseFilter.java:80) ~[?:?]
	at tc.oc.pgm.filters.matcher.CauseFilter.matches(CauseFilter.java:27) ~[?:?]
	at tc.oc.pgm.filters.matcher.TypedFilter.queryTyped(TypedFilter.java:13) ~[?:?]
	at tc.oc.pgm.filters.matcher.WeakTypedFilter.query(WeakTypedFilter.java:21) ~[?:?]
	at tc.oc.pgm.filters.operator.AnyFilter.query(AnyFilter.java:18) ~[?:?]
	at tc.oc.pgm.filters.operator.InverseFilter.query(InverseFilter.java:15) ~[?:?]
	at tc.oc.pgm.regions.RegionMatchModule.processQuery(RegionMatchModule.java:421) ~[?:?]
	at tc.oc.pgm.regions.RegionMatchModule.checkBlockPhysics(RegionMatchModule.java:245) ~[?:?]
```