### PR TITLE
Add /region, fix bounds & improve union perf

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
@@ -3,26 +3,36 @@ package tc.oc.pgm.command;
 import static net.kyori.adventure.text.Component.join;
 import static net.kyori.adventure.text.Component.text;
 import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
+import static tc.oc.pgm.util.text.TextException.exception;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
+import org.bukkit.util.Vector;
 import org.incendo.cloud.annotations.Argument;
 import org.incendo.cloud.annotations.Command;
 import org.incendo.cloud.annotations.CommandDescription;
 import org.incendo.cloud.annotations.Default;
 import org.incendo.cloud.annotations.Flag;
 import org.incendo.cloud.annotations.Permission;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
+import tc.oc.pgm.util.block.BlockFaces;
+import tc.oc.pgm.util.block.BlockVectors;
+import tc.oc.pgm.util.bukkit.Effects;
+import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.text.TextFormatter;
 import tc.oc.pgm.variables.Variable;
 import tc.oc.pgm.variables.VariablesMatchModule;
@@ -109,5 +119,43 @@ public class MapDevCommand {
         .append(text(filter.query(target) + "", NamedTextColor.AQUA))
         .append(text(" to ", NamedTextColor.YELLOW))
         .append(target.getName()));
+  }
+
+  @Command("region <region>")
+  @CommandDescription("Visualize a region")
+  @Permission(Permissions.DEBUG)
+  public void visualizeRegion(MatchPlayer viewer, @Argument("region") Region region) {
+    var pl = viewer.getBukkit();
+    var world = pl.getWorld();
+    var reg = region.getStatic(world);
+    if (!reg.getBounds().isBlockFinite()) {
+      throw exception("Region is not finite");
+    }
+
+    var block = MaterialData.block(Material.GLASS);
+
+    PGM.get().getAsyncExecutor().execute(() -> reg.getBlockVectors().forEach(bv -> {
+      var b = BlockVectors.blockAt(world, bv);
+      for (var dir : BlockFaces.NEIGHBORS) {
+        if (!reg.contains(b.getRelative(dir))) {
+          block.sendBlockChange(pl, b.getLocation());
+          break;
+        }
+      }
+    }));
+
+    PGM.get()
+        .getAsyncExecutor()
+        .schedule(
+            () -> reg.getBlockVectors().forEach(bv -> {
+              var b = BlockVectors.blockAt(world, bv);
+              MaterialData.block(b).sendBlockChange(pl, b.getLocation());
+            }),
+            15,
+            TimeUnit.SECONDS);
+
+    var bounds = region.getStatic(pl.getWorld()).getBounds();
+    Vector min = bounds.getMin(), max = bounds.getMax();
+    Effects.EFFECTS.renderRegion(pl, min, max, PGM.get().getExecutor());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
@@ -3,18 +3,23 @@ package tc.oc.pgm.command;
 import static net.kyori.adventure.text.Component.join;
 import static net.kyori.adventure.text.Component.text;
 import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
+import static tc.oc.pgm.util.bukkit.Effects.EFFECTS;
 import static tc.oc.pgm.util.text.TextException.exception;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Color;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.incendo.cloud.annotations.Argument;
 import org.incendo.cloud.annotations.Command;
@@ -31,7 +36,7 @@ import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.PrettyPaginatedComponentResults;
 import tc.oc.pgm.util.block.BlockFaces;
 import tc.oc.pgm.util.block.BlockVectors;
-import tc.oc.pgm.util.bukkit.Effects;
+import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.text.TextFormatter;
 import tc.oc.pgm.variables.Variable;
@@ -131,31 +136,103 @@ public class MapDevCommand {
     if (!reg.getBounds().isBlockFinite()) {
       throw exception("Region is not finite");
     }
+    new DisplayRunner(pl, reg);
+  }
 
-    var block = MaterialData.block(Material.GLASS);
+  private static class DisplayRunner implements Runnable {
+    private static final BlockMaterialData GLASS = MaterialData.block(Material.GLASS);
+    private static final float SPREAD_MUL = 0.2f;
+    private static final float COUNT_MUL = 0.1f;
 
-    PGM.get().getAsyncExecutor().execute(() -> reg.getBlockVectors().forEach(bv -> {
-      var b = BlockVectors.blockAt(world, bv);
-      for (var dir : BlockFaces.NEIGHBORS) {
-        if (!reg.contains(b.getRelative(dir))) {
-          block.sendBlockChange(pl, b.getLocation());
-          break;
+    private final Player player;
+    private final Region.Static region;
+    private final Location loc;
+
+    private final float[][] directions;
+    private final double[][] edges, vertices;
+
+    private final Future<?> task;
+    private int ticks = 150;
+
+    private DisplayRunner(Player player, Region.Static region) {
+      this.player = player;
+      this.region = region;
+      this.loc = new Location(player.getWorld(), 0, 0, 0);
+
+      var bounds = region.getBounds();
+      Vector min = bounds.getMin(), max = bounds.getMax();
+      boolean hasBottom = min.getY() >= -64, hasTop = max.getY() <= 320;
+      if (!hasBottom) min.setY(-32);
+      if (!hasTop) max.setY(288);
+
+      var center = min.clone().add(max).multiply(0.5);
+      var size = max.clone().subtract(min);
+
+      this.directions = new float[][] {
+        {(float) size.getX() * SPREAD_MUL, 0, 0, (float) Math.max(10, size.getX() * COUNT_MUL)},
+        {0, (float) size.getY() * SPREAD_MUL, 0, (float) Math.max(10, size.getY() * COUNT_MUL)},
+        {0, 0, (float) size.getZ() * SPREAD_MUL, (float) Math.max(10, size.getZ() * COUNT_MUL)}
+      };
+      if (!hasBottom) min.setY(Double.NaN);
+      if (!hasTop) max.setY(Double.NaN);
+
+      this.edges = new double[][] {
+        {center.getX(), min.getY(), min.getZ()},
+        {center.getX(), min.getY(), max.getZ()},
+        {center.getX(), max.getY(), min.getZ()},
+        {center.getX(), max.getY(), max.getZ()},
+        {min.getX(), center.getY(), min.getZ()},
+        {min.getX(), center.getY(), max.getZ()},
+        {max.getX(), center.getY(), min.getZ()},
+        {max.getX(), center.getY(), max.getZ()},
+        {min.getX(), min.getY(), center.getZ()},
+        {min.getX(), max.getY(), center.getZ()},
+        {max.getX(), min.getY(), center.getZ()},
+        {max.getX(), max.getY(), center.getZ()},
+      };
+      this.vertices = new double[][] {
+        {min.getX(), min.getY(), min.getZ()},
+        {min.getX(), min.getY(), max.getZ()},
+        {min.getX(), max.getY(), min.getZ()},
+        {min.getX(), max.getY(), max.getZ()},
+        {max.getX(), min.getY(), min.getZ()},
+        {max.getX(), min.getY(), max.getZ()},
+        {max.getX(), max.getY(), min.getZ()},
+        {max.getX(), max.getY(), max.getZ()},
+      };
+
+      region.getBlockVectors().forEach(bv -> {
+        var b = BlockVectors.blockAt(loc.getWorld(), bv);
+        for (var dir : BlockFaces.NEIGHBORS) {
+          if (!region.contains(b.getRelative(dir))) {
+            GLASS.sendBlockChange(player, b.getLocation());
+            break;
+          }
         }
+      });
+
+      task = PGM.get().getExecutor().scheduleWithFixedDelay(this, 0, 100, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void run() {
+      if (ticks-- < 0) {
+        task.cancel(true);
+        region.getBlocks(player.getWorld()).forEach(b -> MaterialData.block(b)
+            .sendBlockChange(player, b.getLocation()));
+        return;
       }
-    }));
-
-    PGM.get()
-        .getAsyncExecutor()
-        .schedule(
-            () -> reg.getBlockVectors().forEach(bv -> {
-              var b = BlockVectors.blockAt(world, bv);
-              MaterialData.block(b).sendBlockChange(pl, b.getLocation());
-            }),
-            15,
-            TimeUnit.SECONDS);
-
-    var bounds = region.getStatic(pl.getWorld()).getBounds();
-    Vector min = bounds.getMin(), max = bounds.getMax();
-    Effects.EFFECTS.renderRegion(pl, min, max, PGM.get().getExecutor());
+      for (int i = 0; i < edges.length; i++) {
+        if (Double.isNaN(edges[i][1])) continue;
+        loc.set(edges[i][0], edges[i][1], edges[i][2]);
+        var dirs = directions[(i / 4)];
+        EFFECTS.spawnFlame(player, loc, dirs[0], dirs[1], dirs[2], (int) dirs[3]);
+      }
+      for (double[] vertex : vertices) {
+        if (Double.isNaN(vertex[1])) continue;
+        loc.set(vertex[0], vertex[1], vertex[2]);
+        EFFECTS.coloredDust(player, loc, Color.RED);
+      }
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/parsers/RegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/RegionParser.java
@@ -1,0 +1,39 @@
+package tc.oc.pgm.command.parsers;
+
+import java.util.List;
+import java.util.Map;
+import org.bukkit.command.CommandSender;
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.parser.ParserParameters;
+import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.features.FeatureDefinitionContext;
+import tc.oc.pgm.filters.FilterMatchModule;
+
+public final class RegionParser
+    extends MatchObjectParser<Region, Map.Entry<String, Region>, FilterMatchModule> {
+
+  public RegionParser(CommandManager<CommandSender> manager, ParserParameters options) {
+    super(manager, options, Region.class, FilterMatchModule.class, "regions");
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected Iterable<Map.Entry<String, Region>> objects(FilterMatchModule module) {
+    if (!(module.getFilterContext() instanceof FeatureDefinitionContext fdc)) return List.of();
+
+    return () -> fdc.stream()
+        .filter(entry -> entry != null && entry.getValue() instanceof Region)
+        .map(entry -> (Map.Entry<String, Region>) (Map.Entry<?, ?>) entry)
+        .iterator();
+  }
+
+  @Override
+  protected String getName(Map.Entry<String, Region> obj) {
+    return obj.getKey();
+  }
+
+  @Override
+  protected Region getValue(Map.Entry<String, Region> obj) {
+    return obj.getValue();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/command/parsers/RegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/command/parsers/RegionParser.java
@@ -5,35 +5,33 @@ import java.util.Map;
 import org.bukkit.command.CommandSender;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.parser.ParserParameters;
+import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.filters.FilterMatchModule;
 
 public final class RegionParser
-    extends MatchObjectParser<Region, Map.Entry<String, Region>, FilterMatchModule> {
+    extends MatchObjectParser<Region, Map.Entry<String, FeatureDefinition>, FilterMatchModule> {
 
   public RegionParser(CommandManager<CommandSender> manager, ParserParameters options) {
     super(manager, options, Region.class, FilterMatchModule.class, "regions");
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  protected Iterable<Map.Entry<String, Region>> objects(FilterMatchModule module) {
+  protected Iterable<Map.Entry<String, FeatureDefinition>> objects(FilterMatchModule module) {
     if (!(module.getFilterContext() instanceof FeatureDefinitionContext fdc)) return List.of();
-
     return () -> fdc.stream()
         .filter(entry -> entry != null && entry.getValue() instanceof Region)
-        .map(entry -> (Map.Entry<String, Region>) (Map.Entry<?, ?>) entry)
         .iterator();
   }
 
   @Override
-  protected String getName(Map.Entry<String, Region> obj) {
+  protected String getName(Map.Entry<String, FeatureDefinition> obj) {
     return obj.getKey();
   }
 
   @Override
-  protected Region getValue(Map.Entry<String, Region> obj) {
-    return obj.getValue();
+  protected Region getValue(Map.Entry<String, FeatureDefinition> obj) {
+    return (Region) obj.getValue();
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/PGMCommandGraph.java
@@ -24,6 +24,7 @@ import tc.oc.pgm.api.match.MatchManager;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.party.VictoryCondition;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
 import tc.oc.pgm.classes.PlayerClass;
@@ -74,6 +75,7 @@ import tc.oc.pgm.command.parsers.PartyParser;
 import tc.oc.pgm.command.parsers.PhasesParser;
 import tc.oc.pgm.command.parsers.PlayerClassParser;
 import tc.oc.pgm.command.parsers.PlayerParser;
+import tc.oc.pgm.command.parsers.RegionParser;
 import tc.oc.pgm.command.parsers.RotationParser;
 import tc.oc.pgm.command.parsers.SettingValueParser;
 import tc.oc.pgm.command.parsers.TeamParser;
@@ -192,6 +194,7 @@ public class PGMCommandGraph extends CommandGraph<PGM> {
         TypeFactory.parameterizedClass(Optional.class, VictoryCondition.class),
         new VictoryConditionParser());
     registerParser(Filter.class, FilterParser::new);
+    registerParser(Region.class, RegionParser::new);
     registerParser(SettingKey.class, new EnumParser<>(SettingKey.class, CommandKeys.SETTING_KEY));
     registerParser(SettingValue.class, new SettingValueParser());
     registerParser(Phase.Phases.class, PhasesParser::new);

--- a/core/src/main/java/tc/oc/pgm/regions/Bounds.java
+++ b/core/src/main/java/tc/oc/pgm/regions/Bounds.java
@@ -178,25 +178,29 @@ public class Bounds implements Cloneable {
         this.min.getZ() + size.getZ() * random.nextDouble());
   }
 
+  private static double roundDown(double value) {
+    return Math.ceil(value - 0.5d);
+  }
+
   public BlockVector getBlockMin() {
     return new BlockVector(
-        (int) this.min.getX() + 0.5d,
-        (int) Math.max(0, Math.min(255, this.min.getY() + 0.5d)),
-        (int) this.min.getZ() + 0.5d);
+        roundDown(min.getX()) + 0.5d,
+        Math.clamp(roundDown(min.getY()), 0, 255) + 0.5d,
+        roundDown(min.getZ()) + 0.5d);
   }
 
   public BlockVector getBlockMaxInside() {
     return new BlockVector(
-        (int) this.max.getX() - 0.5d,
-        (int) Math.max(0, Math.min(255, this.max.getY() - 0.5d)),
-        (int) this.max.getZ() - 0.5d);
+        Math.round(max.getX()) - 0.5d,
+        Math.clamp(Math.round(max.getY()), 1, 255) - 0.5,
+        Math.round(max.getZ()) - 0.5d);
   }
 
   public BlockVector getBlockMaxOutside() {
     return new BlockVector(
-        (int) this.max.getX() + 0.5d,
-        (int) Math.max(0, Math.min(256, this.max.getY() + 0.5d)),
-        (int) this.max.getZ() + 0.5d);
+        Math.round(max.getX()) + 0.5d,
+        Math.clamp(Math.round(max.getY()), 0, 255) + 0.5d,
+        Math.round(max.getZ()) + 0.5d);
   }
 
   public boolean containsBlock(BlockVector v) {

--- a/core/src/main/java/tc/oc/pgm/regions/Union.java
+++ b/core/src/main/java/tc/oc/pgm/regions/Union.java
@@ -1,12 +1,19 @@
 package tc.oc.pgm.regions;
 
+import static com.google.common.collect.Iterators.*;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.api.region.RegionDefinition;
+import tc.oc.pgm.util.block.BlockVectorSet;
 
 public class Union implements RegionDefinition.Static {
   private final Region[] regions;
+  private Supplier<Iterator<BlockVector>> iteratorFactory;
 
   public Union(Region... regions) {
     this.regions = regions;
@@ -80,6 +87,58 @@ public class Union implements RegionDefinition.Static {
       bounds = Bounds.union(bounds, region.getBounds());
     }
     return bounds;
+  }
+
+  @Override
+  public Iterator<BlockVector> getBlockVectorIterator() {
+    if (iteratorFactory == null) iteratorFactory = createIteratorFactory();
+    return iteratorFactory.get();
+  }
+
+  /**
+   * Decides on the best strategy for iterating all blocks in the union. There's 3 possible
+   * strategies: - Full-scan: iterate the whole region bounds, and for each block check if
+   * this::contains. - Pros: Always correct, no memory overhead. - Cons: is slow! for very disperse
+   * cuboids this is very bad. - Child-scan: concatenate iterating each of the children. - Pros:
+   * Fastest, no memory overhead. - Cons: if children overlap, you can pass through a block twice.
+   * Not acceptable. - Filtered-child-scan: concatenate iterating of each child, but filter by
+   * visited. - Pros: Always correct, fast even for disperse cuboids - Cons: requires extra memory
+   * to keep track of already visited positions. Ideally whenever possible, child scan is preferred
+   * (non-overlapping children). When children overlap, pgm will pick full-scan or filtered child
+   * scan based on how much emptiness exists.
+   *
+   * @return A supplier for iterators over the region
+   */
+  private Supplier<Iterator<BlockVector>> createIteratorFactory() {
+    if (!isStatic()) return this::fullScan;
+
+    // Checking all children are disjoint is O(n²), assume overlap and skip the check if too many.
+    boolean disjoint = regions.length < 100;
+    var childrenVolume = 0;
+    for (int i = 0; i < regions.length; i++) {
+      var bounds = regions[i].getBounds();
+      childrenVolume += bounds.getBlockVolume();
+      for (int j = i + 1; disjoint && j < regions.length; j++) {
+        if (!Bounds.disjoint(bounds, regions[j].getBounds())) disjoint = false;
+      }
+    }
+
+    if (disjoint) return this::childScan;
+    if (getBounds().getBlockVolume() < childrenVolume * 5) return this::fullScan;
+
+    final int sumVolume = childrenVolume;
+    return () -> {
+      var visited = new BlockVectorSet(sumVolume);
+      return filter(childScan(), visited::add);
+    };
+  }
+
+  private Iterator<BlockVector> fullScan() {
+    return filter(getBounds().getBlockIterator(), this::contains);
+  }
+
+  private Iterator<BlockVector> childScan() {
+    return concat(transform(forArray(regions), r -> r.getStatic().getBlockVectorIterator()));
   }
 
   @Override

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernEffects.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernEffects.java
@@ -3,8 +3,6 @@ package tc.oc.pgm.platform.modern.impl;
 import static tc.oc.pgm.util.material.ColorUtils.COLOR_UTILS;
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
@@ -12,12 +10,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.World;
-import org.bukkit.entity.BlockDisplay;
 import org.bukkit.entity.Player;
-import org.bukkit.util.Vector;
-import org.joml.Matrix4f;
 import tc.oc.pgm.platform.modern.material.ModernBlockMaterialData;
-import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.bukkit.Effects;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Supports;
@@ -87,22 +81,7 @@ public class ModernEffects implements Effects {
   }
 
   @Override
-  public void renderRegion(
-      Player player, Vector min, Vector max, ScheduledExecutorService executor) {
-    var center = min.toLocation(player.getWorld());
-    var size = max.clone().subtract(min);
-    var entity = player.getWorld().spawn(center, BlockDisplay.class, e -> {
-      e.setVisibleByDefault(false);
-      e.setPersistent(false);
-
-      e.setBlock(Material.WHITE_STAINED_GLASS.createBlockData());
-      e.setShadowRadius(500);
-      e.setShadowRadius(0);
-      e.setTransformationMatrix(
-          new Matrix4f().scale((float) size.getX(), (float) size.getY(), (float) size.getZ()));
-    });
-
-    player.showEntity(BukkitUtils.getPlugin(), entity);
-    executor.schedule(entity::remove, 15, TimeUnit.SECONDS);
+  public void spawnFlame(Player player, Location loc, float x, float y, float z, int amt) {
+    player.spawnParticle(Particle.FLAME, loc, amt, x, y, z, 0, null, true);
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernEffects.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernEffects.java
@@ -3,6 +3,8 @@ package tc.oc.pgm.platform.modern.impl;
 import static tc.oc.pgm.util.material.ColorUtils.COLOR_UTILS;
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
@@ -10,8 +12,12 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.World;
+import org.bukkit.entity.BlockDisplay;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import org.joml.Matrix4f;
 import tc.oc.pgm.platform.modern.material.ModernBlockMaterialData;
+import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.bukkit.Effects;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Supports;
@@ -78,5 +84,25 @@ public class ModernEffects implements Effects {
     location
         .getWorld()
         .playEffect(location, Effect.STEP_SOUND, ((ModernBlockMaterialData) material).getBlock());
+  }
+
+  @Override
+  public void renderRegion(
+      Player player, Vector min, Vector max, ScheduledExecutorService executor) {
+    var center = min.toLocation(player.getWorld());
+    var size = max.clone().subtract(min);
+    var entity = player.getWorld().spawn(center, BlockDisplay.class, e -> {
+      e.setVisibleByDefault(false);
+      e.setPersistent(false);
+
+      e.setBlock(Material.WHITE_STAINED_GLASS.createBlockData());
+      e.setShadowRadius(500);
+      e.setShadowRadius(0);
+      e.setTransformationMatrix(
+          new Matrix4f().scale((float) size.getX(), (float) size.getY(), (float) size.getZ()));
+    });
+
+    player.showEntity(BukkitUtils.getPlugin(), entity);
+    executor.schedule(entity::remove, 15, TimeUnit.SECONDS);
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpEffects.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpEffects.java
@@ -2,6 +2,9 @@ package tc.oc.pgm.platform.sportpaper.impl;
 
 import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
 
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
@@ -9,6 +12,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
 import tc.oc.pgm.util.bukkit.Effects;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Supports;
@@ -102,6 +106,83 @@ public class SpEffects implements Effects {
   @Override
   public void blockBreak(Location location, BlockMaterialData material) {
     location.getWorld().playEffect(location, Effect.STEP_SOUND, material.encoded());
+  }
+
+  @Override
+  public void renderRegion(
+      Player player, Vector min, Vector max, ScheduledExecutorService executor) {
+    boolean hasBottom = min.getY() >= -64, hasTop = max.getY() <= 320;
+    if (!hasBottom) min.setY(-32);
+    if (!hasTop) max.setY(288);
+
+    var center = min.clone().add(max).multiply(0.5);
+    var size = max.clone().subtract(min);
+
+    float spreadMul = 0.20f;
+    float countMul = 0.1f;
+    float[][] directions = {
+      {(float) size.getX() * spreadMul, 0, 0, (float) Math.max(10, size.getX() * countMul)},
+      {0, (float) size.getY() * spreadMul, 0, (float) Math.max(10, size.getY() * countMul)},
+      {0, 0, (float) size.getZ() * spreadMul, (float) Math.max(10, size.getZ() * countMul)}
+    };
+    if (!hasBottom) min.setY(Double.NaN);
+    if (!hasTop) max.setY(Double.NaN);
+
+    double[][] edges = {
+      {center.getX(), min.getY(), min.getZ()},
+      {center.getX(), min.getY(), max.getZ()},
+      {center.getX(), max.getY(), min.getZ()},
+      {center.getX(), max.getY(), max.getZ()},
+      {min.getX(), center.getY(), min.getZ()},
+      {min.getX(), center.getY(), max.getZ()},
+      {max.getX(), center.getY(), min.getZ()},
+      {max.getX(), center.getY(), max.getZ()},
+      {min.getX(), min.getY(), center.getZ()},
+      {min.getX(), max.getY(), center.getZ()},
+      {max.getX(), min.getY(), center.getZ()},
+      {max.getX(), max.getY(), center.getZ()},
+    };
+    double[][] vertices = {
+      {min.getX(), min.getY(), min.getZ()},
+      {min.getX(), min.getY(), max.getZ()},
+      {min.getX(), max.getY(), min.getZ()},
+      {min.getX(), max.getY(), max.getZ()},
+      {max.getX(), min.getY(), min.getZ()},
+      {max.getX(), min.getY(), max.getZ()},
+      {max.getX(), max.getY(), min.getZ()},
+      {max.getX(), max.getY(), max.getZ()},
+    };
+
+    class ParticleRunner implements Runnable {
+      private final Future<?> task =
+          executor.scheduleWithFixedDelay(this, 0, 100, TimeUnit.MILLISECONDS);
+      private final Location loc = new Location(player.getWorld(), 0, 0, 0);
+      private int ticks = 150;
+
+      @Override
+      public void run() {
+        if (ticks-- < 0) {
+          task.cancel(true);
+          return;
+        }
+        for (int i = 0; i < edges.length; i++) {
+          if (Double.isNaN(edges[i][1])) continue;
+          loc.set(edges[i][0], edges[i][1], edges[i][2]);
+          var dirs = directions[(i / 4)];
+          player
+              .spigot()
+              .playEffect(
+                  loc, Effect.FLAME, 0, 0, dirs[0], dirs[1], dirs[2], 0, (int) dirs[3], 256);
+        }
+        for (double[] vertex : vertices) {
+          if (Double.isNaN(vertex[1])) continue;
+          loc.set(vertex[0], vertex[1], vertex[2]);
+          player.spigot().playEffect(loc, Effect.COLOURED_DUST, 0, 0, 1f, 0.01f, 0.01f, 1, 0, 256);
+        }
+      }
+    }
+    ;
+    new ParticleRunner();
   }
 
   private float rgbToParticle(int rgb) {

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpEffects.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpEffects.java
@@ -2,9 +2,6 @@ package tc.oc.pgm.platform.sportpaper.impl;
 
 import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
 
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Effect;
@@ -12,7 +9,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.util.Vector;
 import tc.oc.pgm.util.bukkit.Effects;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Supports;
@@ -109,80 +105,8 @@ public class SpEffects implements Effects {
   }
 
   @Override
-  public void renderRegion(
-      Player player, Vector min, Vector max, ScheduledExecutorService executor) {
-    boolean hasBottom = min.getY() >= -64, hasTop = max.getY() <= 320;
-    if (!hasBottom) min.setY(-32);
-    if (!hasTop) max.setY(288);
-
-    var center = min.clone().add(max).multiply(0.5);
-    var size = max.clone().subtract(min);
-
-    float spreadMul = 0.20f;
-    float countMul = 0.1f;
-    float[][] directions = {
-      {(float) size.getX() * spreadMul, 0, 0, (float) Math.max(10, size.getX() * countMul)},
-      {0, (float) size.getY() * spreadMul, 0, (float) Math.max(10, size.getY() * countMul)},
-      {0, 0, (float) size.getZ() * spreadMul, (float) Math.max(10, size.getZ() * countMul)}
-    };
-    if (!hasBottom) min.setY(Double.NaN);
-    if (!hasTop) max.setY(Double.NaN);
-
-    double[][] edges = {
-      {center.getX(), min.getY(), min.getZ()},
-      {center.getX(), min.getY(), max.getZ()},
-      {center.getX(), max.getY(), min.getZ()},
-      {center.getX(), max.getY(), max.getZ()},
-      {min.getX(), center.getY(), min.getZ()},
-      {min.getX(), center.getY(), max.getZ()},
-      {max.getX(), center.getY(), min.getZ()},
-      {max.getX(), center.getY(), max.getZ()},
-      {min.getX(), min.getY(), center.getZ()},
-      {min.getX(), max.getY(), center.getZ()},
-      {max.getX(), min.getY(), center.getZ()},
-      {max.getX(), max.getY(), center.getZ()},
-    };
-    double[][] vertices = {
-      {min.getX(), min.getY(), min.getZ()},
-      {min.getX(), min.getY(), max.getZ()},
-      {min.getX(), max.getY(), min.getZ()},
-      {min.getX(), max.getY(), max.getZ()},
-      {max.getX(), min.getY(), min.getZ()},
-      {max.getX(), min.getY(), max.getZ()},
-      {max.getX(), max.getY(), min.getZ()},
-      {max.getX(), max.getY(), max.getZ()},
-    };
-
-    class ParticleRunner implements Runnable {
-      private final Future<?> task =
-          executor.scheduleWithFixedDelay(this, 0, 100, TimeUnit.MILLISECONDS);
-      private final Location loc = new Location(player.getWorld(), 0, 0, 0);
-      private int ticks = 150;
-
-      @Override
-      public void run() {
-        if (ticks-- < 0) {
-          task.cancel(true);
-          return;
-        }
-        for (int i = 0; i < edges.length; i++) {
-          if (Double.isNaN(edges[i][1])) continue;
-          loc.set(edges[i][0], edges[i][1], edges[i][2]);
-          var dirs = directions[(i / 4)];
-          player
-              .spigot()
-              .playEffect(
-                  loc, Effect.FLAME, 0, 0, dirs[0], dirs[1], dirs[2], 0, (int) dirs[3], 256);
-        }
-        for (double[] vertex : vertices) {
-          if (Double.isNaN(vertex[1])) continue;
-          loc.set(vertex[0], vertex[1], vertex[2]);
-          player.spigot().playEffect(loc, Effect.COLOURED_DUST, 0, 0, 1f, 0.01f, 0.01f, 1, 0, 256);
-        }
-      }
-    }
-    ;
-    new ParticleRunner();
+  public void spawnFlame(Player player, Location loc, float x, float y, float z, int amt) {
+    player.spigot().playEffect(loc, Effect.FLAME, 0, 0, x, y, z, 0, amt, 256);
   }
 
   private float rgbToParticle(int rgb) {

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/Effects.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/Effects.java
@@ -1,10 +1,12 @@
 package tc.oc.pgm.util.bukkit;
 
+import java.util.concurrent.ScheduledExecutorService;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Platform;
 
@@ -26,4 +28,6 @@ public interface Effects {
   void explosion(Player player, Location location);
 
   void blockBreak(Location location, BlockMaterialData material);
+
+  void renderRegion(Player player, Vector min, Vector max, ScheduledExecutorService executor);
 }

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/Effects.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/Effects.java
@@ -1,12 +1,10 @@
 package tc.oc.pgm.util.bukkit;
 
-import java.util.concurrent.ScheduledExecutorService;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.util.Vector;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.platform.Platform;
 
@@ -29,5 +27,5 @@ public interface Effects {
 
   void blockBreak(Location location, BlockMaterialData material);
 
-  void renderRegion(Player player, Vector min, Vector max, ScheduledExecutorService executor);
+  void spawnFlame(Player player, Location loc, float x, float y, float z, int amt);
 }


### PR DESCRIPTION
# Region viewing command
Adds `/region <region-id>`  command, which will display a regions' bounds and blocks.

This is useful for mapmakers creating maps, or mapdevs double-checking maps.


# Block-bounded off-by-one region fix
Fixes a very old bug with block iterating in regions, where some blocks were excluded. This can affect only contexts where the region is used for block-bounded things, like fill actions, structures, or core, monument or hill definitions; things where pgm wants to "list the blocks" in the region.

### Fix impact
Looking thru 2000 maps none of them seem to be affected negatively by this, most will end up with larger iterating area but pgm discards the blocks when checking contains. Only a few (20 maps) had a modified block count included, where the blocks in the region increased count. However we did not find it affecting gameplay (eg: a core definition region being 1 block bigger means nothing if there's no obsidian there, it ends up being exactly the same). Also note this only affects regions defined in non-full-block coordinates, so a cuboid with max=-10.0 is unaffected, one with max=-10.5 will be moved over by one.


# Optimization to block-traversing of unions
Additionally optimizes union iterating, where instead of going thru the whole bounds we can take some smarter approaches by iterating the children instead. This is purely a technical change with no gameplay implications.