### PR TITLE
Implement custom objective modes

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -38,26 +38,22 @@ public final class ModeCommand {
 
     if (countdowns.isEmpty()) throwNoResults();
 
-    TextComponent.Builder builder =
-        text().append(translatable("command.nextMode", NamedTextColor.DARK_PURPLE).append(space()));
+    TextComponent.Builder builder = text()
+        .append(translatable("command.nextMode", NamedTextColor.DARK_PURPLE).append(space()));
 
     ModeChangeCountdown next = countdowns.get(0);
     Duration timeLeft = modes.getCountdown().getTimeLeft(next);
 
     if (timeLeft == null) {
-      builder.append(text(next.getMode().getPreformattedMaterialName(), NamedTextColor.GOLD));
+      builder.append(text(next.getMode().getLegacyName(), NamedTextColor.GOLD));
     } else if (timeLeft.getSeconds() >= 0) {
-      builder.append(
-          text(
-                  WordUtils.capitalize(next.getMode().getPreformattedMaterialName()),
-                  NamedTextColor.GOLD)
-              .append(space())
-              .append(text("(", NamedTextColor.AQUA))
-              .append(
-                  new ModesPaginatedResult(modes)
-                      .formatSingleCountdown(next)
-                      .color(NamedTextColor.AQUA))
-              .append(text(")", NamedTextColor.AQUA)));
+      builder.append(text(WordUtils.capitalize(next.getMode().getLegacyName()), NamedTextColor.GOLD)
+          .append(space())
+          .append(text("(", NamedTextColor.AQUA))
+          .append(new ModesPaginatedResult(modes)
+              .formatSingleCountdown(next)
+              .color(NamedTextColor.AQUA))
+          .append(text(")", NamedTextColor.AQUA)));
     } else {
       throwNoResults();
     }
@@ -83,14 +79,13 @@ public final class ModeCommand {
     List<ModeChangeCountdown> modeList = modes.getSortedCountdowns(true);
     int resultsPerPage = 8;
     int pages = (modeList.size() + resultsPerPage - 1) / resultsPerPage;
-    Component header =
-        TextFormatter.paginate(
-            translatable("command.monumentModes"),
-            page,
-            pages,
-            NamedTextColor.DARK_AQUA,
-            NamedTextColor.AQUA,
-            true);
+    Component header = TextFormatter.paginate(
+        translatable("command.monumentModes"),
+        page,
+        pages,
+        NamedTextColor.DARK_AQUA,
+        NamedTextColor.AQUA,
+        true);
 
     new ModesPaginatedResult(header, resultsPerPage, modes).display(audience, modeList, page);
   }
@@ -122,7 +117,8 @@ public final class ModeCommand {
     TextComponent.Builder builder =
         text().append(translatable("command.modesPushed", NamedTextColor.GOLD).append(space()));
     if (duration.isNegative()) {
-      builder.append(translatable("command.modesPushedBack", NamedTextColor.GOLD).append(space()));
+      builder.append(
+          translatable("command.modesPushedBack", NamedTextColor.GOLD).append(space()));
     } else {
       builder.append(
           translatable("command.modesPushedForwards", NamedTextColor.GOLD).append(space()));
@@ -152,12 +148,10 @@ public final class ModeCommand {
     context.cancel(countdown);
     context.start(countdown, time);
 
-    TextComponent.Builder builder =
-        text()
-            .append(
-                translatable("command.selectedModePushed", mode.getComponentName())
-                    .color(NamedTextColor.GOLD)
-                    .append(space()));
+    TextComponent.Builder builder = text()
+        .append(translatable("command.selectedModePushed", mode.getComponentName())
+            .color(NamedTextColor.GOLD)
+            .append(space()));
     builder.append(clock(Math.abs(time.getSeconds())).color(NamedTextColor.AQUA));
     audience.sendMessage(builder);
   }

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -7,7 +7,6 @@ import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.format.Style.style;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.Set;
 import net.kyori.adventure.text.Component;
@@ -132,8 +131,10 @@ public class Core extends TouchableGoal<CoreFactory>
     return proximityLocations;
   }
 
-  public ImmutableSet<Mode> getModes() {
-    return this.definition.getModes();
+  @Override
+  public boolean isAffectedBy(Mode mode) {
+    return mode.getMaterialData() != null
+        && (this.definition.getModes() == null || this.definition.getModes().contains(mode));
   }
 
   public boolean isCoreMaterial(MaterialData material) {
@@ -241,6 +242,7 @@ public class Core extends TouchableGoal<CoreFactory>
     return material.matches(block.getState());
   }
 
+  @Override
   public String getModeChangeMessage(Material material) {
     return ModeUtils.formatMaterial(material) + " CORE MODE";
   }

--- a/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreMatchModule.java
@@ -161,7 +161,7 @@ public class CoreMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.HIGHEST)
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Core core : this.cores) {
-      if (core.getModes() == null || core.getModes().contains(event.getMode())) {
+      if (core.isAffectedBy(event.getMode())) {
         core.replaceBlocks(event.getMode().getMaterialData());
         // if at least one of the cores are visible, the mode change message will be sent
         if (core.hasShowOption(ShowOption.SHOW_MESSAGES)) {

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -8,7 +8,6 @@ import static net.kyori.adventure.text.format.Style.style;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.time.Instant;
@@ -171,8 +170,10 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return proximityLocations;
   }
 
-  public ImmutableSet<Mode> getModes() {
-    return this.definition.getModes();
+  @Override
+  public boolean isAffectedBy(Mode mode) {
+    return mode.getMaterialData() != null
+        && (this.definition.getModes() == null || this.definition.getModes().contains(mode));
   }
 
   /** Calculate maximum/current health */
@@ -611,6 +612,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return this.hasMaterial(MaterialData.block(block));
   }
 
+  @Override
   public String getModeChangeMessage(Material material) {
     return ModeUtils.formatMaterial(material) + " OBJECTIVE MODE";
   }

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -128,7 +128,7 @@ public class DestroyableMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.HIGHEST)
   public void onObjectiveModeSwitch(final ObjectiveModeChangeEvent event) {
     for (Destroyable destroyable : this.destroyables) {
-      if (destroyable.getModes() == null || destroyable.getModes().contains(event.getMode())) {
+      if (destroyable.isAffectedBy(event.getMode())) {
         double oldCompletion = destroyable.getCompletion();
         destroyable.replaceBlocks(event.getMode().getMaterialData());
         // if at least one of the destroyables are visible, the mode change message will be sent

--- a/core/src/main/java/tc/oc/pgm/goals/ModeChangeGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/ModeChangeGoal.java
@@ -1,15 +1,17 @@
 package tc.oc.pgm.goals;
 
-import com.google.common.collect.ImmutableSet;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.util.material.BlockMaterialData;
 
 public interface ModeChangeGoal<T extends GoalDefinition> extends Goal<T> {
 
+  boolean isAffectedBy(Mode mode);
+
   void replaceBlocks(BlockMaterialData newMaterial);
 
   boolean isObjectiveMaterial(Block block);
 
-  ImmutableSet<Mode> getModes();
+  String getModeChangeMessage(Material material);
 }

--- a/core/src/main/java/tc/oc/pgm/modes/Mode.java
+++ b/core/src/main/java/tc/oc/pgm/modes/Mode.java
@@ -3,53 +3,51 @@ package tc.oc.pgm.modes;
 import static net.kyori.adventure.text.Component.text;
 
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Objects;
+import java.util.function.Supplier;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.action.Action;
 import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.util.material.BlockMaterialData;
 
 @FeatureInfo(name = "mode")
 public class Mode extends SelfIdentifyingFeatureDefinition {
-  private final BlockMaterialData material;
-  private final Duration after;
-  private final @Nullable Filter filter;
   private final @Nullable String name;
   private final String legacyName;
   private final Component componentName;
-  private final Duration showBefore;
 
-  public Mode(final BlockMaterialData material, final Duration after, Duration showBefore) {
-    this(null, material, after, null, null, showBefore);
-  }
+  private final Duration after;
+  private final Duration showBefore;
+  private final @Nullable Filter filter;
+  private final @Nullable BlockMaterialData material;
+  private final @Nullable Action<? super Match> action;
 
   public Mode(
-      final @Nullable String id,
-      final BlockMaterialData material,
-      final Duration after,
-      final @Nullable Filter filter,
+      final String id,
       final @Nullable String name,
-      Duration showBefore) {
+      final Duration after,
+      final Duration showBefore,
+      final @Nullable Filter filter,
+      final @Nullable BlockMaterialData material,
+      final @Nullable Action<? super Match> action) {
     super(id);
-    this.material = material;
-    this.after = after;
-    this.filter = filter;
     this.name = name;
-    this.legacyName = name != null ? name : getPreformattedMaterialName();
+    this.legacyName = getName(() -> ModeUtils.formatMaterial(material));
     this.componentName = text(legacyName, NamedTextColor.RED);
+    this.after = after;
     this.showBefore = showBefore;
+    this.filter = filter;
+    this.material = material;
+    this.action = action;
   }
 
-  @Override
-  protected String getDefaultId() {
-    return makeDefaultId() + "--" + makeId(legacyName);
-  }
-
-  public BlockMaterialData getMaterialData() {
-    return this.material;
+  public String getName(Supplier<String> ifNull) {
+    return Objects.requireNonNullElseGet(this.name, ifNull);
   }
 
   public String getLegacyName() {
@@ -58,10 +56,6 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
 
   public Component getComponentName() {
     return componentName;
-  }
-
-  public String getPreformattedMaterialName() {
-    return ModeUtils.formatMaterial(this.material);
   }
 
   public Duration getAfter() {
@@ -76,11 +70,11 @@ public class Mode extends SelfIdentifyingFeatureDefinition {
     return this.filter;
   }
 
-  public @Nullable String getName() {
-    return this.name;
+  public @Nullable BlockMaterialData getMaterialData() {
+    return this.material;
   }
 
-  public static String makeDefaultId(@Nullable String name, AtomicInteger serial) {
-    return "--" + makeTypeName(Mode.class) + "-" + makeId(name);
+  public @Nullable Action<? super Match> getAction() {
+    return this.action;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modes/ModeUtils.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModeUtils.java
@@ -5,15 +5,14 @@ import tc.oc.pgm.util.material.MaterialData;
 
 public class ModeUtils {
   public static String formatMaterial(Material m) {
-    switch (m) {
-      case GOLD_BLOCK:
-        return "GOLD";
-      default:
-        return m.name().replaceAll("_", " ");
-    }
+    return switch (m) {
+      case GOLD_BLOCK -> "GOLD";
+      default -> m.name().replaceAll("_", " ");
+    };
   }
 
   public static String formatMaterial(MaterialData m) {
+    if (m == null) return "Unknown mode";
     return formatMaterial(m.getItemType());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ObjectiveModesMatchModule.java
@@ -117,7 +117,16 @@ public class ObjectiveModesMatchModule implements MatchModule, Listener {
         .orElse(null);
   }
 
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.HIGHEST)
+  public void onObjectiveModeAction(ObjectiveModeChangeEvent event) {
+    var action = event.getMode().getAction();
+    if (action != null) {
+      action.trigger(event.getMatch());
+      event.setVisible(true);
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
   public void onObjectiveModeChange(ObjectiveModeChangeEvent event) {
     if (event.isVisible()) {
       Component broadcast = text()

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.util.xml;
 
+import java.time.Duration;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 import org.jdom2.Element;
@@ -24,6 +25,7 @@ import tc.oc.pgm.util.xml.parsers.NumberBuilder;
 import tc.oc.pgm.util.xml.parsers.PrimitiveBuilder;
 import tc.oc.pgm.util.xml.parsers.ReferenceBuilder;
 import tc.oc.pgm.util.xml.parsers.RegionBuilder;
+import tc.oc.pgm.util.xml.parsers.StringBuilder;
 import tc.oc.pgm.util.xml.parsers.VariableBuilder;
 import tc.oc.pgm.variables.VariablesModule;
 
@@ -66,11 +68,15 @@ public class XMLFluentParser {
     };
   }
 
-  public PrimitiveBuilder.Generic<String> string(Element el, String... prop) {
+  public StringBuilder string(Element el, String... prop) {
+    return new StringBuilder(el, prop);
+  }
+
+  public PrimitiveBuilder.Generic<Duration> duration(Element el, String... prop) {
     return new PrimitiveBuilder.Generic<>(el, prop) {
       @Override
-      protected String parse(String text) throws TextException {
-        return text;
+      protected Duration parse(String text) throws TextException {
+        return TextParser.parseDuration(text);
       }
     };
   }

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/StringBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/StringBuilder.java
@@ -1,0 +1,29 @@
+package tc.oc.pgm.util.xml.parsers;
+
+import org.bukkit.ChatColor;
+import org.jdom2.Element;
+import tc.oc.pgm.util.text.TextException;
+
+public class StringBuilder extends PrimitiveBuilder<String, StringBuilder> {
+  private boolean colored;
+
+  public StringBuilder(Element el, String... props) {
+    super(el, props);
+  }
+
+  public StringBuilder colored() {
+    this.colored = true;
+    return this;
+  }
+
+  @Override
+  protected String parse(String text) throws TextException {
+    if (colored) text = ChatColor.translateAlternateColorCodes('`', text);
+    return text;
+  }
+
+  @Override
+  protected StringBuilder getThis() {
+    return this;
+  }
+}


### PR DESCRIPTION
Allows for objective modes that are not transforming a core or monument's blocks, and instead run an action.

This is useful for things like water lanes, since it gives the framework of alerting players (bossbar, the /modes command) as well as allowing mapdev tweaks (/modes push).

Changes:
- `material` is no longer required, but if not set, `action` and `name` become required.
- `action` can now be included, and will run alongside the mode change. This can be used alongside material just fine.
- cores and monuments will ignore modes with no material

![image](https://github.com/user-attachments/assets/d5797506-8073-48c7-9f87-ded7cce21301)
