### PR TITLE
Fix filters invalidating players from other matches

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
@@ -380,6 +380,8 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
   }
 
   public void invalidate(Filterable<?> filterable) {
+    // Ignore invalidations from other matches
+    if (filterable instanceof MatchPlayer mp && mp.getMatch() != match) return;
     if (dirtySet.add(Objects.requireNonNull(filterable))) {
       filterable.getFilterableChildren().forEach(this::invalidate);
     }
@@ -467,6 +469,7 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
   }
 
   public void onPartyChange(PlayerPartyChangeEvent event) throws EventException {
+    if (event.getMatch() != match) return;
     if (event.getNewParty() != null) {
       invalidate(event.getPlayer());
     } else {

--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -756,8 +756,7 @@ public class MatchImpl implements Match {
         try {
           tickable.tick(MatchImpl.this, tick);
         } catch (Throwable t) {
-          logger.log(Level.SEVERE, "Could not tick " + tickable, t);
-          tickables.remove(tickable);
+          logger.log(Level.SEVERE, "Could not tick " + tickable + " in match #" + id, t);
         }
       }
     }


### PR DESCRIPTION
Hopefully this fixes the NPE of:
```
java.lang.NullPointerException: state
	at tc.oc.pgm.util.Assert.assertNotNull(Assert.java:19) ~[?:?]
	at tc.oc.pgm.features.MatchFeatureContext.getState(MatchFeatureContext.java:33) ~[?:?]
	at tc.oc.pgm.api.filter.query.MatchQuery.state(MatchQuery.java:30) ~[?:?]
	at tc.oc.pgm.filters.matcher.match.PulseFilter.matches(PulseFilter.java:37) ~[?:?]
	at tc.oc.pgm.filters.matcher.match.PulseFilter.matches(PulseFilter.java:18) ~[?:?]
	at tc.oc.pgm.filters.matcher.TypedFilter.queryTyped(TypedFilter.java:13) ~[?:?]
	at tc.oc.pgm.filters.matcher.WeakTypedFilter.query(WeakTypedFilter.java:21) ~[?:?]
	at tc.oc.pgm.api.filter.Filter.response(Filter.java:37) ~[?:?]
	at tc.oc.pgm.filters.XMLFilterReference.response(XMLFilterReference.java:29) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.lambda$check$8(FilterMatchModule.java:326) ~[?:?]
	at java.util.Map.forEach(Map.java:733) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.lambda$check$9(FilterMatchModule.java:314) ~[?:?]
	at java.util.Map.forEach(Map.java:733) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.check(FilterMatchModule.java:311) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.lambda$tick$10(FilterMatchModule.java:372) ~[?:?]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.tick(FilterMatchModule.java:372) ~[?:?]
	at tc.oc.pgm.filters.FilterMatchModule.tick(FilterMatchModule.java:356) ~[?:?]
	at tc.oc.pgm.match.MatchImpl$TickableTask.run(MatchImpl.java:757) ~[?:?]
```

Also adds the match id to failures to run a ticking task, and gets rid of a `remove` that was never doing anything, as that Map has scope as key, not runnable (so it was doing nothing, no behavior change) and i don't think we should stop any tickable that throws an exception, as that can break pgm even more (ie: a single error checking filters means no more dynamic filters for the rest of the match)