### PR TITLE
Fix inconsistencies with joining state

### DIFF
--- a/core/src/main/java/tc/oc/pgm/compass/CompassModule.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassModule.java
@@ -74,7 +74,7 @@ public class CompassModule implements MapModule<CompassMatchModule> {
         }
       }
       ImmutableList<CompassTarget<?>> targets = compassTargets.build();
-      if (targets == null) return null;
+      if (targets.isEmpty()) return null;
       return new CompassModule(targets, orderStrategy, showDistance);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -216,7 +216,7 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
     if (event.getOldParty() == null) {
       // Join match
       if (event.getNewParty().isParticipating()) {
-        transition(player, null, new Joining(this, player, getJoinPenalty(event)));
+        transition(player, null, new Joining(this, player, getJoinPenalty(event), false));
       } else {
         transition(player, null, new Observing(this, player, true, true));
       }

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
@@ -111,7 +111,7 @@ public class Alive extends Participating {
     super.onEvent(event);
 
     if (event.getNewParty() instanceof Competitor) {
-      transition(new Joining(smm, player, smm.getJoinPenalty(event)));
+      transition(new Joining(smm, player, smm.getJoinPenalty(event), true));
     } else {
       transition(new Observing(smm, player, true, true));
     }

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Dead.java
@@ -37,6 +37,9 @@ public class Dead extends Spawning {
 
   public Dead(SpawnMatchModule smm, MatchPlayer player) {
     super(smm, player, player.getMatch().getTick().tick, 0);
+
+    // Allow stuff like /tp or /j
+    if (options.spectate) this.permission = new StatePermissions.Observer();
   }
 
   @Override
@@ -108,7 +111,10 @@ public class Dead extends Spawning {
   @Override
   public void onEvent(PlayerJoinPartyEvent event) {
     super.onEvent(event);
-    if (!(event.getNewParty() instanceof Competitor)) {
+
+    if (event.getNewParty() instanceof Competitor) {
+      transition(new Joining(smm, player, smm.getJoinPenalty(event), true));
+    } else {
       transition(new Observing(smm, player, true, false));
     }
   }

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Joining.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Joining.java
@@ -11,20 +11,21 @@ import tc.oc.pgm.spawns.SpawnMatchModule;
 /** Player is waiting to spawn after joining a team */
 public class Joining extends Spawning {
 
-  public Joining(SpawnMatchModule smm, MatchPlayer player) {
-    this(smm, player, 0);
-  }
+  private final boolean reset;
 
-  public Joining(SpawnMatchModule smm, MatchPlayer player, long minSpawnTick) {
+  public Joining(SpawnMatchModule smm, MatchPlayer player, long minSpawnTick, boolean reset) {
     super(smm, player, smm.getDeathTick(player), minSpawnTick);
     this.spawnRequested = true;
+    this.reset = reset;
+    this.permission = new StatePermissions.Observer();
   }
 
   @Override
   public void enterState() {
     player.setVisible(false);
-
     super.enterState();
+
+    if (reset) Observing.resetPlayer(smm, player, true, false);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Participating.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Participating.java
@@ -1,37 +1,14 @@
 package tc.oc.pgm.spawns.states;
 
-import java.util.List;
-import org.bukkit.event.Event;
-import org.bukkit.permissions.PermissionAttachment;
-import tc.oc.pgm.api.Config;
-import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.spawns.SpawnMatchModule;
 
 public class Participating extends State {
 
-  private PermissionAttachment permissionAttachment;
-
   public Participating(SpawnMatchModule smm, MatchPlayer player) {
     super(smm, player);
-  }
-
-  @Override
-  public void enterState() {
-    super.enterState();
-    permissionAttachment = bukkit.addAttachment(PGM.get());
-    for (Config.Group group : PGM.get().getConfiguration().getGroups()) {
-      if (bukkit.hasPermission(group.getPermission())) {
-        permissionAttachment.setPermission(group.getParticipantPermission(), true);
-      }
-    }
-  }
-
-  @Override
-  public void leaveState(List<Event> events) {
-    if (permissionAttachment != null) bukkit.removeAttachment(permissionAttachment);
-    super.leaveState(events);
+    this.permission = new StatePermissions.Participant();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawns/states/State.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/State.java
@@ -22,6 +22,8 @@ public abstract class State {
   protected final MatchPlayer player;
   protected final Player bukkit;
 
+  protected StatePermissions permission = null;
+
   private boolean entered, exited;
 
   public State(SpawnMatchModule smm, MatchPlayer player) {
@@ -41,6 +43,8 @@ public abstract class State {
       throw new IllegalStateException("Tried to enter already entered state " + this);
     }
     entered = true;
+
+    if (permission != null) permission.givePermission(player);
   }
 
   /**
@@ -50,6 +54,8 @@ public abstract class State {
    *     nested within each other.
    */
   public void leaveState(List<Event> events) {
+    if (permission != null) permission.revokePermission(player);
+
     if (!entered) {
       throw new IllegalStateException("Tried to leave state before entering " + this);
     } else if (exited) {

--- a/core/src/main/java/tc/oc/pgm/spawns/states/StatePermissions.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/StatePermissions.java
@@ -1,0 +1,44 @@
+package tc.oc.pgm.spawns.states;
+
+import java.util.function.Function;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionAttachment;
+import tc.oc.pgm.api.Config;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.player.MatchPlayer;
+
+public class StatePermissions {
+
+  private final Function<Config.Group, Permission> groupFunction;
+  private PermissionAttachment permissionAttachment;
+
+  private StatePermissions(Function<Config.Group, Permission> groupFunction) {
+    this.groupFunction = groupFunction;
+  }
+
+  public void givePermission(MatchPlayer player) {
+    var bukkit = player.getBukkit();
+    permissionAttachment = bukkit.addAttachment(PGM.get());
+    for (Config.Group group : PGM.get().getConfiguration().getGroups()) {
+      if (bukkit.hasPermission(group.getPermission())) {
+        permissionAttachment.setPermission(groupFunction.apply(group), true);
+      }
+    }
+  }
+
+  public void revokePermission(MatchPlayer player) {
+    if (permissionAttachment != null) player.getBukkit().removeAttachment(permissionAttachment);
+  }
+
+  public static class Observer extends StatePermissions {
+    public Observer() {
+      super(Config.Group::getObserverPermission);
+    }
+  }
+
+  public static class Participant extends StatePermissions {
+    public Participant() {
+      super(Config.Group::getParticipantPermission);
+    }
+  }
+}


### PR DESCRIPTION
Fixes a few issues:
 - Dead players joining a diff team weren't passed thru `joining` state
 - Joining or Dead (with spectate=true) have no obs perms, this is annoying since it means compass doesn't work
 - Joining gets their state reset (inventory cleared, given obs tools, and set in creative!!)
   - Before, ending up in joining state while you were playing in the match meant you kept all inventory state, and you were left in survival mode too
  - Noticed that compass module was created even when no compasses are defined, fixed that too