### PR TITLE
Prevent multiple listener registration

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchImpl.java
@@ -140,7 +140,7 @@ public class MatchImpl implements Match {
     this.tickables = new EnumMap<>(MatchScope.class);
     for (MatchScope scope : MatchScope.values()) {
       executors.put(scope, new BukkitExecutorService(PGM.get(), false));
-      listeners.put(scope, new LinkedList<>());
+      listeners.put(scope, new LinkedHashSet<>());
       tickables.put(scope, new CopyOnWriteArraySet<>());
     }
     this.tick = new AtomicReference<>(null);


### PR DESCRIPTION
Some listeners may get registered twice since pgm doesn't use a datastructure that prevents duplicates. This was the case for flags, where all events were being handled twice.