### PR TITLE
Prevent players from getting doors as observers

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -43,7 +43,7 @@ public enum SettingKey implements Aliased {
       PICKER_MANUAL), // Changes when the picker is displayed
   JOIN(
       Arrays.asList("join", "jms"),
-      Materials.WOOD_DOOR_ITEM,
+      Materials.WOOD_DOOR,
       JOIN_ON,
       JOIN_FRIENDS,
       JOIN_OFF), // Changes if join messages are seen

--- a/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/core/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -43,7 +43,7 @@ public enum SettingKey implements Aliased {
       PICKER_MANUAL), // Changes when the picker is displayed
   JOIN(
       Arrays.asList("join", "jms"),
-      Materials.WOOD_DOOR,
+      Materials.WOOD_DOOR_ITEM,
       JOIN_ON,
       JOIN_FRIENDS,
       JOIN_OFF), // Changes if join messages are seen

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
@@ -28,8 +28,18 @@ public class Observing extends State {
 
   // A set of item types which, when used to interact with the match environment by non-playing
   // users, can potentially cause client-server de-sync
-  private static final Set<Material> BAD_TYPES =
-      EnumSet.of(Materials.LILY_PAD, Material.BUCKET, Material.LAVA_BUCKET, Material.WATER_BUCKET);
+  private static final Set<Material> BAD_TYPES = EnumSet.of(
+      Materials.LILY_PAD,
+      Material.BUCKET,
+      Material.LAVA_BUCKET,
+      Material.WATER_BUCKET,
+      Materials.WOOD_DOOR_ITEM,
+      Materials.IRON_DOOR_ITEM,
+      Materials.ACACIA_DOOR_ITEM,
+      Materials.JUNGLE_DOOR_ITEM,
+      Materials.DARK_OAK_DOOR_ITEM,
+      Materials.SPRUCE_DOOR_ITEM,
+      Materials.BIRCH_DOOR_ITEM);
 
   private static final double VOID_HEIGHT = -64;
 

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Observing.java
@@ -1,10 +1,7 @@
 package tc.oc.pgm.spawns.states;
 
-import java.util.EnumSet;
-import java.util.Set;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -12,7 +9,6 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.material.Door;
 import tc.oc.pgm.api.match.event.MatchStartEvent;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -25,21 +21,6 @@ import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.material.Materials;
 
 public class Observing extends State {
-
-  // A set of item types which, when used to interact with the match environment by non-playing
-  // users, can potentially cause client-server de-sync
-  private static final Set<Material> BAD_TYPES = EnumSet.of(
-      Materials.LILY_PAD,
-      Material.BUCKET,
-      Material.LAVA_BUCKET,
-      Material.WATER_BUCKET,
-      Materials.WOOD_DOOR_ITEM,
-      Materials.IRON_DOOR_ITEM,
-      Materials.ACACIA_DOOR_ITEM,
-      Materials.JUNGLE_DOOR_ITEM,
-      Materials.DARK_OAK_DOOR_ITEM,
-      Materials.SPRUCE_DOOR_ITEM,
-      Materials.BIRCH_DOOR_ITEM);
 
   private static final double VOID_HEIGHT = -64;
 
@@ -141,7 +122,7 @@ public class Observing extends State {
         || event.getCursor() == null) return;
 
     ItemStack item = event.getCursor();
-    if (BAD_TYPES.contains(item.getType()) || item.getData() instanceof Door) {
+    if (Materials.FORBIDDEN_OBSERVER_TYPES.matches(item)) {
       event.setCancelled(true);
     }
   }

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -53,7 +53,7 @@ public interface Materials {
       .build();
 
   MaterialMatcher DOOR_ITEMS = MaterialMatcher.builder()
-      .addAll(m -> m.name().contains("DOOR") && !m.name().contains("TRAPDOOR") && !m.isBlock())
+      .addAll(m -> m.name().contains("_DOOR") && !m.isBlock())
       .build();
 
   // A set of item types which, when used to interact with the match environment by non-playing

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -28,7 +28,13 @@ public interface Materials {
   Material SIGN = parse("SIGN", "OAK_SIGN");
   Material SKULL = parse("SKULL_ITEM", "SKELETON_SKULL");
   Material PLAYER_HEAD = parse("SKULL_ITEM", "PLAYER_HEAD");
-  Material WOOD_DOOR = parse("WOOD_DOOR", "OAK_DOOR");
+  Material WOOD_DOOR_ITEM = parse("WOOD_DOOR", "OAK_DOOR");
+  Material ACACIA_DOOR_ITEM = parse("ACACIA_DOOR_ITEM", "ACACIA_DOOR");
+  Material JUNGLE_DOOR_ITEM = parse("JUNGLE_DOOR_ITEM", "JUNGLE_DOOR");
+  Material DARK_OAK_DOOR_ITEM = parse("DARK_OAK_DOOR_ITEM", "DARK_OAK_DOOR");
+  Material SPRUCE_DOOR_ITEM = parse("SPRUCE_DOOR_ITEM", "SPRUCE_DOOR");
+  Material BIRCH_DOOR_ITEM = parse("BIRCH_DOOR_ITEM", "BIRCH_DOOR");
+  Material IRON_DOOR_ITEM = parse("IRON_DOOR");
   Material BOOK_AND_QUILL = parse("BOOK_AND_QUILL", "WRITABLE_BOOK");
   Material EYE_OF_ENDER = parse("EYE_OF_ENDER", "ENDER_EYE");
   Material FIREWORK = parse("FIREWORK", "FIREWORK_ROCKET");

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -28,13 +28,7 @@ public interface Materials {
   Material SIGN = parse("SIGN", "OAK_SIGN");
   Material SKULL = parse("SKULL_ITEM", "SKELETON_SKULL");
   Material PLAYER_HEAD = parse("SKULL_ITEM", "PLAYER_HEAD");
-  Material WOOD_DOOR_ITEM = parse("WOOD_DOOR", "OAK_DOOR");
-  Material ACACIA_DOOR_ITEM = parse("ACACIA_DOOR_ITEM", "ACACIA_DOOR");
-  Material JUNGLE_DOOR_ITEM = parse("JUNGLE_DOOR_ITEM", "JUNGLE_DOOR");
-  Material DARK_OAK_DOOR_ITEM = parse("DARK_OAK_DOOR_ITEM", "DARK_OAK_DOOR");
-  Material SPRUCE_DOOR_ITEM = parse("SPRUCE_DOOR_ITEM", "SPRUCE_DOOR");
-  Material BIRCH_DOOR_ITEM = parse("BIRCH_DOOR_ITEM", "BIRCH_DOOR");
-  Material IRON_DOOR_ITEM = parse("IRON_DOOR");
+  Material WOOD_DOOR = parse("WOOD_DOOR", "OAK_DOOR");
   Material BOOK_AND_QUILL = parse("BOOK_AND_QUILL", "WRITABLE_BOOK");
   Material EYE_OF_ENDER = parse("EYE_OF_ENDER", "ENDER_EYE");
   Material FIREWORK = parse("FIREWORK", "FIREWORK_ROCKET");
@@ -56,6 +50,17 @@ public interface Materials {
       .addAll(BOW, FLINT_AND_STEEL, SHEARS, STICK)
       .addNullable(Material.getMaterial("TRIDENT"))
       .addNullable(Material.getMaterial("MACE"))
+      .build();
+
+  MaterialMatcher DOOR_ITEMS = MaterialMatcher.builder()
+      .addAll(m -> m.name().contains("DOOR") && !m.name().contains("TRAPDOOR") && !m.isBlock())
+      .build();
+
+  // A set of item types which, when used to interact with the match environment by non-playing
+  // users, can potentially cause client-server de-sync
+  MaterialMatcher FORBIDDEN_OBSERVER_TYPES = MaterialMatcher.builder()
+      .addAll(m -> DOOR_ITEMS.matches(m))
+      .addAll(Materials.LILY_PAD, Material.BUCKET, Material.LAVA_BUCKET, Material.WATER_BUCKET)
       .build();
 
   MaterialMatcher SOLID_EXCLUSIONS = MaterialMatcher.builder()

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -59,7 +59,7 @@ public interface Materials {
   // A set of item types which, when used to interact with the match environment by non-playing
   // users, can potentially cause client-server de-sync
   MaterialMatcher FORBIDDEN_OBSERVER_TYPES = MaterialMatcher.builder()
-      .addAll(m -> DOOR_ITEMS.matches(m))
+      .add(DOOR_ITEMS)
       .addAll(Materials.LILY_PAD, Material.BUCKET, Material.LAVA_BUCKET, Material.WATER_BUCKET)
       .build();
 


### PR DESCRIPTION
Players can place doors in observer mode, and the top half remains client-side due to a desync bug which lets them more easily block glitch around.

PGM has the following code, I believe, to prevent players from acquiring blocks that let them create desyncs to block glitch:
```java
    if (BAD_TYPES.contains(item.getType()) || item.getData() instanceof Door) {
      event.setCancelled(true);
    }
```

Unfortunately, at least in 1.8, `instanceof Door` only works on the block materials, not the item materials. I've left it as perhaps it works for higher versions.

I have expanded `BAD_TYPES` to include all the doors available in 1.8.

For now I've not included modern version doors (e.g. copper), since I'm not sure if this desync bug exists in modern versions, I'm not sure if the existing check gets the doors in modern versions, and I'm not set up to test modern versions.

The existing `IRON_DOOR` in `Materials` is an iron door _block_ in 1.8. This is used & needed for some iron door map conversion fix — I tried changing it to the item and it filled maps with barrier blocks upon loading. Thus I have made a new `IRON_DOOR_ITEM` in `Materials` and have named the other doors to match, renaming the old `WOOD_DOOR`.

Some inconsistencies in the door naming in sportpaper:\
`Material.WOOD_DOOR` is the item and `Material.WOODEN_DOOR` is the block.\
`Material.IRON_DOOR` is the item and `Material.IRON_DOOR_BLOCK` is the block.\
`Material.SPRUCE_DOOR_ITEM` is the item and `Material.SPRUCE_DOOR` is the block.\
The rest match the spruce door's pattern.

I have **not** tested this in modern versions yet. I'm going to have it tested soon — please don't merge it before then.