### PR TITLE
Automatically unlock recipes and warn for advancements

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
@@ -3,9 +3,12 @@ package tc.oc.pgm.platform.modern;
 import static tc.oc.pgm.util.platform.Supports.Priority.HIGHEST;
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
+import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
+import org.spigotmc.SpigotConfig;
 import tc.oc.pgm.platform.modern.packets.PacketManipulations;
+import tc.oc.pgm.platform.modern.util.RecipeUnlocker;
 import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.platform.Supports;
 
@@ -19,9 +22,25 @@ public class ModernPlatform implements Platform.Manifest {
           "ProtocolLib is not installed, and is required for PGM modern version support");
     }
 
-    Bukkit.getServer().getPluginManager().registerEvents(new ModernListener(), plugin);
-    Bukkit.getServer().getPluginManager().registerEvents(new SpawnEggUseListener(), plugin);
+    List.of(
+            new ModernListener(),
+            new SpawnEggUseListener(),
+            new PacketManipulations(plugin),
+            new RecipeUnlocker())
+        .forEach(l -> Bukkit.getServer().getPluginManager().registerEvents(l, plugin));
 
-    Bukkit.getServer().getPluginManager().registerEvents(new PacketManipulations(plugin), plugin);
+    if (!SpigotConfig.disabledAdvancements.contains("*")) {
+      plugin
+          .getLogger()
+          .warning(
+              """
+              You have not disabled advancements in your spigot config.
+              If you want to remove them you should modify your spigot.yml config to have:
+              advancements:
+                disable-saving: true
+                disabled:
+                - '*'
+              """);
+    }
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/RecipeUnlocker.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/RecipeUnlocker.java
@@ -1,0 +1,25 @@
+package tc.oc.pgm.platform.modern.util;
+
+import net.minecraft.server.MinecraftServer;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.spigotmc.event.player.PlayerSpawnLocationEvent;
+
+public class RecipeUnlocker implements Listener {
+
+  // PlayerJoinEvent is too late as recipe init packet was already sent, so we use spawn location
+  // event
+  @EventHandler
+  public void onPlayerJoin(PlayerSpawnLocationEvent event) {
+    // Non-joined players haven't been added to the player list yet
+    if (Bukkit.getPlayer(event.getPlayer().getUniqueId()) != null) return;
+
+    var player = ((CraftPlayer) event.getPlayer()).getHandle();
+    player
+        .getRecipeBook()
+        .known
+        .addAll(MinecraftServer.getServer().getRecipeManager().byName.keySet());
+  }
+}


### PR DESCRIPTION
Warns you to disable advancements via spigot config if you haven't, and automatically unlocks all recipes as known on join, making it so it doesn't display flashing toasts for new unlocks every time you craft something new