### PR TITLE
Add proximity setting for auto

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -102,7 +102,7 @@ public final class PGMConfig implements Config {
   private final boolean showTabList;
   private final boolean resizeTabList;
   private final boolean showTabListPing;
-  private final boolean showProximity;
+  private final Boolean showProximity;
   private final boolean showFireworks;
   private final boolean participantsSeeObservers;
   private final boolean verboseStats;
@@ -202,7 +202,8 @@ public final class PGMConfig implements Config {
     this.queueJoin = parseBoolean(config.getString("join.queue", "false"));
     this.anytimeJoin = parseBoolean(config.getString("join.anytime", "true"));
 
-    this.showProximity = parseBoolean(config.getString("ui.proximity", "false"));
+    var proximityStr = config.getString("ui.proximity", "false");
+    this.showProximity = proximityStr.equalsIgnoreCase("auto") ? null : parseBoolean(proximityStr);
     this.showSideBar = parseBoolean(config.getString("ui.sidebar", "true"));
     this.showTabList = parseBoolean(config.getString("ui.tablist", "true"));
     this.resizeTabList = parseBoolean(config.getString("ui.tablist-resize", "false"));
@@ -558,8 +559,8 @@ public final class PGMConfig implements Config {
   }
 
   @Override
-  public boolean showProximity() {
-    return showProximity;
+  public boolean showProximity(boolean relevant) {
+    return showProximity != null ? showProximity : relevant;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -166,7 +166,17 @@ public interface Config {
    *
    * @return If proximity is visible.
    */
-  boolean showProximity();
+  default boolean showProximity() {
+    return showProximity(false);
+  }
+
+  /**
+   * Gets whether proximity metrics are visible to players.
+   *
+   * @param relevant If proximity is currently relevant (ie: an active time limit)
+   * @return If proximity is visible.
+   */
+  boolean showProximity(boolean relevant);
 
   /**
    * Gets whether the side bar is rendered.

--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -205,7 +205,7 @@ public class Core extends TouchableGoal<CoreFactory>
     return StringUtils.percentage(this.getCompletion());
   }
 
-  @Nullable
+  @NotNull
   @Override
   public String renderPreciseCompletion() {
     return this.leak + "/" + this.leakRequired;

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -491,6 +491,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return StringUtils.percentage(this.getCompletion());
   }
 
+  @NotNull
   @Override
   public String renderPreciseCompletion() {
     return this.getBreaks() + "/" + this.getBreaksRequired();

--- a/core/src/main/java/tc/oc/pgm/goals/ProximityGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/ProximityGoal.java
@@ -25,6 +25,7 @@ import tc.oc.pgm.events.ParticipantBlockTransformEvent;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalProximityChangeEvent;
 import tc.oc.pgm.goals.events.GoalTouchEvent;
+import tc.oc.pgm.timelimit.TimeLimitMatchModule;
 import tc.oc.pgm.util.LegacyFormatUtils;
 import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.collection.DefaultMapAdapter;
@@ -91,13 +92,12 @@ public abstract class ProximityGoal<T extends ProximityGoalDefinition> extends O
     Integer oldProximity = proximity.remove(team);
     if (oldProximity != null) {
       getMatch()
-          .callEvent(
-              new GoalProximityChangeEvent(
-                  this,
-                  team,
-                  null,
-                  distanceFromDistanceSquared(oldProximity),
-                  Double.POSITIVE_INFINITY));
+          .callEvent(new GoalProximityChangeEvent(
+              this,
+              team,
+              null,
+              distanceFromDistanceSquared(oldProximity),
+              Double.POSITIVE_INFINITY));
     }
   }
 
@@ -145,13 +145,12 @@ public abstract class ProximityGoal<T extends ProximityGoalDefinition> extends O
       if (newProximity < oldProximity) {
         proximity.put(player.getParty(), newProximity);
         getMatch()
-            .callEvent(
-                new GoalProximityChangeEvent(
-                    this,
-                    player.getParty(),
-                    location,
-                    distanceFromDistanceSquared(oldProximity),
-                    distanceFromDistanceSquared(newProximity)));
+            .callEvent(new GoalProximityChangeEvent(
+                this,
+                player.getParty(),
+                location,
+                distanceFromDistanceSquared(oldProximity),
+                distanceFromDistanceSquared(newProximity)));
         return true;
       }
     }
@@ -160,7 +159,9 @@ public abstract class ProximityGoal<T extends ProximityGoalDefinition> extends O
 
   public boolean shouldShowProximity(@Nullable Competitor team, Party viewer) {
     return team != null
-        && PGM.get().getConfiguration().showProximity()
+        && PGM.get()
+            .getConfiguration()
+            .showProximity(match.moduleRequire(TimeLimitMatchModule.class).willUseProximity())
         && isProximityRelevant(team)
         && (viewer == team || viewer.isObserving());
   }

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarMatchModule.java
@@ -32,6 +32,8 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
 import tc.oc.pgm.blitz.BlitzMatchModule;
 import tc.oc.pgm.destroyable.Destroyable;
+import tc.oc.pgm.events.CountdownCancelEvent;
+import tc.oc.pgm.events.CountdownStartEvent;
 import tc.oc.pgm.events.FeatureChangeEvent;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerJoinMatchEvent;
@@ -47,6 +49,8 @@ import tc.oc.pgm.goals.events.GoalTouchEvent;
 import tc.oc.pgm.score.ScoreMatchModule;
 import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
 import tc.oc.pgm.teams.events.TeamRespawnsChangeEvent;
+import tc.oc.pgm.timelimit.TimeLimitCountdown;
+import tc.oc.pgm.timelimit.TimeLimitMatchModule;
 import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.concurrent.RateLimiter;
@@ -209,9 +213,22 @@ public class SidebarMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void goalProximityChange(final GoalProximityChangeEvent event) {
-    if (PGM.get().getConfiguration().showProximity()) {
+    boolean willUseProx = match.moduleRequire(TimeLimitMatchModule.class).willUseProximity();
+    if (PGM.get().getConfiguration().showProximity(willUseProx)) {
       renderSidebarDebounce();
     }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void timelimitToggle(final CountdownStartEvent event) {
+    if (!(event.getCountdown() instanceof TimeLimitCountdown)) return;
+    renderSidebarDebounce();
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void timelimitToggle(final CountdownCancelEvent event) {
+    if (!(event.getCountdown() instanceof TimeLimitCountdown)) return;
+    renderSidebarDebounce();
   }
 
   @EventHandler(priority = EventPriority.MONITOR)

--- a/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/TimeLimit.java
@@ -13,6 +13,8 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.VictoryCondition;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+import tc.oc.pgm.goals.GoalsVictoryCondition;
+import tc.oc.pgm.result.ImmediateVictoryCondition;
 import tc.oc.pgm.util.collection.RankedSet;
 
 @FeatureInfo(name = "time-limit")
@@ -66,6 +68,12 @@ public class TimeLimit extends SelfIdentifyingFeatureDefinition implements Victo
 
   public @Nullable VictoryCondition getResult() {
     return result;
+  }
+
+  public boolean isProximityRelevant(boolean includeOvertime) {
+    return result == null
+        || result instanceof GoalsVictoryCondition
+        || (includeOvertime && overtime != null && !(result instanceof ImmediateVictoryCondition));
   }
 
   public boolean getShow() {

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -102,7 +102,7 @@ ui:
   tablist: true    # Enable the tab list?
   tablist-resize: false # Resize the tab list for 1.7 players? Requires ProtocolLib
   ping: false      # Should tab list show real ping?
-  proximity: false # Should the proximity of objectives be visible?
+  proximity: auto # Should the proximity of objectives be visible?
   fireworks: true  # Spawn fireworks after objectives are completed?
   participants-see-observers: true # Can participants see observers in the tab list?
   flag-beams: false # Should everyone see floating wool flag beams?


### PR DESCRIPTION
The `ui.proximity` setting currently only allows true & false, which works allright for tournament settings to have it enabled, and more public/casual to hide it. However this poses a problem when some maps have timelimit that can end up deciding the winner based on proximity. It's not intuitive to win/lose a match and not see in the scoreboard why it was.

This PR fixes it by adding an 'auto' setting to proximity, which means it will hide proximity most of the time (similar to false),  with the exception of when there's an active timelimit, and the tl will use proximity to decide its result (eg: a TL with result = defenders won't show proximity). Additionally things like score-results will hide proximity, but show it during overtime as then it could end up deciding the result.