### PR TITLE
Improve performance of the region command

### DIFF
--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpPlayerUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpPlayerUtils.java
@@ -1,31 +1,52 @@
 package tc.oc.pgm.platform.sportpaper.impl;
 
+import static org.bukkit.craftbukkit.v1_8_R3.util.LongHash.lsw;
+import static org.bukkit.craftbukkit.v1_8_R3.util.LongHash.msw;
+import static org.bukkit.craftbukkit.v1_8_R3.util.LongHash.toLong;
 import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
+import static tc.oc.pgm.util.reflect.ReflectionUtils.getField;
+import static tc.oc.pgm.util.reflect.ReflectionUtils.setField;
 
 import com.mojang.authlib.GameProfile;
+import it.unimi.dsi.fastutil.shorts.ShortArrayList;
+import it.unimi.dsi.fastutil.shorts.ShortList;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
+import net.minecraft.server.v1_8_R3.ChunkCoordIntPair;
+import net.minecraft.server.v1_8_R3.IBlockData;
 import net.minecraft.server.v1_8_R3.MinecraftServer;
 import net.minecraft.server.v1_8_R3.MovingObjectPosition;
+import net.minecraft.server.v1_8_R3.PacketPlayOutMultiBlockChange;
 import net.minecraft.server.v1_8_R3.Vec3D;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_8_R3.CraftChunk;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_8_R3.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_8_R3.util.CraftMagicNumbers;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.platform.sportpaper.material.LegacyMaterialData;
+import tc.oc.pgm.platform.sportpaper.packets.PacketSender;
 import tc.oc.pgm.platform.sportpaper.utils.Skins;
+import tc.oc.pgm.util.block.BlockVectorSet;
+import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.block.RayBlockIntersection;
+import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.nms.PlayerUtils;
 import tc.oc.pgm.util.platform.Supports;
 import tc.oc.pgm.util.skin.Skin;
 
 @Supports(SPORTPAPER)
