### PR TITLE
Resolve references before trying to validate them

### DIFF
--- a/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
+++ b/core/src/main/java/tc/oc/pgm/features/FeatureDefinitionContext.java
@@ -217,7 +217,10 @@ public class FeatureDefinitionContext extends ContextStore<FeatureDefinition> {
 
     public void validate() throws InvalidXMLException {
       if (definition != null) validation.validate(definition, node);
-      if (reference != null) validation.validate(reference.get(), node);
+      if (reference != null) {
+        if (!reference.isResolved()) reference.resolve();
+        validation.validate(reference.get(), node);
+      }
     }
   }
 }


### PR DESCRIPTION
At the moment a non-found reference causes an illegal state exception instead of an invalid xml exception, attempting to resolve fixes this