### PR TITLE
Fix slabs not supporting in newer versions

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/block/BlockVectors.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/BlockVectors.java
@@ -153,6 +153,7 @@ public interface BlockVectors {
     // blocks that aren't listed as occluding but can support a player
     if (type.isBlock()) {
       if (type.name().endsWith("STAIRS")) return true;
+      if (type.name().endsWith("SLAB")) return true;
       if (type.name().endsWith("STEP")) return true;
       if (type.name().endsWith("STAINED_GLASS")) return true;
       if (type.name().endsWith("CARPET")) return true;


### PR DESCRIPTION
In legacy the materials are called "STEP", but in modern it's "SLAB"