### PR TITLE
Implemement `player-kit`

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -45,6 +45,7 @@ import tc.oc.pgm.events.PlayerJoinPartyEvent;
 import tc.oc.pgm.events.PlayerParticipationStopEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.join.JoinRequest;
+import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.spawns.states.Joining;
 import tc.oc.pgm.spawns.states.Observing;
 import tc.oc.pgm.spawns.states.State;
@@ -93,6 +94,10 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
 
   public List<Spawn> getSpawns() {
     return module.spawns;
+  }
+
+  public List<Kit> getPlayerKits() {
+    return module.playerKits;
   }
 
   public ObserverToolFactory getObserverToolFactory() {

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
@@ -17,6 +17,7 @@ import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
 import tc.oc.pgm.classes.ClassMatchModule;
 import tc.oc.pgm.events.PlayerJoinPartyEvent;
 import tc.oc.pgm.killreward.KillRewardMatchModule;
+import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.modules.ItemKeepMatchModule;
 import tc.oc.pgm.spawns.Spawn;
 import tc.oc.pgm.spawns.SpawnMatchModule;
@@ -69,6 +70,11 @@ public class Alive extends Participating {
     player.resetVisibility();
     player.setGameMode(GameMode.SURVIVAL);
     bukkit.setAllowFlight(false);
+
+    // Apply player kit
+    for (Kit kit : smm.getPlayerKits()) {
+      player.applyKit(kit, false);
+    }
 
     // Apply spawn kit
     spawn.applyKit(player);


### PR DESCRIPTION
This PR implements/backports `player-kit` from ProjectAres. `player-kit` is a kit applied alive players in the match on spawn. On Overcast Network, the use case seemed to be applying a global `generic.attackSpeed` attribute multiplier to all players. This does not differ greatly from the intended use case now.