### PR TITLE
Add potion effect improvements for modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/PotionKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/PotionKit.java
@@ -17,16 +17,21 @@ public class PotionKit extends AbstractKit {
 
   @Override
   public void applyPostEvent(MatchPlayer player, boolean force, List<ItemStack> displacedItems) {
+    var pl = player.getBukkit();
     if (force) {
       for (PotionEffect effect : this.effects) {
-        player.getBukkit().addPotionEffect(effect, true);
+        // Forced potion eff with duration = 0 is used to remove effects, however in modern versions
+        // due to allowing multiple of the same effect, they aren't removed.
+        // This makes the behavior explicit that forcing an effect with duration 0 removes it.
+        if (effect.getDuration() != 0) pl.addPotionEffect(effect, true);
+        else pl.removePotionEffect(effect.getType());
       }
     } else {
-      player.getBukkit().addPotionEffects(this.effects);
+      pl.addPotionEffects(this.effects);
     }
 
     // No swirls by default, KitNode can re-enable them if it so desires
-    PLAYER_UTILS.setPotionParticles(player.getBukkit(), false);
+    PLAYER_UTILS.setPotionParticles(pl, false);
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/platform/Platform.java
+++ b/util/src/main/java/tc/oc/pgm/util/platform/Platform.java
@@ -52,6 +52,14 @@ public abstract class Platform {
     return (T) Platform.getBestSupported(clazz);
   }
 
+  public static boolean isLegacy() {
+    return VARIANT == Variant.SPORTPAPER;
+  }
+
+  public static boolean isModern() {
+    return VARIANT == Variant.PAPER;
+  }
+
   private static <T> Iterable<Class<?>> getSupported(Class<T> parent) {
     return REFLECTIONS.get(TypesAnnotated.with(Supports.class, Supports.List.class)
         .asClass()

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TablistResizer.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TablistResizer.java
@@ -1,7 +1,5 @@
 package tc.oc.pgm.util.tablist;
 
-import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
-
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.events.ListenerPriority;
@@ -13,7 +11,7 @@ import tc.oc.pgm.util.platform.Platform;
 public class TablistResizer {
   private static final int TAB_SIZE = 80;
   // In 1.20.6 the field to edit is 1, unsure what version exactly broke it
-  private static final int FIELD = Platform.VARIANT == SPORTPAPER ? 2 : 1;
+  private static final int FIELD = Platform.isLegacy() ? 2 : 1;
 
   public static void registerAdapter(Plugin plugin) {
     ProtocolLibrary.getProtocolManager().addPacketListener(new TablistResizePacketAdapter(plugin));

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -39,6 +39,7 @@ import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.material.matcher.AllMaterialMatcher;
 import tc.oc.pgm.util.material.matcher.BlockMaterialMatcher;
 import tc.oc.pgm.util.math.OffsetVector;
+import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.range.Ranges;
 import tc.oc.pgm.util.skin.Skin;
 import tc.oc.pgm.util.text.TextException;
@@ -833,7 +834,11 @@ public final class XMLUtils {
 
   private static PotionEffect createPotionEffect(
       PotionEffectType type, Duration duration, int amplifier, boolean ambient) {
-    return new PotionEffect(type, (int) TimeUtils.toTicks(duration), amplifier, ambient);
+    // Modern supports infinite durations with value -1
+    int ticks = Platform.isModern() && TimeUtils.isInfinite(duration)
+        ? -1
+        : (int) TimeUtils.toTicks(duration);
+    return new PotionEffect(type, ticks, amplifier, ambient);
   }
 
   public static PotionEffect parsePotionEffect(Element el) throws InvalidXMLException {


### PR DESCRIPTION
Fixes:
- Force-applying potion effects with duration=0 in modern does nothing, as they can stack without one overriding the other
- Infinite duration potion effects were using large numbers, when in modern you can just use -1 for "infinite"