### PR TITLE
Several bugfixes & improvements to stats

### DIFF
--- a/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
+++ b/core/src/main/java/tc/oc/pgm/ffa/Tribute.java
@@ -148,6 +148,11 @@ public class Tribute implements Competitor {
     return this.players;
   }
 
+  @Nullable
+  public MatchPlayer getPlayer() {
+    return this.player;
+  }
+
   @Override
   public @Nullable MatchPlayer getPlayer(final UUID playerId) {
     return player != null && player.getId().equals(playerId) ? player : null;

--- a/core/src/main/java/tc/oc/pgm/menu/InventoryMenu.java
+++ b/core/src/main/java/tc/oc/pgm/menu/InventoryMenu.java
@@ -40,12 +40,11 @@ public abstract class InventoryMenu implements InventoryProvider {
       Component title, int rows, MatchPlayer viewer, @Nullable SmartInventory parent) {
     this.viewer = viewer;
 
-    SmartInventory.Builder builder =
-        SmartInventory.builder()
-            .manager(PGM.get().getInventoryManager())
-            .title(translateLegacy(title, getBukkit()))
-            .size(rows, 9)
-            .provider(this);
+    SmartInventory.Builder builder = SmartInventory.builder()
+        .manager(PGM.get().getInventoryManager())
+        .title(translateLegacy(title, getBukkit()))
+        .size(rows, 9)
+        .provider(this);
 
     if (parent != null) {
       builder.parent(parent);
@@ -70,6 +69,10 @@ public abstract class InventoryMenu implements InventoryProvider {
     return inventory;
   }
 
+  public int lastRow() {
+    return inventory.getRows() - 1;
+  }
+
   public void addBackButton(
       InventoryContents contents, Component parentMenuTitle, int row, int col) {
     Component back = translatable("menu.page.return", NamedTextColor.GRAY, parentMenuTitle);
@@ -78,18 +81,8 @@ public abstract class InventoryMenu implements InventoryProvider {
         row,
         col,
         ClickableItem.of(
-            new ItemBuilder()
-                .material(Material.BARRIER)
-                .name(translateLegacy(back, getBukkit()))
-                .build(),
-            c -> {
-              getInventory()
-                  .getParent()
-                  .ifPresent(
-                      parent -> {
-                        parent.open(getBukkit());
-                      });
-            }));
+            new ItemBuilder().material(Material.BARRIER).name(getBukkit(), back).build(),
+            c -> getInventory().getParent().ifPresent(parent -> parent.open(getBukkit()))));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/menu/PagedInventoryMenu.java
+++ b/core/src/main/java/tc/oc/pgm/menu/PagedInventoryMenu.java
@@ -84,14 +84,18 @@ public abstract class PagedInventoryMenu extends InventoryMenu {
    *
    * @return a {@link SlotPos} where previous page button will be located.
    */
-  public abstract SlotPos getPreviousPageSlot();
+  public SlotPos getPreviousPageSlot() {
+    return SlotPos.of(lastRow(), 0);
+  }
 
   /**
    * The position of the next page button.
    *
    * @return a {@link SlotPos} where next page button will be located.
    */
-  public abstract SlotPos getNextPageSlot();
+  public SlotPos getNextPageSlot() {
+    return SlotPos.of(lastRow(), 8);
+  }
 
   /**
    * The position of the no page contents button, only displayed when page contents is empty or
@@ -112,8 +116,10 @@ public abstract class PagedInventoryMenu extends InventoryMenu {
 
   protected ClickableItem getEmptyContentsButton(Player viewer) {
     Component name = translatable("menu.page.empty", NamedTextColor.DARK_RED, TextDecoration.BOLD);
-    return ClickableItem.empty(
-        new ItemBuilder().material(Material.BARRIER).name(translateLegacy(name, viewer)).build());
+    return ClickableItem.empty(new ItemBuilder()
+        .material(Material.BARRIER)
+        .name(translateLegacy(name, viewer))
+        .build());
   }
 
   protected ClickableItem getPageItem(Player player, int page, String key) {

--- a/core/src/main/java/tc/oc/pgm/stats/menu/TeamStatsMenu.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/TeamStatsMenu.java
@@ -7,15 +7,12 @@ import fr.minuskube.inv.SmartInventory;
 import fr.minuskube.inv.content.InventoryContents;
 import fr.minuskube.inv.content.SlotPos;
 import java.util.List;
-import java.util.stream.Collectors;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.menu.PagedInventoryMenu;
-import tc.oc.pgm.stats.TeamStats;
 import tc.oc.pgm.stats.menu.items.PlayerStatsMenuItem;
 import tc.oc.pgm.util.text.TextFormatter;
 
@@ -28,16 +25,14 @@ public class TeamStatsMenu extends PagedInventoryMenu {
   private static final int STARTING_COL = 0;
 
   private final Competitor team;
-  private final TeamStats stats;
   private final List<PlayerStatsMenuItem> members;
-  private ItemStack teamItem;
+  private final ClickableItem teamItem;
 
   public TeamStatsMenu(
       Competitor team,
-      TeamStats stats,
       List<PlayerStatsMenuItem> members,
       MatchPlayer viewer,
-      ItemStack teamItem,
+      ClickableItem teamItem,
       SmartInventory parent) {
     super(
         translatable("match.stats.team", TextFormatter.convert(team.getColor()), team.getName()),
@@ -48,10 +43,8 @@ public class TeamStatsMenu extends PagedInventoryMenu {
         STARTING_ROW,
         STARTING_COL);
     this.team = team;
-    this.stats = stats;
     this.members = members;
     this.teamItem = teamItem;
-    open();
   }
 
   public Competitor getTeam() {
@@ -60,31 +53,18 @@ public class TeamStatsMenu extends PagedInventoryMenu {
 
   @Override
   public void init(Player player, InventoryContents contents) {
-    contents.set(0, 4, ClickableItem.empty(teamItem));
+    contents.set(0, 4, teamItem);
     this.setupPageContents(player, contents);
     this.addBackButton(
         contents,
         translatable("match.stats.title", NamedTextColor.GOLD, TextDecoration.BOLD),
-        5,
+        lastRow(),
         4);
   }
 
   @Override
   public ClickableItem[] getPageContents(Player viewer) {
-    List<ClickableItem> items =
-        members.stream().map(ps -> ps.getClickableItem(viewer)).collect(Collectors.toList());
-
-    return items.isEmpty() ? null : items.toArray(new ClickableItem[items.size()]);
-  }
-
-  @Override
-  public SlotPos getPreviousPageSlot() {
-    return SlotPos.of(4, 0);
-  }
-
-  @Override
-  public SlotPos getNextPageSlot() {
-    return SlotPos.of(4, 8);
+    return members.stream().map(p -> p.getClickableItem(viewer)).toArray(ClickableItem[]::new);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.stats.menu.items;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
 import static tc.oc.pgm.stats.StatsMatchModule.damageComponent;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 import static tc.oc.pgm.util.nms.PlayerUtils.PLAYER_UTILS;
@@ -14,7 +15,6 @@ import java.util.List;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -33,7 +33,6 @@ import tc.oc.pgm.util.text.TextTranslations;
 /** Represents a player's stats via player head & lore * */
 public class PlayerStatsMenuItem implements MenuItem {
 
-  private final TextColor RESET = NamedTextColor.GRAY;
   private final UUID uuid;
   private final PlayerStats stats;
   private final Skin skin;
@@ -57,27 +56,27 @@ public class PlayerStatsMenuItem implements MenuItem {
 
     Component statLore = translatable(
         "match.stats.concise",
-        RESET,
+        GRAY,
         number(stats.getKills(), NamedTextColor.GREEN),
         number(stats.getDeaths(), NamedTextColor.RED),
         number(stats.getKD(), NamedTextColor.GREEN));
     Component killstreakLore = translatable(
         "match.stats.killstreak.concise",
-        RESET,
+        GRAY,
         number(stats.getMaxKillstreak(), NamedTextColor.GREEN));
     Component damageDealtLore = translatable(
         "match.stats.damage.dealt",
-        RESET,
+        GRAY,
         damageComponent(stats.getDamageDone(), NamedTextColor.GREEN),
         damageComponent(stats.getBowDamage(), NamedTextColor.YELLOW));
     Component damageReceivedLore = translatable(
         "match.stats.damage.received",
-        RESET,
+        GRAY,
         damageComponent(stats.getDamageTaken(), NamedTextColor.RED),
         damageComponent(stats.getBowDamageTaken(), NamedTextColor.GOLD));
     Component bowLore = translatable(
         "match.stats.bow",
-        RESET,
+        GRAY,
         number(stats.getShotsHit(), NamedTextColor.YELLOW),
         number(stats.getShotsTaken(), NamedTextColor.YELLOW),
         number(stats.getArrowAccuracy(), NamedTextColor.YELLOW).append(text('%')));
@@ -95,7 +94,7 @@ public class PlayerStatsMenuItem implements MenuItem {
         lore.add(TextTranslations.translateLegacy(
             translatable(
                 "match.stats.flaghold.concise",
-                RESET,
+                GRAY,
                 TemporalComponent.briefNaturalApproximate(stats.getLongestFlagHold())
                     .color(NamedTextColor.AQUA)
                     .decoration(TextDecoration.BOLD, true)),
@@ -110,7 +109,7 @@ public class PlayerStatsMenuItem implements MenuItem {
   private boolean optionalStat(List<String> lore, Number stat, String key, Player player) {
     if (stat.doubleValue() > 0) {
       lore.add(null);
-      Component loreComponent = translatable(key, RESET, number(stat, NamedTextColor.AQUA));
+      Component loreComponent = translatable(key, GRAY, number(stat, NamedTextColor.AQUA));
       lore.add(TextTranslations.translateLegacy(loreComponent, player));
       return true;
     }

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/VerboseStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/VerboseStatsMenuItem.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.stats.menu.items;
 
 import static net.kyori.adventure.text.Component.translatable;
 
-import com.google.common.collect.Lists;
 import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -23,9 +22,8 @@ public class VerboseStatsMenuItem implements MenuItem {
 
   @Override
   public List<String> getLore(Player player) {
-    return Lists.newArrayList(
-        TextTranslations.translateLegacy(
-            translatable("setting.lore", NamedTextColor.GRAY), player));
+    return List.of(TextTranslations.translateLegacy(
+        translatable("setting.lore", NamedTextColor.GRAY), player));
   }
 
   @Override


### PR DESCRIPTION
Fixes a few issues with stats:
 - Custom projectiles hitting players with resistance would cause negative damage to be recorded
   - Extreme cases (resistance level 255 and rage projectiles) could cause damages in the -300k range per projectile
 - Bow shots and bow lands were tracking differently, causing mismatches like:
   - Shooting a custom projectile that launches an arrow (eg: La Piazza's crossbow) would increase your landed shots but not your "shot" arrows, meaning you could get 100% bow accuracy.
   - Shooting a bow that modifies the projectile (eg: Glacial impact shooting snowballs) would increase your shots but would never count towards landed projectiles, meaning your accuracy would drop even if you land your projectiles.
 - The stats menu now supports FFA, prior to this it wouldn't give you the item at all.
 - The stats menu was not centered for a bunch of team sizes (it really only worked well for even amounts), so 3-team or 5-team maps would be off-centered. Now they all display in a more reasonable manner.
 - The stats menu always reserved just 2 rows for teams, now it will be flexible from 2 to 4 rows depending on how many teams there are. This applies to FFA too.