### PR TITLE
Fix payload init breaking

### DIFF
--- a/core/src/main/java/tc/oc/pgm/payload/Payload.java
+++ b/core/src/main/java/tc/oc/pgm/payload/Payload.java
@@ -17,6 +17,7 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.controlpoint.ControlPoint;
 import tc.oc.pgm.payload.track.Track;
+import tc.oc.pgm.regions.EmptyRegion;
 
 public class Payload extends ControlPoint {
 
@@ -64,7 +65,7 @@ public class Payload extends ControlPoint {
 
   @Override
   public Region getCaptureRegion() {
-    return captureRegion;
+    return captureRegion == null ? EmptyRegion.INSTANCE : captureRegion;
   }
 
   public Vector getCenterPoint() {


### PR DESCRIPTION
Payload initialization was having null as a region at the time at which control point was creating the tracker, causing an issue on load, this fixes it by initializing to empty then later replacing it with a real region