-public class SpPlayerUtils implements PlayerUtils {
+public class SpPlayerUtils implements PlayerUtils, PacketSender {
 
   @Override
   public boolean teleportRelative(
@@ -131,5 +152,48 @@ public class SpPlayerUtils implements PlayerUtils {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public void sendMultiBlockPacket(
+      Player pl, BlockVectorSet positions, @Nullable BlockMaterialData data) {
+    // Build a map of chunk -> block[]
+    Map<Long, ShortArrayList> sectionMap = new HashMap<>();
+
+    var locCache = new Location(null, 0, 0, 0);
+    positions.getLongSet().forEach((long encoded) -> {
+      BlockVectors.decodeInto(encoded, locCache);
+      int x = locCache.getBlockX(), y = locCache.getBlockY(), z = locCache.getBlockZ();
+      sectionMap
+          .computeIfAbsent(toLong(x >> 4, z >> 4), k -> new ShortArrayList())
+          .add((short) ((x & 15) << 12 | (z & 15) << 8 | y));
+    });
+
+    // Send each chunk
+    if (data instanceof LegacyMaterialData l) {
+      var blockData = CraftMagicNumbers.getBlock(data.getItemType()).fromLegacyData(l.getData());
+      for (Map.Entry<Long, ShortArrayList> entry : sectionMap.entrySet())
+        send(multiBlock(entry.getKey(), entry.getValue(), blockData), pl);
+    } else {
+      for (Map.Entry<Long, ShortArrayList> entry : sectionMap.entrySet()) {
+        var chunk = (CraftChunk) pl.getWorld().getChunkAt(msw(entry.getKey()), lsw(entry.getKey()));
+        var bl = entry.getValue();
+        send(new PacketPlayOutMultiBlockChange(bl.size(), bl.elements(), chunk.getHandle()), pl);
+      }
+    }
+  }
+
+  private static final Field CHUNK = getField(PacketPlayOutMultiBlockChange.class, "a");
+  private static final Field BLOCKS = getField(PacketPlayOutMultiBlockChange.class, "b");
+
+  private PacketPlayOutMultiBlockChange multiBlock(long ch, ShortList blocks, IBlockData data) {
+    var packet = new PacketPlayOutMultiBlockChange();
+    var changes = new PacketPlayOutMultiBlockChange.MultiBlockChangeInfo[blocks.size()];
+    for (int i = 0; i < blocks.size(); i++)
+      changes[i] = packet.new MultiBlockChangeInfo(blocks.getShort(i), data);
+
+    setField(packet, new ChunkCoordIntPair(msw(ch), lsw(ch)), CHUNK);
+    setField(packet, changes, BLOCKS);
+    return packet;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/block/BlockVectorSet.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/BlockVectorSet.java
@@ -157,6 +157,10 @@ public class BlockVectorSet implements Set<BlockVector> {
     this.set.clear();
   }
 
+  public LongSet getLongSet() {
+    return this.set;
+  }
+
   @Override
   public Object[] toArray() {
     throw new UnsupportedOperationException();

--- a/util/src/main/java/tc/oc/pgm/util/block/BlockVectors.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/BlockVectors.java
@@ -15,6 +15,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.material.Materials;
 
 public interface BlockVectors {
@@ -74,6 +75,14 @@ public interface BlockVectors {
     return world.getBlockAt(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ());
   }
 
+  static BlockVector getRelative(BlockVector base, BlockFace dir, @Nullable BlockVector out) {
+    if (out == null) out = new BlockVector();
+    out.setX(base.getX() + dir.getModX());
+    out.setY(base.getY() + dir.getModY());
+    out.setZ(base.getZ() + dir.getModZ());
+    return out;
+  }
+
   /** BlockVector encoding API - pack a BlockVector into a single long */
   int SHIFT = 21;
 
@@ -81,7 +90,7 @@ public interface BlockVectors {
   long SIGN_MASK = 1 << (SHIFT - 1);
 
   /** Decode a single component from the packed coordinates */
-  static long unpack(long packed, int shift) {
+  private static long unpack(long packed, int shift) {
     packed >>= shift;
 
     // Sign extension
@@ -97,6 +106,12 @@ public interface BlockVectors {
   static BlockVector decodePos(long encoded) {
     return new BlockVector(
         unpack(encoded, 0), unpack(encoded, SHIFT), unpack(encoded, SHIFT + SHIFT));
+  }
+
+  static void decodeInto(long encoded, Location loc) {
+    loc.setX(unpack(encoded, 0));
+    loc.setY(unpack(encoded, SHIFT));
+    loc.setZ(unpack(encoded, SHIFT + SHIFT));
   }
 
   static final long ENCODED_NULL_POS = Long.MIN_VALUE;

--- a/util/src/main/java/tc/oc/pgm/util/nms/PlayerUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/PlayerUtils.java
@@ -5,7 +5,12 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.util.block.BlockVectorSet;
+import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.block.RayBlockIntersection;
+import tc.oc.pgm.util.material.BlockMaterialData;
+import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.skin.Skin;
 
@@ -46,4 +51,15 @@ public interface PlayerUtils {
   void setPotionParticles(Player player, boolean enabled);
 
   RayBlockIntersection getTargetedBlock(Player player);
+
+  default void sendMultiBlockPacket(
+      Player player, BlockVectorSet positions, @Nullable BlockMaterialData data) {
+    var location = player.getLocation();
+
+    positions.getLongSet().forEach((long encoded) -> {
+      BlockVectors.decodeInto(encoded, location);
+      (data != null ? data : MaterialData.block(location.getBlock()))
+          .sendBlockChange(player, location);
+    });
+  }
 }


### PR DESCRIPTION
Greatly improves the perf of the `/region <id>`  command in several ways:
- Block outline of region won't show above the max build height, this alone greatly decreases the total number of blocks to change for large regions (those going from y=0 to y=255), since typical max build heights are 50 or less.
- Block changes are sent using one MultiBlockChange packet per chunk, instead of one per block. This is a huge difference in network lag, and was the main lag contributor.
- Only the blocks that were sent (glass) are later reset, this was also heavy on the lag as it was previously re-sending all the blocks in the region when resetting