### PR TITLE
Team becomes its own filter!

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -46,7 +46,6 @@ import tc.oc.pgm.filters.matcher.party.CompetitorFilter;
 import tc.oc.pgm.filters.matcher.party.GoalFilter;
 import tc.oc.pgm.filters.matcher.party.RankFilter;
 import tc.oc.pgm.filters.matcher.party.ScoreFilter;
-import tc.oc.pgm.filters.matcher.party.TeamFilter;
 import tc.oc.pgm.filters.matcher.player.CanFlyFilter;
 import tc.oc.pgm.filters.matcher.player.CarryingFlagFilter;
 import tc.oc.pgm.filters.matcher.player.CarryingItemFilter;
@@ -80,7 +79,6 @@ import tc.oc.pgm.flag.state.State;
 import tc.oc.pgm.goals.GoalDefinition;
 import tc.oc.pgm.regions.BlockBoundedValidation;
 import tc.oc.pgm.teams.TeamFactory;
-import tc.oc.pgm.teams.Teams;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
 import tc.oc.pgm.util.StringUtils;
@@ -193,8 +191,8 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
   }
 
   /**
-   * Return a list containing any and all of the following: - A filter reference in an attribute of
-   * the given name - Inline filters inside child tags of the given name
+   * @param name the attribute/child name
+   * @return list with all filters defined as either attribute or child named {@param name}
    */
   public List<Filter> parseFiltersProperty(Element el, String name) throws InvalidXMLException {
     List<Filter> filters = new ArrayList<>();
@@ -240,8 +238,8 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
   }
 
   @MethodParser("team")
-  public TeamFilter parseTeam(Element el) throws InvalidXMLException {
-    return new TeamFilter(Teams.getTeamRef(new Node(el), this.factory));
+  public Filter parseTeam(Element el) throws InvalidXMLException {
+    return FilterWrapper.of(el, parseReference(new Node(el)));
   }
 
   @MethodParser("same-team")

--- a/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
@@ -10,9 +10,11 @@ import tc.oc.pgm.api.filter.FilterDefinition;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.filters.matcher.block.MaterialFilter;
+import tc.oc.pgm.filters.matcher.party.TeamFilter;
 import tc.oc.pgm.filters.operator.AnyFilter;
 import tc.oc.pgm.filters.operator.FilterNode;
 import tc.oc.pgm.filters.operator.InverseFilter;
+import tc.oc.pgm.teams.Teams;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -112,6 +114,12 @@ public class LegacyFilterParser extends FilterParser {
     } else {
       return this.parseAll(el);
     }
+  }
+
+  // Legacy has separate context, team wouldn't be found in the filter context.
+  @MethodParser("team")
+  public TeamFilter parseTeam(Element el) throws InvalidXMLException {
+    return new TeamFilter(Teams.getTeamRef(new Node(el), this.factory));
   }
 
   // Legacy not allows for multiple children and is an implicit and

--- a/core/src/main/java/tc/oc/pgm/teams/TeamFactory.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamFactory.java
@@ -1,16 +1,24 @@
 package tc.oc.pgm.teams;
 
+import java.util.Collection;
+import java.util.Collections;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
+import org.bukkit.event.Event;
 import org.bukkit.scoreboard.NameTagVisibility;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureInfo;
+import tc.oc.pgm.api.filter.query.PartyQuery;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+import tc.oc.pgm.filters.matcher.TypedFilter;
 
 /** Immutable class to represent a team in a map that is not tied to any specific match. */
 @FeatureInfo(name = "team")
-public class TeamFactory extends SelfIdentifyingFeatureDefinition {
+public class TeamFactory extends SelfIdentifyingFeatureDefinition
+    implements TypedFilter<PartyQuery> {
   protected final String defaultName;
   protected final boolean defaultNamePlural;
   protected final ChatColor defaultColor;
@@ -135,5 +143,22 @@ public class TeamFactory extends SelfIdentifyingFeatureDefinition {
 
   public NameTagVisibility getNameTagVisibility() {
     return nameTagVisibility;
+  }
+
+  // Filter implementation:
+  @Override
+  public Class<? extends PartyQuery> queryType() {
+    return PartyQuery.class;
+  }
+
+  @Override
+  public boolean matches(PartyQuery query) {
+    final Party party = query.getParty();
+    return party instanceof Team team && team.isInstance(this);
+  }
+
+  @Override
+  public Collection<Class<? extends Event>> getRelevantEvents() {
+    return Collections.singleton(PlayerPartyChangeEvent.class);
   }
 }


### PR DESCRIPTION
Teams (for protos 1.4 and up) are now a filter for themselves. This means that anywhere a filter is expected, you can use the team itself.

```xml
<teams>
  <team id="red-team" ...>Red</team>
  <team id="blue-team" ...>Blue</team>
</teams>
<regions>
  <apply enter="deny(red-team)" region="..."/>
  <apply enter="deny(blue-team)" region="..."/>
</regions>
```

This will likely not work in 1.3.x proto as there you could already have teams and filters with same ids, so they don't share a context.

