### PR TITLE
Permit specifying world for default map variant

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -375,7 +375,7 @@ public class MapInfoImpl implements MapInfo {
       if (variantEl == null) {
         this.variantId = DEFAULT_VARIANT;
         this.mapName = name;
-        this.world = null;
+        this.world = assertNotNull(root).getChildTextNormalize("world");
       } else {
         this.variantId = XMLUtils.parseRequiredId(variantEl);
         if (DEFAULT_VARIANT.equals(variantId))


### PR DESCRIPTION
I am proposing this change however there are some differences to consider when comparing to ProjectAres.

In ProjectAres, the terrain module had more options that it currently does in present-day PGM, in that it was possible to specify both a world folder and to disable pre-match block physics. Further, in PGM we can define dimension in the terrain module, while ProjectAres moved this to the main map element as `dimension`, separate from the terrain module.

The idea with this change is that we are able to define a `world` conditionally for certain versions, while avoiding an entirely new variant for a map. An example where this may be used is with the map Azure: Azure has path blocks in its original 1.12 map world, however we have simply NBT converted the map to be used on OCC 1.8. Preferably, we do not need to create an entirely new variant just to use the original world on relevant server versions.

Alternatively to this PR, we could implement the world folder feature in the terrain module but given the pre-existing framework in place for variants this does seem more trivial.