### PR TITLE
Expose kill and death scores

### DIFF
--- a/core/src/main/java/tc/oc/pgm/score/ScoreDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreDefinition.java
@@ -10,7 +10,7 @@ import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.util.named.NameStyle;
 
-public record ScoreConfig(
+public record ScoreDefinition(
     int scoreLimit,
     int deathScore,
     int killScore,

--- a/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
@@ -47,13 +47,13 @@ import tc.oc.pgm.util.text.TextFormatter;
 public class ScoreMatchModule implements MatchModule, Listener {
 
   private final Match match;
-  private final ScoreConfig config;
+  private final ScoreDefinition config;
   private final Set<ScoreBox> scoreBoxes;
   private final Map<UUID, Double> contributions = new DefaultMapAdapter<>(new HashMap<>(), 0d);
   private final Map<Competitor, Double> scores = new DefaultMapAdapter<>(new HashMap<>(), 0d);
   private MercyRule mercyRule;
 
-  public ScoreMatchModule(Match match, ScoreConfig config, Set<ScoreBox> scoreBoxes) {
+  public ScoreMatchModule(Match match, ScoreDefinition config, Set<ScoreBox> scoreBoxes) {
     this.match = match;
     this.config = config;
     this.scoreBoxes = scoreBoxes;
@@ -70,7 +70,7 @@ public class ScoreMatchModule implements MatchModule, Listener {
     match.addVictoryCondition(new ScoreVictoryCondition());
   }
 
-  public ScoreConfig.Display getDisplay() {
+  public ScoreDefinition.Display getDisplay() {
     return config.display();
   }
 
@@ -96,12 +96,8 @@ public class ScoreMatchModule implements MatchModule, Listener {
     return this.config.scoreLimit();
   }
 
-  public int getKillScore() {
-    return this.config.killScore();
-  }
-
-  public int getDeathScore() {
-    return this.config.deathScore();
+  public ScoreDefinition getDefinition() {
+    return this.config;
   }
 
   public Map<Competitor, Double> getScores() {

--- a/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
@@ -96,6 +96,14 @@ public class ScoreMatchModule implements MatchModule, Listener {
     return this.config.scoreLimit();
   }
 
+  public int getKillScore() {
+    return this.config.killScore();
+  }
+
+  public int getDeathScore() {
+    return this.config.deathScore();
+  }
+
   public Map<Competitor, Double> getScores() {
     return this.scores;
   }

--- a/core/src/main/java/tc/oc/pgm/score/ScoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreModule.java
@@ -37,11 +37,11 @@ public class ScoreModule implements MapModule<ScoreMatchModule> {
   private static final MapTag SCORE_TAG = new MapTag("deathmatch", Gamemode.DEATHMATCH, false);
   private static final MapTag BOX_TAG = new MapTag("scorebox", "Scorebox");
 
-  private final @NotNull ScoreConfig config;
+  private final @NotNull ScoreDefinition config;
   private final @NotNull Set<ScoreBoxDefinition> scoreBoxDefinitions;
 
   public ScoreModule(
-      @NotNull ScoreConfig config, @NotNull Set<ScoreBoxDefinition> scoreBoxDefinitions) {
+      @NotNull ScoreDefinition config, @NotNull Set<ScoreBoxDefinition> scoreBoxDefinitions) {
     assertNotNull(config, "score config");
     assertNotNull(scoreBoxDefinitions, "score box factories");
 
@@ -50,7 +50,7 @@ public class ScoreModule implements MapModule<ScoreMatchModule> {
   }
 
   @NotNull
-  public ScoreConfig getConfig() {
+  public ScoreDefinition getConfig() {
     return config;
   }
 
@@ -100,7 +100,7 @@ public class ScoreModule implements MapModule<ScoreMatchModule> {
       int killScore = 0;
       int mercyLimit = -1;
       int mercyLimitMin = -1;
-      var display = ScoreConfig.Display.NUMERICAL;
+      var display = ScoreDefinition.Display.NUMERICAL;
       Filter sbFilter = StaticFilter.ALLOW;
       ImmutableSet.Builder<ScoreBoxDefinition> scoreBoxes = ImmutableSet.builder();
 
@@ -120,7 +120,7 @@ public class ScoreModule implements MapModule<ScoreMatchModule> {
           mercyLimitMin = parser.parseInt(mercyEl, "min").attr().optional(-1);
         }
 
-        display = parser.parseEnum(ScoreConfig.Display.class, el, "display").optional(display);
+        display = parser.parseEnum(ScoreDefinition.Display.class, el, "display").optional(display);
 
         sbFilter = parser.filter(el, "scoreboard-filter").dynamic(Party.class).orAllow();
 
@@ -144,7 +144,7 @@ public class ScoreModule implements MapModule<ScoreMatchModule> {
         }
       }
 
-      var config = new ScoreConfig(
+      var config = new ScoreDefinition(
           scoreLimit, deathScore, killScore, mercyLimit, mercyLimitMin, display, sbFilter);
       return new ScoreModule(config, scoreBoxes.build());
     }

--- a/core/src/main/java/tc/oc/pgm/scoreboard/RenderContext.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/RenderContext.java
@@ -15,7 +15,7 @@ import tc.oc.pgm.blitz.BlitzMatchModule;
 import tc.oc.pgm.goals.Goal;
 import tc.oc.pgm.goals.GoalMatchModule;
 import tc.oc.pgm.goals.ShowOption;
-import tc.oc.pgm.score.ScoreConfig;
+import tc.oc.pgm.score.ScoreDefinition;
 import tc.oc.pgm.score.ScoreMatchModule;
 import tc.oc.pgm.wool.WoolMatchModule;
 
@@ -24,7 +24,7 @@ class RenderContext {
   public final @NotNull Party viewer;
   public final ScoreMatchModule smm;
   public final boolean hasScores;
-  public final ScoreConfig.Display display;
+  public final ScoreDefinition.Display display;
   public final boolean isBlitz;
   public final boolean isCompactWool;
   public final Map<Competitor, List<Goal<?>>> competitorGoals;
@@ -40,7 +40,7 @@ class RenderContext {
     this.viewer = viewer;
     this.smm = match.getModule(ScoreMatchModule.class);
     this.hasScores = smm != null;
-    this.display = smm != null ? smm.getDisplay() : ScoreConfig.Display.NUMERICAL;
+    this.display = smm != null ? smm.getDisplay() : ScoreDefinition.Display.NUMERICAL;
     this.isBlitz = match.getModule(BlitzMatchModule.class) != null;
     this.isCompactWool = isCompactWool();
 


### PR DESCRIPTION
This makes the kill and death scores of a `ScoreMatchModule` publicly visible.

### Motivation

We use this to check if a map cares about kills or not.

Specifically, if someone enters a scorebox on a map where there is a kill score, we scale their droplet reward with the number of points the scorebox is worth, since the 10 point scorebox on BlockBlock is more significant than a 3 point scorebox on Facility. On maps with no kill score, the point value of the scorebox likely is not related to how important or difficult it is to score, so we use a fixed value instead.

Since we're using the kill score when looking at a scorebox, we can't easily get the kill score off a `MatchPlayerScoreEvent`.

The death score is also made public since it seems weird to only provide the one.

