### PR TITLE
Restore channel change when player has no perms

### DIFF
--- a/core/src/main/java/tc/oc/pgm/channels/ChatManager.java
+++ b/core/src/main/java/tc/oc/pgm/channels/ChatManager.java
@@ -126,7 +126,14 @@ public class ChatManager implements Listener {
 
   private <T> boolean processChannelMessage(
       Channel<T> channel, MatchPlayer sender, CommandContext<CommandSender> context) {
-    if (!channel.canSendMessage(sender)) throw noPermission();
+    if (!channel.canSendMessage(sender)) {
+      if (sender.getSettings().getValue(SettingKey.CHAT).equals(SettingValue.CHAT_ADMIN)) {
+        sender.getSettings().resetValue(SettingKey.CHAT);
+        SettingKey.CHAT.update(sender);
+      }
+      throw noPermission();
+    }
+
     throwMuted(sender);
 
     T target = channel.getTarget(sender, context);


### PR DESCRIPTION
Restores [previous functionality](https://github.com/PGMDev/PGM/blob/fccf7ba2028c8707c5c5d6b5442bfd72f35fd702/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java#L167C7-L167C7) where, if a player sets their chat channel to ADMIN and they don't have the adequate permission their channel setting will be reset the next time they try to send a message. 

There have been cases of newer players doing this (likely by incorrectly trying to use `/a` for "all") and then being left confused and unable to send messages at all, as they'd just get the "_You don't have permission_" error over and over.