### PR TITLE
Publish util module

### DIFF
--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("buildlogic.java-conventions")
+    `maven-publish`
 }
 
 dependencies {
@@ -15,6 +16,26 @@ sourceSets {
                 "src/main/resources",
                 "src/main/i18n/templates",
                 "src/main/i18n/translations")
+        }
+    }
+}
+
+publishing {
+    publications.create<MavenPublication>("pgm") {
+        groupId = project.group as String
+        artifactId = project.name
+        version = project.version as String
+
+        artifact(tasks["jar"])
+    }
+    repositories {
+        maven {
+            name = "ghPackages"
+            url = uri("https://maven.pkg.github.com/PGMDev/PGM")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
         }
     }
 }


### PR DESCRIPTION
When trying to test Community against upstream changes I found out that the only module that is published post-Gradle migration is `core`. This can be seen in our [GitHub Packages](https://github.com/orgs/PGMDev/packages?repo_name=PGM) page, where `util`, `server`, and both platform packages have not been updated since pre-Gradle migration, while `core` has been updated consistently.

~~This does not re-add the `platform-all` and `platform` packages since they do not seem necessary. This also does not add the catch-all `pgm` package, which with Maven was simply a package that depended on every other module, which also does not seem necessary.~~

There really isn't any reason to publish either of the platform modules or the server module. However, `util` should be published, so let's do that.