### PR TITLE
Add safeguard to cycle command

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/CycleCommand.java
@@ -30,9 +30,13 @@ public final class CycleCommand {
       MapOrder mapOrder,
       @Argument("duration") Duration duration,
       @Argument("map") @FlagYielding MapInfo map,
-      @Flag(value = "force", aliases = "f") boolean force) {
-    if (match.isRunning() && !force) {
-      throw exception("admin.matchRunning.cycle");
+      @Flag(value = "force", aliases = "f") boolean force,
+      @Flag(value = "override") boolean override) {
+    if (match.isRunning()) {
+      if (!force) throw exception("admin.matchRunning.cycle");
+      if (needsOverride(match) && !override) {
+        throw exception("admin.matchRunning.cycle.override");
+      }
     }
 
     if (map != null && mapOrder.getNextMap() != map) {
@@ -56,7 +60,12 @@ public final class CycleCommand {
       Match match,
       MapOrder mapOrder,
       @Argument("duration") Duration duration,
-      @Flag(value = "force", aliases = "f") boolean force) {
-    cycle(sender, match, mapOrder, duration, match.getMap(), force);
+      @Flag(value = "force", aliases = "f") boolean force,
+      @Flag(value = "override") boolean override) {
+    cycle(sender, match, mapOrder, duration, match.getMap(), force, override);
+  }
+
+  private boolean needsOverride(Match match) {
+    return match.getPlayers().size() >= 8 && match.getDuration().toMinutes() >= 5;
   }
 }

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -209,6 +209,8 @@ admin.matchRunning.restart = You may not restart during a match. Use -f to overr
 
 admin.matchRunning.cycle = You may not cycle during a match. Use -f to override.
 
+admin.matchRunning.cycle.override = The match is running for long, are you sure about this? Use --override.
+
 admin.queueRestart.restartingNow = Server will restart now.
 
 admin.queueRestart.restartQueued = Server will restart at the next available opportunity.


### PR DESCRIPTION
Prevents big oopsie moments where you may run `/cycle 0 -f` or equivalent on a big/long-running match. If you wish to do it you'll have to add an additional `--override`