### PR TITLE
Fix balance message being used for priority kick

### DIFF
--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -80,6 +80,11 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
     return getConfig().canPriorityKick() && !match.isRunning();
   }
 
+  public boolean canPriorityKick(MatchPlayer player) {
+    JoinRequest request = requests.get(player.getBukkit());
+    return request != null && canPriorityKick(request);
+  }
+
   public boolean canPriorityKick(JoinRequest request) {
     return priorityKickAllowed() && request.isForcedOr(JoinRequest.Flag.JOIN_FULL);
   }

--- a/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -526,7 +526,7 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
     }
 
     // Give them the bad news
-    if (jmm.canBePriorityKicked(kickMe)) {
+    if (jmm.canPriorityKick(kickMe)) {
       kickMe.sendMessage(translatable("join.ok.moved", kickTo.getName()));
       kickMe.sendMessage(translatable("join.ok.moved.explanation"));
     } else {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d2eb1b6e-1e5f-4970-846b-d82031b39ab8)

In this image, the player was actually kicked not due to balance, but because someone else with perms joined and there was no longer room for the pleyer, ie: it was a priority kick. The current logic for messages makes no sense, anyone without perms will *always* get the "for balance" message.
Changed it so if the kick is for balance it shows the balance message, but priority kicks properly use the priority kick msg