### PR TITLE
Make assists part of stats

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/player/event/MatchPlayerDeathEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/event/MatchPlayerDeathEvent.java
@@ -122,6 +122,11 @@ public class MatchPlayerDeathEvent extends MatchPlayerEvent {
     return PlayerRelation.get(getVictim().getParticipantState(), getKiller());
   }
 
+  /** Get the relationship between the victim and assister */
+  public final PlayerRelation getAssistRelation() {
+    return PlayerRelation.get(getVictim().getParticipantState(), getAssister());
+  }
+
   /**
    * Get whether the death was caused by a teammate.
    *
@@ -141,6 +146,15 @@ public class MatchPlayerDeathEvent extends MatchPlayerEvent {
   }
 
   /**
+   * Get whether the assist was caused by an enemy.
+   *
+   * @return Whether the assist was from an enemy.
+   */
+  public final boolean isEnemyAssist() {
+    return PlayerRelation.ENEMY == getAssistRelation();
+  }
+
+  /**
    * Get whether the {@link MatchPlayer} killed themselves.
    *
    * @return Whether the death was suicide.
@@ -149,22 +163,31 @@ public class MatchPlayerDeathEvent extends MatchPlayerEvent {
     return PlayerRelation.SELF == getRelation();
   }
 
-  /**
-   * Get whether the victim and killer are the same {@link MatchPlayer}.
-   *
-   * @return
-   */
+  /** Get whether the victim and killer are the same {@link MatchPlayer}. */
   public final boolean isSelfKill() {
     return getKiller() != null && getKiller().isPlayer(getVictim());
   }
 
+  public final boolean isSelfAssist() {
+    return getAssister() != null && getAssister().isPlayer(getVictim());
+  }
+
   /**
-   * Get whether the death was from an enemy and it was no caused by suicide.
+   * Get whether the death was from an enemy and it was not caused by suicide.
    *
    * @return Whether the death was actually "challenging."
    */
   public final boolean isChallengeKill() {
     return isEnemyKill() && !isSelfKill();
+  }
+
+  /**
+   * Get whether the assist was from an enemy and it was not caused by suicide.
+   *
+   * @return Whether the assist was actually "challenging."
+   */
+  public final boolean isChallengeAssist() {
+    return isEnemyAssist() && !isSelfAssist();
   }
 
   private static final HandlerList handlers = new HandlerList();

