### PR TITLE
fix(MatchManagerImpl): lower the match load listener priority

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchManagerImpl.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.Config;
@@ -64,7 +65,7 @@ public class MatchManagerImpl implements MatchManager, Listener {
     this.destroyDelaySecs = delaySecs;
   }
 
-  @EventHandler
+  @EventHandler(priority = EventPriority.LOWEST)
   public void onMatchLoad(MatchLoadEvent event) {
     final Match match = event.getMatch();
 


### PR DESCRIPTION
Fixes an issue introduced in 0da8f1cc2e26978b642fc3a95c89b827cefc99e8 where running filtered fill actions on match load using variable filters would result in the variable filter abstaining due to the world not being registered with the match manager.