### PR TITLE
Support no-update structure placing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -368,6 +368,7 @@ public class ActionParser {
         parser.region(el, "region").blockBounded().orSelf(),
         XMLUtils.parseBlockMaterialData(Node.fromRequiredAttr(el, "material")),
         parser.filter(el, "filter").orNull(),
+        parser.parseBool(el, "update").orTrue(),
         parser.parseBool(el, "events").orFalse());
   }
 
@@ -414,7 +415,8 @@ public class ActionParser {
     var zFormula = parser.formula(scope, el, "z").required();
 
     var structure = parser.reference(StructureDefinition.class, el, "structure").required();
+    var update = parser.parseBool(el, "update").orTrue();
 
-    return new PasteStructureAction<>(scope, xFormula, yFormula, zFormula, structure);
+    return new PasteStructureAction<>(scope, xFormula, yFormula, zFormula, structure, update);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/FillAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/FillAction.java
@@ -15,14 +15,20 @@ public class FillAction extends AbstractAction<Match> {
   private final Region region;
   private final BlockMaterialData materialData;
   private final @Nullable Filter filter;
+  private final boolean update;
   private final boolean events;
 
   public FillAction(
-      Region region, BlockMaterialData materialData, @Nullable Filter filter, boolean events) {
+      Region region,
+      BlockMaterialData materialData,
+      @Nullable Filter filter,
+      boolean update,
+      boolean events) {
     super(Match.class);
     this.region = region;
     this.materialData = materialData;
     this.filter = filter;
+    this.update = update;
     this.events = events;
   }
 
@@ -32,7 +38,7 @@ public class FillAction extends AbstractAction<Match> {
       if (filter != null && filter.query(new BlockQuery(block)).isDenied()) continue;
 
       if (!events) {
-        materialData.applyTo(block, true);
+        materialData.applyTo(block, update);
       } else {
         BlockState newState = block.getState();
         materialData.applyTo(newState);
@@ -40,7 +46,7 @@ public class FillAction extends AbstractAction<Match> {
         BlockFormEvent event = new BlockFormEvent(block, newState);
         match.callEvent(event);
         if (event.isCancelled()) continue;
-        newState.update(true, true);
+        newState.update(true, update);
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/action/actions/PasteStructureAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/PasteStructureAction.java
@@ -12,25 +12,26 @@ public class PasteStructureAction<T extends Filterable<?>> extends AbstractActio
   private final Formula<T> yformula;
   private final Formula<T> zformula;
   private final FeatureReference<StructureDefinition> structureReference;
+  private final boolean update;
 
   public PasteStructureAction(
       Class<T> scope,
       Formula<T> xformula,
       Formula<T> yformula,
       Formula<T> zformula,
-      FeatureReference<StructureDefinition> structureReference) {
+      FeatureReference<StructureDefinition> structureReference,
+      boolean update) {
     super(scope);
     this.xformula = xformula;
     this.yformula = yformula;
     this.zformula = zformula;
     this.structureReference = structureReference;
+    this.update = update;
   }
 
   @Override
   public void trigger(T t) {
-    BlockVector placeLocation = new BlockVector(
-        xformula.applyAsDouble(t), yformula.applyAsDouble(t), zformula.applyAsDouble(t));
-
-    structureReference.get().getStructure(t.getMatch()).placeAbsolute(placeLocation);
+    var loc = new BlockVector(xformula.apply(t), yformula.apply(t), zformula.apply(t));
+    structureReference.get().getStructure(t.getMatch()).placeAbsolute(loc, update);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointBlockDisplay.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/ControlPointBlockDisplay.java
@@ -46,26 +46,26 @@ public class ControlPointBlockDisplay implements Listener {
     if (progressDisplayRegion == null) {
       this.progressDisplayRegion = null;
     } else {
-      this.progressDisplayRegion =
-          FiniteBlockRegion.fromWorld(
-              progressDisplayRegion, match.getWorld(), visualMaterials, match.getMap().getProto());
+      this.progressDisplayRegion = FiniteBlockRegion.fromWorld(
+          progressDisplayRegion,
+          match.getWorld(),
+          visualMaterials,
+          match.getMap().getProto());
       snapshot.saveRegion(progressDisplayRegion);
     }
 
     if (controllerDisplayRegion == null) {
       this.controllerDisplayRegion = null;
     } else {
-      Filter controllerDisplayFilter =
-          this.progressDisplayRegion == null
-              ? visualMaterials
-              : AllFilter.of(visualMaterials, new InverseFilter(progressDisplayRegion));
+      Filter controllerDisplayFilter = this.progressDisplayRegion == null
+          ? visualMaterials
+          : AllFilter.of(visualMaterials, new InverseFilter(progressDisplayRegion));
 
-      this.controllerDisplayRegion =
-          FiniteBlockRegion.fromWorld(
-              controllerDisplayRegion,
-              match.getWorld(),
-              controllerDisplayFilter,
-              match.getMap().getProto());
+      this.controllerDisplayRegion = FiniteBlockRegion.fromWorld(
+          controllerDisplayRegion,
+          match.getWorld(),
+          controllerDisplayFilter,
+          match.getMap().getProto());
       snapshot.saveRegion(controllerDisplayRegion);
     }
   }
@@ -76,7 +76,7 @@ public class ControlPointBlockDisplay implements Listener {
   public void setController(Competitor controllingTeam) {
     if (this.controllingTeam != controllingTeam && this.controllerDisplayRegion != null) {
       if (controllingTeam == null) {
-        snapshot.placeBlocks(this.controllerDisplayRegion, null);
+        snapshot.placeBlocks(this.controllerDisplayRegion, null, false);
       } else {
         COLOR_UTILS.setColor(
             match.getWorld(),
@@ -97,7 +97,7 @@ public class ControlPointBlockDisplay implements Listener {
       if (team != null) {
         COLOR_UTILS.setColor(block, team.getDyeColor());
       } else {
-        snapshot.getOriginalMaterial(pos).applyTo(block, true);
+        snapshot.getOriginalMaterial(pos).applyTo(block, false);
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/snapshot/BudgetWorldEdit.java
+++ b/core/src/main/java/tc/oc/pgm/snapshot/BudgetWorldEdit.java
@@ -29,10 +29,10 @@ class BudgetWorldEdit {
    * @param region region where the blocks were when they got saved
    * @param offset the offset to add when placing blocks
    */
-  public void placeBlocks(Region region, BlockVector offset) {
+  public void placeBlocks(Region region, BlockVector offset, boolean update) {
     if (offset == null) offset = NO_OFFSET;
     for (BlockData blockData : snapshot.getMaterials(region)) {
-      blockData.applyTo(blockData.getBlock(world, offset), true);
+      blockData.applyTo(blockData.getBlock(world, offset), update);
     }
   }
 
@@ -42,12 +42,12 @@ class BudgetWorldEdit {
    * @param region The region to remove blocks from
    * @param offset an offset to add to the region coordinates if the blocks were offset when placed
    */
-  public void removeBlocks(Region region, BlockVector offset) {
+  public void removeBlocks(Region region, BlockVector offset, boolean update) {
     if (offset == null) offset = NO_OFFSET;
     for (BlockData blockData : snapshot.getMaterials(region)) {
       Block block = blockData.getBlock(world, offset);
       // Ignore if already air
-      if (!block.getType().equals(Material.AIR)) block.setType(Material.AIR);
+      if (!block.getType().equals(Material.AIR)) block.setType(Material.AIR, update);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/snapshot/WorldSnapshot.java
+++ b/core/src/main/java/tc/oc/pgm/snapshot/WorldSnapshot.java
@@ -83,12 +83,12 @@ public class WorldSnapshot {
     region.getChunkPositions().forEach(cv -> this.saveSnapshot(cv, null));
   }
 
-  public void placeBlocks(Region region, BlockVector offset) {
-    worldEdit.placeBlocks(region, offset);
+  public void placeBlocks(Region region, BlockVector offset, boolean update) {
+    worldEdit.placeBlocks(region, offset, update);
   }
 
-  public void removeBlocks(Region region, BlockVector offset) {
-    worldEdit.removeBlocks(region, offset);
+  public void removeBlocks(Region region, BlockVector offset, boolean update) {
+    worldEdit.removeBlocks(region, offset, update);
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/structure/DynamicStructure.java
+++ b/core/src/main/java/tc/oc/pgm/structure/DynamicStructure.java
@@ -45,7 +45,7 @@ public class DynamicStructure implements Feature<DynamicStructureDefinition> {
   public void place() {
     if (placed) return;
     placed = true;
-    structure.place(offset);
+    structure.place(offset, definition.shouldUpdate());
   }
 
   /** Remove the structure from the world */
@@ -53,6 +53,6 @@ public class DynamicStructure implements Feature<DynamicStructureDefinition> {
     if (!placed) return;
     placed = false;
 
-    snapshot.placeBlocks(region, new BlockVector());
+    snapshot.placeBlocks(region, new BlockVector(), definition.shouldUpdate());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/structure/DynamicStructureDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/structure/DynamicStructureDefinition.java
@@ -17,18 +17,21 @@ public class DynamicStructureDefinition extends SelfIdentifyingFeatureDefinition
   private final Filter passive;
   private final @Nullable BlockVector position;
   private final @NotNull BlockVector offset;
+  private final boolean update;
 
   DynamicStructureDefinition(
       String id,
       StructureDefinition structure,
       Filter trigger,
       Filter passive,
+      boolean update,
       @Nullable BlockVector position,
       @Nullable BlockVector offset) {
     super(id);
     this.structure = assertNotNull(structure);
     this.trigger = assertNotNull(trigger);
     this.passive = assertNotNull(passive);
+    this.update = update;
     this.position = position;
     this.offset = offset == null ? new BlockVector() : offset;
   }
@@ -58,6 +61,11 @@ public class DynamicStructureDefinition extends SelfIdentifyingFeatureDefinition
    */
   public Filter getPassive() {
     return passive;
+  }
+
+  /** @return If this dynamic should generate block updates when placing */
+  public boolean shouldUpdate() {
+    return update;
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/structure/Structure.java
+++ b/core/src/main/java/tc/oc/pgm/structure/Structure.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.structure;
 
 import org.bukkit.Material;
 import org.bukkit.util.BlockVector;
-import org.bukkit.util.Vector;
 import tc.oc.pgm.api.feature.Feature;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
@@ -28,7 +27,7 @@ public class Structure implements Feature<StructureDefinition> {
           match.getMap().getProto());
 
     snapshot.saveRegion(region);
-    if (definition.clearSource()) snapshot.removeBlocks(region, new BlockVector());
+    if (definition.clearSource()) snapshot.removeBlocks(region, new BlockVector(), false);
   }
 
   @Override
@@ -45,12 +44,12 @@ public class Structure implements Feature<StructureDefinition> {
     return region;
   }
 
-  public void place(BlockVector offset) {
-    snapshot.placeBlocks(region, offset);
+  public void place(BlockVector offset, boolean update) {
+    snapshot.placeBlocks(region, offset, update);
   }
 
-  public void placeAbsolute(BlockVector vector) {
-    place(new BlockVector(
-        new Vector(0, 0, 0).subtract(getRegion().getBounds().getBlockMin()).add(vector)));
+  public void placeAbsolute(BlockVector vector, boolean update) {
+    vector.subtract(getRegion().getBounds().getBlockMin());
+    place(vector, update);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.util.xml;
 
+import org.bukkit.util.BlockVector;
+import org.bukkit.util.Vector;
 import org.jdom2.Element;
 import tc.oc.pgm.action.Action;
 import tc.oc.pgm.action.ActionParser;
@@ -63,19 +65,46 @@ public class XMLFluentParser {
     };
   }
 
-  public FilterBuilder filter(Element el, String... prop) throws InvalidXMLException {
+  public PrimitiveBuilder.Generic<String> string(Element el, String... prop) {
+    return new PrimitiveBuilder.Generic<>(el, prop) {
+      @Override
+      protected String parse(String text) throws TextException {
+        return text;
+      }
+    };
+  }
+
+  public Builder.Generic<Vector> vector(Element el, String... prop) {
+    return new Builder.Generic<>(el, prop) {
+      @Override
+      protected Vector parse(Node node) throws InvalidXMLException {
+        return XMLUtils.parseVector(node);
+      }
+    };
+  }
+
+  public Builder.Generic<BlockVector> blockVector(Element el, String... prop) {
+    return new Builder.Generic<>(el, prop) {
+      @Override
+      protected BlockVector parse(Node node) throws InvalidXMLException {
+        return XMLUtils.parseBlockVector(node);
+      }
+    };
+  }
+
+  public FilterBuilder filter(Element el, String... prop) {
     return new FilterBuilder(filters, el, prop);
   }
 
-  public RegionBuilder region(Element el, String... prop) throws InvalidXMLException {
+  public RegionBuilder region(Element el, String... prop) {
     return new RegionBuilder(regions, el, prop);
   }
 
-  public ItemBuilder item(Element el, String... prop) throws InvalidXMLException {
+  public ItemBuilder item(Element el, String... prop) {
     return new ItemBuilder(kits, el, prop);
   }
 
-  public Builder.Generic<Kit> kit(Element el, String... prop) throws InvalidXMLException {
+  public Builder.Generic<Kit> kit(Element el, String... prop) {
     return new Builder.Generic<>(el, prop) {
       @Override
       protected Kit parse(Node node) throws InvalidXMLException {
@@ -87,16 +116,16 @@ public class XMLFluentParser {
   }
 
   public <T extends FeatureDefinition> ReferenceBuilder<T> reference(
-      Class<T> clazz, Element el, String... prop) throws InvalidXMLException {
+      Class<T> clazz, Element el, String... prop) {
     return new ReferenceBuilder<T>(features, clazz, el, prop);
   }
 
-  public VariableBuilder<?> variable(Element el, String... prop) throws InvalidXMLException {
+  public VariableBuilder<?> variable(Element el, String... prop) {
     return new VariableBuilder<>(features, el, prop);
   }
 
   public <T extends Filterable<?>> Builder.Generic<Action<? super T>> action(
-      Class<T> clazz, Element el, String... prop) throws InvalidXMLException {
+      Class<T> clazz, Element el, String... prop) {
     return new Builder.Generic<>(el, prop) {
       @Override
       protected Action<? super T> parse(Node node) throws InvalidXMLException {
@@ -112,7 +141,7 @@ public class XMLFluentParser {
   }
 
   public <T extends Filterable<?>> Builder<Formula<T>, ?> formula(
-      Class<T> clazz, Element el, String... prop) throws InvalidXMLException {
+      Class<T> clazz, Element el, String... prop) {
     return new Builder.Generic<>(el, prop) {
       @Override
       protected Formula<T> parse(Node node) {

--- a/util/src/main/java/tc/oc/pgm/util/math/AddedFunctions.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/AddedFunctions.java
@@ -1,0 +1,49 @@
+package tc.oc.pgm.util.math;
+
+import java.util.List;
+import net.objecthunter.exp4j.function.Function;
+
+class AddedFunctions {
+  public static final List<Function> ALL = List.of(
+      new Function("bound", 3) {
+        @Override
+        public double apply(double... doubles) {
+          double val = doubles[0];
+          double min = doubles[1];
+          double max = doubles[2];
+          return Math.max(min, Math.min(val, max));
+        }
+      },
+      new Function("random", 0) {
+        @Override
+        public double apply(double... doubles) {
+          return Math.random();
+        }
+      },
+      new Function("max") {
+        @Override
+        public double apply(double... doubles) {
+          double max = doubles[0];
+          for (int i = 1; i < doubles.length; i++) max = Math.max(max, doubles[i]);
+          return max;
+        }
+
+        @Override
+        public boolean isValidArgCount(int count) {
+          return count >= 1;
+        }
+      },
+      new Function("min") {
+        @Override
+        public double apply(double... doubles) {
+          double min = doubles[0];
+          for (int i = 1; i < doubles.length; i++) min = Math.min(min, doubles[i]);
+          return min;
+        }
+
+        @Override
+        public boolean isValidArgCount(int count) {
+          return count >= 1;
+        }
+      });
+}

--- a/util/src/main/java/tc/oc/pgm/util/math/Formula.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/Formula.java
@@ -11,52 +11,6 @@ import net.objecthunter.exp4j.function.Function;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 
 public interface Formula<T> extends ToDoubleFunction<T> {
-
-  Function BOUND = new Function("bound", 3) {
-    @Override
-    public double apply(double... doubles) {
-      double val = doubles[0];
-      double min = doubles[1];
-      double max = doubles[2];
-      return Math.max(min, Math.min(val, max));
-    }
-  };
-
-  Function RANDOM = new Function("random", 0) {
-    @Override
-    public double apply(double... doubles) {
-      return Math.random();
-    }
-  };
-
-  Function MAX = new Function("max") {
-    @Override
-    public double apply(double... doubles) {
-      double max = doubles[0];
-      for (int i = 1; i < doubles.length; i++) max = Math.max(max, doubles[i]);
-      return max;
-    }
-
-    @Override
-    public boolean isValidArgCount(int count) {
-      return count >= 1;
-    }
-  };
-
-  Function MIN = new Function("min") {
-    @Override
-    public double apply(double... doubles) {
-      double min = doubles[0];
-      for (int i = 1; i < doubles.length; i++) min = Math.min(min, doubles[i]);
-      return min;
-    }
-
-    @Override
-    public boolean isValidArgCount(int count) {
-      return count >= 1;
-    }
-  };
-
   /**
    * Create a formula for a config, if there's a misconfiguration it logs and uses fallback
    *
@@ -84,7 +38,7 @@ public interface Formula<T> extends ToDoubleFunction<T> {
       throws IllegalArgumentException {
     Expression exp = new ExpressionBuilder(expression)
         .variables(context.getVariables())
-        .functions(BOUND, RANDOM, MAX, MIN)
+        .functions(AddedFunctions.ALL)
         .functions(context.getArrays().stream()
             .map(str -> new Function(str, 1) {
               @Override
@@ -97,6 +51,11 @@ public interface Formula<T> extends ToDoubleFunction<T> {
         .build();
 
     return new ExpFormula<>(exp, context);
+  }
+
+  /** Shorthand for {@link #applyAsDouble} */
+  default double apply(T value) {
+    return applyAsDouble(value);
   }
 
   class ExpFormula<T> implements Formula<T> {


### PR DESCRIPTION
Adds an `update="true"` or `update="false"` attribute to:
 - `<fill>` action
 - `<paste-structure>` action
 - Structure's `<dynamic>`

It defaults to true for backwards compatibility.

When true, blocks placed will generate `block updates`, which means things like reddstone getting updated, but also things like ladders popping-off if placed mid-air.
By setting it to false, you get more performant places/pastes, as well as preventing blocks popping-off, at the expense of redstone not triggering