### PR TITLE
feat: support switch-case replacements and definitions at root level

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionModule.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionModule.java
@@ -8,6 +8,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.action.actions.ExposedAction;
+import tc.oc.pgm.action.replacements.ReplacementParser;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
@@ -58,6 +59,13 @@ public class ActionModule implements MapModule<ActionMatchModule> {
     public ActionModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
       ActionParser parser = factory.getParser().getActionParser();
+      var replacementParser = new ReplacementParser(factory, true);
+      var features = factory.getFeatures();
+
+      for (var replacement : XMLUtils.flattenElements(
+          doc.getRootElement(), Set.of("replacements"), replacementParser.replacementTypes())) {
+        features.addFeature(replacement, replacementParser.parse(replacement, null));
+      }
 
       for (Element action :
           XMLUtils.flattenElements(doc.getRootElement(), Set.of("actions"), parser.actionTypes())) {

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -3,15 +3,11 @@ package tc.oc.pgm.action;
 import static net.kyori.adventure.key.Key.key;
 import static net.kyori.adventure.sound.Sound.sound;
 import static net.kyori.adventure.text.Component.empty;
-import static net.kyori.adventure.text.Component.text;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Method;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import net.kyori.adventure.sound.Sound;
@@ -37,6 +33,8 @@ import tc.oc.pgm.action.actions.TakePaymentAction;
 import tc.oc.pgm.action.actions.TeleportAction;
 import tc.oc.pgm.action.actions.VelocityAction;
 import tc.oc.pgm.action.actions.WeatherAction;
+import tc.oc.pgm.action.replacements.Replacement;
+import tc.oc.pgm.action.replacements.ReplacementParser;
 import tc.oc.pgm.api.feature.FeatureValidation;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.Filterables;
@@ -55,12 +53,10 @@ import tc.oc.pgm.modules.WeatherMatchModule;
 import tc.oc.pgm.shops.ShopModule;
 import tc.oc.pgm.shops.menu.Payable;
 import tc.oc.pgm.structure.StructureDefinition;
-import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
 import tc.oc.pgm.util.inventory.ItemMatcher;
 import tc.oc.pgm.util.math.Formula;
-import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLFluentParser;
@@ -69,13 +65,12 @@ import tc.oc.pgm.variables.Variable;
 
 public class ActionParser {
 
-  private static final NumberFormat DEFAULT_FORMAT = NumberFormat.getIntegerInstance();
-
   private final MapFactory factory;
   private final boolean legacy;
   private final FeatureDefinitionContext features;
   private final XMLFluentParser parser;
   private final Map<String, Method> methodParsers;
+  private final ReplacementParser replacementParser;
 
   public ActionParser(MapFactory factory) {
     this.factory = factory;
@@ -83,6 +78,7 @@ public class ActionParser {
     this.features = factory.getFeatures();
     this.parser = factory.getParser();
     this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
+    replacementParser = new ReplacementParser(factory);
   }
 
   public <B extends Filterable<?>> Action<? super B> parseProperty(
@@ -291,40 +287,17 @@ public class ActionParser {
 
     List<Element> replacements = XMLUtils.flattenElements(el, "replacements");
     if (replacements.isEmpty()) {
-      return new MessageAction<>(Audience.class, text, actionbar, title, null);
+      return new MessageAction<>(Filterable.class, text, actionbar, title, null);
     }
 
     scope = parseScope(el, scope);
 
-    ImmutableMap.Builder<String, MessageAction.Replacement<T>> replacementMap =
-        ImmutableMap.builder();
+    ImmutableMap.Builder<String, Replacement> replacementMap = ImmutableMap.builder();
     for (Element replacement : XMLUtils.flattenElements(el, "replacements")) {
       replacementMap.put(
-          XMLUtils.parseRequiredId(replacement), parseReplacement(replacement, scope));
+          XMLUtils.parseRequiredId(replacement), replacementParser.parse(replacement, scope));
     }
     return new MessageAction<>(scope, text, actionbar, title, replacementMap.build());
-  }
-
-  private <T extends Filterable<?>> MessageAction.Replacement<T> parseReplacement(
-      Element el, Class<T> scope) throws InvalidXMLException {
-    // TODO: Support alternative replacement types (eg: player(s), team(s), or durations)
-    switch (el.getName().toLowerCase(Locale.ROOT)) {
-      case "decimal":
-        Formula<T> formula = parser.formula(scope, el, "value").required();
-        Node formatNode = Node.fromAttr(el, "format");
-        NumberFormat format =
-            formatNode != null ? new DecimalFormat(formatNode.getValue()) : DEFAULT_FORMAT;
-        return (T filterable) -> text(format.format(formula.applyAsDouble(filterable)));
-      case "player":
-        var variable = parser.variable(el, "var").scope(MatchPlayer.class).singleExclusive();
-        var fallback = XMLUtils.parseFormattedText(el, "fallback", empty());
-        var nameStyle = parser.parseEnum(NameStyle.class, el, "style").optional(NameStyle.VERBOSE);
-
-        return (T filterable) ->
-            variable.getHolder(filterable).map(mp -> mp.getName(nameStyle)).orElse(fallback);
-      default:
-        throw new InvalidXMLException("Unknown replacement type", el);
-    }
   }
 
   @MethodParser("sound")

--- a/core/src/main/java/tc/oc/pgm/action/replacements/Replacement.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/Replacement.java
@@ -1,0 +1,26 @@
+package tc.oc.pgm.action.replacements;
+
+import net.kyori.adventure.text.ComponentLike;
+import tc.oc.pgm.api.feature.FeatureDefinition;
+import tc.oc.pgm.filters.Filterable;
+
+/** A replacement object provides replacement text in message actions. */
+public interface Replacement extends FeatureDefinition {
+  /**
+   * Tests if the replacement can be used with the passed filterable.
+   *
+   * @param filterable The filterable to test
+   * @return Whether the replacement can be used with the passed filterable
+   */
+  default boolean canUse(Class<? extends Filterable<?>> filterable) {
+    return true;
+  }
+
+  /**
+   * Creates a replacement component tailored to the given filterable.
+   *
+   * @param filterable The filterable to use when creating the replacement component
+   * @return The replacement component
+   */
+  ComponentLike get(Filterable<?> filterable);
+}

--- a/core/src/main/java/tc/oc/pgm/action/replacements/Replacement.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/Replacement.java
@@ -3,18 +3,20 @@ package tc.oc.pgm.action.replacements;
 import net.kyori.adventure.text.ComponentLike;
 import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
 
 /** A replacement object provides replacement text in message actions. */
 public interface Replacement extends FeatureDefinition {
   /**
    * Tests if the replacement can be used with the passed filterable.
    *
-   * @param filterable The filterable to test
-   * @return Whether the replacement can be used with the passed filterable
+   * @param scope The filterable to test
+   * @param node The node reference used for parsing
+   * @throws InvalidXMLException if the replacement cannot be used with the passed scope
    */
-  default boolean canUse(Class<? extends Filterable<?>> filterable) {
-    return true;
-  }
+  default void validate(Class<? extends Filterable<?>> scope, Node node)
+      throws InvalidXMLException {}
 
   /**
    * Creates a replacement component tailored to the given filterable.

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
@@ -1,0 +1,164 @@
+package tc.oc.pgm.action.replacements;
+
+import static net.kyori.adventure.text.Component.empty;
+import static net.kyori.adventure.text.Component.text;
+
+import com.google.common.collect.Range;
+import java.lang.reflect.Method;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import net.kyori.adventure.text.Component;
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.Filterables;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.features.FeatureDefinitionContext;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.filters.matcher.StaticFilter;
+import tc.oc.pgm.util.MethodParser;
+import tc.oc.pgm.util.MethodParsers;
+import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLFluentParser;
+
+public class ReplacementParser {
+  private static final NumberFormat DEFAULT_FORMAT = NumberFormat.getIntegerInstance();
+  private final Map<String, Method> methodParsers =
+      MethodParsers.getMethodParsersForClass(getClass());
+  private final FeatureDefinitionContext features;
+  private final XMLFluentParser parser;
+  private final boolean isTopLevel;
+
+  public ReplacementParser(MapFactory factory, boolean topLevel) {
+    features = factory.getFeatures();
+    parser = factory.getParser();
+    isTopLevel = topLevel;
+  }
+
+  public ReplacementParser(MapFactory factory) {
+    this(factory, false);
+  }
+
+  public <B extends Filterable<?>> Replacement parse(Element el, @Nullable Class<B> scope)
+      throws InvalidXMLException {
+    Method parser = getParserFor(el);
+    if (parser != null) {
+      try {
+        return (Replacement) parser.invoke(this, el, scope);
+      } catch (Exception e) {
+        throw InvalidXMLException.coerce(e, new Node(el));
+      }
+    } else {
+      throw new InvalidXMLException("Unknown replacement type: " + el.getName(), el);
+    }
+  }
+
+  public Set<String> replacementTypes() {
+    return methodParsers.keySet();
+  }
+
+  protected Method getParserFor(Element el) {
+    return methodParsers.get(el.getName().toLowerCase());
+  }
+
+  private <B extends Filterable<?>> Class<B> parseScope(Element el, Class<B> scope)
+      throws InvalidXMLException {
+    if (scope == null) return Filterables.parse(Node.fromRequiredAttr(el, "scope"));
+    Node node = Node.fromAttr(el, "scope");
+    if (node != null && !Filterables.isAssignable(Filterables.parse(node), scope))
+      throw new InvalidXMLException(
+          "Wrong scope defined for replacement, scope must be " + scope.getSimpleName(), el);
+    return scope;
+  }
+
+  @MethodParser("decimal")
+  public <T extends Filterable<?>> Replacement parseDecimal(Element el, Class<T> scope)
+      throws InvalidXMLException {
+    scope = parseScope(el, scope);
+    var formula = parser.formula(scope, el, "value").required();
+    var format = parser
+        .string(el, "format")
+        .attr()
+        .optional()
+        .<NumberFormat>map(DecimalFormat::new)
+        .orElse(DEFAULT_FORMAT);
+
+    return ScopedReplacement.of(scope, ctx -> text(format.format(formula.applyAsDouble(ctx))));
+  }
+
+  @MethodParser("player")
+  public <T extends Filterable<?>> Replacement parsePlayer(Element el, Class<T> scope)
+      throws InvalidXMLException {
+    var variable = parser.variable(el, "var").scope(MatchPlayer.class).singleExclusive();
+    var fallback = parser.component(el, "fallback").optional(empty());
+    var nameStyle = parser.parseEnum(NameStyle.class, el, "style").optional(NameStyle.VERBOSE);
+    return filterable ->
+        variable.getHolder(filterable).map(mp -> mp.getName(nameStyle)).orElse(fallback);
+  }
+
+  @MethodParser("switch")
+  public <T extends Filterable<?>> Replacement parseSwitch(Element el, Class<T> scope)
+      throws InvalidXMLException {
+    scope = parseScope(el, scope);
+    var formula = parser.formula(scope, el, "value").orNull();
+    var fallback = parser.component(el, "fallback").child().optional(empty());
+    var children = el.getChildren("case");
+    var branches = new ArrayList<SwitchBranch>(children.size());
+
+    for (var innerEl : children) {
+      var valueRange = parser
+          .doubleRange(innerEl, "match")
+          .validate((r, n) -> {
+            if (formula == null) {
+              throw new InvalidXMLException(
+                  "A match attribute is specified but there's no switch value to bind to", n);
+            }
+          })
+          .optional();
+      var filter = parser.filter(innerEl, "filter").respondsTo(scope).optional(() -> {
+        if (valueRange.isEmpty())
+          throw new InvalidXMLException(
+              "At least a filter or a match attribute must be specified", innerEl);
+        return StaticFilter.ALLOW;
+      });
+      var result = parser.component(innerEl, "result").required();
+      branches.add(new SwitchBranch(result, valueRange.orElse(Range.all()), filter));
+    }
+
+    return ScopedReplacement.of(scope, ctx -> {
+      var formulaResult = formula != null ? formula.applyAsDouble(ctx) : null;
+      for (var branch : branches) {
+        if ((formula == null || branch.valueRange.contains(formulaResult))
+            && branch.filter.query(ctx).isAllowed()) return branch.result;
+      }
+
+      return fallback;
+    });
+  }
+
+  @MethodParser("replacement")
+  public <T extends Filterable<?>> Replacement parseReference(Element el, Class<T> scope)
+      throws InvalidXMLException {
+    if (isTopLevel)
+      throw new InvalidXMLException(
+          "References to replacements at the root level are not allowed", el);
+
+    Replacement replacement = features.resolve(new Node(el), Replacement.class);
+
+    if (!replacement.canUse(scope)) {
+      throw new InvalidXMLException(
+          replacement.getClass().getSimpleName() + " cannot be used with " + scope.getSimpleName(),
+          el);
+    }
+
+    return replacement;
+  }
+
+  public record SwitchBranch(Component result, Range<Double> valueRange, Filter filter) {}
+}

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
@@ -121,6 +121,10 @@ public class ReplacementParser {
     for (var innerEl : children) {
       var valueRange = formula != null ? parser.doubleRange(innerEl, "match").orNull() : null;
       var filter = parser.filter(innerEl, "filter").optional(() -> {
+        if (formula == null)
+          throw new InvalidXMLException(
+              "The filter attribute is required if value attribute is not specified in the switch element",
+              innerEl);
         if (valueRange == null)
           throw new InvalidXMLException(
               "At least a filter or a match attribute must be specified", innerEl);

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
@@ -123,11 +123,10 @@ public class ReplacementParser {
       var filter = parser.filter(innerEl, "filter").optional(() -> {
         if (formula == null)
           throw new InvalidXMLException(
-              "The filter attribute is required if value attribute is not specified in the switch element",
-              innerEl);
+              "The filter is required if value is not specified in the switch element", innerEl);
         if (valueRange == null)
           throw new InvalidXMLException(
-              "At least a filter or a match attribute must be specified", innerEl);
+              "At least a filter or a case match must be specified", innerEl);
         return StaticFilter.ALLOW;
       });
       var result = parser.component(innerEl, "result").required();

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
@@ -119,23 +119,15 @@ public class ReplacementParser {
     var branches = new ArrayList<SwitchBranch>(children.size());
 
     for (var innerEl : children) {
-      var valueRange = parser
-          .doubleRange(innerEl, "match")
-          .validate((r, n) -> {
-            if (formula == null) {
-              throw new InvalidXMLException(
-                  "A match attribute is specified but there's no switch value to bind to", n);
-            }
-          })
-          .optional();
+      var valueRange = formula != null ? parser.doubleRange(innerEl, "match").orNull() : null;
       var filter = parser.filter(innerEl, "filter").respondsTo(scope).optional(() -> {
-        if (valueRange.isEmpty())
+        if (valueRange == null)
           throw new InvalidXMLException(
               "At least a filter or a match attribute must be specified", innerEl);
         return StaticFilter.ALLOW;
       });
       var result = parser.component(innerEl, "result").required();
-      branches.add(new SwitchBranch(result, valueRange.orElse(Range.all()), filter));
+      branches.add(new SwitchBranch(result, valueRange != null ? valueRange : Range.all(), filter));
     }
 
     return ScopedReplacement.of(scope, ctx -> {

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
@@ -51,8 +51,7 @@ public class ReplacementParser {
     if (parser != null) {
       try {
         var replacement = (Replacement) parser.invoke(this, el, scope);
-        if (scope != null)
-          replacement.validate(scope, new Node(el));
+        if (scope != null) replacement.validate(scope, new Node(el));
         return replacement;
       } catch (Exception e) {
         throw InvalidXMLException.coerce(e, new Node(el));

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
@@ -50,7 +50,10 @@ public class ReplacementParser {
     Method parser = getParserFor(el);
     if (parser != null) {
       try {
-        return (Replacement) parser.invoke(this, el, scope);
+        var replacement = (Replacement) parser.invoke(this, el, scope);
+        if (scope != null)
+          replacement.validate(scope, new Node(el));
+        return replacement;
       } catch (Exception e) {
         throw InvalidXMLException.coerce(e, new Node(el));
       }
@@ -71,9 +74,12 @@ public class ReplacementParser {
       throws InvalidXMLException {
     if (scope == null) return Filterables.parse(Node.fromRequiredAttr(el, "scope"));
     Node node = Node.fromAttr(el, "scope");
-    if (node != null && !Filterables.isAssignable(Filterables.parse(node), scope))
+    // Narrower replacements cannot be used with broader scope
+    if (node != null && !Filterables.isAssignable(scope, Filterables.parse(node)))
       throw new InvalidXMLException(
-          "Wrong scope defined for replacement, scope must be " + scope.getSimpleName(), el);
+          "Wrong scope defined for replacement, scope must be " + scope.getSimpleName()
+              + " or higher",
+          el);
     return scope;
   }
 
@@ -106,6 +112,8 @@ public class ReplacementParser {
   public <T extends Filterable<?>> Replacement parseSwitch(Element el, Class<T> scope)
       throws InvalidXMLException {
     scope = parseScope(el, scope);
+    record SwitchBranch(Component result, Range<Double> valueRange, Filter filter) {}
+
     var formula = parser.formula(scope, el, "value").orNull();
     var fallback = parser.component(el, "fallback").child().optional(empty());
     var children = el.getChildren("case");
@@ -149,16 +157,6 @@ public class ReplacementParser {
       throw new InvalidXMLException(
           "References to replacements at the root level are not allowed", el);
 
-    Replacement replacement = features.resolve(new Node(el), Replacement.class);
-
-    if (!replacement.canUse(scope)) {
-      throw new InvalidXMLException(
-          replacement.getClass().getSimpleName() + " cannot be used with " + scope.getSimpleName(),
-          el);
-    }
-
-    return replacement;
+    return features.resolve(new Node(el), Replacement.class);
   }
-
-  public record SwitchBranch(Component result, Range<Double> valueRange, Filter filter) {}
 }

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
@@ -120,7 +120,7 @@ public class ReplacementParser {
 
     for (var innerEl : children) {
       var valueRange = formula != null ? parser.doubleRange(innerEl, "match").orNull() : null;
-      var filter = parser.filter(innerEl, "filter").respondsTo(scope).optional(() -> {
+      var filter = parser.filter(innerEl, "filter").optional(() -> {
         if (valueRange == null)
           throw new InvalidXMLException(
               "At least a filter or a match attribute must be specified", innerEl);

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ScopedReplacement.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ScopedReplacement.java
@@ -1,0 +1,45 @@
+package tc.oc.pgm.action.replacements;
+
+import java.util.function.Function;
+import net.kyori.adventure.text.ComponentLike;
+import tc.oc.pgm.api.filter.Filterables;
+import tc.oc.pgm.filters.Filterable;
+
+public abstract class ScopedReplacement<S extends Filterable<?>> implements Replacement {
+  private final Class<S> scope;
+
+  public ScopedReplacement(Class<S> scope) {
+    this.scope = scope;
+  }
+
+  @Override
+  public boolean canUse(Class<? extends Filterable<?>> filterable) {
+    return Filterables.isAssignable(filterable, scope);
+  }
+
+  protected abstract ComponentLike getImpl(S ctx);
+
+  @Override
+  public ComponentLike get(Filterable<?> filterable) {
+    S ctx = filterable.getFilterableAncestor(scope);
+    if (ctx == null)
+      throw new IllegalStateException("Wrong replacement scope for '"
+          + this
+          + "', expected "
+          + scope.getSimpleName()
+          + " which cannot be found in "
+          + filterable.getClass().getSimpleName());
+
+    return getImpl(ctx);
+  }
+
+  public static <S extends Filterable<?>> ScopedReplacement<S> of(
+      Class<S> scope, Function<S, ComponentLike> get) {
+    return new ScopedReplacement<>(scope) {
+      @Override
+      protected ComponentLike getImpl(S ctx) {
+        return get.apply(ctx);
+      }
+    };
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ScopedReplacement.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ScopedReplacement.java
@@ -4,6 +4,8 @@ import java.util.function.Function;
 import net.kyori.adventure.text.ComponentLike;
 import tc.oc.pgm.api.filter.Filterables;
 import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
 
 public abstract class ScopedReplacement<S extends Filterable<?>> implements Replacement {
   private final Class<S> scope;
@@ -13,8 +15,14 @@ public abstract class ScopedReplacement<S extends Filterable<?>> implements Repl
   }
 
   @Override
-  public boolean canUse(Class<? extends Filterable<?>> filterable) {
-    return Filterables.isAssignable(filterable, scope);
+  public void validate(Class<? extends Filterable<?>> filterable, Node node)
+      throws InvalidXMLException {
+    if (!Filterables.isAssignable(filterable, scope)) {
+      throw new InvalidXMLException(
+          "Wrong replacement scope, got " + filterable.getSimpleName() + " but expected "
+              + scope.getSimpleName() + " or lower",
+          node);
+    }
   }
 
   protected abstract ComponentLike getImpl(S ctx);

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.util.xml;
 
+import com.google.common.collect.Range;
 import java.time.Duration;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
@@ -95,6 +96,24 @@ public class XMLFluentParser {
 
   public <T extends Number> NumberBuilder<T> number(Class<T> cls, Element el, String... prop) {
     return new NumberBuilder<>(cls, el, prop);
+  }
+
+  public Builder.Generic<Range<Integer>> intRange(Element el, String... prop) {
+    return numericRange(Integer.class, el, prop);
+  }
+
+  public Builder.Generic<Range<Double>> doubleRange(Element el, String... prop) {
+    return numericRange(Double.class, el, prop);
+  }
+
+  public <T extends Number & Comparable<T>> Builder.Generic<Range<T>> numericRange(
+      Class<T> cls, Element el, String... prop) {
+    return new Builder.Generic<>(el, prop) {
+      @Override
+      protected Range<T> parse(Node node) throws InvalidXMLException {
+        return XMLUtils.parseNumericRange(node, cls);
+      }
+    };
   }
 
   public Builder.Generic<Material> material(Element el, String... prop) {

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/FilterBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/FilterBuilder.java
@@ -1,7 +1,9 @@
 package tc.oc.pgm.util.xml.parsers;
 
 import org.jdom2.Element;
+import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.Filterables;
 import tc.oc.pgm.filters.Filterable;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.parse.DynamicFilterValidation;
@@ -24,6 +26,26 @@ public class FilterBuilder extends Builder<Filter, FilterBuilder> {
 
   public FilterBuilder dynamic(Class<? extends Filterable<?>> type) {
     validate((f, n) -> filters.validate(f, DynamicFilterValidation.of(type), n));
+    return this;
+  }
+
+  public FilterBuilder respondsTo(@NotNull Class<? extends Filterable<?>> type) {
+    validate((filter, node) -> filters.validate(
+        filter,
+        (definition, n) -> {
+          if (!definition.respondsTo(type)) {
+            throw new InvalidXMLException(
+                "Expected a filter that can respond to "
+                    + type.getSimpleName()
+                    + ". The filter "
+                    + definition.getDefinitionType().getSimpleName()
+                    + " only responds to "
+                    + Filterables.scope(definition).getSimpleName()
+                    + " or lower",
+                n);
+          }
+        },
+        node));
     return this;
   }
 

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/FilterBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/FilterBuilder.java
@@ -1,9 +1,7 @@
 package tc.oc.pgm.util.xml.parsers;
 
 import org.jdom2.Element;
-import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.filter.Filter;
-import tc.oc.pgm.api.filter.Filterables;
 import tc.oc.pgm.filters.Filterable;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.parse.DynamicFilterValidation;
@@ -26,26 +24,6 @@ public class FilterBuilder extends Builder<Filter, FilterBuilder> {
 
   public FilterBuilder dynamic(Class<? extends Filterable<?>> type) {
     validate((f, n) -> filters.validate(f, DynamicFilterValidation.of(type), n));
-    return this;
-  }
-
-  public FilterBuilder respondsTo(@NotNull Class<? extends Filterable<?>> type) {
-    validate((filter, node) -> filters.validate(
-        filter,
-        (definition, n) -> {
-          if (!definition.respondsTo(type)) {
-            throw new InvalidXMLException(
-                "Expected a filter that can respond to "
-                    + type.getSimpleName()
-                    + ". The filter "
-                    + definition.getDefinitionType().getSimpleName()
-                    + " only responds to "
-                    + Filterables.scope(definition).getSimpleName()
-                    + " or lower",
-                n);
-          }
-        },
-        node));
     return this;
   }
 


### PR DESCRIPTION
Adds support for switch-case style replacement in message actions, inspired by pattern matching found in modern programming languages, for example (preliminary syntax, some details may be subject to change):

```xml
<message text="The outcome is {outcome}">
    <replacements>
        <!-- 
             value supports formulas and may be omitted 
             (in this case, the match attribute in <case>
             is disallowed)
        -->
        <switch id="outcome" value="variable">
            <!-- matches if the formula result is 0 -->
            <case match="0" result="Outcome 1"/>
            
            <!-- matches if the formula result is 1 AND only-team-1 allows -->
            <case match="1" filter="only-team-1" result="`aOutcome 2"/>
            
            <!-- matches if only-team-2 allows regardless of formula result -->
            <case filter="only-team-2" result="`bOutcome 3"/>
            
            <!--
                full syntax (matches if the formula result is between 2 and 5,
                and the inner filter allows)
            -->
            <case>
                <match>2..5</match>
                <filter>
                    <all id="not-moving">
                        <variable var="player.vel_x">0</variable>
                        <variable var="player.vel_y">..0</variable>
                        <variable var="player.vel_z">0</variable>
                    </all>
                </filter>
                <result>`cOutcome 4</result>
            </case>
            
            <!-- a fallback value if no cases match (defaults to an empty component) -->
            <fallback>`dA fallback outcome</fallback>
        </switch>
    </replacements>
</message>
```

Additionally, replacements can now be specified at the root level:
```xml
<map>
    <replacements>
        <!--
            scope is required for all replacements except <player />
            and it will be enforced if specified
        -->
        <decimal id="decimal" value="money" scope="player" format="0.00"/>
        <switch id="team" scope="team">
            <case filter="only-team-1" result="`aLime"/>
        </switch>
        
        <!-- 
            This will error as only-team-1 is team-scoped
            Not true as of commit 54666274 anymore. `only-team-1` will match as it abstains.
        -->
        <switch id="team2" scope="match">
            <case filter="only-team-1" result="`aLime"/>
        </switch>
    </replacements>
    <actions>
        <action id="action" scope="match">
            <switch-scope inner="player">
                <message text="The variable is {variable} and your team is {team}!">
                    <replacements>
                        <!--
                            the syntax for replacement references is
                            <replacement id="local-id">global-id</replacement>
                        -->
                        <replacement id="variable">decimal</replacement>
                        <replacement id="team">team</replacement>
                    </replacements>
                </message>
            </switch-scope>
        </action>
    </actions>
</map>
```

---

Launch checklist:
- [x] Cannot use higher-scope filters in `<case>` than defined in `<switch>`
- [x] Cannot specify higher-scope replacements than defined in `<action>`
- [x] Cannot use lower-scope variables in `<switch>` value
- [x] Validation???
  - [x] Using a reference of lower scope replacement should not work in a higher-scope action
  - [x] Declaring a lower scope replacement in a higher scope action should not work?