### PR TITLE
Add built-in initial match loading

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
@@ -18,6 +18,7 @@ repositories {
     maven("https://repo.pgm.fyi/snapshots") // Sportpaper & other pgm-specific stuff
     maven("https://repo.dmulloy2.net/repository/public/") // ProtocolLib repo
     maven("https://repo.papermc.io/repository/maven-public/") // Paper builds & paperweight plugin
+    maven("https://jitpack.io") // Backup: jitpack
 }
 
 dependencies {
@@ -37,7 +38,10 @@ dependencies {
     api("org.reflections:reflections:0.10.2")
 
     // Optional plugin deps
-    compileOnly("com.comphenix.protocol:ProtocolLib:5.3.0")
+    // Official repository is giving 403 when running on gh actions, switch to jitpack for now
+    //  See: https://github.com/dmulloy2/ProtocolLib/issues/3353#issuecomment-2701859137
+    // compileOnly("com.comphenix.protocol:ProtocolLib:5.3.0")
+    compileOnly("com.github.dmulloy2:ProtocolLib:5.3.0") // Sourced from jitpack
     compileOnly("com.viaversion:viaversion-api:5.0.0")
 
     // Minecraft includes these (or equivalents)

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -49,6 +49,7 @@ import tc.oc.pgm.integrations.SimpleVanishIntegration;
 import tc.oc.pgm.listeners.AntiGriefListener;
 import tc.oc.pgm.listeners.BlockTransformListener;
 import tc.oc.pgm.listeners.FormattingListener;
+import tc.oc.pgm.listeners.InitialMatchLoader;
 import tc.oc.pgm.listeners.JoinLeaveAnnouncer;
 import tc.oc.pgm.listeners.MatchAnnouncer;
 import tc.oc.pgm.listeners.MotdListener;
@@ -393,6 +394,8 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     registerEvents(new ServerPingDataListener(matchManager, mapOrder, getLogger()));
     registerEvents(new JoinLeaveAnnouncer(matchManager));
     registerEvents(chatManager);
+
+    registerEvents(new InitialMatchLoader(this, matchManager));
   }
 
   private boolean loadInitialMaps() {

--- a/core/src/main/java/tc/oc/pgm/listeners/InitialMatchLoader.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/InitialMatchLoader.java
@@ -1,0 +1,62 @@
+package tc.oc.pgm.listeners;
+
+import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.ReentrantLock;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.plugin.Plugin;
+import tc.oc.pgm.api.match.MatchManager;
+import tc.oc.pgm.util.text.TextTranslations;
+
+public class InitialMatchLoader implements Listener {
+
+  private final MatchManager mm;
+  private final ReentrantLock lock;
+
+  public InitialMatchLoader(Plugin plugin, MatchManager mm) {
+    this.mm = mm;
+    this.lock = new ReentrantLock();
+    Bukkit.getScheduler().runTaskAsynchronously(plugin, this::tryCreateMatch);
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onPrePlayerLogin(final AsyncPlayerPreLoginEvent event) {
+    if (event.getLoginResult() != AsyncPlayerPreLoginEvent.Result.ALLOWED) return;
+    if (mm.getMatches().hasNext()) {
+      HandlerList.unregisterAll(this);
+      return;
+    }
+
+    tryCreateMatch();
+
+    if (!mm.getMatches().hasNext()) {
+      event.disallow(
+          AsyncPlayerPreLoginEvent.Result.KICK_OTHER,
+          TextTranslations.translate("misc.incorrectWorld"));
+    }
+  }
+
+  private void tryCreateMatch() {
+    try {
+      lock.lock();
+      // Already created
+      if (mm.getMatches().hasNext()) return;
+
+      // If the server is suspended, need to release so match can be created
+      NMS_HACKS.resumeServer();
+      try {
+        mm.createMatch(null).get();
+        if (mm.getMatches().hasNext()) HandlerList.unregisterAll(this);
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
@@ -145,6 +145,7 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
 
   @Override
   public Match get() throws InterruptedException, ExecutionException {
+    await();
     return get(0, TimeUnit.MILLISECONDS);
   }
 


### PR DESCRIPTION
Currently pgm will only create the first match once a player attempts to log-in, this can be troublesome (eg: no MOTD because no match) and is the reason for other plugins adding this functionality (ie: https://github.com/applenick/AlwaysLoad), this bakes it right into pgm as there's no good reason for this not to be default behavior