### PR TITLE
Minor fixes to voted pools

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapData.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapData.java
@@ -2,7 +2,6 @@ package tc.oc.pgm.api.map;
 
 import java.time.Duration;
 import java.time.Instant;
-import tc.oc.pgm.api.match.Match;
 
 public interface MapData {
 
@@ -16,5 +15,5 @@ public interface MapData {
 
   void setScore(double score, boolean update);
 
-  void saveMatch(Match match, double score);
+  void saveMatch(Duration duration, double score);
 }

--- a/core/src/main/java/tc/oc/pgm/db/SQLDatastore.java
+++ b/core/src/main/java/tc/oc/pgm/db/SQLDatastore.java
@@ -22,7 +22,6 @@ import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapActivity;
 import tc.oc.pgm.api.map.MapData;
-import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.Username;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
@@ -332,10 +331,9 @@ public class SQLDatastore extends ThreadSafeConnection implements Datastore {
     }
 
     @Override
-    public void saveMatch(Match match, double score) {
-      this.score = score;
+    public void saveMatch(Duration duration, double score) {
       this.lastPlayed = Instant.now();
-      this.lastDuration = match.getDuration();
+      this.lastDuration = duration;
       this.score = score;
       submitQuery(new UpdateQuery());
     }

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
@@ -114,8 +114,7 @@ public class VotingPool extends MapPool {
 
   @Override
   public MapInfo popNextMap() {
-    if (currentPoll == null) return getRandom();
-
+    if (currentPoll == null) return mapPicker.getMap(List.of(), mapScores);
     MapInfo map = currentPoll.finishVote();
     updateScores(currentPoll.getVotes());
     manager.getVoteOptions().clearMaps();

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
@@ -98,7 +98,7 @@ public class MapVotePicker {
     return selected;
   }
 
-  protected MapInfo getMap(List<MapInfo> selected, Map<MapInfo, VoteData> mapScores) {
+  public MapInfo getMap(List<MapInfo> selected, Map<MapInfo, VoteData> mapScores) {
     NavigableMap<Double, MapInfo> cumulativeScores = new TreeMap<>();
     double maxWeight = 0;
     for (Map.Entry<MapInfo, VoteData> map : mapScores.entrySet()) {


### PR DESCRIPTION
Fixes a couple minor things with voted pools:
- Cycling with no vote used to pick a totally random map, now it will pick using the votebook random selection algorithm
- If somehow a match played while a map was on cooldown, it would reset the duration and take it off of cooldown. Now instead it will, for those cases, keep the longest of the two durations.