--- a/core/src/main/java/tc/oc/pgm/command/StatsCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/StatsCommand.java
@@ -30,13 +30,12 @@ public final class StatsCommand {
     if (match.isFinished()
         && PGM.get().getConfiguration().showVerboseStats()
         && match.hasModule(TeamMatchModule.class)) { // Should not try to trigger on FFA
-      stats.giveVerboseStatsItem(player, true);
+      stats.openStatsMenu(player);
     } else if (player.getSettings().getValue(SettingKey.STATS).equals(SettingValue.STATS_ON)) {
-      audience.sendMessage(
-          TextFormatter.horizontalLineHeading(
-              sender,
-              translatable("match.stats.you", NamedTextColor.DARK_GREEN),
-              NamedTextColor.WHITE));
+      audience.sendMessage(TextFormatter.horizontalLineHeading(
+          sender,
+          translatable("match.stats.you", NamedTextColor.DARK_GREEN),
+          NamedTextColor.WHITE));
       audience.sendMessage(stats.getBasicStatsMessage(player.getId()));
     } else {
       throw exception("match.stats.disabled");

--- a/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
@@ -6,8 +6,14 @@ import static tc.oc.pgm.util.text.NumberComponent.number;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.setting.SettingKey;
+import tc.oc.pgm.api.setting.SettingValue;
+import tc.oc.pgm.util.Audience;
 
 /** A wrapper for stat info belonging to a {@link tc.oc.pgm.api.player.MatchPlayer} */
 public class PlayerStats {
@@ -22,6 +28,7 @@ public class PlayerStats {
   // K/D
   private int kills;
   private int deaths;
+  private int assists;
   private int killstreak; // Current killstreak
   private int killstreakMax; // The highest killstreak reached this match
 
@@ -53,7 +60,7 @@ public class PlayerStats {
 
   // The task responsible for displaying the stats over the hotbar
   // See StatsMatchModule#sendLongHotbarMessage
-  private Future<?> hotbarTaskCache;
+  private Future<?> hotbarTask;
 
   public PlayerStats() {
     this(null, null);
@@ -68,17 +75,25 @@ public class PlayerStats {
 
   // Methods to update the stats, should only be accessed by StatsMatchModule
 
-  protected void onMurder() {
+  protected void onMurder(MatchPlayer player) {
     kills++;
     killstreak++;
     if (killstreak > killstreakMax) killstreakMax = killstreak;
-    if (parent != null) parent.onMurder();
+    if (parent != null) parent.onMurder(null);
+    sendPlayerStats(player);
   }
 
-  protected void onDeath() {
+  protected void onDeath(MatchPlayer player) {
     deaths++;
     killstreak = 0;
-    if (parent != null) parent.onDeath();
+    if (parent != null) parent.onDeath(null);
+    sendPlayerStats(player);
+  }
+
+  protected void onAssist(MatchPlayer player) {
+    assists++;
+    if (parent != null) parent.onAssist(null);
+    sendPlayerStats(player);
   }
 
   protected void onDamage(double damage, boolean bow) {
@@ -148,9 +163,7 @@ public class PlayerStats {
   }
 
   protected void setLongestBowKill(double distance) {
-    if (distance > longestBowKill) {
-      longestBowKill = (int) Math.round(distance);
-    }
+    if (distance > longestBowKill) longestBowKill = (int) Math.round(distance);
     if (parent != null) parent.setLongestBowKill(distance);
   }
 
@@ -173,7 +186,8 @@ public class PlayerStats {
         number(kills, NamedTextColor.GREEN),
         number(killstreak, NamedTextColor.GREEN),
         number(deaths, NamedTextColor.RED),
-        number(getKD(), NamedTextColor.GREEN));
+        number(getKD(), NamedTextColor.GREEN),
+        number(assists, NamedTextColor.GREEN));
   }
 
   // Getters, both raw stats and some handy calculations
@@ -194,6 +208,10 @@ public class PlayerStats {
 
   public int getDeaths() {
     return deaths;
+  }
+
+  public int getAssists() {
+    return assists;
   }
 
   public int getKillstreak() {
@@ -264,12 +282,18 @@ public class PlayerStats {
     return longestFlagHold;
   }
 
-  public Future<?> getHotbarTask() {
-    return hotbarTaskCache;
+  private void setHotbarTask(Future<?> task) {
+    if (hotbarTask != null && !hotbarTask.isDone()) hotbarTask.cancel(true);
+    hotbarTask = task;
   }
 
-  public void putHotbarTaskCache(Future<?> task) {
-    hotbarTaskCache = task;
+  public void sendPlayerStats(MatchPlayer player) {
+    if (player == null) return;
+    if (player.getSettings().getValue(SettingKey.STATS) == SettingValue.STATS_OFF) return;
+    setHotbarTask(player
+        .getMatch()
+        .getExecutor(MatchScope.LOADED)
+        .scheduleWithFixedDelay(new HotbarStatsRunner(player), 0, 1, TimeUnit.SECONDS));
   }
 
   public Component getPlayerComponent() {
@@ -297,6 +321,23 @@ public class PlayerStats {
   }
 
   public Duration getActiveSessionDuration() {
-    return (inTime == null) ? Duration.ZERO : Duration.between(inTime, Instant.now());
+    return inTime == null ? Duration.ZERO : Duration.between(inTime, Instant.now());
+  }
+
+  protected class HotbarStatsRunner implements Runnable {
+    private final Audience audience;
+    private final Component message;
+    private int remaining = 4;
+
+    private HotbarStatsRunner(Audience audience) {
+      this.audience = audience;
+      this.message = getBasicStatsMessage();
+    }
+
+    @Override
+    public void run() {
+      audience.sendActionBar(message);
+      if (remaining-- < 0) setHotbarTask(null);
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/PlayerStats.java
@@ -1,7 +1,10 @@
 package tc.oc.pgm.stats;
 
-import static net.kyori.adventure.text.Component.translatable;
-import static tc.oc.pgm.util.text.NumberComponent.number;
+import static tc.oc.pgm.stats.StatType.ASSISTS;
+import static tc.oc.pgm.stats.StatType.DEATHS;
+import static tc.oc.pgm.stats.StatType.KILLS;
+import static tc.oc.pgm.stats.StatType.KILL_DEATH_RATIO;
+import static tc.oc.pgm.stats.StatType.KILL_STREAK;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -16,7 +19,7 @@ import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.util.Audience;
 
 /** A wrapper for stat info belonging to a {@link tc.oc.pgm.api.player.MatchPlayer} */
-public class PlayerStats {
+public class PlayerStats implements StatHolder {
 
   // A reference to the players global stats to be incremented along with team based stats
   private final PlayerStats parent;
@@ -180,17 +183,24 @@ public class PlayerStats {
   // Makes a simple stat message for this player that fits in one line
 
   public Component getBasicStatsMessage() {
-    return translatable(
-        "match.stats",
-        NamedTextColor.GRAY,
-        number(kills, NamedTextColor.GREEN),
-        number(killstreak, NamedTextColor.GREEN),
-        number(deaths, NamedTextColor.RED),
-        number(getKD(), NamedTextColor.GREEN),
-        number(assists, NamedTextColor.GREEN));
+    return pipeSeparated(KILLS, DEATHS, ASSISTS, KILL_STREAK, KILL_DEATH_RATIO)
+        .color(NamedTextColor.GRAY);
   }
 
   // Getters, both raw stats and some handy calculations
+  @Override
+  public Number getStat(StatType type) {
+    return switch (type) {
+      case KILLS -> kills;
+      case DEATHS -> deaths;
+      case ASSISTS -> assists;
+      case KILL_STREAK -> killstreak;
+      case BEST_KILL_STREAK -> killstreakMax;
+      case KILL_DEATH_RATIO -> getKD();
+      case LONGEST_BOW_SHOT -> longestBowKill;
+      case DAMAGE -> damageDone;
+    };
+  }
 
   public double getKD() {
     return kills / Math.max(1d, deaths);

--- a/core/src/main/java/tc/oc/pgm/stats/StatHolder.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatHolder.java
@@ -1,0 +1,29 @@
+package tc.oc.pgm.stats;
+
+import static net.kyori.adventure.text.Component.join;
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.JoinConfiguration.separator;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+
+public interface StatHolder {
+  JoinConfiguration PIPE = separator(text("  |  "));
+  JoinConfiguration SPACES = separator(text("  "));
+
+  Number getStat(StatType type);
+
+  default Component pipeSeparated(StatType... types) {
+    return getComponent(PIPE, types);
+  }
+
+  default Component spaceSeparated(StatType... types) {
+    return getComponent(SPACES, types);
+  }
+
+  default Component getComponent(JoinConfiguration joining, StatType... types) {
+    Component[] children = new Component[types.length];
+    for (int i = 0; i < types.length; i++) children[i] = types[i].component(this);
+    return join(joining, children);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/stats/StatType.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatType.java
@@ -1,0 +1,43 @@
+package tc.oc.pgm.stats;
+
+import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.format.NamedTextColor.*;
+import static tc.oc.pgm.stats.StatsMatchModule.damageComponent;
+import static tc.oc.pgm.util.text.NumberComponent.number;
+
+import java.util.Locale;
+import net.kyori.adventure.text.Component;
+
+public enum StatType {
+  KILLS,
+  DEATHS,
+  ASSISTS,
+  KILL_STREAK,
+  BEST_KILL_STREAK,
+  KILL_DEATH_RATIO,
+  LONGEST_BOW_SHOT {
+    private final String blocks = key + ".blocks";
+
+    @Override
+    public Component makeNumber(Number number) {
+      return translatable(blocks, number(number, YELLOW));
+    }
+  },
+  DAMAGE {
+    @Override
+    public Component makeNumber(Number number) {
+      return damageComponent(number.doubleValue(), GREEN);
+    }
+  };
+
+  public final String key = "match.stats.type." + name().toLowerCase(Locale.ROOT);
+  public static final StatType[] VALUES = values();
+
+  public Component makeNumber(Number number) {
+    return number(number, this == DEATHS ? RED : GREEN);
+  }
+
+  public Component component(StatHolder stats) {
+    return translatable(key, makeNumber(stats.getStat(this)));
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -1,30 +1,31 @@
 package tc.oc.pgm.stats;
 
+import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
-import static net.kyori.adventure.text.event.HoverEvent.showText;
-import static tc.oc.pgm.util.nms.PlayerUtils.PLAYER_UTILS;
 import static tc.oc.pgm.util.player.PlayerComponent.player;
 import static tc.oc.pgm.util.text.NumberComponent.number;
+import static tc.oc.pgm.util.text.TextFormatter.list;
 
+import com.google.common.collect.Collections2;
 import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -70,11 +71,13 @@ import tc.oc.pgm.menu.MenuItem;
 import tc.oc.pgm.stats.menu.StatsMainMenu;
 import tc.oc.pgm.stats.menu.items.PlayerStatsMenuItem;
 import tc.oc.pgm.stats.menu.items.TeamStatsMenuItem;
+import tc.oc.pgm.stats.menu.items.VerboseStatsMenuItem;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.tracker.TrackerMatchModule;
 import tc.oc.pgm.tracker.info.ProjectileInfo;
-import tc.oc.pgm.util.Pair;
 import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.player.PlayerComponent;
+import tc.oc.pgm.util.text.RenderableComponent;
 import tc.oc.pgm.util.text.TextFormatter;
 import tc.oc.pgm.util.usernames.UsernameResolvers;
 import tc.oc.pgm.wool.MonumentWool;
@@ -129,12 +132,12 @@ public class StatsMatchModule implements MatchModule, Listener {
 
     // End time tracking for old party
     if (event.getOldParty() instanceof Competitor) {
-      computeTeamStatsIfAbsent(event.getPlayer().getId(), event.getOldParty()).endParticipation();
+      getPlayerTeamStats(event.getPlayer().getId(), event.getOldParty()).endParticipation();
     }
 
     // When joining a party that's playing, start time tracking
     if (event.getNewParty() instanceof Competitor) {
-      computeTeamStatsIfAbsent(event.getPlayer().getId(), event.getNewParty()).startParticipation();
+      getPlayerTeamStats(event.getPlayer().getId(), event.getNewParty()).startParticipation();
     }
   }
 
@@ -267,7 +270,9 @@ public class StatsMatchModule implements MatchModule, Listener {
     // when the inventory GUI is created. If usernames needs to be resolved using the mojang api
     // (UsernameResolver) it can take some time, and we cant really know how long.
     UsernameResolvers.startBatch();
-    this.getOfflinePlayersWithStats().forEach(id -> PGM.get().getDatastore().getUsername(id));
+    allPlayerStats.keySet().stream()
+        .filter(id -> match.getPlayer(id) == null)
+        .forEach(id -> PGM.get().getDatastore().getUsername(id));
     UsernameResolvers.endBatch();
 
     // Schedule displaying stats after match end
@@ -281,45 +286,25 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   @EventHandler(ignoreCancelled = true)
   public void onStatsDisplay(MatchStatsEvent event) {
-    if (allPlayerStats.isEmpty()) return;
+    if (allPlayerStats.isEmpty() || (!event.isShowOwn() && !event.isShowBest())) return;
 
-    // Gather all player stats from this match
-    Pair<UUID, Integer> bestKills = null;
-    Pair<UUID, Integer> bestStreaks = null;
-    Pair<UUID, Integer> bestDeaths = null;
-    Pair<UUID, Integer> bestAssists = null;
-    Pair<UUID, Integer> bestBowShots = null;
-    Pair<UUID, Double> bestDamage = null;
+    // Gather aggregated player stats from this match
+    List<AggStat<?>> stats = new ArrayList<>();
+    stats.add(new AggStat<>(StatType.KILLS, 0, new HashSet<>()));
+    stats.add(new AggStat<>(StatType.DEATHS, 0, new HashSet<>()));
+    stats.add(new AggStat<>(StatType.ASSISTS, 0, new HashSet<>()));
+    stats.add(new AggStat<>(StatType.BEST_KILL_STREAK, 0, new HashSet<>()));
+    stats.add(new AggStat<>(StatType.LONGEST_BOW_SHOT, 0, new HashSet<>()));
+    if (verboseStats) stats.add(new AggStat<>(StatType.DAMAGE, 0d, new HashSet<>()));
 
-    for (Map.Entry<UUID, PlayerStats> mapEntry : allPlayerStats.entrySet()) {
-      UUID uuid = mapEntry.getKey();
-      PlayerStats s = mapEntry.getValue();
-      bestKills = getBest(bestKills, uuid, s.getKills());
-      bestStreaks = getBest(bestStreaks, uuid, s.getMaxKillstreak());
-      bestDeaths = getBest(bestDeaths, uuid, s.getDeaths());
-      bestAssists = getBest(bestAssists, uuid, s.getAssists());
-      bestBowShots = getBest(bestBowShots, uuid, s.getLongestBowKill());
-      bestDamage = getBest(bestDamage, uuid, s.getDamageDone());
-    }
+    allPlayerStats.forEach((uuid, s) -> stats.replaceAll(stat -> stat.track(uuid, s)));
 
-    List<Component> best = new ArrayList<>();
-    if (event.isShowBest()) {
-      best.add(getMessage("match.stats.kills", bestKills, NamedTextColor.GREEN));
-      best.add(getMessage("match.stats.killstreak", bestStreaks, NamedTextColor.GREEN));
-      best.add(getMessage("match.stats.deaths", bestDeaths, NamedTextColor.RED));
-      best.add(getMessage("match.stats.assists", bestAssists, NamedTextColor.GREEN));
+    var best = stats.stream()
+        .filter(agg -> agg.value().doubleValue() > 0)
+        .map(stat -> getMessage(stat, event.isShowBest(), event.isShowOwn()))
+        .toList();
 
-      if (bestBowShots.getRight() > 0)
-        best.add(getMessage("match.stats.bowshot", bestBowShots, NamedTextColor.YELLOW));
-
-      if (verboseStats) {
-        best.add(translatable(
-            "match.stats.damage",
-            player(bestDamage.getLeft(), NameStyle.VERBOSE),
-            damageComponent(bestDamage.getRight(), NamedTextColor.GREEN)));
-      }
-    }
-
+    var item = new VerboseStatsMenuItem();
     for (MatchPlayer viewer : match.getPlayers()) {
       if (viewer.getSettings().getValue(SettingKey.STATS) == SettingValue.STATS_OFF) continue;
 
@@ -329,25 +314,7 @@ public class StatsMatchModule implements MatchModule, Listener {
           NamedTextColor.WHITE));
 
       best.forEach(viewer::sendMessage);
-
-      PlayerStats stats = getPlayerStat(viewer);
-
-      if (event.isShowOwn() && stats != null) {
-        Component ksHover = translatable(
-            "match.stats.killstreak.concise",
-            number(stats.getMaxKillstreak(), NamedTextColor.GREEN));
-
-        viewer.sendMessage(translatable(
-            "match.stats.own",
-            number(stats.getKills(), NamedTextColor.GREEN),
-            number(stats.getMaxKillstreak(), NamedTextColor.GREEN).hoverEvent(showText(ksHover)),
-            number(stats.getDeaths(), NamedTextColor.RED),
-            number(stats.getKD(), NamedTextColor.GREEN),
-            damageComponent(stats.getDamageDone(), NamedTextColor.GREEN),
-            number(stats.getAssists(), NamedTextColor.GREEN)));
-      }
-
-      giveVerboseStatsItem(viewer, false);
+      viewer.getInventory().setItem(verboseItemSlot, item.createItem(viewer.getBukkit()));
     }
   }
 
@@ -358,47 +325,59 @@ public class StatsMatchModule implements MatchModule, Listener {
     Action action = event.getAction();
     if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) {
       MatchPlayer player = match.getPlayer(event.getPlayer());
-      if (player != null) giveVerboseStatsItem(player, true);
+      if (player != null) openStatsMenu(player);
     }
   }
 
-  public PlayerStatsMenuItem getPlayerStatsItem(MatchPlayer player) {
-    return new PlayerStatsMenuItem(
-        player.getId(),
-        this.getGlobalPlayerStat(player),
-        PLAYER_UTILS.getPlayerSkin(player.getBukkit()));
-  }
-
-  public void giveVerboseStatsItem(MatchPlayer player, boolean forceOpen) {
+  public void openStatsMenu(MatchPlayer player) {
     if (!verboseStats) return;
-    final Collection<Competitor> competitors = match.getSortedCompetitors();
-
     if (teams == null) {
-      teams = Lists.newArrayList();
+      var competitors = match.getSortedCompetitors();
+      teams = new ArrayList<>(competitors.size());
       for (Competitor competitor : competitors) {
-        if (competitor instanceof Team t) {
+        MatchPlayer tribute;
+        if (competitor instanceof Team t)
           teams.add(new TeamStatsMenuItem(match, competitor, stats.row(t)));
-        } else if (competitor instanceof Tribute t) {
-          MatchPlayer tribute = t.getPlayer();
-          if (tribute != null) teams.add(getPlayerStatsItem(tribute));
-        }
+        else if (competitor instanceof Tribute t && (tribute = t.getPlayer()) != null)
+          teams.add(new PlayerStatsMenuItem(tribute, getGlobalPlayerStat(tribute)));
       }
     }
-
-    StatsMainMenu menu = new StatsMainMenu(player, teams, this);
-    player.getInventory().setItem(verboseItemSlot, menu.getItem());
-    if (forceOpen) menu.open();
+    new StatsMainMenu(player, teams, this).open();
   }
 
-  private <T extends Comparable<T>> Pair<UUID, T> getBest(Pair<UUID, T> curr, UUID uuid, T alt) {
-    return curr != null && curr.getRight().compareTo(alt) >= 0 ? curr : Pair.of(uuid, alt);
+  private Component getMessage(AggStat<?> agg, boolean best, boolean own) {
+    Component who = empty();
+    if (best)
+      who = translatable("misc.authorship", agg.type.makeNumber(agg.value), credit(agg.players));
+    if (own)
+      who = who.append((RenderableComponent) v -> {
+        if (!(v instanceof Player p)) return empty();
+        if (agg.players.contains(p.getUniqueId()) || hasNoStats(p.getUniqueId())) return empty();
+        var number = agg.type.makeNumber(getGlobalPlayerStat(p.getUniqueId()).getStat(agg.type));
+        return !best ? number : text("   ").append(translatable("match.stats.you.short", number));
+      });
+    return translatable(agg.type.key, who);
   }
 
-  Component getMessage(String messageKey, Pair<UUID, ? extends Number> mapEntry, TextColor color) {
-    return translatable(
-        messageKey,
-        player(mapEntry.getLeft(), NameStyle.VERBOSE),
-        number(mapEntry.getRight(), color));
+  private Component credit(Set<UUID> players) {
+    if (players.size() >= 10)
+      return translatable("objective.credit.many", NamedTextColor.GRAY, TextDecoration.ITALIC);
+
+    var list = list(Collections2.transform(players, this::getPlayerComponent), null);
+    if (players.size() > 3)
+      return translatable("match.stats.severalPlayers", NamedTextColor.GRAY, TextDecoration.ITALIC)
+          .hoverEvent(list);
+    return list;
+  }
+
+  private Component getPlayerComponent(UUID uuid) {
+    var player = player(uuid, NameStyle.VERBOSE);
+    if (player != PlayerComponent.UNKNOWN_PLAYER && player != PlayerComponent.UNKNOWN)
+      return player;
+    return stats.column(uuid).values().stream()
+        .max(Comparator.comparing(PlayerStats::getTimePlayed))
+        .map(PlayerStats::getPlayerComponent)
+        .orElse(player);
   }
 
   /** Formats raw damage to damage relative to the amount of hearths the player would have broken */
@@ -407,20 +386,12 @@ public class StatsMatchModule implements MatchModule, Listener {
     return number(hearts, color).append(HEART_SYMBOL);
   }
 
-  private Stream<UUID> getOfflinePlayersWithStats() {
-    return allPlayerStats.keySet().stream().filter(id -> match.getPlayer(id) == null);
-  }
-
   @Deprecated
   public final PlayerStats getPlayerStat(UUID uuid) {
     return getGlobalPlayerStat(uuid);
   }
 
-  private void putNewPlayer(UUID player) {
-    allPlayerStats.put(player, new PlayerStats());
-  }
-
-  private PlayerStats computeTeamStatsIfAbsent(UUID id, Party party) {
+  private PlayerStats getPlayerTeamStats(UUID id, Party party) {
     // Only players on a team have team specific stats
     PlayerStats globalStats = getGlobalPlayerStat(id);
     if (!(party instanceof Team team)) return globalStats;
@@ -439,7 +410,7 @@ public class StatsMatchModule implements MatchModule, Listener {
   }
 
   public boolean hasNoStats(UUID player) {
-    return allPlayerStats.get(player) == null;
+    return !allPlayerStats.containsKey(player);
   }
 
   public final PlayerStats getGlobalPlayerStat(MatchPlayer player) {
@@ -448,20 +419,19 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   // Creates a new PlayerStat if the player does not have one yet
   public final PlayerStats getGlobalPlayerStat(UUID uuid) {
-    if (hasNoStats(uuid)) putNewPlayer(uuid);
-    return allPlayerStats.get(uuid);
+    return allPlayerStats.computeIfAbsent(uuid, k -> new PlayerStats());
   }
 
   public final PlayerStats getPlayerStat(ParticipantState player) {
-    return computeTeamStatsIfAbsent(player.getId(), player.getParty());
+    return getPlayerTeamStats(player.getId(), player.getParty());
   }
 
   public final PlayerStats getPlayerStat(MatchPlayer player) {
-    return computeTeamStatsIfAbsent(player.getId(), player.getParty());
+    return getPlayerTeamStats(player.getId(), player.getParty());
   }
 
   private PlayerStats getPlayerStat(MatchPlayerState playerState) {
-    return computeTeamStatsIfAbsent(playerState.getId(), playerState.getParty());
+    return getPlayerTeamStats(playerState.getId(), playerState.getParty());
   }
 
   public Component getBasicStatsMessage(UUID player) {
@@ -491,5 +461,17 @@ public class StatsMatchModule implements MatchModule, Listener {
     }
 
     return primaryTeam.getKey();
+  }
+
+  private record AggStat<T extends Number & Comparable<T>>(
+      StatType type, T value, Set<UUID> players) {
+    public AggStat<T> track(UUID uuid, StatHolder stat) {
+      T newVal = (T) stat.getStat(type);
+      int cmp = value.compareTo(newVal);
+      if (cmp > 0) return this;
+      if (cmp < 0) players.clear();
+      players.add(uuid);
+      return cmp == 0 ? this : new AggStat<>(type, newVal, players);
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
@@ -50,7 +49,6 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.MatchPlayerState;
 import tc.oc.pgm.api.player.ParticipantState;
-import tc.oc.pgm.api.player.PlayerRelation;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
@@ -238,57 +236,27 @@ public class StatsMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPlayerDeath(MatchPlayerDeathEvent event) {
     MatchPlayer victim = event.getVictim();
-    MatchPlayer murderer = null;
+    getPlayerStat(victim).onDeath(victim);
 
-    if (event.getKiller() != null)
-      murderer = event.getKiller().getParty().getPlayer(event.getKiller().getId());
+    if (event.isChallengeKill()) {
+      MatchPlayerState killer = event.getKiller();
+      assert killer != null;
+      PlayerStats murdererStats = getPlayerStat(killer);
+      if (event.getDamageInfo() instanceof ProjectileInfo projectile)
+        murdererStats.setLongestBowKill(victim.getLocation().distance(projectile.getOrigin()));
+      murdererStats.onMurder(killer.getPlayer().orElse(null));
+    }
 
-    PlayerStats victimStats = getPlayerStat(victim);
-
-    victimStats.onDeath();
-
-    sendPlayerStats(victim, victimStats);
-
-    if (murderer != null
-        && PlayerRelation.get(victim.getParticipantState(), murderer) != PlayerRelation.ALLY
-        && PlayerRelation.get(victim.getParticipantState(), murderer) != PlayerRelation.SELF) {
-
-      PlayerStats murdererStats = getPlayerStat(murderer);
-
-      if (event.getDamageInfo() instanceof ProjectileInfo) {
-        murdererStats.setLongestBowKill(victim
-            .getState()
-            .getLocation()
-            .distance(((ProjectileInfo) event.getDamageInfo()).getOrigin()));
-      }
-
-      murdererStats.onMurder();
-
-      sendPlayerStats(murderer, murdererStats);
+    if (event.isChallengeAssist()) {
+      MatchPlayerState assister = event.getAssister();
+      assert assister != null;
+      getPlayerStat(assister).onAssist(assister.getPlayer().orElse(null));
     }
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onParticipationStop(PlayerParticipationStopEvent event) {
     getPlayerStat(event.getPlayer()).onTeamSwitch();
-  }
-
-  private void sendPlayerStats(MatchPlayer player, PlayerStats stats) {
-    if (player.getSettings().getValue(SettingKey.STATS) == SettingValue.STATS_OFF) return;
-    if (stats.getHotbarTask() != null && !stats.getHotbarTask().isDone()) {
-      stats.getHotbarTask().cancel(true);
-    }
-    stats.putHotbarTaskCache(sendLongHotbarMessage(player, stats.getBasicStatsMessage()));
-  }
-
-  private Future<?> sendLongHotbarMessage(MatchPlayer player, Component message) {
-    Future<?> task = match
-        .getExecutor(MatchScope.LOADED)
-        .scheduleWithFixedDelay(() -> player.sendActionBar(message), 0, 1, TimeUnit.SECONDS);
-
-    match.getExecutor(MatchScope.LOADED).schedule(() -> task.cancel(true), 4, TimeUnit.SECONDS);
-
-    return task;
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
@@ -319,6 +287,7 @@ public class StatsMatchModule implements MatchModule, Listener {
     Pair<UUID, Integer> bestKills = null;
     Pair<UUID, Integer> bestStreaks = null;
     Pair<UUID, Integer> bestDeaths = null;
+    Pair<UUID, Integer> bestAssists = null;
     Pair<UUID, Integer> bestBowShots = null;
     Pair<UUID, Double> bestDamage = null;
 
@@ -328,6 +297,7 @@ public class StatsMatchModule implements MatchModule, Listener {
       bestKills = getBest(bestKills, uuid, s.getKills());
       bestStreaks = getBest(bestStreaks, uuid, s.getMaxKillstreak());
       bestDeaths = getBest(bestDeaths, uuid, s.getDeaths());
+      bestAssists = getBest(bestAssists, uuid, s.getAssists());
       bestBowShots = getBest(bestBowShots, uuid, s.getLongestBowKill());
       bestDamage = getBest(bestDamage, uuid, s.getDamageDone());
     }
@@ -337,6 +307,7 @@ public class StatsMatchModule implements MatchModule, Listener {
       best.add(getMessage("match.stats.kills", bestKills, NamedTextColor.GREEN));
       best.add(getMessage("match.stats.killstreak", bestStreaks, NamedTextColor.GREEN));
       best.add(getMessage("match.stats.deaths", bestDeaths, NamedTextColor.RED));
+      best.add(getMessage("match.stats.assists", bestAssists, NamedTextColor.GREEN));
 
       if (bestBowShots.getRight() > 0)
         best.add(getMessage("match.stats.bowshot", bestBowShots, NamedTextColor.YELLOW));
@@ -363,7 +334,8 @@ public class StatsMatchModule implements MatchModule, Listener {
 
       if (event.isShowOwn() && stats != null) {
         Component ksHover = translatable(
-            "match.stats.killstreak.concise", number(stats.getKillstreak(), NamedTextColor.GREEN));
+            "match.stats.killstreak.concise",
+            number(stats.getMaxKillstreak(), NamedTextColor.GREEN));
 
         viewer.sendMessage(translatable(
             "match.stats.own",
@@ -371,7 +343,8 @@ public class StatsMatchModule implements MatchModule, Listener {
             number(stats.getMaxKillstreak(), NamedTextColor.GREEN).hoverEvent(showText(ksHover)),
             number(stats.getDeaths(), NamedTextColor.RED),
             number(stats.getKD(), NamedTextColor.GREEN),
-            damageComponent(stats.getDamageDone(), NamedTextColor.GREEN)));
+            damageComponent(stats.getDamageDone(), NamedTextColor.GREEN),
+            number(stats.getAssists(), NamedTextColor.GREEN)));
       }
 
       giveVerboseStatsItem(viewer, false);

--- a/core/src/main/java/tc/oc/pgm/stats/TeamStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/TeamStats.java
@@ -7,6 +7,7 @@ public class TeamStats {
 
   private int teamKills = 0;
   private int teamDeaths = 0;
+  private int teamAssists = 0;
   private double damageDone = 0;
   private double damageTaken = 0;
   private double bowDamage = 0;
@@ -22,6 +23,7 @@ public class TeamStats {
     for (PlayerStats stats : playerStats) {
       teamKills += stats.getKills();
       teamDeaths += stats.getDeaths();
+      teamAssists += stats.getAssists();
       damageDone += stats.getDamageDone();
       damageTaken += stats.getDamageTaken();
       bowDamage += stats.getBowDamage();
@@ -40,6 +42,10 @@ public class TeamStats {
 
   public int getTeamDeaths() {
     return teamDeaths;
+  }
+
+  public int getTeamAssists() {
+    return teamAssists;
   }
 
   public double getDamageDone() {

--- a/core/src/main/java/tc/oc/pgm/stats/TeamStats.java
+++ b/core/src/main/java/tc/oc/pgm/stats/TeamStats.java
@@ -3,11 +3,10 @@ package tc.oc.pgm.stats;
 import java.util.Collection;
 
 // Holds calculated total stats for a single team
-public class TeamStats {
+public class TeamStats implements StatHolder {
 
   private int teamKills = 0;
   private int teamDeaths = 0;
-  private int teamAssists = 0;
   private double damageDone = 0;
   private double damageTaken = 0;
   private double bowDamage = 0;
@@ -23,7 +22,6 @@ public class TeamStats {
     for (PlayerStats stats : playerStats) {
       teamKills += stats.getKills();
       teamDeaths += stats.getDeaths();
-      teamAssists += stats.getAssists();
       damageDone += stats.getDamageDone();
       damageTaken += stats.getDamageTaken();
       bowDamage += stats.getBowDamage();
@@ -36,16 +34,23 @@ public class TeamStats {
     teamBowAcc = shotsTaken == 0 ? Double.NaN : shotsHit / (shotsTaken / (double) 100);
   }
 
+  @Override
+  public Number getStat(StatType type) {
+    return switch (type) {
+      case KILLS -> teamKills;
+      case DEATHS -> teamDeaths;
+      case KILL_DEATH_RATIO -> teamKD;
+      case DAMAGE -> damageDone;
+      default -> Double.NaN;
+    };
+  }
+
   public int getTeamKills() {
     return teamKills;
   }
 
   public int getTeamDeaths() {
     return teamDeaths;
-  }
-
-  public int getTeamAssists() {
-    return teamAssists;
   }
 
   public double getDamageDone() {

--- a/core/src/main/java/tc/oc/pgm/stats/menu/StatsMainMenu.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/StatsMainMenu.java
@@ -13,6 +13,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.menu.MenuItem;
 import tc.oc.pgm.menu.PagedInventoryMenu;
 import tc.oc.pgm.stats.StatsMatchModule;
+import tc.oc.pgm.stats.menu.items.PlayerStatsMenuItem;
 import tc.oc.pgm.stats.menu.items.TeamStatsMenuItem;
 import tc.oc.pgm.stats.menu.items.VerboseStatsMenuItem;
 
@@ -59,7 +60,11 @@ public class StatsMainMenu extends PagedInventoryMenu {
 
   @Override
   public void init(Player player, InventoryContents contents) {
-    contents.set(0, 4, stats.getPlayerStatsItem(getViewer()).getClickableItem(getBukkit()));
+    contents.set(
+        0,
+        4,
+        new PlayerStatsMenuItem(getViewer(), stats.getGlobalPlayerStat(player.getUniqueId()))
+            .getClickableItem(getBukkit()));
 
     // Use pagination when too many teams are present
     if (teams.size() > MAX_FANCY_SLOTS) {

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
@@ -1,19 +1,24 @@
 package tc.oc.pgm.stats.menu.items;
 
+import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.JoinConfiguration.separator;
 import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
+import static tc.oc.pgm.stats.StatType.*;
 import static tc.oc.pgm.stats.StatsMatchModule.damageComponent;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 import static tc.oc.pgm.util.nms.PlayerUtils.PLAYER_UTILS;
 import static tc.oc.pgm.util.player.PlayerComponent.player;
 import static tc.oc.pgm.util.text.NumberComponent.number;
 
+import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
@@ -22,6 +27,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.menu.MenuItem;
 import tc.oc.pgm.stats.PlayerStats;
 import tc.oc.pgm.util.material.Materials;
@@ -32,10 +38,15 @@ import tc.oc.pgm.util.text.TextTranslations;
 
 /** Represents a player's stats via player head & lore * */
 public class PlayerStatsMenuItem implements MenuItem {
+  private static final JoinConfiguration TWO_SPACES = separator(text("  "));
 
   private final UUID uuid;
   private final PlayerStats stats;
   private final Skin skin;
+
+  public PlayerStatsMenuItem(MatchPlayer player, PlayerStats stats) {
+    this(player.getId(), stats, PLAYER_UTILS.getPlayerSkin(player.getBukkit()));
+  }
 
   public PlayerStatsMenuItem(UUID uuid, PlayerStats stats, Skin skin) {
     this.uuid = uuid;
@@ -52,66 +63,42 @@ public class PlayerStatsMenuItem implements MenuItem {
 
   @Override
   public List<String> getLore(Player player) {
-    List<String> lore = new ArrayList<>();
+    List<Component> lore = new ArrayList<>();
 
-    Component statLore = translatable(
-        "match.stats.concise",
-        GRAY,
-        number(stats.getKills(), NamedTextColor.GREEN),
-        number(stats.getDeaths(), NamedTextColor.RED),
-        number(stats.getKD(), NamedTextColor.GREEN),
-        number(stats.getAssists(), NamedTextColor.GREEN));
-    Component killstreakLore = translatable(
-        "match.stats.killstreak.concise",
-        GRAY,
-        number(stats.getMaxKillstreak(), NamedTextColor.GREEN));
-    Component damageDealtLore = translatable(
+    lore.add(stats.spaceSeparated(KILLS, DEATHS, KILL_DEATH_RATIO));
+    lore.add(stats.spaceSeparated(ASSISTS, KILL_STREAK));
+    lore.add(translatable(
         "match.stats.damage.dealt",
-        GRAY,
         damageComponent(stats.getDamageDone(), NamedTextColor.GREEN),
-        damageComponent(stats.getBowDamage(), NamedTextColor.YELLOW));
-    Component damageReceivedLore = translatable(
+        damageComponent(stats.getBowDamage(), NamedTextColor.YELLOW)));
+    lore.add(translatable(
         "match.stats.damage.received",
-        GRAY,
         damageComponent(stats.getDamageTaken(), NamedTextColor.RED),
-        damageComponent(stats.getBowDamageTaken(), NamedTextColor.GOLD));
-    Component bowLore = translatable(
+        damageComponent(stats.getBowDamageTaken(), NamedTextColor.GOLD)));
+    lore.add(translatable(
         "match.stats.bow",
-        GRAY,
         number(stats.getShotsHit(), NamedTextColor.YELLOW),
         number(stats.getShotsTaken(), NamedTextColor.YELLOW),
-        number(stats.getArrowAccuracy(), NamedTextColor.YELLOW).append(text('%')));
+        number(stats.getArrowAccuracy(), NamedTextColor.YELLOW).append(text('%'))));
 
-    lore.add(TextTranslations.translateLegacy(statLore, player));
-    lore.add(TextTranslations.translateLegacy(killstreakLore, player));
-    lore.add(TextTranslations.translateLegacy(damageDealtLore, player));
-    lore.add(TextTranslations.translateLegacy(damageReceivedLore, player));
-    lore.add(TextTranslations.translateLegacy(bowLore, player));
-
-    if (!optionalStat(
-        lore, stats.getFlagsCaptured(), "match.stats.flagsCaptured.concise", player)) {
+    if (!optionalStat(lore, stats.getFlagsCaptured(), "match.stats.flagsCaptured.concise")) {
       if (!stats.getLongestFlagHold().equals(Duration.ZERO)) {
-        lore.add(null);
-        lore.add(TextTranslations.translateLegacy(
-            translatable(
-                "match.stats.flaghold.concise",
-                GRAY,
-                TemporalComponent.briefNaturalApproximate(stats.getLongestFlagHold())
-                    .color(NamedTextColor.AQUA)
-                    .decoration(TextDecoration.BOLD, true)),
-            player));
+        lore.add(empty());
+        lore.add(translatable(
+            "match.stats.flaghold.concise",
+            TemporalComponent.duration(stats.getLongestFlagHold(), NamedTextColor.AQUA)
+                .decoration(TextDecoration.BOLD, true)));
       }
     }
-    optionalStat(lore, stats.getDestroyablePiecesBroken(), "match.stats.broken.concise", player);
+    optionalStat(lore, stats.getDestroyablePiecesBroken(), "match.stats.broken.concise");
 
-    return lore;
+    return Lists.transform(lore, c -> TextTranslations.translateLegacy(c.color(GRAY), player));
   }
 
-  private boolean optionalStat(List<String> lore, Number stat, String key, Player player) {
+  private boolean optionalStat(List<Component> lore, Number stat, String key) {
     if (stat.doubleValue() > 0) {
-      lore.add(null);
-      Component loreComponent = translatable(key, GRAY, number(stat, NamedTextColor.AQUA));
-      lore.add(TextTranslations.translateLegacy(loreComponent, player));
+      lore.add(empty());
+      lore.add(translatable(key, number(stat, NamedTextColor.AQUA)));
       return true;
     }
     return false;

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/PlayerStatsMenuItem.java
@@ -59,7 +59,8 @@ public class PlayerStatsMenuItem implements MenuItem {
         GRAY,
         number(stats.getKills(), NamedTextColor.GREEN),
         number(stats.getDeaths(), NamedTextColor.RED),
-        number(stats.getKD(), NamedTextColor.GREEN));
+        number(stats.getKD(), NamedTextColor.GREEN),
+        number(stats.getAssists(), NamedTextColor.GREEN));
     Component killstreakLore = translatable(
         "match.stats.killstreak.concise",
         GRAY,

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/TeamStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/TeamStatsMenuItem.java
@@ -2,9 +2,12 @@ package tc.oc.pgm.stats.menu.items;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
+import static tc.oc.pgm.stats.StatType.DEATHS;
+import static tc.oc.pgm.stats.StatType.KILLS;
+import static tc.oc.pgm.stats.StatType.KILL_DEATH_RATIO;
 import static tc.oc.pgm.stats.StatsMatchModule.damageComponent;
 import static tc.oc.pgm.util.nms.PlayerUtils.PLAYER_UTILS;
-import static tc.oc.pgm.util.player.PlayerComponent.player;
 import static tc.oc.pgm.util.text.NumberComponent.number;
 
 import com.google.common.collect.Lists;
@@ -63,39 +66,24 @@ public class TeamStatsMenuItem implements MenuItem {
 
   @Override
   public List<String> getLore(Player player) {
-    List<String> lore = Lists.newArrayList();
+    List<Component> lore = Lists.newArrayList();
 
-    Component statLore = translatable(
-        "match.stats.concise",
-        NamedTextColor.GRAY,
-        number(stats.getTeamKills(), NamedTextColor.GREEN),
-        number(stats.getTeamDeaths(), NamedTextColor.RED),
-        number(stats.getTeamKD(), NamedTextColor.GREEN),
-        number(stats.getTeamAssists(), NamedTextColor.GREEN));
-
-    Component damageDealtLore = translatable(
+    lore.add(stats.spaceSeparated(KILLS, DEATHS, KILL_DEATH_RATIO));
+    lore.add(translatable(
         "match.stats.damage.dealt",
-        NamedTextColor.GRAY,
         damageComponent(stats.getDamageDone(), NamedTextColor.GREEN),
-        damageComponent(stats.getBowDamage(), NamedTextColor.YELLOW));
-    Component damageReceivedLore = translatable(
+        damageComponent(stats.getBowDamage(), NamedTextColor.YELLOW)));
+    lore.add(translatable(
         "match.stats.damage.received",
-        NamedTextColor.GRAY,
         damageComponent(stats.getDamageTaken(), NamedTextColor.RED),
-        damageComponent(stats.getBowDamageTaken(), NamedTextColor.GOLD));
-    Component bowLore = translatable(
+        damageComponent(stats.getBowDamageTaken(), NamedTextColor.GOLD)));
+    lore.add(translatable(
         "match.stats.bow",
-        NamedTextColor.GRAY,
         number(stats.getShotsHit(), NamedTextColor.YELLOW),
         number(stats.getShotsTaken(), NamedTextColor.YELLOW),
-        number(stats.getTeamBowAcc(), NamedTextColor.YELLOW).append(text('%')));
+        number(stats.getTeamBowAcc(), NamedTextColor.YELLOW).append(text('%'))));
 
-    lore.add(TextTranslations.translateLegacy(statLore, player));
-    lore.add(TextTranslations.translateLegacy(damageDealtLore, player));
-    lore.add(TextTranslations.translateLegacy(damageReceivedLore, player));
-    lore.add(TextTranslations.translateLegacy(bowLore, player));
-
-    return lore;
+    return Lists.transform(lore, c -> TextTranslations.translateLegacy(c.color(GRAY), player));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/stats/menu/items/TeamStatsMenuItem.java
+++ b/core/src/main/java/tc/oc/pgm/stats/menu/items/TeamStatsMenuItem.java
@@ -70,7 +70,8 @@ public class TeamStatsMenuItem implements MenuItem {
         NamedTextColor.GRAY,
         number(stats.getTeamKills(), NamedTextColor.GREEN),
         number(stats.getTeamDeaths(), NamedTextColor.RED),
-        number(stats.getTeamKD(), NamedTextColor.GREEN));
+        number(stats.getTeamKD(), NamedTextColor.GREEN),
+        number(stats.getTeamAssists(), NamedTextColor.GREEN));
 
     Component damageDealtLore = translatable(
         "match.stats.damage.dealt",

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -51,19 +51,22 @@ match.class.notFound = No class matched query.
 # {1} = number of consecutive kills
 # {2} = number of deaths
 # {3} = numbers of kills divided by the number of deaths (kill-death ratio)
-match.stats = Kills: {0}  |  Killstreak: {1}  |  Deaths: {2}  |  K/D: {3}
+# {4} = numbers of assists
+match.stats = Kills: {0}  |  Killstreak: {1}  |  Deaths: {2}  |  Assists: {4}  |  K/D: {3}
 
 # {0} = number of kills
 # {1} = number of deaths
 # {2} = numbers of kills divided by the number of deaths (kill-death ratio)
-match.stats.concise = Kills: {0}  Deaths: {1}  K/D: {2}
+# {3} = numbers of assists
+match.stats.concise = Kills: {0}  Deaths: {1}  Assists: {3}  K/D: {2}
 
 # {0} = number of kills
 # {1} = number of consecutive kills
 # {2} = number of deaths
 # {3} = numbers of kills divided by the number of deaths (kill-death ratio)
 # {4} = an amount of damage
-match.stats.own = Your stats: {0} Kills ({1}), {2} Deaths, {3} K/D, {4} Damage
+# {5} = number of assists
+match.stats.own = Your stats: {0} Kills ({1}), {2} Deaths, {5} Assists, {3} K/D, {4} Damage
 
 # {0} = a player name
 # {1} = an amount of kills(number)
@@ -79,6 +82,10 @@ match.stats.killstreak.concise = Best Killstreak: {0}
 # {0} = a player name
 # {1} = an amount of deaths(number)
 match.stats.deaths = Deaths: {1} by {0}
+
+# {0} = a player name
+# {1} = an amount of assists(number)
+match.stats.assists = Assists: {1} by {0}
 
 # {0} = a player name
 # {1} = an amount of blocks

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -47,53 +47,22 @@ match.class.notEnabled = Classes are not enabled on this map.
 
 match.class.notFound = No class matched query.
 
-# {0} = number of kills
-# {1} = number of consecutive kills
-# {2} = number of deaths
-# {3} = numbers of kills divided by the number of deaths (kill-death ratio)
-# {4} = numbers of assists
-match.stats = Kills: {0}  |  Killstreak: {1}  |  Deaths: {2}  |  Assists: {4}  |  K/D: {3}
+# These are tied to tc.oc.pgm.stats.StatType enum:
+match.stats.type.kills = Kills: {0}
+match.stats.type.deaths = Deaths: {0}
+match.stats.type.assists = Assists: {0}
+match.stats.type.kill_streak = Killstreak: {0}
+match.stats.type.best_kill_streak = Killstreak: {0}
+match.stats.type.kill_death_ratio = K/D: {0}
+match.stats.type.longest_bow_shot = Longest Shot: {0}
+match.stats.type.longest_bow_shot.blocks = {0} blocks
+match.stats.type.damage = Damage: {0}
 
-# {0} = number of kills
-# {1} = number of deaths
-# {2} = numbers of kills divided by the number of deaths (kill-death ratio)
-# {3} = numbers of assists
-match.stats.concise = Kills: {0}  Deaths: {1}  Assists: {3}  K/D: {2}
+# Used for anywhere from 4 to 10 players
+match.stats.severalPlayers = Several Players
 
-# {0} = number of kills
-# {1} = number of consecutive kills
-# {2} = number of deaths
-# {3} = numbers of kills divided by the number of deaths (kill-death ratio)
-# {4} = an amount of damage
-# {5} = number of assists
-match.stats.own = Your stats: {0} Kills ({1}), {2} Deaths, {5} Assists, {3} K/D, {4} Damage
-
-# {0} = a player name
-# {1} = an amount of kills(number)
-match.stats.kills = Kills: {1} by {0}
-
-# {0} = a player name
-# {1} = a killstreak(number)
-match.stats.killstreak = Killstreak: {1} by {0}
-
-# {0} = a killstreak(number)
-match.stats.killstreak.concise = Best Killstreak: {0}
-
-# {0} = a player name
-# {1} = an amount of deaths(number)
-match.stats.deaths = Deaths: {1} by {0}
-
-# {0} = a player name
-# {1} = an amount of assists(number)
-match.stats.assists = Assists: {1} by {0}
-
-# {0} = a player name
-# {1} = an amount of blocks
-match.stats.bowshot = Longest Shot: {1} blocks by {0}
-
-# {0} = a player name
-# {1} = an amount of damage
-match.stats.damage = Damage: {1} by {0}
+# {0} = a number, how much of a certain stat you got
+match.stats.you.short = (You: {0})
 
 # {0} = an amount of damage
 # {1} = an amount of damage


### PR DESCRIPTION
Supercedes #1467 , makes it so assists are fully integrated into pgm, showing on match end stats, tablist, etc

Adding assists made certain things not work out as well as they used to (eg: "Your stats: " line) so they were modified and enhanded, here's how it looks:

![image](https://github.com/user-attachments/assets/54440dc0-6404-49b6-b6a6-b63597a1cfbd)

![image](https://github.com/user-attachments/assets/a092af6d-c919-498a-bb4f-b7857fec5828)

- Multiple players can be shown for a stat now
- If over 3 players have a stat, it instead goes to "several Players" with a hover
- If over 10 players have a stat, it will just show "many, many players" and no hover (no point in showing the 20 ppl who all got 1 death in blitz)
- Instead of showing "Your stats", they show as "(You: x)"
- "You" is omitted if you're in the list of top players for that stat
- If a stat max is 0 , it is no longer displayed at match end
