### PR TITLE
Fix dispenser and tnt tracking in modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -42,7 +42,6 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -68,6 +67,7 @@ import tc.oc.pgm.util.block.BlockStates;
 import tc.oc.pgm.util.bukkit.Events;
 import tc.oc.pgm.util.event.block.BlockFallEvent;
 import tc.oc.pgm.util.event.entity.ExplosionPrimeByEntityEvent;
+import tc.oc.pgm.util.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.util.material.Materials;
 
 public class BlockTransformListener implements Listener {

--- a/core/src/main/java/tc/oc/pgm/tntrender/TNTRenderMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tntrender/TNTRenderMatchModule.java
@@ -15,13 +15,13 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.util.event.block.BlockDispenseEntityEvent;
+import tc.oc.pgm.util.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.MaterialData;
 

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/TNTTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/TNTTracker.java
@@ -6,7 +6,6 @@ import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.events.ParticipantBlockTransformEvent;
@@ -15,6 +14,7 @@ import tc.oc.pgm.tracker.info.EntityInfo;
 import tc.oc.pgm.tracker.info.TNTInfo;
 import tc.oc.pgm.util.event.block.BlockDispenseEntityEvent;
 import tc.oc.pgm.util.event.entity.ExplosionPrimeByEntityEvent;
+import tc.oc.pgm.util.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.util.event.player.PlayerSpawnEntityEvent;
 
 /** Updates the state of owned TNT blocks and entities */

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
@@ -7,9 +7,13 @@ import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.spigotmc.SpigotConfig;
+import tc.oc.pgm.platform.modern.listeners.DispenserListener;
+import tc.oc.pgm.platform.modern.listeners.ModernListener;
+import tc.oc.pgm.platform.modern.listeners.PlayerTracker;
+import tc.oc.pgm.platform.modern.listeners.RecipeUnlocker;
+import tc.oc.pgm.platform.modern.listeners.SpawnEggUseListener;
+import tc.oc.pgm.platform.modern.listeners.TntListener;
 import tc.oc.pgm.platform.modern.packets.PacketManipulations;
-import tc.oc.pgm.platform.modern.util.PlayerTracker;
-import tc.oc.pgm.platform.modern.util.RecipeUnlocker;
 import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.platform.Supports;
 
@@ -25,10 +29,12 @@ public class ModernPlatform implements Platform.Manifest {
 
     PlayerTracker tracker;
     List.of(
+            new DispenserListener(),
             new ModernListener(),
-            new SpawnEggUseListener(),
+            tracker = new PlayerTracker(),
             new RecipeUnlocker(),
-            tracker = new PlayerTracker())
+            new SpawnEggUseListener(),
+            new TntListener())
         .forEach(l -> Bukkit.getServer().getPluginManager().registerEvents(l, plugin));
 
     new PacketManipulations(plugin, tracker);

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernInventoryUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernInventoryUtil.java
@@ -9,7 +9,8 @@ import org.bukkit.Material;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
-import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.EquipmentSlot;
@@ -54,10 +55,11 @@ public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatfor
   }
 
   @Override
