### PR TITLE
Implement enchant item action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -17,10 +17,12 @@ import java.util.Set;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.action.actions.ActionNode;
+import tc.oc.pgm.action.actions.EnchantItemAction;
 import tc.oc.pgm.action.actions.ExposedAction;
 import tc.oc.pgm.action.actions.FillAction;
 import tc.oc.pgm.action.actions.KillEntitiesAction;
@@ -360,6 +362,15 @@ public class ActionParser {
     boolean keepEnchants = parser.parseBool(el, "keep-enchants").orFalse();
 
     return new ReplaceItemAction(matcher, item, keepAmount, keepEnchants);
+  }
+
+  @MethodParser("enchant-item")
+  public EnchantItemAction parseEnchantItem(Element el, Class<?> scope) throws InvalidXMLException {
+    ItemMatcher matcher = factory.getKits().parseItemMatcher(el, "find");
+    Enchantment enchant = XMLUtils.parseEnchantment(Node.fromRequiredAttr(el, "enchantment"));
+    Formula<MatchPlayer> level = parser.formula(MatchPlayer.class, el, "level").required();
+
+    return new EnchantItemAction(matcher, enchant, level);
   }
 
   @MethodParser("fill")

--- a/core/src/main/java/tc/oc/pgm/action/actions/EnchantItemAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/EnchantItemAction.java
@@ -1,0 +1,45 @@
+package tc.oc.pgm.action.actions;
+
+import java.util.Objects;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.util.inventory.ItemMatcher;
+import tc.oc.pgm.util.math.Formula;
+
+public class EnchantItemAction extends AbstractAction<MatchPlayer> {
+
+  private final ItemMatcher matcher;
+  private final Enchantment enchant;
+  private final Formula<MatchPlayer> level;
+
+  public EnchantItemAction(ItemMatcher matcher, Enchantment enchant, Formula<MatchPlayer> level) {
+    super(MatchPlayer.class);
+    this.matcher = matcher;
+    this.enchant = enchant;
+    this.level = level;
+  }
+
+  @Override
+  public void trigger(MatchPlayer player) {
+    PlayerInventory inv = Objects.requireNonNull(player.getInventory());
+
+    int level = Math.max(0, (int) this.level.applyAsDouble(player));
+
+    for (ItemStack current : inv.getArmorContents()) {
+      if (current != null && matcher.matches(current)) enchant(current, level);
+    }
+    for (int i = 0; i < inv.getSize(); i++) {
+      ItemStack current = inv.getItem(i);
+      if (current != null && matcher.matches(current)) enchant(current, level);
+    }
+  }
+
+  private void enchant(ItemStack current, int level) {
+    if (current.getEnchantmentLevel(enchant) != level) {
+      if (level == 0) current.removeEnchantment(enchant);
+      else current.addUnsafeEnchantment(enchant, level);
+    }
+  }
+}


### PR DESCRIPTION
Works similar to replace-item action, but instead of replacing the item enchants it with a level which can be variables/formulas

```xml
<enchant-item enchantment="efficiency" level="some_var+1" ignore-metadata="true">
  <find material="diamond_pickaxe"/>
</enchant-item>
```

The inner element `find` is an item definition of what to search for in the inventory. Works the same as replace-item, where you can define extra item matching attributes like ignore-metadata and such.

Ontop of that you have the attributes:
`enchantment` the enchantment to apply
`level` a formula that says what level. Like all formulas it can be just a constant too like `level="5"`
