### PR TITLE
Fix shop issues with category filtering

### DIFF
--- a/core/src/main/java/tc/oc/pgm/menu/InventoryMenu.java
+++ b/core/src/main/java/tc/oc/pgm/menu/InventoryMenu.java
@@ -57,6 +57,10 @@ public abstract class InventoryMenu implements InventoryProvider {
     inventory.open(getBukkit());
   }
 
+  public void close() {
+    inventory.close(getBukkit());
+  }
+
   public Player getBukkit() {
     return viewer.getBukkit();
   }

--- a/core/src/main/java/tc/oc/pgm/shops/Shop.java
+++ b/core/src/main/java/tc/oc/pgm/shops/Shop.java
@@ -4,7 +4,6 @@ import static net.kyori.adventure.text.Component.translatable;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.stream.Collectors;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.shops.menu.Category;
@@ -33,7 +32,7 @@ public class Shop extends SelfIdentifyingFeatureDefinition {
   public List<Category> getVisibleCategories(MatchPlayer player) {
     return categories.stream()
         .filter(c -> c.getFilter().query(player).isAllowed())
-        .collect(Collectors.toList());
+        .toList();
   }
 
   public void purchase(Icon icon, MatchPlayer buyer) {


### PR DESCRIPTION
Fixes bugs regarding filtering categories in the shop:
- Categories with filters would cause index out of bounds exceptions
- When the categories change due to filters, they get updated instead of keeping the same list until re-opening
- Paginated Categories now properly highlight when going back and forth between pages