### PR TITLE
Implement resize transformed region

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/actions/EnchantItemAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/EnchantItemAction.java
@@ -32,7 +32,11 @@ public class EnchantItemAction extends AbstractAction<MatchPlayer> {
     }
     for (int i = 0; i < inv.getSize(); i++) {
       ItemStack current = inv.getItem(i);
-      if (current != null && matcher.matches(current)) enchant(current, level);
+      if (current != null && matcher.matches(current)) {
+        enchant(current, level);
+        // Makes item sync with client instantly
+        inv.setItem(i, current);
+      }
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -459,11 +459,6 @@ public abstract class KitParser {
     boolean ignoreEnchantments =
         XMLUtils.parseBoolean(Node.fromAttr(parent, "ignore-enchantments"), ignoreMetadata);
 
-    if (ignoreMetadata && (!ignoreName || !ignoreEnchantments)) {
-      throw new InvalidXMLException(
-          "Cannot ignore metadata but respect name or enchantments", parent);
-    }
-
     return new ItemMatcher(
         stack, amount, ignoreDurability, ignoreMetadata, ignoreName, ignoreEnchantments);
   }

--- a/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
@@ -296,10 +296,12 @@ public abstract class RegionParser implements XMLParser<Region, RegionDefinition
 
   @MethodParser("resize")
   public ResizedRegion parseResize(Element el) throws InvalidXMLException {
+    Region child = this.parseChildren(el);
     Vector min = parser.vector(el, "min").attr().required();
     Vector max = parser.vector(el, "max").attr().required();
     boolean relative = parser.parseBool(el, "relative").attr().orFalse();
-    return new ResizedRegion(this.parseChildren(el), min, max, relative);
+    validate(child, BlockBoundedValidation.INSTANCE, new Node(el));
+    return new ResizedRegion(child, min, max, relative);
   }
 
   @MethodParser("everywhere")

--- a/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
@@ -16,16 +16,19 @@ import tc.oc.pgm.util.MethodParsers;
 import tc.oc.pgm.util.XMLParser;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLFluentParser;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public abstract class RegionParser implements XMLParser<Region, RegionDefinition> {
 
   protected final Map<String, Method> methodParsers;
   protected final MapFactory factory;
+  protected final XMLFluentParser parser;
 
   public RegionParser(MapFactory factory) {
     this.factory = factory;
     this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
+    this.parser = factory.getParser();
   }
 
   @Override
@@ -289,6 +292,14 @@ public abstract class RegionParser implements XMLParser<Region, RegionDefinition
     Vector origin = XMLUtils.parseVector(el.getAttribute("origin"), new Vector());
 
     return new MirroredRegion(this.parseChildren(el), origin, normal);
+  }
+
+  @MethodParser("resize")
+  public ResizedRegion parseResize(Element el) throws InvalidXMLException {
+    Vector min = parser.vector(el, "min").attr().required();
+    Vector max = parser.vector(el, "max").attr().required();
+    boolean relative = parser.parseBool(el, "relative").attr().orFalse();
+    return new ResizedRegion(this.parseChildren(el), min, max, relative);
   }
 
   @MethodParser("everywhere")

--- a/core/src/main/java/tc/oc/pgm/regions/ResizedRegion.java
+++ b/core/src/main/java/tc/oc/pgm/regions/ResizedRegion.java
@@ -1,0 +1,63 @@
+package tc.oc.pgm.regions;
+
+import org.bukkit.util.Vector;
+import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.util.math.TransformMatrix;
+
+public class ResizedRegion extends TransformedRegion {
+  private final Vector min, max;
+  private final boolean relative;
+  private TransformMatrix matrix;
+  private TransformMatrix inverse;
+
+  public ResizedRegion(Region region, Vector min, Vector max, boolean relative) {
+    super(region);
+    this.min = min;
+    this.max = max;
+    this.relative = relative;
+  }
+
+  @Override
+  protected Vector transform(Vector point) {
+    if (matrix == null) ensureInitialized();
+    return matrix.transform(point);
+  }
+
+  @Override
+  protected Vector untransform(Vector point) {
+    if (inverse == null) ensureInitialized();
+    return inverse.transform(point);
+  }
+
+  @Override
+  public Bounds getBounds() {
+    ensureInitialized();
+    return super.getBounds();
+  }
+
+  private void ensureInitialized() {
+    if (matrix != null) return;
+
+    var oldBounds = region.getBounds();
+    var oldSize = oldBounds.getSize();
+
+    if (relative) {
+      min.multiply(oldSize);
+      max.multiply(oldSize);
+    }
+
+    this.bounds =
+        new Bounds(oldBounds.getMin().subtract(min), oldBounds.getMax().add(max));
+    var newSize = bounds.getSize();
+
+    this.matrix = TransformMatrix.concat(
+        TransformMatrix.untranslate(oldBounds.getMin()),
+        TransformMatrix.scale(newSize.clone().divide(oldSize)),
+        TransformMatrix.translate(bounds.getMin()));
+
+    this.inverse = TransformMatrix.concat(
+        TransformMatrix.untranslate(bounds.getMin()),
+        TransformMatrix.scale(oldSize.clone().divide(newSize)),
+        TransformMatrix.translate(oldBounds.getMin()));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/regions/ResizedRegion.java
+++ b/core/src/main/java/tc/oc/pgm/regions/ResizedRegion.java
@@ -39,6 +39,12 @@ public class ResizedRegion extends TransformedRegion {
     if (matrix != null) return;
 
     var oldBounds = region.getBounds();
+    if (oldBounds.isEmpty() || !oldBounds.isBlockFinite()) {
+      this.bounds = oldBounds;
+      this.matrix = this.inverse = TransformMatrix.identity();
+      return;
+    }
+
     var oldSize = oldBounds.getSize();
 
     if (relative) {

--- a/core/src/main/java/tc/oc/pgm/shops/menu/Payment.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/Payment.java
@@ -45,7 +45,7 @@ public class Payment {
 
   public boolean matches(ItemStack item) {
     return this.item != null
-        ? Materials.itemsSimilar(item, this.item, true, false)
+        ? Materials.itemsSimilar(item, this.item, true)
         : item.getType() == currency;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -20,6 +20,7 @@ import tc.oc.pgm.util.xml.parsers.BoolBuilder;
 import tc.oc.pgm.util.xml.parsers.Builder;
 import tc.oc.pgm.util.xml.parsers.FilterBuilder;
 import tc.oc.pgm.util.xml.parsers.ItemBuilder;
+import tc.oc.pgm.util.xml.parsers.NumberBuilder;
 import tc.oc.pgm.util.xml.parsers.PrimitiveBuilder;
 import tc.oc.pgm.util.xml.parsers.ReferenceBuilder;
 import tc.oc.pgm.util.xml.parsers.RegionBuilder;
@@ -72,6 +73,18 @@ public class XMLFluentParser {
         return text;
       }
     };
+  }
+
+  public NumberBuilder<Integer> parseInt(Element el, String... prop) {
+    return number(Integer.class, el, prop);
+  }
+
+  public NumberBuilder<Double> parseDouble(Element el, String... prop) {
+    return number(Double.class, el, prop);
+  }
+
+  public <T extends Number> NumberBuilder<T> number(Class<T> cls, Element el, String... prop) {
+    return new NumberBuilder<>(cls, el, prop);
   }
 
   public Builder.Generic<Vector> vector(Element el, String... prop) {

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/NumberBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/NumberBuilder.java
@@ -1,0 +1,34 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLUtils;
+
+public class NumberBuilder<T extends Number> extends Builder<T, NumberBuilder<T>> {
+
+  private final Class<T> type;
+  private boolean infinity;
+
+  public NumberBuilder(Class<T> type, @Nullable Element el, String... prop) {
+    super(el, prop);
+    this.type = type;
+  }
+
+  /** Allow infinity like oo or -oo */
+  public NumberBuilder<T> inf() {
+    this.infinity = true;
+    return this;
+  }
+
+  @Override
+  protected T parse(Node node) throws InvalidXMLException {
+    return XMLUtils.parseNumber(node, type, infinity);
+  }
+
+  @Override
+  protected NumberBuilder<T> getThis() {
+    return this;
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -94,8 +94,7 @@ public interface Materials {
     return material != null && material.isSolid() && !SOLID_EXCLUSIONS.matches(material);
   }
 
-  static boolean itemsSimilar(
-      ItemStack first, ItemStack second, boolean skipDur, boolean skipCheckingName) {
+  static boolean itemsSimilar(ItemStack first, ItemStack second, boolean skipDur) {
     if (first == second) {
       return true;
     }
@@ -107,36 +106,12 @@ public interface Materials {
     }
     final boolean hasMeta1 = first.hasItemMeta();
     final boolean hasMeta2 = second.hasItemMeta();
-    if (!hasMeta1 && !hasMeta2) {
-      return true;
-    }
+    if (!hasMeta1 && !hasMeta2) return true;
 
     final ItemMeta meta1 = hasMeta1 ? first.getItemMeta() : null;
     final ItemMeta meta2 = hasMeta2 ? second.getItemMeta() : null;
 
-    final String prevName1 = meta1 != null ? meta1.getDisplayName() : null;
-    final String prevName2 = meta2 != null ? meta2.getDisplayName() : null;
-    if (skipCheckingName) {
-      if (meta1 != null) {
-        meta1.setDisplayName(null);
-      }
-      if (meta2 != null) {
-        meta2.setDisplayName(null);
-      }
-    }
-
-    try {
-      return Bukkit.getItemFactory().equals(meta1, meta2);
-    } finally {
-      if (skipCheckingName) {
-        if (meta1 != null) {
-          meta1.setDisplayName(prevName1);
-        }
-        if (meta2 != null) {
-          meta2.setDisplayName(prevName2);
-        }
-      }
-    }
+    return Bukkit.getItemFactory().equals(meta1, meta2);
   }
 
   static boolean isSolid(MaterialData material) {

--- a/util/src/main/java/tc/oc/pgm/util/math/TransformMatrix.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/TransformMatrix.java
@@ -3,10 +3,21 @@ package tc.oc.pgm.util.math;
 import org.bukkit.util.Vector;
 
 public class TransformMatrix {
+
+  private static final TransformMatrix IDENTITY = new TransformMatrix(new double[] {
+    1, 0, 0, 0, //
+    0, 1, 0, 0, //
+    0, 0, 1, 0, //
+    0, 0, 0, 1 //
+  });
   private final double[] matrix;
 
   private TransformMatrix(double[] matrix) {
     this.matrix = matrix;
+  }
+
+  public static TransformMatrix identity() {
+    return IDENTITY;
   }
 
   public static TransformMatrix translate(Vector vector) {
@@ -31,7 +42,12 @@ public class TransformMatrix {
     double x = vector.getX();
     double y = vector.getY();
     double z = vector.getZ();
-    return new TransformMatrix(new double[] {x, 0, 0, 0, 0, y, 0, 0, 0, 0, z, 0, 0, 0, 0, 1});
+    return new TransformMatrix(new double[] {
+      x, 0, 0, 0, //
+      0, y, 0, 0, //
+      0, 0, z, 0, //
+      0, 0, 0, 1 //
+    });
   }
 
   public static TransformMatrix concat(TransformMatrix... a) {

--- a/util/src/main/java/tc/oc/pgm/util/math/TransformMatrix.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/TransformMatrix.java
@@ -1,0 +1,81 @@
+package tc.oc.pgm.util.math;
+
+import org.bukkit.util.Vector;
+
+public class TransformMatrix {
+  private final double[] matrix;
+
+  private TransformMatrix(double[] matrix) {
+    this.matrix = matrix;
+  }
+
+  public static TransformMatrix translate(Vector vector) {
+    return new TransformMatrix(new double[] {
+      1, 0, 0, vector.getX(),
+      0, 1, 0, vector.getY(),
+      0, 0, 1, vector.getZ(),
+      0, 0, 0, 1
+    });
+  }
+
+  public static TransformMatrix untranslate(Vector vector) {
+    return new TransformMatrix(new double[] {
+      1, 0, 0, -vector.getX(),
+      0, 1, 0, -vector.getY(),
+      0, 0, 1, -vector.getZ(),
+      0, 0, 0, 1
+    });
+  }
+
+  public static TransformMatrix scale(Vector vector) {
+    double x = vector.getX();
+    double y = vector.getY();
+    double z = vector.getZ();
+    return new TransformMatrix(new double[] {x, 0, 0, 0, 0, y, 0, 0, 0, 0, z, 0, 0, 0, 0, 1});
+  }
+
+  public static TransformMatrix concat(TransformMatrix... a) {
+    if (a.length == 1) return a[0];
+
+    TransformMatrix result = a[a.length - 1];
+    for (int i = a.length - 2; i >= 0; i--) {
+      result = result.multiply(a[i]);
+    }
+    return result;
+  }
+
+  public TransformMatrix multiply(TransformMatrix other) {
+    double[] a = this.matrix;
+    double[] b = other.matrix;
+
+    return new TransformMatrix(new double[] {
+      a[0] * b[0] + a[1] * b[4] + a[2] * b[8] + a[3] * b[12],
+      a[0] * b[1] + a[1] * b[5] + a[2] * b[9] + a[3] * b[13],
+      a[0] * b[2] + a[1] * b[6] + a[2] * b[10] + a[3] * b[14],
+      a[0] * b[3] + a[1] * b[7] + a[2] * b[11] + a[3] * b[15],
+      a[4] * b[0] + a[5] * b[4] + a[6] * b[8] + a[7] * b[12],
+      a[4] * b[1] + a[5] * b[5] + a[6] * b[9] + a[7] * b[13],
+      a[4] * b[2] + a[5] * b[6] + a[6] * b[10] + a[7] * b[14],
+      a[4] * b[3] + a[5] * b[7] + a[6] * b[11] + a[7] * b[15],
+      a[8] * b[0] + a[9] * b[4] + a[10] * b[8] + a[11] * b[12],
+      a[8] * b[1] + a[9] * b[5] + a[10] * b[9] + a[11] * b[13],
+      a[8] * b[2] + a[9] * b[6] + a[10] * b[10] + a[11] * b[14],
+      a[8] * b[3] + a[9] * b[7] + a[10] * b[11] + a[11] * b[15],
+      a[12] * b[0] + a[13] * b[4] + a[14] * b[8] + a[15] * b[12],
+      a[12] * b[1] + a[13] * b[5] + a[14] * b[9] + a[15] * b[13],
+      a[12] * b[2] + a[13] * b[6] + a[14] * b[10] + a[15] * b[14],
+      a[12] * b[3] + a[13] * b[7] + a[14] * b[11] + a[15] * b[15],
+    });
+  }
+
+  public Vector transform(Vector point) {
+    double oldX = point.getX();
+    double oldY = point.getY();
+    double oldZ = point.getZ();
+
+    double x = matrix[0] * oldX + matrix[1] * oldY + matrix[2] * oldZ + matrix[3];
+    double y = matrix[4] * oldX + matrix[5] * oldY + matrix[6] * oldZ + matrix[7];
+    double z = matrix[8] * oldX + matrix[9] * oldY + matrix[10] * oldZ + matrix[11];
+    return new Vector(x, y, z);
+  }
+}


### PR DESCRIPTION
# Resized regions

Resized regions take in another region and resize it by a certain amount. I think the best way to visualize this is with an example:

```xml
    <action id="fill-regions" expose="true" scope="match">
      <fill material="glass">
        <resize min="5,6,5" max="5,4,5" region="monument-region"/>
      </fill>
      <fill material="stained_glass:1">
        <resize min="1,1,1" max="1,1,1"  relative="true" region="monument-region"/>
      </fill>
      <fill material="obsidian">
        <region id="monument-region"/>
      </fill>
    </action>
```
This will fill an area 5 blocks sideways, 6 down and 4 up with glass, then will fill a region that expands by 100% of the original size to each direction with orange glass, and finally places back the obsidian.
Result is as follows:
![image](https://github.com/user-attachments/assets/38039fd1-70a7-40a9-b0ff-771c18da9b77)

### Attributes
- `min` How much to expand in the -x, -y and -z directions
- `max` How much to expand in the +x, +y and +z directions
- `relative` If the min&max should be relative to the original size of the region (proportion) or absolute (number of blocks)
  - `false` (default):  min & max are a number of blocks to expand in each direction
  - `true`: min & max represent a multiplier of the original size, eg: 2 = means 200% in each direction
  - Example: to expand a region by 50% you would `relative="true" min="0.5,0.5,0.5" max="0.5,0.5,0.5"`
- `region` Can be an attribute, or be a direct child.

## Relative resize

Expand the region by a factor of 100% in each direction (notice: relative="true"), so because the original is 2 tall, and 1 wide, it expands 2 up/down, and 1 to each side.
```xml
<resize min="1,1,1" max="1,1,1"  relative="true" region="monument-region"/> <!-- Filled with orange glass -->
```
![image](https://github.com/user-attachments/assets/5f2b6391-16e4-4e18-9e26-fe1b76deca77)


## Absolute resize

Expand the region by an absolute 5 blocks sideways, 6 down, 4 up:
```xml
<resize min="5,6,5" max="5,4,5" region="monument-region"/> <!-- Filled with regular glass -->
```
![image](https://github.com/user-attachments/assets/38039fd1-70a7-40a9-b0ff-771c18da9b77)


## Caution with unions

**BE AWARE: Multiple children will act as a union. You probably do not want to use this region type with unions, as it will likely not create the effect you desire!!**

What happens with a union:
```xml
    <action id="fill-regions" expose="true" scope="match">
      <fill material="glass">
        <resize min="5,6,5" max="5,4,5" region="monument-region"/>
      </fill>
      <fill material="stained_glass:1">
        <resize min="1,1,1" max="1,1,1"  relative="true" region="monument-region"/>
      </fill>
      <fill material="obsidian">
        <region id="monument-region"/>
      </fill>
    </action>
    <action id="fill-regions-union" expose="true" scope="match">
      <fill material="glass">
        <resize min="5,6,5" max="5,4,5">
          <region id="monument-region1"/>
          <region id="monument-region2"/>
          <region id="monument-region3"/>
        </resize>
      </fill>
      <fill material="stained_glass:1">
        <resize min="1,1,1" max="1,1,1"  relative="true">
          <region id="monument-region1"/>
          <region id="monument-region2"/>
          <region id="monument-region3"/>
        </resize>
      </fill>
    </action>
```
**Relative result:**
The union is like 34 blocks across, so the relative resize by an extra factor of 100% in each direction, it triples the size and the result of the resize is a region 102 blocks wide (orange glass).
![image](https://github.com/user-attachments/assets/72de2c5f-95df-43bf-a220-884f7404ab8b)

**Absolute result:**
The absolute region ends up looking pretty broken, because it's "only" enlarging by 5 blocks a region that is over 30 blocks across, meaning its a very small % increase, and barely creates extra area.
So the region did in fact grow by 4 blocks up and 5 sideways, and the area of the monument (the two blocks) enlarge to this 2x4 glass column:
![image](https://github.com/user-attachments/assets/2e0c92e8-a3dd-4313-9492-8e4eec8a063c)

# Other changes/fixes
The PR includes a couple minor fixes too:
- You can now use item matchers that ignore all meta *except* name/enchants, before pgm wouldn't allow it.
- Enchant item action calls setItem so that the update is instantly sent to the client instead of waiting a few ticks for the next inventory sync


