### PR TITLE
Disable player collisions in modern paper

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/party/Party.java
+++ b/core/src/main/java/tc/oc/pgm/api/party/Party.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
@@ -96,7 +96,7 @@ public interface Party extends Audience, Named, Filterable<PartyQuery>, PartyQue
    */
   ChatColor getColor();
 
-  TextColor getTextColor();
+  NamedTextColor getTextColor();
 
   /**
    * Gets the {@link Color} of the party.

--- a/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
+++ b/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
@@ -8,7 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
@@ -36,8 +36,8 @@ import tc.oc.pgm.util.text.TextFormatter;
  * rejoins the same match, the FFA module will retrieve their existing Tribute and add them back to
  * it, instead of creating a new one.
  *
- * <p>Attempting to add the wrong player, or add multiple players, will throw {@link
- * UnsupportedOperationException}.
+ * <p>Attempting to add the wrong player, or add multiple players, will throw
+ * {@link UnsupportedOperationException}.
  */
 public class Tribute implements Competitor {
 
@@ -49,7 +49,7 @@ public class Tribute implements Competitor {
   private final ChatColor chatColor;
   private final Color color;
   private final DyeColor dyeColor;
-  private final TextColor textColor;
+  private final NamedTextColor textColor;
   private final PartyQuery query;
   private NameTagVisibility nameTagOverride;
 
@@ -104,7 +104,7 @@ public class Tribute implements Competitor {
   }
 
   @Override
-  public TextColor getTextColor() {
+  public NamedTextColor getTextColor() {
     return this.textColor;
   }
 

--- a/core/src/main/java/tc/oc/pgm/match/PartyImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/PartyImpl.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -35,7 +36,7 @@ public abstract class PartyImpl implements Party, Audience {
   private final ChatColor chatColor;
   private final Color color;
   private final DyeColor dyeColor;
-  private final TextColor textColor;
+  private final NamedTextColor textColor;
   private String legacyName;
   private Component name;
   private Component prefix;
@@ -160,7 +161,7 @@ public abstract class PartyImpl implements Party, Audience {
   }
 
   @Override
-  public TextColor getTextColor() {
+  public NamedTextColor getTextColor() {
     return this.textColor;
   }
 

--- a/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardMatchModule.java
@@ -1,7 +1,7 @@
 package tc.oc.pgm.scoreboard;
 
 import static tc.oc.pgm.util.Assert.assertNotNull;
-import static tc.oc.pgm.util.material.ColorUtils.COLOR_UTILS;
+import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -80,7 +80,7 @@ public class ScoreboardMatchModule implements MatchModule, Listener {
         StringUtils.truncate(TextTranslations.translateLegacy(party.getName(NameStyle.FANCY)), 32));
     team.setPrefix(party.getColor().toString());
     team.setSuffix(ChatColor.WHITE.toString());
-    COLOR_UTILS.setColor(team, party.getColor());
+    MISC_UTILS.initScoreboardTeam(team, party.getTextColor());
 
     team.setCanSeeFriendlyInvisibles(true);
     team.setAllowFriendlyFire(match.getFriendlyFire());

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import java.nio.file.Path;
 import java.util.List;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.NbtUtils;
@@ -29,6 +30,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scoreboard.Team;
 import tc.oc.pgm.platform.modern.material.ModernBlockMaterialData;
 import tc.oc.pgm.util.bukkit.MiscUtils;
 import tc.oc.pgm.util.material.BlockMaterialData;
@@ -108,5 +110,11 @@ public class ModernMiscUtil implements MiscUtils {
   @Override
   public Key getSound(Sound enumConstant) {
     return enumConstant.key();
+  }
+
+  @Override
+  public void initScoreboardTeam(Team team, NamedTextColor color) {
+    team.color(color);
+    team.setOption(Team.Option.COLLISION_RULE, Team.OptionStatus.NEVER);
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernColorUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernColorUtils.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -18,7 +17,6 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Rotatable;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BannerMeta;
-import org.bukkit.scoreboard.Team;
 import tc.oc.pgm.util.block.BlockFaces;
 import tc.oc.pgm.util.material.ColorUtils;
 import tc.oc.pgm.util.material.MaterialData;
@@ -107,11 +105,6 @@ public class ModernColorUtils implements ColorUtils {
   @Override
   public boolean isColor(MaterialData data, DyeColor color) {
     return setColor(data.getItemType(), color) == data.getItemType();
-  }
-
-  @Override
-  public void setColor(Team team, ChatColor color) {
-    team.setColor(color);
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import java.nio.file.Path;
 import java.util.List;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -20,6 +21,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scoreboard.Team;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Platform;
 
@@ -55,4 +57,6 @@ public interface MiscUtils {
   int getWorldDataVersion(Path levelDat);
 
   Key getSound(Sound constant);
+
+  default void initScoreboardTeam(Team team, NamedTextColor color) {}
 }

--- a/util/src/main/java/tc/oc/pgm/util/material/ColorUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/ColorUtils.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.util.material;
 
 import net.kyori.adventure.text.Component;
-import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -11,7 +10,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BannerMeta;
-import org.bukkit.scoreboard.Team;
 import org.bukkit.util.BlockVector;
 import tc.oc.pgm.util.platform.Platform;
 
@@ -33,8 +31,6 @@ public interface ColorUtils {
       setColor(world.getBlockAt(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()), color);
     }
   }
-
-  default void setColor(Team team, ChatColor color) {}
 
   BannerData createBanner(Banner banner);
 


### PR DESCRIPTION
Makes it so player collisions are disabled for modern when creating the scoreboard teams