-  public EquipmentSlot getUsedHand(PlayerEvent event) {
+  public EquipmentSlot getUsedHand(Event event) {
     return switch (event) {
       case PlayerItemConsumeEvent e -> e.getHand();
       case PlayerInteractEvent e -> e.getHand();
+      case BlockPlaceEvent e -> e.getHand();
       default -> EquipmentSlot.HAND;
     };
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/DispenserListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/DispenserListener.java
@@ -1,0 +1,71 @@
+package tc.oc.pgm.platform.modern.listeners;
+
+import static tc.oc.pgm.util.event.EventUtil.handleCall;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.type.Dispenser;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
+import org.bukkit.event.vehicle.VehicleCreateEvent;
+import tc.oc.pgm.util.event.block.BlockDispenseEntityEvent;
+
+public class DispenserListener implements Listener {
+
+  private BlockDispenseEvent lastEvent;
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onDispense(BlockDispenseEvent event) {
+    Block block = event.getBlock();
+    if (!(block.getBlockData() instanceof Dispenser dispenser)) return;
+    var placeLocation = event.getVelocity();
+    var frontBlock = block.getRelative(dispenser.getFacing()).getLocation().toVector();
+
+    // When placing/removing a block (eg: water bucket), velocity is the block location
+    // When spawning entities, it's either:
+    //  - zero (0,0,0) for item or egg spawning
+    //  - the direction (eg: 0,0,-1) for projectiles
+    //  - the entity location (eg: 12.5,10.0,1.5) for tnt or boats
+    // If the location is exactly the block, ignore it as it's not an entity dispense
+    if (placeLocation.equals(frontBlock) && !placeLocation.isZero()) return;
+    lastEvent = event;
+  }
+
+  @EventHandler(priority = EventPriority.HIGH)
+  public void onEntitySpawn(EntitySpawnEvent event) {
+    if (lastEvent != null && !event.isCancelled())
+      handleEntitySpawn(lastEvent, event, event.getEntity());
+    lastEvent = null;
+  }
+
+  @EventHandler(priority = EventPriority.HIGH)
+  public void onVehicleSpawn(VehicleCreateEvent event) {
+    // Dispensing boats/minecarts/TNT minecarst creates no EntitySpawnEvent
+    if (lastEvent != null && !event.isCancelled())
+      handleEntitySpawn(lastEvent, event, event.getVehicle());
+    lastEvent = null;
+  }
+
+  public void handleEntitySpawn(BlockDispenseEvent dispenseEvent, Event spawnEvent, Entity entity) {
+    Block block = dispenseEvent.getBlock();
+    if (!(block.getBlockData() instanceof Dispenser dispenser)) return;
+    Block expected = block.getRelative(dispenser.getFacing());
+    Location actual = entity.getLocation();
+
+    double xDiff = Math.abs(actual.getX() - ((double) expected.getX() + 0.5d));
+    double yDiff = actual.getY() - expected.getY();
+    double zDiff = Math.abs(actual.getZ() - ((double) expected.getZ() + 0.5d));
+
+    // Within same block x/z, and up to 1.5 blocks up in Y dir (spawning a boat in water)
+    if (xDiff > 0.5 || yDiff < 0 || yDiff > 1.5 || zDiff > 0.5) return;
+
+    BlockDispenseEntityEvent pgmEvent = new BlockDispenseEntityEvent(
+        dispenseEvent.getBlock(), dispenseEvent.getItem(), dispenseEvent.getVelocity(), entity);
+    handleCall(pgmEvent, spawnEvent);
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
@@ -1,4 +1,6 @@
-package tc.oc.pgm.platform.modern;
+package tc.oc.pgm.platform.modern.listeners;
+
+import static tc.oc.pgm.util.event.EventUtil.handleCall;
 
 import com.destroystokyo.paper.ClientOption;
 import com.destroystokyo.paper.event.player.PlayerClientOptionsChangeEvent;
@@ -9,7 +11,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -29,23 +30,9 @@ import tc.oc.pgm.util.event.player.PlayerSkinPartsChangeEvent;
 
 /**
  * TODO: fix unsupported events: <br>
- * - BlockDispenseEntityEvent <br>
- * - ExplosionPrimeByEntityEvent <br>
  * - EntityExtinguishEvent <br>
  */
 public class ModernListener implements Listener {
-
-  private static void handleCall(Event pgmEvent, Event modernEvent) {
-    if (pgmEvent == null) return;
-    if (modernEvent instanceof Cancellable modernCancel
-        && pgmEvent instanceof Cancellable pgmCancel) {
-      pgmCancel.setCancelled(modernCancel.isCancelled());
-      Bukkit.getServer().getPluginManager().callEvent(pgmEvent);
-      modernCancel.setCancelled(pgmCancel.isCancelled());
-    } else {
-      Bukkit.getServer().getPluginManager().callEvent(pgmEvent);
-    }
-  }
 
   @EventHandler(ignoreCancelled = true)
   public void onBlockFall(EntitySpawnEvent event) {
@@ -102,10 +89,10 @@ public class ModernListener implements Listener {
 
   @EventHandler(ignoreCancelled = true)
   @SuppressWarnings("removal")
-  public void onEntityDespawn(org.bukkit.event.entity.EntityRemoveEvent sportEvent) {
-    if (sportEvent.getCause() == org.bukkit.event.entity.EntityRemoveEvent.Cause.OUT_OF_WORLD) {
-      EntityDespawnInVoidEvent pgmEvent = new EntityDespawnInVoidEvent(sportEvent.getEntity());
-      handleCall(pgmEvent, sportEvent);
+  public void onEntityDespawn(org.bukkit.event.entity.EntityRemoveEvent modernEvent) {
+    if (modernEvent.getCause() == org.bukkit.event.entity.EntityRemoveEvent.Cause.OUT_OF_WORLD) {
+      EntityDespawnInVoidEvent pgmEvent = new EntityDespawnInVoidEvent(modernEvent.getEntity());
+      handleCall(pgmEvent, modernEvent);
     }
   }
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/PlayerTracker.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/PlayerTracker.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.util;
+package tc.oc.pgm.platform.modern.listeners;
 
 import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/RecipeUnlocker.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/RecipeUnlocker.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.util;
+package tc.oc.pgm.platform.modern.listeners;
 
 import net.minecraft.server.MinecraftServer;
 import org.bukkit.Bukkit;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/SpawnEggUseListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/SpawnEggUseListener.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern;
+package tc.oc.pgm.platform.modern.listeners;
 
 import static org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER_EGG;
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/TntListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/TntListener.java
@@ -1,0 +1,49 @@
+package tc.oc.pgm.platform.modern.listeners;
+
+import org.bukkit.craftbukkit.entity.CraftTNTPrimed;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.TNTPrimeEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
+import tc.oc.pgm.util.event.EventUtil;
+import tc.oc.pgm.util.event.entity.ExplosionPrimeByEntityEvent;
+import tc.oc.pgm.util.event.entity.ExplosionPrimeEvent;
+
+public class TntListener implements Listener {
+
+  private TNTPrimeEvent lastEvent;
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onTntPrime(TNTPrimeEvent event) {
+    lastEvent = event;
+  }
+
+  @EventHandler
+  public void onEntitySpawn(EntitySpawnEvent event) {
+    var primeEvent = lastEvent;
+    lastEvent = null; // Always cleanup
+
+    if (primeEvent == null || event.isCancelled()) return;
+    if (!(event.getEntity() instanceof TNTPrimed tnt)) return;
+    if (!tnt.getLocation().getBlock().equals(primeEvent.getBlock())) return;
+
+    ExplosionPrimeEvent pgmEvent;
+    if (primeEvent.getPrimingEntity() != null) {
+      pgmEvent = new ExplosionPrimeByEntityEvent(tnt, primeEvent.getPrimingEntity());
+    } else {
+      pgmEvent = new ExplosionPrimeEvent(tnt);
+    }
+    EventUtil.handleCall(pgmEvent, event);
+    tnt.setYield(pgmEvent.getRadius());
+    tnt.setIsIncendiary(pgmEvent.getFire());
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onTntSpawn(EntitySpawnEvent event) {
+    if (!(event.getEntity() instanceof TNTPrimed tnt)) return;
+    // Ensure self tnt damage isn't negated due to friendly fire being off
+    ((CraftTNTPrimed) tnt).getHandle().owner = null;
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/PacketManipulations.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/PacketManipulations.java
@@ -14,8 +14,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import tc.oc.pgm.platform.modern.listeners.PlayerTracker;
 import tc.oc.pgm.platform.modern.util.Packets;
-import tc.oc.pgm.platform.modern.util.PlayerTracker;
 import tc.oc.pgm.util.reflect.ReflectionUtils;
 
 public class PacketManipulations implements PacketSender {
@@ -108,7 +108,7 @@ public class PacketManipulations implements PacketSender {
 
       if (checkHealth && item.id() == DATA_HEALTH_ID.id()) {
         float val = (float) item.value();
-        if (!isSelf || val <= 0) {
+        if (isSelf ? val <= 0 : val > 0) {
           val = isSelf ? Math.max(val, 1f) : 0f;
           items.set(i, SynchedEntityData.DataValue.create(DATA_HEALTH_ID, val));
         }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SportPaperListener.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SportPaperListener.java
@@ -9,6 +9,7 @@ import tc.oc.pgm.util.event.block.BlockFallEvent;
 import tc.oc.pgm.util.event.entity.EntityDespawnInVoidEvent;
 import tc.oc.pgm.util.event.entity.EntityExtinguishEvent;
 import tc.oc.pgm.util.event.entity.ExplosionPrimeByEntityEvent;
+import tc.oc.pgm.util.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.util.event.entity.PotionEffectAddEvent;
 import tc.oc.pgm.util.event.entity.PotionEffectRemoveEvent;
 import tc.oc.pgm.util.event.player.PlayerAttackEntityEvent;
@@ -89,14 +90,17 @@ public class SportPaperListener implements Listener {
   }
 
   @EventHandler(ignoreCancelled = true)
-  public void onExplosionPrimeByEntity(
-      org.bukkit.event.entity.ExplosionPrimeByEntityEvent sportEvent) {
-    ExplosionPrimeByEntityEvent pgmEvent = new ExplosionPrimeByEntityEvent(
-        sportEvent.getEntity(),
-        sportEvent.getRadius(),
-        sportEvent.getFire(),
-        sportEvent.getPrimer());
-    handleCall(pgmEvent, sportEvent);
+  public void onExplosionPrime(org.bukkit.event.entity.ExplosionPrimeEvent e) {
+    ExplosionPrimeEvent pgmEvent;
+    if (e instanceof org.bukkit.event.entity.ExplosionPrimeByEntityEvent e2) {
+      pgmEvent = new ExplosionPrimeByEntityEvent(
+          e2.getEntity(), e2.getRadius(), e2.getFire(), e2.getPrimer());
+    } else {
+      pgmEvent = new ExplosionPrimeEvent(e.getEntity(), e.getRadius(), e.getFire());
+    }
+    handleCall(pgmEvent, e);
+    e.setRadius(pgmEvent.getRadius());
+    e.setFire(pgmEvent.getFire());
   }
 
   @EventHandler(ignoreCancelled = true)

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpInventoryUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpInventoryUtil.java
@@ -8,7 +8,7 @@ import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
-import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.Event;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -47,7 +47,7 @@ public class SpInventoryUtil implements InventoryUtils.InventoryUtilsPlatform {
   }
 
   @Override
-  public EquipmentSlot getUsedHand(PlayerEvent event) {
+  public EquipmentSlot getUsedHand(Event event) {
     return EquipmentSlot.HAND;
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/event/EventUtil.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/EventUtil.java
@@ -7,6 +7,7 @@ import org.bukkit.event.Event;
 public class EventUtil {
 
   public static void handleCall(Event pgmEvent, Event bukkitEvent) {
+    if (pgmEvent == null) return;
     if (bukkitEvent instanceof Cancellable bCancellable
         && pgmEvent instanceof Cancellable pgmCancellable) {
       pgmCancellable.setCancelled(bCancellable.isCancelled());

--- a/util/src/main/java/tc/oc/pgm/util/event/block/BlockDispenseEntityEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/block/BlockDispenseEntityEvent.java
@@ -2,21 +2,41 @@ package tc.oc.pgm.util.event.block;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
-import org.bukkit.event.Cancellable;
-import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.BlockEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.util.event.SportPaper;
 
 /** Called when an entity is dispensed from a block. */
 @SportPaper
-public class BlockDispenseEntityEvent extends BlockDispenseEvent implements Cancellable {
+public class BlockDispenseEntityEvent extends BlockEvent {
+  private ItemStack item;
+  private Vector velocity;
   private final Entity entity;
 
   public BlockDispenseEntityEvent(
       final Block block, final ItemStack dispensed, final Vector velocity, final Entity entity) {
-    super(block, dispensed, velocity);
+    super(block);
+    this.item = dispensed;
+    this.velocity = velocity;
     this.entity = entity;
+  }
+
+  public ItemStack getItem() {
+    return this.item.clone();
+  }
+
+  public void setItem(ItemStack item) {
+    this.item = item;
+  }
+
+  public Vector getVelocity() {
+    return this.velocity.clone();
+  }
+
+  public void setVelocity(Vector vel) {
+    this.velocity = vel;
   }
 
   /**
@@ -26,5 +46,16 @@ public class BlockDispenseEntityEvent extends BlockDispenseEvent implements Canc
    */
   public Entity getEntity() {
     return entity;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/event/entity/ExplosionPrimeByEntityEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/entity/ExplosionPrimeByEntityEvent.java
@@ -4,7 +4,6 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Explosive;
-import org.bukkit.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.util.event.SportPaper;
 
 /**
@@ -16,7 +15,6 @@ import tc.oc.pgm.util.event.SportPaper;
  */
 @SportPaper
 public class ExplosionPrimeByEntityEvent extends ExplosionPrimeEvent {
-
   private final Entity primer;
 
   public ExplosionPrimeByEntityEvent(Entity what, float radius, boolean fire, Entity primer) {

--- a/util/src/main/java/tc/oc/pgm/util/event/entity/ExplosionPrimeEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/entity/ExplosionPrimeEvent.java
@@ -1,0 +1,58 @@
+package tc.oc.pgm.util.event.entity;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Explosive;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+
+public class ExplosionPrimeEvent extends EntityEvent implements Cancellable {
+  private static final HandlerList handlers = new HandlerList();
+
+  private boolean cancel;
+  private float radius;
+  private boolean fire;
+
+  public ExplosionPrimeEvent(Entity what, float radius, boolean fire) {
+    super(what);
+    this.cancel = false;
+    this.radius = radius;
+    this.fire = fire;
+  }
+
+  public ExplosionPrimeEvent(Explosive explosive) {
+    this(explosive, explosive.getYield(), explosive.isIncendiary());
+  }
+
+  public boolean isCancelled() {
+    return this.cancel;
+  }
+
+  public void setCancelled(boolean cancel) {
+    this.cancel = cancel;
+  }
+
+  public float getRadius() {
+    return this.radius;
+  }
+
+  public void setRadius(float radius) {
+    this.radius = radius;
+  }
+
+  public boolean getFire() {
+    return this.fire;
+  }
+
+  public void setFire(boolean fire) {
+    this.fire = fire;
+  }
+
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -12,6 +12,7 @@ import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
+import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
@@ -154,15 +155,20 @@ public final class InventoryUtils {
     return stack;
   }
 
-  public static void consumeItem(PlayerEvent player) {
-    PlayerInventory inv = player.getPlayer().getInventory();
-    EquipmentSlot hand = INVENTORY_UTILS.getUsedHand(player);
-    ItemStack itemInHand = inv.getItem(hand);
-    if (itemInHand.getAmount() > 1) {
-      itemInHand.setAmount(itemInHand.getAmount() - 1);
+  public static void consumeItem(PlayerEvent event) {
+    consumeItem(event, event.getPlayer());
+  }
+
+  public static void consumeItem(Event event, Player player) {
+    PlayerInventory inv = player.getInventory();
+    EquipmentSlot hand = INVENTORY_UTILS.getUsedHand(event);
+    ItemStack inHand = inv.getItem(hand);
+    if (inHand.getAmount() == 1) {
+      inHand = null;
     } else {
-      inv.setItem(hand, null);
+      inHand.setAmount(inHand.getAmount() - 1);
     }
+    inv.setItem(hand, inHand);
   }
 
   public interface InventoryUtilsPlatform {
@@ -180,7 +186,7 @@ public final class InventoryUtils {
 
     ItemStack craftItemCopy(ItemStack item);
 
-    EquipmentSlot getUsedHand(PlayerEvent event);
+    EquipmentSlot getUsedHand(Event event);
 
     void setCanDestroy(ItemMeta itemMeta, Set<Material> materials);
 


### PR DESCRIPTION
This is a bit of a landmine topic, there are so many differences between modern and sportpaper, but i'm pretty sure i've managed to get tnt and dispensing logic properly fixed.

Main annoyance is that bukkit's `ExplosionPrimeEvent` triggers when tnt lights up in SportPaper, but when the tnt actually explodes (after the fuse) in modern. This makes the event basically useless for tracking purposes.

We drop the use of bukkit's and just have PGM have its own, where in modern it's launched from EntitySpawnEvent of tnt, while in legacy it's launched from ExplosionPrimeEvent. Same applies for the child (ExplosionPrimeByEntityEvent).

Also found out in modern tnt owned by you won't damage you (because same-team friendly fire is off), so pgm will explicitly void vanilla's "owner", otherwise if you used flint n steel you'd take no dmg from your tnt.

Also fixes bugs like autoignote tnt not consuming if in the offhand
