### PR TITLE
Avoid health variable allowing killing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/variables/types/PlayerVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/PlayerVariable.java
@@ -81,8 +81,7 @@ public class PlayerVariable extends AbstractVariable<MatchPlayer> {
     PLACE_Y(p -> intersection(p, i -> i.getPlaceAt().getY())),
     PLACE_Z(p -> intersection(p, i -> i.getPlaceAt().getZ())),
     HAS_TARGET(p -> intersection(p) == null ? 0 : 1),
-    HEALTH(
-        Damageable::getHealth, (p, h) -> p.setHealth(Math.max(0, Math.min(p.getMaxHealth(), h)))),
+    HEALTH(Damageable::getHealth, (p, h) -> p.setHealth(Math.clamp(h, 0.1f, p.getMaxHealth()))),
     MAX_HEALTH(Damageable::getMaxHealth, (p, h) -> p.setMaxHealth(Math.max(0.1f, h))),
     FOOD(Player::getFoodLevel, (p, f) -> p.setFoodLevel((int) f)),
     SATURATION(Player::getSaturation, (p, s) -> p.setSaturation((float) s)),


### PR DESCRIPTION
Fixes #1485 , for the time being it's best to just avoid health being set to 0 as it bugs pgm, since the event is launched first, and then the health is set to 0, meaning it remains 0 even if pgm resets it back up to 20 on death, and that means vanilla respawn screen and buggy behavior.

If really needed we could maybe look into a kill-player action in the future, but usually just setting their hp very low and a tp to the void does the trick