### PR TITLE
Fix damage history order not being respected

### DIFF
--- a/core/src/main/java/tc/oc/pgm/damagehistory/DamageEntry.java
+++ b/core/src/main/java/tc/oc/pgm/damagehistory/DamageEntry.java
@@ -1,11 +1,15 @@
 package tc.oc.pgm.damagehistory;
 
+import java.util.UUID;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.ParticipantState;
 
 public class DamageEntry {
 
-  @Nullable private ParticipantState damager;
+  @Nullable
+  private ParticipantState damager;
+
   private double damage;
 
   public DamageEntry(@Nullable ParticipantState damager, double damage) {
@@ -29,5 +33,12 @@ public class DamageEntry {
 
   public void removeDamage(double damage) {
     this.damage -= damage;
+  }
+
+  public boolean canAssist(MatchPlayer victim, ParticipantState killer) {
+    // Filter out damage without players, or damage from self or killer
+    if (damager == null) return false;
+    UUID dmg = damager.getId();
+    return damager != null && !dmg.equals(victim.getId()) && !dmg.equals(killer.getId());
   }
 }


### PR DESCRIPTION
Fixes damage history being reversed but later putting everything into a non-order-respecting HashMap which turns it into arbitrary order