### PR TITLE
Refresh map data when reloading

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/AdminCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/AdminCommand.java
@@ -15,6 +15,7 @@ public final class AdminCommand {
   @Permission(Permissions.RELOAD)
   public void pgm() {
     PGM.get().reloadConfig();
+    PGM.get().getDatastore().refreshMapData();
   }
 
   @Command("loadnewmaps|findnewmaps|newmaps")


### PR DESCRIPTION
Doing `/pgm reload` will now not only reload the config, but also map data, which in a sense is almost like a config too, storing what maps shouldn't play right away etc