### PR TITLE
fix: CycleMatchModule should not cycle erroneously when players drop below the `join.min-players` amount

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -197,7 +197,7 @@ public final class PGMConfig implements Config {
     this.maxExtraVotes = parseInteger(config.getString("votes.max-extra-votes", "5"));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
-    this.endEmptyMatches = config.getBoolean("join.end-empty-matches", true);
+    this.endEmptyMatches = config.getBoolean("join.end-empty-matches", minPlayers > 0);
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));
     this.priorityKick = parseBoolean(config.getString("join.priority-kick", "true"));
     this.balanceJoin = parseBoolean(config.getString("join.balance", "true"));

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -90,7 +90,7 @@ public final class PGMConfig implements Config {
 
   // join.*
   private final long minPlayers;
-  private final long minPlayersMaintain;
+  private final boolean endEmptyMatches;
   private final boolean limitJoin;
   private final boolean priorityKick;
   private final boolean balanceJoin;
@@ -197,7 +197,7 @@ public final class PGMConfig implements Config {
     this.maxExtraVotes = parseInteger(config.getString("votes.max-extra-votes", "5"));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
-    this.minPlayersMaintain = parseInteger(config.getString("gameplay.min-players-maintain", "1"));
+    this.endEmptyMatches = config.getBoolean("join.end-empty-matches", true);
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));
     this.priorityKick = parseBoolean(config.getString("join.priority-kick", "true"));
     this.balanceJoin = parseBoolean(config.getString("join.balance", "true"));
@@ -586,8 +586,8 @@ public final class PGMConfig implements Config {
   }
 
   @Override
-  public long getMinimumPlayersMaintain() {
-    return this.minPlayersMaintain;
+  public boolean allowEndingEmptyMatches() {
+    return this.endEmptyMatches;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -90,6 +90,7 @@ public final class PGMConfig implements Config {
 
   // join.*
   private final long minPlayers;
+  private final long minPlayersMaintain;
   private final boolean limitJoin;
   private final boolean priorityKick;
   private final boolean balanceJoin;
@@ -196,6 +197,7 @@ public final class PGMConfig implements Config {
     this.maxExtraVotes = parseInteger(config.getString("votes.max-extra-votes", "5"));
 
     this.minPlayers = parseInteger(config.getString("join.min-players", "1"));
+    this.minPlayersMaintain = parseInteger(config.getString("gameplay.min-players-maintain", "1"));
     this.limitJoin = parseBoolean(config.getString("join.limit", "true"));
     this.priorityKick = parseBoolean(config.getString("join.priority-kick", "true"));
     this.balanceJoin = parseBoolean(config.getString("join.balance", "true"));
@@ -581,6 +583,11 @@ public final class PGMConfig implements Config {
   @Override
   public Duration getTimePenalty(TimePenalty penalty) {
     return timePenalties.get(penalty);
+  }
+
+  @Override
+  public long getMinimumPlayersMaintain() {
+    return this.minPlayersMaintain;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -331,11 +331,12 @@ public interface Config {
   }
 
   /**
-   * Get the number of players needed to keep a match running.
+   * Should we end the match if there are no players?
    *
-   * @return number of players
+   * @return {@code true} if the match should end when there are no participating players,
+   *     {@code false} if not
    */
-  long getMinimumPlayersMaintain();
+  boolean allowEndingEmptyMatches();
 
   /**
    * Gets if extra votes are allowed based on the "pgm.vote.extra.#" permission.

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -331,6 +331,13 @@ public interface Config {
   }
 
   /**
+   * Get the number of players needed to keep a match running.
+   *
+   * @return number of players
+   */
+  long getMinimumPlayersMaintain();
+
+  /**
    * Gets if extra votes are allowed based on the "pgm.vote.extra.#" permission.
    *
    * @return {@code true} if extra votes are enabled, {@code false} otherwise.

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -47,7 +47,7 @@ public class CycleMatchModule implements MatchModule, Listener {
   public void onPartyChange(PlayerPartyChangeEvent event) {
     if (event.wasParticipating()
         && match.isRunning()
-        && match.getParticipants().size() < PGM.get().getConfiguration().getMinimumPlayers()) {
+        && match.getParticipants().isEmpty()) {
       match.getLogger().info("Cycling due to empty match");
       match.finish();
       startCountdown(null);

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -49,9 +49,7 @@ public class CycleMatchModule implements MatchModule, Listener {
         && match.isRunning()
         && match.getParticipants().size()
             < PGM.get().getConfiguration().getMinimumPlayersMaintain()) {
-      match
-          .getLogger()
-          .info("Ending match due to an insufficient number of players.");
+      match.getLogger().info("Ending match due to an insufficient number of players.");
       match.finish();
       startCountdown(null);
     }

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -47,8 +47,8 @@ public class CycleMatchModule implements MatchModule, Listener {
   public void onPartyChange(PlayerPartyChangeEvent event) {
     if (event.wasParticipating()
         && match.isRunning()
-        && match.getParticipants().size()
-            < PGM.get().getConfiguration().getMinimumPlayersMaintain()) {
+        && match.getParticipants().isEmpty()
+        && PGM.get().getConfiguration().allowEndingEmptyMatches()) {
       match.getLogger().info("Ending match due to an insufficient number of players.");
       match.finish();
       startCountdown(null);

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -47,8 +47,11 @@ public class CycleMatchModule implements MatchModule, Listener {
   public void onPartyChange(PlayerPartyChangeEvent event) {
     if (event.wasParticipating()
         && match.isRunning()
-        && match.getParticipants().isEmpty()) {
-      match.getLogger().info("Cycling due to empty match");
+        && match.getParticipants().size()
+            < PGM.get().getConfiguration().getMinimumPlayersMaintain()) {
+      match
+          .getLogger()
+          .info("Ending match due to an insufficient number of players.");
       match.finish();
       startCountdown(null);
     }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -66,7 +66,7 @@ restart:
 # Changes behaviour when players try to /join a match.
 join:
   min-players: 1      # Minimum number of players before a match can start.
-  min-players-maintain: 1 # Minimum number of players that a match should maintain before PGM ends the match
+  end-empty-matches: true # Should the match be ended when there are no players?
   anytime: true       # Can players join after a match has started?
   balance: true       # Can players be moved to make teams more balanced?
   queue: false        # Should players be put in a queue before joining the match?

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -66,6 +66,7 @@ restart:
 # Changes behaviour when players try to /join a match.
 join:
   min-players: 1      # Minimum number of players before a match can start.
+  min-players-maintain: 1 # Minimum number of players that a match should maintain before PGM ends the match
   anytime: true       # Can players join after a match has started?
   balance: true       # Can players be moved to make teams more balanced?
   queue: false        # Should players be put in a queue before joining the match?


### PR DESCRIPTION
This fixes an issue that most servers will not encounter, unless they changed the `join.min-players` setting.

`join.min-players` defines the minimum players to start a match, this option is default to `1` meaning most servers will run correctly if their configurations are not modified, however, previously if you change it to a value higher than 1 and you have `<=` that amount of players playing/participating, the matches will cycle/end erroneously when players leave/join mid-match due to an incorrect comparison that triggers a cycle if empty.