### PR TITLE
Log death messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/death/DeathMessageMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/death/DeathMessageMatchModule.java
@@ -19,6 +19,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.util.Audience;
 
 @ListenerScope(MatchScope.RUNNING)
 public class DeathMessageMatchModule implements MatchModule, Listener {
@@ -40,6 +41,8 @@ public class DeathMessageMatchModule implements MatchModule, Listener {
 
     DeathMessageBuilder builder = new DeathMessageBuilder(event, logger);
     Component message = builder.getMessage().color(NamedTextColor.GRAY);
+
+    Audience.console().sendMessage(message);
 
     for (MatchPlayer viewer : event.getMatch().getPlayers()) {
       boolean involved = event.isInvolved(viewer) || event.isInvolved(viewer.getSpectatorTarget());


### PR DESCRIPTION
I find death messages very helpful when they are logged. It helps see what's going on on a server at a glance from a terminal, and it also helps find short clips in the logs since you can search by death messages.

I've just entirely enabled it in this PR since other match messages are logged by default. I'm happy to put it behind a config flag (defaulting whichever way is preferred) if some people wouldn't want this enabled.