### PR TITLE
Optimize list of material filters

### DIFF
--- a/core/src/main/java/tc/oc/pgm/broadcast/Broadcast.java
+++ b/core/src/main/java/tc/oc/pgm/broadcast/Broadcast.java
@@ -17,7 +17,6 @@ import tc.oc.pgm.util.bukkit.Sounds;
 public class Broadcast implements Comparable<Broadcast> {
   public enum Type {
     TIP(translatable("misc.tip", NamedTextColor.BLUE), Sounds.TIP),
-
     ALERT(translatable("misc.alert", NamedTextColor.YELLOW), Sounds.ALERT);
 
     final Component prefix;

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/block/MaterialFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/block/MaterialFilter.java
@@ -17,6 +17,10 @@ public class MaterialFilter extends TypedFilter.Impl<MaterialQuery> {
     this.pattern = pattern;
   }
 
+  public MaterialMatcher getPattern() {
+    return pattern;
+  }
+
   @Override
   public Class<? extends MaterialQuery> queryType() {
     return MaterialQuery.class;

--- a/core/src/main/java/tc/oc/pgm/filters/operator/AnyFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/AnyFilter.java
@@ -1,8 +1,11 @@
 package tc.oc.pgm.filters.operator;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
+import tc.oc.pgm.filters.matcher.block.MaterialFilter;
+import tc.oc.pgm.util.material.MaterialMatcher;
 
 public class AnyFilter extends MultiFilterFunction {
 
@@ -26,10 +29,28 @@ public class AnyFilter extends MultiFilterFunction {
   }
 
   public static Filter of(Filter... filters) {
-    return MultiFilterFunction.of(AnyFilter::new, filters);
+    return MultiFilterFunction.of(AnyFilter::mergeMaterials, filters);
   }
 
   public static Filter of(Collection<Filter> filters) {
-    return MultiFilterFunction.of(AnyFilter::new, filters);
+    return MultiFilterFunction.of(AnyFilter::mergeMaterials, filters);
+  }
+
+  /**
+   * Optimization when creating any -> materials type of filters. The material filters get unwrapped
+   * and turned into just one material filter with a multi-material matcher.
+   *
+   * @param filters collection of the filters to wrap into an AnyFilter
+   * @return an equivalent of AnyFilter, but with optimized materials
+   */
+  private static Filter mergeMaterials(Collection<Filter> filters) {
+    var materials = MaterialMatcher.builder();
+    var children = new ArrayList<Filter>(filters.size());
+    for (Filter filter : filters) {
+      if (filter instanceof MaterialFilter mf) materials.add(mf.getPattern());
+      else children.add(filter);
+    }
+    if (!materials.isEmpty()) children.add(new MaterialFilter(materials.build()));
+    return MultiFilterFunction.of(AnyFilter::new, children);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/FilterWrapper.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/FilterWrapper.java
@@ -1,0 +1,32 @@
+package tc.oc.pgm.filters.operator;
+
+import org.jdom2.Element;
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.query.Query;
+
+/**
+ * Wrapper around a child filter, exists only as a parsing optimization. Single-child "any", "all"
+ * or "one" filters can often be replaced with their single child, but when the child is a
+ * reference, they can instead be turned into a wrapped filter. <br>
+ * For example, {@code <all id="outer"><region id="other"/></all>}. Because the child is a
+ * reference, if we simplified parsing to returning "other", pgm wouldn't register it under the
+ * "outer" name (you can't register a reference, otherwise it creates duplicates). For those cases,
+ * we create a filter wrapper around "other", and return that instead.
+ */
+public class FilterWrapper extends SingleFilterFunction {
+
+  private FilterWrapper(Filter filter) {
+    super(filter);
+  }
+
+  @Override
+  public QueryResponse query(Query query) {
+    return filter.query(query);
+  }
+
+  public static Filter of(Element el, Filter filter) {
+    if (el.getAttribute("id") == null || !(filter instanceof FeatureReference<?>)) return filter;
+    return new FilterWrapper(filter);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/filters/operator/MultiFilterFunction.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/MultiFilterFunction.java
@@ -49,25 +49,19 @@ public abstract class MultiFilterFunction implements FilterDefinition {
   }
 
   public static Filter of(Function<Collection<Filter>, Filter> builder, Filter... filters) {
-    switch (filters.length) {
-      case 0:
-        return StaticFilter.ABSTAIN;
-      case 1:
-        return filters[0];
-      default:
-        return builder.apply(Arrays.asList(filters));
-    }
+    return switch (filters.length) {
+      case 0 -> StaticFilter.ABSTAIN;
+      case 1 -> filters[0];
+      default -> builder.apply(Arrays.asList(filters));
+    };
   }
 
   public static Filter of(
       Function<Collection<Filter>, Filter> builder, Collection<Filter> filters) {
-    switch (filters.size()) {
-      case 0:
-        return StaticFilter.ABSTAIN;
-      case 1:
-        return filters.iterator().next();
-      default:
-        return builder.apply(filters);
-    }
+    return switch (filters.size()) {
+      case 0 -> StaticFilter.ABSTAIN;
+      case 1 -> filters.iterator().next();
+      default -> builder.apply(filters);
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -89,12 +89,6 @@ public class FeatureFilterParser extends FilterParser {
     return new DenyFilter(parseChild(el));
   }
 
-  // Override with a version that only accepts a single child filter
-  @MethodParser("not")
-  public Filter parseNot(Element el) throws InvalidXMLException {
-    return new InverseFilter(parseChild(el));
-  }
-
   private static final Pattern INLINE_VARIABLE =
       Pattern.compile("(%VAR%)(?:\\[(\\d+)])?\\s*=\\s*(%RANGE%|%NUM%)"
           .replace("%VAR%", VariablesModule.Factory.VARIABLE_ID.pattern())

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -66,6 +66,7 @@ import tc.oc.pgm.filters.modifier.PlayerQueryModifier;
 import tc.oc.pgm.filters.modifier.SameTeamQueryModifier;
 import tc.oc.pgm.filters.operator.AllFilter;
 import tc.oc.pgm.filters.operator.AnyFilter;
+import tc.oc.pgm.filters.operator.FilterWrapper;
 import tc.oc.pgm.filters.operator.InverseFilter;
 import tc.oc.pgm.filters.operator.OneFilter;
 import tc.oc.pgm.filters.operator.TeamFilterAdapter;
@@ -220,22 +221,22 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
 
   @MethodParser("any")
   public Filter parseAny(Element el) throws InvalidXMLException {
-    return new AnyFilter(parseChildren(el));
+    return FilterWrapper.of(el, AnyFilter.of(parseChildren(el)));
   }
 
   @MethodParser("all")
   public Filter parseAll(Element el) throws InvalidXMLException {
-    return new AllFilter(parseChildren(el));
+    return FilterWrapper.of(el, AllFilter.of(parseChildren(el)));
   }
 
   @MethodParser("one")
   public Filter parseOne(Element el) throws InvalidXMLException {
-    return new OneFilter(parseChildren(el));
+    return FilterWrapper.of(el, OneFilter.of(parseChildren(el)));
   }
 
   @MethodParser("not")
   public Filter parseNot(Element el) throws InvalidXMLException {
-    return new InverseFilter(AnyFilter.of(parseChildren(el)));
+    return new InverseFilter(parseChild(el));
   }
 
   @MethodParser("team")

--- a/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
@@ -10,7 +10,9 @@ import tc.oc.pgm.api.filter.FilterDefinition;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.matcher.block.MaterialFilter;
+import tc.oc.pgm.filters.operator.AnyFilter;
 import tc.oc.pgm.filters.operator.FilterNode;
+import tc.oc.pgm.filters.operator.InverseFilter;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -110,6 +112,12 @@ public class LegacyFilterParser extends FilterParser {
     } else {
       return this.parseAll(el);
     }
+  }
+
+  // Legacy not allows for multiple children and is an implicit and
+  @MethodParser("not")
+  public Filter parseNot(Element el) throws InvalidXMLException {
+    return new InverseFilter(AnyFilter.of(parseChildren(el)));
   }
 
   // Removed in proto 1.4 to avoid conflict with <block> region

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/BlockStateMaterialMatcher.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/BlockStateMaterialMatcher.java
@@ -8,8 +8,7 @@ import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
-@SuppressWarnings("deprecation")
-public class BlockStateMaterialMatcher implements MaterialMatcher {
+public class BlockStateMaterialMatcher implements MaterialMatcher.Singular {
   private final BlockData data;
 
   public BlockStateMaterialMatcher(BlockData data) {
@@ -19,6 +18,11 @@ public class BlockStateMaterialMatcher implements MaterialMatcher {
   @Override
   public Set<Material> getMaterials() {
     return Set.of(data.getMaterial());
+  }
+
+  @Override
+  public Material getMaterial() {
+    return data.getMaterial();
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/ExactMaterialMatcher.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/ExactMaterialMatcher.java
@@ -8,7 +8,7 @@ import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
 @SuppressWarnings("deprecation")
-public class ExactMaterialMatcher implements MaterialMatcher {
+public class ExactMaterialMatcher implements MaterialMatcher.Singular {
   private final Material material;
   private final byte data;
 
@@ -20,6 +20,11 @@ public class ExactMaterialMatcher implements MaterialMatcher {
   @Override
   public Set<Material> getMaterials() {
     return Set.of(material);
+  }
+
+  @Override
+  public Material getMaterial() {
+    return material;
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
@@ -76,6 +76,10 @@ public interface MaterialMatcher {
     return MATERIAL_UTILS.matcherBuilder();
   }
 
+  interface Singular extends MaterialMatcher {
+    Material getMaterial();
+  }
+
   interface Builder {
     /**
      * Set the builder to only accept materials, error on material:data syntax
@@ -206,6 +210,16 @@ public interface MaterialMatcher {
 
     @Override
     public Builder add(MaterialMatcher matcher) {
+      // Already part of the matcher in form of material, can ignore
+      if (matcher instanceof Singular s && materials.contains(s.getMaterial())) return this;
+      if (matcher instanceof SingularMaterialMatcher
+          || matcher instanceof MultipleMaterialMatcher) {
+        Set<Material> toAdd = matcher.getMaterials();
+        materials.addAll(toAdd);
+        // Ignore any matcher already handled by our generic material list
+        matchers.removeIf(m -> m instanceof Singular s && toAdd.contains(s.getMaterial()));
+        return this;
+      }
       matchers.add(matcher);
       return this;
     }

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/MultipleMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/MultipleMaterialMatcher.java
@@ -55,4 +55,9 @@ public class MultipleMaterialMatcher implements MaterialMatcher {
       default -> new MultipleMaterialMatcher(materials);
     };
   }
+
+  @Override
+  public String toString() {
+    return "MultipleMaterialMatcher{" + "materials=" + materials + '}';
+  }
 }

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/SingularMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/SingularMaterialMatcher.java
@@ -9,7 +9,7 @@ import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
-public class SingularMaterialMatcher implements MaterialMatcher {
+public class SingularMaterialMatcher implements MaterialMatcher.Singular {
   private final Material material;
 
   private SingularMaterialMatcher(Material material) {
@@ -37,11 +37,21 @@ public class SingularMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
+  public Material getMaterial() {
+    return material;
+  }
+
+  @Override
   public Set<BlockMaterialData> getPossibleBlocks() {
     return MATERIAL_UTILS.getPossibleBlocks(material);
   }
 
   public static MaterialMatcher of(Material material) {
     return material == null ? NoMaterialMatcher.INSTANCE : new SingularMaterialMatcher(material);
+  }
+
+  @Override
+  public String toString() {
+    return "SingularMaterialMatcher{" + "material=" + material + '}';
   }
 }


### PR DESCRIPTION
Purely an internal change, i optimizes things like this:

(yes, this is a real filter used in a real map)
```xml
<any>
  <material>stone:6</material>
  <material>stone button</material>
  <material>smooth brick</material>
  <material>smooth brick:2</material>
  <material>cobblestone</material>
  <material>mossy cobblestone</material>
  <material>cobblestone stairs</material>
  <material>cobble wall</material>
  <material>cobble wall:1</material>
  <material>double step</material>
  <material>double step:3</material>
  <material>double step:4</material>
  <material>double step:5</material>
  <material>double step:8</material>
  <material>step</material>
  <material>step:3</material>
  <material>step:5</material>
  <material>stone plate</material>
  <material>stained glass</material>
  <material>iron fence</material>
  <material>vine</material>
  <material>smooth stairs</material>
  <material>water lily</material>
  <material>wall banner</material>
  <material>trap door</material>
  <material>long grass</material>
  <material>red rose</material>
  <material>double plant</material>   
  <material>red mushroom</material>
  <material>brown mushroom</material>
  <material>diamond block</material>
  <material>gold block</material>
  <material>gold ore</material>
  <material>long grass</material>
  <material>long grass:2</material>
  <material>red rose</material>
  <material>red rose:1</material>
  <material>red rose:2</material>
  <material>red rose:3</material>
  <material>red rose:4</material>
  <material>red rose:5</material>
  <material>red rose:6</material>
  <material>red rose:7</material>
  <material>red rose:8</material>
  <material>lapis ore</material>
  <material>redstone ore</material>
  <material>leaves:2</material>
  <material>leaves:3</material>
  <material>leaves:4</material>
  <material>leaves</material>
  <material>leaves 2</material>
  <material>leaves:1</material>
</any>
```

By turning this into just one material filter with a composite matcher having a multiple-material-matcher, and an exact material matcher:
```
MaterialFilter{pattern=CompoundMaterialMatcher{children=[

MultipleMaterialMatcher{materials=[COBBLESTONE, GOLD_ORE, LEAVES, LAPIS_ORE, LONG_GRASS, RED_ROSE, BROWN_MUSHROOM, RED_MUSHROOM, GOLD_BLOCK, DOUBLE_STEP, STEP, MOSSY_COBBLESTONE, DIAMOND_BLOCK, COBBLESTONE_STAIRS, STONE_PLATE, REDSTONE_ORE, STONE_BUTTON, STAINED_GLASS, TRAP_DOOR, SMOOTH_BRICK, IRON_FENCE, VINE, SMOOTH_STAIRS, WATER_LILY, COBBLE_WALL, LEAVES_2, DOUBLE_PLANT, WALL_BANNER]}, 

ExactMaterialMatcher{material=STONE, data=6}
]}}
```

What this means is it will be solved in one set-check against materials O(1), and then a follow-up check for the exact stone:6, instead of having to perform up to 50 checks
