### PR TITLE
Implement persisted map scores & cooldowns

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Datastore.java
+++ b/core/src/main/java/tc/oc/pgm/api/Datastore.java
@@ -1,9 +1,13 @@
 package tc.oc.pgm.api;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 import tc.oc.pgm.api.map.MapActivity;
+import tc.oc.pgm.api.map.MapData;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.Settings;
+import tc.oc.pgm.rotation.pools.VotingPool;
 import tc.oc.pgm.util.skin.Skin;
 
 /** A fast, persistent datastore that provides synchronous responses. */
@@ -48,6 +52,28 @@ public interface Datastore {
    * @return A {@link MapActivity}.
    */
   MapActivity getMapActivity(String poolName);
+
+  /**
+   * Get the data related to a map
+   *
+   * @param mapId the map id or slug
+   * @param score default score if no map data exists
+   * @return A {@link MapData}
+   */
+  MapData getMapData(String mapId, double score);
+
+  /**
+   * Get the data related to several maps in bulk
+   *
+   * @param mapIds The map ids wanted
+   * @param score default score if no map data exists
+   * @return A map containing at least all maps in {@param mapIds}, potentially more
+   */
+  Map<String, ? extends MapData> getMapData(Collection<String> mapIds, double score);
+
+  void tickMapScores(VotingPool.VoteConstants constants);
+
+  void refreshMapData();
 
   /** Cleans up any resources or connections. */
   void close();

--- a/core/src/main/java/tc/oc/pgm/api/map/MapData.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapData.java
@@ -1,0 +1,20 @@
+package tc.oc.pgm.api.map;
+
+import java.time.Duration;
+import java.time.Instant;
+import tc.oc.pgm.api.match.Match;
+
+public interface MapData {
+
+  String getId();
+
+  Instant lastPlayed();
+
+  Duration lastDuration();
+
+  double score();
+
+  void setScore(double score, boolean update);
+
+  void saveMatch(Match match, double score);
+}

--- a/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
+++ b/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
@@ -3,11 +3,15 @@ package tc.oc.pgm.db;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.map.MapActivity;
+import tc.oc.pgm.api.map.MapData;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.Settings;
+import tc.oc.pgm.rotation.pools.VotingPool;
 import tc.oc.pgm.util.skin.Skin;
 
 @SuppressWarnings({"UnstableApiUsage"})
@@ -21,43 +25,32 @@ public class CacheDatastore implements Datastore {
 
   public CacheDatastore(Datastore datastore) {
     this.datastore = datastore;
-    this.usernames =
-        CacheBuilder.newBuilder()
-            .softValues()
-            .build(
-                new CacheLoader<UUID, Username>() {
-                  @Override
-                  public Username load(UUID id) {
-                    return datastore.getUsername(id);
-                  }
-                });
-    this.settings =
-        CacheBuilder.newBuilder()
-            .build(
-                new CacheLoader<UUID, Settings>() {
-                  @Override
-                  public Settings load(UUID id) {
-                    return datastore.getSettings(id);
-                  }
-                });
-    this.skins =
-        CacheBuilder.newBuilder()
-            .build(
-                new CacheLoader<UUID, Skin>() {
-                  @Override
-                  public Skin load(UUID id) {
-                    return datastore.getSkin(id);
-                  }
-                });
-    this.activities =
-        CacheBuilder.newBuilder()
-            .build(
-                new CacheLoader<String, MapActivity>() {
-                  @Override
-                  public MapActivity load(String name) {
-                    return datastore.getMapActivity(name);
-                  }
-                });
+    this.usernames = CacheBuilder.newBuilder()
+        .softValues()
+        .build(new CacheLoader<UUID, Username>() {
+          @Override
+          public Username load(UUID id) {
+            return datastore.getUsername(id);
+          }
+        });
+    this.settings = CacheBuilder.newBuilder().build(new CacheLoader<UUID, Settings>() {
+      @Override
+      public Settings load(UUID id) {
+        return datastore.getSettings(id);
+      }
+    });
+    this.skins = CacheBuilder.newBuilder().build(new CacheLoader<UUID, Skin>() {
+      @Override
+      public Skin load(UUID id) {
+        return datastore.getSkin(id);
+      }
+    });
+    this.activities = CacheBuilder.newBuilder().build(new CacheLoader<String, MapActivity>() {
+      @Override
+      public MapActivity load(String name) {
+        return datastore.getMapActivity(name);
+      }
+    });
   }
 
   @Override
@@ -83,6 +76,26 @@ public class CacheDatastore implements Datastore {
   @Override
   public MapActivity getMapActivity(String poolName) {
     return activities.getUnchecked(poolName);
+  }
+
+  @Override
+  public MapData getMapData(String mapId, double score) {
+    return datastore.getMapData(mapId, score);
+  }
+
+  @Override
+  public Map<String, ? extends MapData> getMapData(Collection<String> mapIds, double score) {
+    return datastore.getMapData(mapIds, score);
+  }
+
+  @Override
+  public void tickMapScores(VotingPool.VoteConstants constants) {
+    datastore.tickMapScores(constants);
+  }
+
+  @Override
+  public void refreshMapData() {
+    datastore.refreshMapData();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/db/MapDataImpl.java
+++ b/core/src/main/java/tc/oc/pgm/db/MapDataImpl.java
@@ -1,0 +1,63 @@
+package tc.oc.pgm.db;
+
+import java.time.Duration;
+import java.time.Instant;
+import tc.oc.pgm.api.map.MapData;
+
+abstract class MapDataImpl implements MapData {
+  protected final String id;
+  protected Instant lastPlayed = Instant.EPOCH;
+  protected Duration lastDuration = Duration.ZERO;
+  protected double score;
+
+  public MapDataImpl(String id, double defaultScore) {
+    this.id = id;
+    this.score = defaultScore;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public Instant lastPlayed() {
+    return lastPlayed;
+  }
+
+  @Override
+  public Duration lastDuration() {
+    return lastDuration;
+  }
+
+  @Override
+  public double score() {
+    return score;
+  }
+
+  @Override
+  public void setScore(double score, boolean update) {
+    this.score = score;
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof MapData mapData)) return false;
+    return getId().equals(mapData.getId());
+  }
+
+  @Override
+  public String toString() {
+    return "MapDataImpl{" + "id='"
+        + id + '\'' + ", lastPlayed="
+        + lastPlayed + ", lastDuration="
+        + lastDuration + ", score="
+        + score + '}';
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
@@ -120,7 +120,8 @@ public class MapVotePicker {
    */
   public double getWeight(@Nullable List<MapInfo> selected, @NotNull MapInfo map, VoteData data) {
     if ((selected != null && selected.contains(map))
-        || data.getScore() <= constants.scoreMinToVote()) return 0;
+        || data.getScore() <= constants.scoreMinToVote()
+        || data.isOnCooldown(constants)) return 0;
 
     var context = new MapVoteContext(
         data.getScore(),

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/VoteData.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/VoteData.java
@@ -1,23 +1,39 @@
 package tc.oc.pgm.rotation.vote;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.map.MapData;
+import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.rotation.pools.VotingPool;
 
 public class VoteData {
-  private final double weight;
-  private double score;
+  private static final long SECONDS_PER_DAY = Duration.of(1, ChronoUnit.DAYS).toSeconds();
 
-  public VoteData(double weight, double score) {
-    this.score = score;
+  protected final double weight;
+  protected final MapData mapData;
+
+  public VoteData(double weight, MapData mapData) {
     this.weight = weight;
+    this.mapData = mapData;
+  }
+
+  public static VoteData of(double weight, double score, MapData data, boolean persist) {
+    return persist ? new VoteData(weight, data) : new Local(weight, score, data);
+  }
+
+  public static VoteData of(double weight, double score, MapInfo map, boolean persist) {
+    return of(weight, score, PGM.get().getDatastore().getMapData(map.getId(), score), persist);
   }
 
   public void setScore(double score) {
-    this.score = score;
+    mapData.setScore(score, true);
   }
 
-  public VoteData withScore(double score) {
-    setScore(score);
-    return this;
+  public void onMatchEnd(Match match, VotingPool.VoteConstants constants) {
+    mapData.saveMatch(match, constants.scoreAfterPlay().apply(match));
   }
 
   public double getWeight() {
@@ -25,12 +41,53 @@ public class VoteData {
   }
 
   public double getScore() {
-    return score;
+    return mapData.score();
+  }
+
+  public boolean isOnCooldown(VotingPool.VoteConstants constants) {
+    long duration = mapData.lastDuration().toMinutes();
+    if (constants.minCooldown() == -1 || constants.minCooldown() > duration) return false;
+    long cooldownSeconds = duration * SECONDS_PER_DAY / constants.minutesPerDay();
+
+    return Instant.now().isAfter(mapData.lastPlayed().plusSeconds(cooldownSeconds));
   }
 
   public void tickScore(VotingPool.VoteConstants constants) {
-    this.score = score > constants.defaultScore()
-        ? Math.max(score - constants.scoreDecay(), constants.defaultScore())
-        : Math.min(score + constants.scoreRise(), constants.defaultScore());
+    mapData.setScore(constants.tickScore(getScore()), false);
+  }
+
+  static class Local extends VoteData {
+    private double score;
+
+    public Local(double weight, double score, MapData mapData) {
+      super(weight, mapData);
+      this.score = score;
+    }
+
+    @Override
+    public double getScore() {
+      return score;
+    }
+
+    @Override
+    public void setScore(double score) {
+      this.score = score;
+    }
+
+    @Override
+    public void tickScore(VotingPool.VoteConstants constants) {
+      this.score = constants.tickScore(score);
+    }
+
+    @Override
+    public void onMatchEnd(Match match, VotingPool.VoteConstants c) {
+      this.score = c.scoreAfterPlay().apply(match);
+
+      // When score isn't persisted, we can be storing a ton of maps all with 0 score.
+      // If this data starts being used later, we'll run into no maps available!
+      // For this reason, store (non-negative) scores as a low value instead
+      mapData.saveMatch(
+          match, score < 0 ? score : Math.max(score, c.scoreMinToVote()) + c.scoreRise());
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/VotePoolOptions.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/VotePoolOptions.java
@@ -71,6 +71,7 @@ public class VotePoolOptions {
 
   public Map<MapInfo, VoteData> getCustomVoteMapsWeighted() {
     return customVoteMaps.keySet().stream()
-        .collect(Collectors.toMap(map -> map, score -> new VoteData(1, VotingPool.DEFAULT_SCORE)));
+        .collect(Collectors.toMap(
+            map -> map, map -> VoteData.of(1, VotingPool.DEFAULT_SCORE, map, false)));
   }
 }

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -34,6 +34,8 @@ pools:
     vote-options: 5
     # Voted pool only: modify how score behaves
     score:
+      # If score should be persisted across server restarts
+      persist: true
       # How much score should maps start with by default.
       default: 0.2
       # How much score decreases/increases after each match. Null to be proportional to amount of maps.
@@ -47,6 +49,14 @@ pools:
       # After the map plays, reset the score to:
       # Supports a formula with play_minutes
       after-playing: 0
+
+    # Voted pool only: make maps be excluded from votes if they recently played for long
+    cooldown:
+      # How long in minutes until a match is considered long. -1 to disable the mechanic
+      min-length: 30
+      # How many minutes of the same map per day is acceptable.
+      # Eg: if set to 30, a match lasting 45min will put the map in cooldown for 1d 12h
+      minutes-per-day: 30
 
     # Voted pools support modifiers which come in the form of a formula (does not affect any other type of pool).
     #

--- a/util/src/main/java/tc/oc/pgm/util/math/Formula.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/Formula.java
@@ -53,6 +53,10 @@ public interface Formula<T> extends ToDoubleFunction<T> {
     return new ExpFormula<>(exp, context);
   }
 
+  default <R> Formula<R> map(java.util.function.Function<R, T> mapper) {
+    return v -> apply(mapper.apply(v));
+  }
+
   /** Shorthand for {@link #applyAsDouble} */
   default double apply(T value) {
     return applyAsDouble(value);


### PR DESCRIPTION
Adds the ability for PGM to persist map data. This means now pools can opt into not losing their scores on server restart, and additionally an option to make maps go on cooldown when playing for too long has been added.