### PR TITLE
Make item matching ignore modifier uuids

### DIFF
--- a/core/src/main/java/tc/oc/pgm/shops/ShopModule.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopModule.java
@@ -43,7 +43,6 @@ import tc.oc.pgm.shops.menu.Category;
 import tc.oc.pgm.shops.menu.Icon;
 import tc.oc.pgm.shops.menu.Payment;
 import tc.oc.pgm.util.xml.InvalidXMLException;
-import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLFluentParser;
 import tc.oc.pgm.util.xml.XMLUtils;
 
@@ -184,20 +183,15 @@ public class ShopModule implements MapModule<ShopMatchModule> {
     return payments;
   }
 
-  public static Payment parsePayment(Element element, XMLFluentParser parser)
+  public static Payment parsePayment(Element el, XMLFluentParser parser)
       throws InvalidXMLException {
-    Node priceAttr = Node.fromAttr(element, "price");
-    Node currencyAttr = Node.fromAttr(element, "currency");
-    Node colorAttr = Node.fromAttr(element, "color");
+    Integer price = parser.parseInt(el, "price").optional(0);
+    Material currency = price <= 0 ? null : parser.material(el, "currency").orNull();
+    ChatColor color = parser.parseEnum(ChatColor.class, el, "color").optional(ChatColor.GOLD);
 
-    Integer price = XMLUtils.parseNumber(priceAttr, Integer.class, 0);
-    Material currency =
-        price <= 0 || currencyAttr == null ? null : XMLUtils.parseMaterial(currencyAttr);
-    ChatColor color = XMLUtils.parseChatColor(colorAttr, ChatColor.GOLD);
-
-    ItemStack item = parser.item(element, "item").child().orNull();
+    ItemStack item = parser.item(el, "item").child().orNull();
     if (currency == null && item == null && price > 0) {
-      throw new InvalidXMLException("A 'currency' attribute or child <item> is required", element);
+      throw new InvalidXMLException("A 'currency' attribute or child <item> is required", el);
     }
 
     return new Payment(currency, price, color, item);

--- a/core/src/main/java/tc/oc/pgm/shops/menu/Payment.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/Payment.java
@@ -39,8 +39,14 @@ public class Payment {
   }
 
   public boolean hasPayment(PlayerInventory inventory) {
-    return price <= 0
-        || (item != null ? inventory.contains(item, price) : inventory.contains(currency, price));
+    if (price <= 0) return true;
+
+    int remaining = price;
+    for (ItemStack item : inventory.getContents()) {
+      if (item == null || !matches(item)) continue;
+      if ((remaining -= item.getAmount()) <= 0) return true;
+    }
+    return false;
   }
 
   public boolean matches(ItemStack item) {

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.util.xml;
 
 import java.time.Duration;
+import org.bukkit.Material;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 import org.jdom2.Element;
@@ -91,6 +92,15 @@ public class XMLFluentParser {
 
   public <T extends Number> NumberBuilder<T> number(Class<T> cls, Element el, String... prop) {
     return new NumberBuilder<>(cls, el, prop);
+  }
+
+  public Builder.Generic<Material> material(Element el, String... prop) {
+    return new Builder.Generic<>(el, prop) {
+      @Override
+      protected Material parse(Node node) throws InvalidXMLException {
+        return XMLUtils.parseMaterial(node);
+      }
+    };
   }
 
   public Builder.Generic<Vector> vector(Element el, String... prop) {

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernInventoryUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernInventoryUtil.java
@@ -71,6 +71,29 @@ public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatfor
   }
 
   @Override
+  public boolean attributesEqual(ItemMeta meta1, ItemMeta meta2) {
+    var attributes1 = meta1.getAttributeModifiers();
+    var attributes2 = meta2.getAttributeModifiers();
+    if (attributes1 == null || attributes2 == null) return false;
+
+    if (!attributes1.keySet().equals(attributes2.keySet())) return false;
+
+    for (Attribute attr : attributes1.keySet()) {
+      if (modifiersDiffer(attributes1.get(attr), attributes2.get(attr))) return false;
+    }
+    return true;
+  }
+
+  @Override
+  public void stripAttributes(ItemMeta meta) {
+    var attributes = meta.getAttributeModifiers();
+
+    if (attributes != null && !attributes.isEmpty()) {
+      attributes.keySet().forEach(meta::removeAttributeModifier);
+    }
+  }
+
+  @Override
   public EquipmentSlot getUsedHand(PlayerEvent event) {
     return switch (event) {
       case PlayerItemConsumeEvent e -> e.getHand();

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpInventoryUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SpInventoryUtil.java
@@ -68,6 +68,25 @@ public class SpInventoryUtil implements InventoryUtils.InventoryUtilsPlatform {
   }
 
   @Override
+  public boolean attributesEqual(ItemMeta meta1, ItemMeta meta2) {
+    var attributes = meta1.getModifiedAttributes();
+    if (!attributes.equals(meta2.getModifiedAttributes())) return false;
+
+    for (String attr : attributes) {
+      if (modifiersDiffer(meta1.getAttributeModifiers(attr), meta2.getAttributeModifiers(attr)))
+        return false;
+    }
+    return true;
+  }
+
+  @Override
+  public void stripAttributes(ItemMeta meta) {
+    for (String attr : meta.getModifiedAttributes()) {
+      meta.getAttributeModifiers(attr).clear();
+    }
+  }
+
+  @Override
   public EquipmentSlot getUsedHand(PlayerEvent event) {
     return EquipmentSlot.HAND;
   }

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.util.material;
 
 import static org.bukkit.Material.*;
+import static tc.oc.pgm.util.inventory.InventoryUtils.INVENTORY_UTILS;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -108,8 +109,21 @@ public interface Materials {
     final boolean hasMeta2 = second.hasItemMeta();
     if (!hasMeta1 && !hasMeta2) return true;
 
-    final ItemMeta meta1 = hasMeta1 ? first.getItemMeta() : null;
-    final ItemMeta meta2 = hasMeta2 ? second.getItemMeta() : null;
+    ItemMeta meta1 = hasMeta1 ? first.getItemMeta() : null;
+    ItemMeta meta2 = hasMeta2 ? second.getItemMeta() : null;
+
+    if (hasMeta1 && hasMeta2 && meta1.hasAttributeModifiers() && meta2.hasAttributeModifiers()) {
+      if (INVENTORY_UTILS.attributesEqual(meta1, meta2)) {
+        // If attributes match, strip them not to affect the comparison.
+        // This is done because attributes have a random UUID in t hem that make them never equal
+        meta1 = meta1.clone();
+        meta2 = meta2.clone();
+        INVENTORY_UTILS.stripAttributes(meta1);
+        INVENTORY_UTILS.stripAttributes(meta2);
+      } else {
+        return false;
+      }
+    }
 
     return Bukkit.getItemFactory().equals(meta1, meta2);
   }


### PR DESCRIPTION
Fixes #1167 

Essentially makes it so item-matching in PGM checks attribute modifiers ignoring their UUID, and  if they're all equal then strips the modifiers from the meta that is passed down to the "equals" check