### PR TITLE
Fix persistent cooldown issues

### DIFF
--- a/core/src/main/java/tc/oc/pgm/db/SQLDatastore.java
+++ b/core/src/main/java/tc/oc/pgm/db/SQLDatastore.java
@@ -310,9 +310,9 @@ public class SQLDatastore extends ThreadSafeConnection implements Datastore {
           while (result.next()) {
             String id = result.getString(1);
             var map = maps.computeIfAbsent(id, k -> new SQLMapData(id, -1));
-            map.lastPlayed = Instant.ofEpochMilli(result.getLong(1));
-            map.lastDuration = Duration.ofMillis(result.getLong(2));
-            map.score = result.getDouble(3);
+            map.lastPlayed = Instant.ofEpochMilli(result.getLong(2));
+            map.lastDuration = Duration.ofMillis(result.getLong(3));
+            map.score = result.getDouble(4);
           }
         }
       }


### PR DESCRIPTION
Fixes a couple issues with cooldowns:
 - They were being read incorrectly from the database, leading to cooldowns of 4000+ years
 - The cooldown was reversed, so it would've *stopped* being on cooldown N time after, instead of N time before

Additionally improved the /pool command to show the map cooldowns, and added option to query for map names, and exposed a function to get the cooldown as a time period instead of a boolean