### PR TITLE
Reimplement setPotionParticles in modern

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     api("org.reflections:reflections:0.10.2")
 
     // Optional plugin deps
-    compileOnly("com.comphenix.protocol:ProtocolLib:5.1.0")
+    compileOnly("com.comphenix.protocol:ProtocolLib:5.3.0")
     compileOnly("com.viaversion:viaversion-api:5.0.0")
 
     // Minecraft includes these (or equivalents)

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -128,7 +128,7 @@ public abstract class KitParser {
     }
 
     Boolean force = XMLUtils.parseBoolean(Node.fromAttr(el, "force"));
-    boolean potionParticles = XMLUtils.parseBoolean(Node.fromAttr(el, "potion-particles"), false);
+    Boolean potionParticles = XMLUtils.parseBoolean(Node.fromAttr(el, "potion-particles"));
     Filter filter = factory.getFilters().parseFilterProperty(el, "filter", StaticFilter.ALLOW);
 
     kits.add(this.parseClearItemsKit(el)); // must be added before anything else
@@ -139,7 +139,7 @@ public abstract class KitParser {
 
     kits.add(this.parseArmorKit(el));
     kits.add(this.parseItemKit(el));
-    kits.add(this.parsePotionKit(el, !potionParticles));
+    kits.add(this.parsePotionKit(el));
     kits.add(this.parseAttributeKit(el));
     kits.add(this.parseHealthKit(el));
     kits.add(this.parseHungerKit(el));
@@ -308,27 +308,23 @@ public abstract class KitParser {
     return slot;
   }
 
-  public PotionKit parsePotionKit(Element el, boolean ambient) throws InvalidXMLException {
-    List<PotionEffect> potions = parsePotions(el, ambient);
+  public PotionKit parsePotionKit(Element el) throws InvalidXMLException {
+    List<PotionEffect> potions = parsePotions(el);
     return potions.isEmpty() ? null : new PotionKit(ImmutableSet.copyOf(potions));
   }
 
   public List<PotionEffect> parsePotions(Element el) throws InvalidXMLException {
-    return parsePotions(el, false);
-  }
-
-  public List<PotionEffect> parsePotions(Element el, boolean ambient) throws InvalidXMLException {
     List<PotionEffect> effects = new ArrayList<>();
 
     Node attr = Node.fromAttr(el, "potion", "potions", "effect", "effects");
     if (attr != null) {
       for (String piece : attr.getValue().split(";")) {
-        effects.add(XMLUtils.parseCompactPotionEffect(attr, piece, ambient));
+        effects.add(XMLUtils.parseCompactPotionEffect(attr, piece));
       }
     }
 
     for (Node elPotion : Node.fromChildren(el, "potion", "effect")) {
-      effects.add(XMLUtils.parsePotionEffect(elPotion.getElement(), ambient));
+      effects.add(XMLUtils.parsePotionEffect(elPotion.getElement()));
     }
 
     return effects;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
@@ -8,6 +8,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.spigotmc.SpigotConfig;
 import tc.oc.pgm.platform.modern.packets.PacketManipulations;
+import tc.oc.pgm.platform.modern.util.PlayerTracker;
 import tc.oc.pgm.platform.modern.util.RecipeUnlocker;
 import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.platform.Supports;
@@ -22,12 +23,15 @@ public class ModernPlatform implements Platform.Manifest {
           "ProtocolLib is not installed, and is required for PGM modern version support");
     }
 
+    PlayerTracker tracker;
     List.of(
             new ModernListener(),
             new SpawnEggUseListener(),
-            new PacketManipulations(plugin),
-            new RecipeUnlocker())
+            new RecipeUnlocker(),
+            tracker = new PlayerTracker())
         .forEach(l -> Bukkit.getServer().getPluginManager().registerEvents(l, plugin));
+
+    new PacketManipulations(plugin, tracker);
 
     if (!SpigotConfig.disabledAdvancements.contains("*")) {
       plugin

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/SpawnEggUseListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/SpawnEggUseListener.java
@@ -22,7 +22,6 @@ public class SpawnEggUseListener implements Listener {
 
   private static final MaterialMatcher MATERIALS =
       MaterialMatcher.builder().addAll(m -> m.name().endsWith("_SPAWN_EGG")).build();
-  ;
 
   private Player lastPlacer;
   private ItemStack placingStack;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernPlayerUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernPlayerUtils.java
@@ -15,9 +15,11 @@ import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.platform.modern.util.Skins;
 import tc.oc.pgm.util.block.RayBlockIntersection;
+import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.nms.PlayerUtils;
 import tc.oc.pgm.util.platform.Supports;
 import tc.oc.pgm.util.skin.Skin;
@@ -111,9 +113,21 @@ public class ModernPlayerUtils implements PlayerUtils {
     return player.getPing();
   }
 
+  public static final String HIDE_PARTICLES = "hideParticles";
+  private static final FixedMetadataValue TRUE =
+      new FixedMetadataValue(BukkitUtils.getPlugin(), true);
+
   @Override
   public void setPotionParticles(Player player, boolean enabled) {
-    // TODO: PLATFORM 1.20 does not support disabling particles
+    if (player.hasMetadata(HIDE_PARTICLES) != enabled) return;
+
+    if (enabled) player.removeMetadata(HIDE_PARTICLES, BukkitUtils.getPlugin());
+    else player.setMetadata(HIDE_PARTICLES, TRUE);
+
+    var nmsPlayer = ((CraftPlayer) player).getHandle();
+    if (!nmsPlayer.getActiveEffects().isEmpty()) {
+      nmsPlayer.effectsDirty = true;
+    }
   }
 
   @Override

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/PacketManipulations.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/PacketManipulations.java
@@ -1,102 +1,87 @@
 package tc.oc.pgm.platform.modern.packets;
 
 import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.events.ListenerPriority;
-import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketEvent;
-import com.comphenix.protocol.wrappers.WrappedDataValue;
-import it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap;
 import java.util.List;
+import java.util.Map;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.Plugin;
+import tc.oc.pgm.platform.modern.util.Packets;
+import tc.oc.pgm.platform.modern.util.PlayerTracker;
+import tc.oc.pgm.util.reflect.ReflectionUtils;
 
-public class PacketManipulations implements Listener {
+public class PacketManipulations {
 
-  private final Int2ReferenceOpenHashMap<Player> playerEntities = new Int2ReferenceOpenHashMap<>();
+  private static final EntityDataAccessor<Float> DATA_HEALTH_ID = LivingEntity.DATA_HEALTH_ID;
+  private static final EntityDataAccessor<List<ParticleOptions>> DATA_EFFECT_PARTICLES =
+      ReflectionUtils.readStaticField(
+          LivingEntity.class, EntityDataAccessor.class, "DATA_EFFECT_PARTICLES");
 
-  public PacketManipulations(Plugin plugin) {
-    ProtocolLibrary.getProtocolManager().addPacketListener(new NoSelfDeathListener(plugin));
+  private final PlayerTracker tracker;
+
+  public PacketManipulations(Plugin plugin, PlayerTracker tracker) {
+    this.tracker = tracker;
+
+    Packets.register(
+        plugin,
+        ListenerPriority.LOWEST,
+        Map.of(
+            PacketType.Play.Server.ENTITY_STATUS, this::handleEntityStatus,
+            PacketType.Play.Server.PLAYER_COMBAT_KILL, this::handleCombatKill,
+            PacketType.Play.Server.ENTITY_METADATA, this::handleEntityMetadata));
   }
 
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-  public void onPlayerJoin(PlayerJoinEvent event) {
-    playerEntities.put(event.getPlayer().getEntityId(), event.getPlayer());
-  }
+  private void handleEntityStatus(PacketEvent event) {
+    var playerId = event.getPlayer().getEntityId();
+    var packet = event.getPacket();
 
-  @EventHandler(priority = EventPriority.MONITOR)
-  public void onPlayerQuit(PlayerQuitEvent player) {
-    playerEntities.remove(player.getPlayer().getEntityId());
-  }
-
-  private class NoSelfDeathListener extends PacketAdapter {
-
-    public NoSelfDeathListener(Plugin plugin) {
-      super(
-          plugin,
-          ListenerPriority.LOWEST,
-          PacketType.Play.Server.ENTITY_STATUS,
-          PacketType.Play.Server.PLAYER_COMBAT_KILL,
-          PacketType.Play.Server.ENTITY_METADATA);
+    int entityId = packet.getIntegers().read(0);
+    // Strip "Living entity dead" status=3 packets if they're for yourself.
+    // This glitches hitboxes
+    if (playerId == entityId && packet.getBytes().read(0) == 3) {
+      event.setCancelled(true);
     }
+  }
 
-    @Override
-    public void onPacketSending(PacketEvent event) {
-      var playerId = event.getPlayer().getEntityId();
-      var packet = event.getPacket();
+  private void handleCombatKill(PacketEvent event) {
+    // Never show deaths screens, ever
+    event.setCancelled(true);
+  }
 
-      // Strip "Living entity dead" status=3 packets if they're for yourself.
-      // This glitches hitboxes
-      if (event.getPacketType() == PacketType.Play.Server.ENTITY_STATUS) {
-        int entityId = packet.getIntegers().read(0);
-        if (playerId == entityId && packet.getBytes().read(0) == 3) {
-          event.setCancelled(true);
-        }
+  private void handleEntityMetadata(PacketEvent event) {
+    var playerId = event.getPlayer().getEntityId();
+    var packet = event.getPacket();
+    int entityId = packet.getIntegers().read(0);
+    ClientboundSetEntityDataPacket nmsPacket = (ClientboundSetEntityDataPacket) packet.getHandle();
+    var items = nmsPacket.packedItems();
+
+    Player pl = tracker.get(entityId);
+    if (pl == null) return;
+
+    boolean isSelf = playerId == entityId;
+    boolean isDead = pl.hasMetadata("isDead");
+    boolean checkHealth = isSelf || isDead;
+    boolean hideParticles = pl.hasMetadata("hideParticles");
+
+    if (!isSelf && !isDead && !hideParticles) return;
+
+    for (int i = 0; i < items.size(); i++) {
+      var packedItem = items.get(i);
+      if (checkHealth && packedItem.id() == DATA_HEALTH_ID.id()) {
+        float val = (float) packedItem.value();
+        if (isSelf && val > 0) continue;
+        items.set(
+            i, SynchedEntityData.DataValue.create(DATA_HEALTH_ID, isSelf ? Math.max(val, 1f) : 0f));
       }
 
-      // Never show deaths screens, ever
-      if (event.getPacketType() == PacketType.Play.Server.PLAYER_COMBAT_KILL) {
-        event.setCancelled(true);
-      }
-
-      // Modify "health = 0" metadata packets if they're for yourself.
-      // Avoid telling you that you reached 0 health. This freezes you even after respawn.
-      if (event.getPacketType() == PacketType.Play.Server.ENTITY_METADATA) {
-        int entityId = packet.getIntegers().read(0);
-        if (playerId == entityId) {
-          List<WrappedDataValue> read = packet.getDataValueCollectionModifier().read(0);
-          for (int i = 0; i < read.size(); i++) {
-            var data = read.get(i);
-            if (data.getIndex() == LivingEntity.DATA_HEALTH_ID.id()) {
-              if ((float) data.getRawValue() <= 0f) {
-                // Your own health gone to 0!! nope, take it back
-                packet = event.getPacket().deepClone();
-                packet.getDataValueCollectionModifier().read(0).get(i).setRawValue(1f);
-                event.setPacket(packet);
-              }
-              break;
-            }
-          }
-        } else {
-          Player pl = playerEntities.get(entityId);
-          if (pl != null && pl.hasMetadata("isDead")) {
-            for (var read : packet.getDataValueCollectionModifier().read(0)) {
-              if (read.getIndex() == LivingEntity.DATA_HEALTH_ID.id()) {
-                // A dead player's health left 0!! nope, take it back
-                if ((float) read.getRawValue() > 0f) {
-                  event.setCancelled(true);
-                }
-                break;
-              }
-            }
-          }
-        }
+      if (hideParticles && packedItem.id() == DATA_EFFECT_PARTICLES.id()) {
+        items.set(i, SynchedEntityData.DataValue.create(DATA_EFFECT_PARTICLES, List.of()));
       }
     }
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/Packets.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/Packets.java
@@ -1,0 +1,30 @@
+package tc.oc.pgm.platform.modern.util;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.bukkit.plugin.Plugin;
+
+public class Packets {
+  private static final Consumer<PacketEvent> NO_OP = event -> {};
+
+  public static void register(
+      Plugin pl, ListenerPriority priority, Map<PacketType, Consumer<PacketEvent>> events) {
+    ProtocolLibrary.getProtocolManager()
+        .addPacketListener(new PacketAdapter(pl, priority, events.keySet()) {
+          @Override
+          public void onPacketReceiving(PacketEvent event) {
+            events.getOrDefault(event.getPacketType(), NO_OP).accept(event);
+          }
+
+          @Override
+          public void onPacketSending(PacketEvent event) {
+            events.getOrDefault(event.getPacketType(), NO_OP).accept(event);
+          }
+        });
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/PlayerTracker.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/PlayerTracker.java
@@ -1,0 +1,55 @@
+package tc.oc.pgm.platform.modern.util;
+
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
+import it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+import java.util.UUID;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class PlayerTracker implements Listener {
+  private final Int2ReferenceOpenHashMap<Player> playerEntities = new Int2ReferenceOpenHashMap<>();
+  private final Reference2IntOpenHashMap<UUID> byUuid = new Reference2IntOpenHashMap<>();
+
+  public PlayerTracker() {
+    byUuid.defaultReturnValue(-1);
+  }
+
+  public Player get(int entityId) {
+    return playerEntities.get(entityId);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onPlayerJoin(PlayerJoinEvent event) {
+    register(event.getPlayer());
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onPlayerJoin(EntityAddToWorldEvent event) {
+    if (event.getEntity() instanceof Player pl) register(pl);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerQuit(PlayerQuitEvent player) {
+    cleanup(player.getPlayer());
+  }
+
+  private void cleanup(Player player) {
+    int oldId = byUuid.removeInt(player.getUniqueId());
+    if (oldId != -1) playerEntities.remove(oldId);
+    int newId = player.getEntityId();
+    if (newId != oldId) playerEntities.remove(newId);
+  }
+
+  private void register(Player player) {
+    int entityId = player.getEntityId();
+    cleanup(player);
+
+    byUuid.put(player.getUniqueId(), entityId);
+    playerEntities.put(entityId, player);
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/reflect/ReflectionUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/reflect/ReflectionUtils.java
@@ -82,6 +82,10 @@ public final class ReflectionUtils {
     }
   }
 
+  public static <T> T readStaticField(Class<?> parent, Class<T> type, String name) {
+    return readField(parent, null, type, name);
+  }
+
   public static Object readField(@Nullable Object obj, Field field) {
     final boolean wasAccessible = field.isAccessible();
     try {

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -843,21 +843,16 @@ public final class XMLUtils {
   }
 
   public static PotionEffect parsePotionEffect(Element el) throws InvalidXMLException {
-    return parsePotionEffect(el, false);
-  }
-
-  public static PotionEffect parsePotionEffect(Element el, boolean ambientDef)
-      throws InvalidXMLException {
     PotionEffectType type = parsePotionEffectType(new Node(el));
     Duration duration =
         parseSecondDuration(Node.fromAttr(el, "duration"), TimeUtils.INFINITE_DURATION);
     int amplifier = parseNumber(Node.fromAttr(el, "amplifier"), Integer.class, 1) - 1;
-    boolean ambient = parseBoolean(Node.fromAttr(el, "ambient"), ambientDef);
+    boolean ambient = parseBoolean(Node.fromAttr(el, "ambient"), false);
 
     return createPotionEffect(type, duration, amplifier, ambient);
   }
 
-  public static PotionEffect parseCompactPotionEffect(Node node, String text, boolean particle)
+  public static PotionEffect parseCompactPotionEffect(Node node, String text)
       throws InvalidXMLException {
     String[] parts = text.split(":");
 
@@ -865,7 +860,7 @@ public final class XMLUtils {
     PotionEffectType type = parsePotionEffectType(node, parts[0]);
     Duration duration = TimeUtils.INFINITE_DURATION;
     int amplifier = 0;
-    boolean ambient = !particle;
+    boolean ambient = false;
 
     if (parts.length >= 2) {
       duration = parseTickDuration(node, parts[1]);


### PR DESCRIPTION
Rolls back the original change in modern to just default particles to ambient, and instead properly re-implements hidden particle logic that was baked-into sportpaper, as events.

PGM will set the metadata for hideParticles in the player, and packetEvents will filter-out any particle effects in the metadata packet.

Additionally cleans-up alot of the logic around the packet manipulations class