### PR TITLE
Display entity projectiles

### DIFF
--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.projectile;
 import java.time.Duration;
 import java.util.List;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.FallingBlock;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
@@ -15,7 +16,7 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
   protected @Nullable Float power;
   protected double velocity;
   protected ClickAction clickAction;
-  protected Class<? extends Entity> projectile;
+  protected ProjectileEntity projectile;
   protected List<PotionEffect> potion;
   protected Filter destroyFilter;
   protected Duration coolDown;
@@ -30,7 +31,7 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
       @Nullable Float power,
       double velocity,
       ClickAction clickAction,
-      Class<? extends Entity> entity,
+      ProjectileEntity entity,
       List<PotionEffect> potion,
       Filter destroyFilter,
       Duration coolDown,
@@ -50,6 +51,25 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
     this.throwable = throwable;
     this.precise = precise;
     this.blockMaterial = blockMaterial;
+  }
+
+  public sealed interface ProjectileEntity permits RealEntity, BlockEntityType {
+    boolean requiresBlockMaterial();
+  }
+
+  record RealEntity(Class<? extends Entity> entityType) implements ProjectileEntity {
+    @Override
+    public boolean requiresBlockMaterial() {
+      return FallingBlock.class.isAssignableFrom(entityType);
+    }
+  }
+
+  record BlockEntityType(float size, boolean solidBlockCollision, Duration maxTravelTime)
+      implements ProjectileEntity {
+    @Override
+    public boolean requiresBlockMaterial() {
+      return true;
+    }
   }
 
   public @Nullable String getName() {

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -336,7 +336,7 @@ public class ProjectileMatchModule implements MatchModule, Listener {
       this.currentLocation.setYaw(0);
 
       this.increment = normalizedDirection.clone().multiply(definition.velocity);
-      this.substeps = Math.max(1, (int) (definition.velocity / ce.size()));
+      this.substeps = Math.min(10, Math.max(1, (int) (definition.velocity / Math.max(0.1, ce.size()))));
       this.substep = increment.clone().divide(new Vector(substeps, substeps, substeps));
       if (this.substep.length() < 0.1) this.substep = normalizedDirection.clone().multiply(0.1);
 

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -4,8 +4,14 @@ import static tc.oc.pgm.util.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Explosive;
@@ -37,6 +43,7 @@ import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.events.ListenerScope;
@@ -44,7 +51,10 @@ import tc.oc.pgm.events.PlayerParticipationStopEvent;
 import tc.oc.pgm.filters.query.BlockQuery;
 import tc.oc.pgm.filters.query.PlayerBlockQuery;
 import tc.oc.pgm.kits.tag.ItemTags;
+import tc.oc.pgm.util.MatchPlayers;
+import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
+import tc.oc.pgm.util.bukkit.entities.BlockEntity;
 import tc.oc.pgm.util.inventory.InventoryUtils;
 import tc.oc.pgm.util.nms.NMSHacks;
 
@@ -78,67 +88,77 @@ public class ProjectileMatchModule implements MatchModule, Listener {
     ParticipantState playerState = match.getParticipantState(player);
     if (playerState == null) return;
 
-    ProjectileDefinition projectileDefinition =
-        this.getProjectileDefinition(player.getItemInHand());
+    var definition = this.getProjectileDefinition(player.getItemInHand());
 
-    if (projectileDefinition != null
-        && isValidProjectileAction(event.getAction(), projectileDefinition.clickAction)) {
-      // Prevent the original projectile from being fired
-      event.setCancelled(true);
+    if (definition == null || !isValidProjectileAction(event.getAction(), definition.clickAction))
+      return;
 
-      if (this.isCooldownActive(player, projectileDefinition)) return;
+    // Prevent the original projectile from being fired
+    event.setCancelled(true);
 
-      boolean realProjectile = Projectile.class.isAssignableFrom(projectileDefinition.projectile);
-      Vector velocity =
-          player.getEyeLocation().getDirection().multiply(projectileDefinition.velocity);
-      Entity projectile;
-      try {
-        assertTrue(launchingDefinition.get() == null, "nested projectile launch");
-        launchingDefinition.set(projectileDefinition);
-        if (realProjectile) {
-          projectile = player.launchProjectile(
-              projectileDefinition.projectile.asSubclass(Projectile.class), velocity);
-          if (projectile instanceof Fireball fireball && projectileDefinition.precise) {
-            NMSHacks.NMS_HACKS.setFireballDirection(fireball, velocity);
-          }
-        } else {
-          if (FallingBlock.class.isAssignableFrom(projectileDefinition.projectile)) {
-            projectile =
-                projectileDefinition.blockMaterial.spawnFallingBlock(player.getEyeLocation());
+    if (this.isCooldownActive(player, definition)) return;
+
+    var projType = definition.projectile;
+    boolean needsEvent = true;
+    Vector velocity = player.getEyeLocation().getDirection().multiply(definition.velocity);
+    Entity projectile = null;
+    try {
+      assertTrue(launchingDefinition.get() == null, "nested projectile launch");
+      launchingDefinition.set(definition);
+      switch (projType) {
+        case ProjectileDefinition.RealEntity(Class<? extends Entity> entityType) -> {
+          if (Projectile.class.isAssignableFrom(entityType)) {
+            needsEvent = false;
+
+            projectile = player.launchProjectile(entityType.asSubclass(Projectile.class), velocity);
+            if (projectile instanceof Fireball fireball && definition.precise) {
+              NMSHacks.NMS_HACKS.setFireballDirection(fireball, velocity);
+            }
           } else {
-            projectile =
-                player.getWorld().spawn(player.getEyeLocation(), projectileDefinition.projectile);
+            if (FallingBlock.class.isAssignableFrom(entityType)) {
+              projectile = definition.blockMaterial.spawnFallingBlock(player.getEyeLocation());
+            } else {
+              projectile = player.getWorld().spawn(player.getEyeLocation(), entityType);
+            }
+            projectile.setVelocity(velocity);
           }
-          projectile.setVelocity(velocity);
         }
-        if (projectileDefinition.power != null && projectile instanceof Explosive) {
-          ((Explosive) projectile).setYield(projectileDefinition.power);
+        case ProjectileDefinition.BlockEntityType ce -> {
+          Location loc = player.getEyeLocation();
+          var be = BlockEntity.spawnBlockEntity(loc, definition.blockMaterial, ce.size(), velocity);
+          new BlockRunner(definition, be, player, loc);
         }
+      }
+
+      if (definition.power != null && projectile instanceof Explosive) {
+        ((Explosive) projectile).setYield(definition.power);
+      }
+      if (projectile != null) {
         projectile.setMetadata(
-            "projectileDefinition", new FixedMetadataValue(PGM.get(), projectileDefinition));
-      } finally {
-        launchingDefinition.remove();
+            "projectileDefinition", new FixedMetadataValue(PGM.get(), definition));
       }
+    } finally {
+      launchingDefinition.remove();
+    }
 
-      // If the entity implements Projectile, it will have already generated a
-      // ProjectileLaunchEvent.
-      // Otherwise, we fire our custom event.
-      if (!realProjectile) {
-        EntityLaunchEvent launchEvent = new EntityLaunchEvent(projectile, event.getPlayer());
-        match.callEvent(launchEvent);
-        if (launchEvent.isCancelled()) {
-          projectile.remove();
-          return;
-        }
+    // If the entity implements Projectile, it will have already generated a
+    // ProjectileLaunchEvent.
+    // Otherwise, we fire our custom event.
+    if (needsEvent && projectile != null) {
+      EntityLaunchEvent launchEvent = new EntityLaunchEvent(projectile, event.getPlayer());
+      match.callEvent(launchEvent);
+      if (launchEvent.isCancelled()) {
+        projectile.remove();
+        return;
       }
+    }
 
-      if (projectileDefinition.throwable) {
-        InventoryUtils.consumeItem(event);
-      }
+    if (definition.throwable) {
+      InventoryUtils.consumeItem(event);
+    }
 
-      if (projectileDefinition.coolDown != null) {
-        startCooldown(player, projectileDefinition);
-      }
+    if (definition.coolDown != null) {
+      startCooldown(player, definition);
     }
   }
 
@@ -283,5 +303,96 @@ public class ProjectileMatchModule implements MatchModule, Listener {
   public boolean isCooldownActive(Player player, ProjectileDefinition definition) {
     ProjectileCooldowns playerCooldowns = projectileCooldowns.get(player.getUniqueId());
     return (playerCooldowns != null && playerCooldowns.isActive(definition));
+  }
+
+  private class BlockRunner {
+    private final ProjectileDefinition definition;
+    private final BlockEntity blockEntity;
+    private final Player player;
+    private final Party shooterParty;
+    private final ProjectileDefinition.BlockEntityType ce;
+    private final Location currentLocation;
+    private final Vector increment;
+    private final int substeps;
+    private Vector substep;
+    private final Future<?> runner;
+    private int remainingTime;
+    private boolean collided = false;
+
+    public BlockRunner(
+        ProjectileDefinition definition,
+        BlockEntity blockEntity,
+        Player player,
+        Location spawnLocation) {
+      this.definition = definition;
+      this.blockEntity = blockEntity;
+      this.player = player;
+      this.shooterParty = Objects.requireNonNull(match.getPlayer(player)).getParty();
+      this.ce = (ProjectileDefinition.BlockEntityType) definition.projectile;
+
+      this.currentLocation = spawnLocation.clone();
+      var normalizedDirection = currentLocation.getDirection().normalize();
+      this.currentLocation.setPitch(0);
+      this.currentLocation.setYaw(0);
+
+      this.increment = normalizedDirection.clone().multiply(definition.velocity);
+      this.substeps = Math.max(1, (int) (definition.velocity / ce.size()));
+      this.substep = increment.clone().divide(new Vector(substeps, substeps, substeps));
+      if (this.substep.length() < 0.1) this.substep = normalizedDirection.clone().multiply(0.1);
+
+      this.remainingTime = (int) TimeUtils.toTicks(ce.maxTravelTime());
+      this.runner = match
+          .getExecutor(MatchScope.RUNNING)
+          .scheduleAtFixedRate(this::tick, 0L, 50L, TimeUnit.MILLISECONDS);
+    }
+
+    public void tick() {
+      if (remainingTime-- <= 0 || collided) {
+        cancel();
+        return;
+      }
+      if (definition.damage != null || ce.solidBlockCollision()) {
+        if (blockDisplayCollision(currentLocation)) {
+          collided = true;
+          return;
+        }
+      }
+
+      currentLocation.add(increment);
+      blockEntity.teleport(currentLocation);
+    }
+
+    private void cancel() {
+      this.runner.cancel(true);
+      blockEntity.remove();
+    }
+
+    private boolean blockDisplayCollision(Location location) {
+      double halfSize = 0.5 * ce.size();
+      
+      if (ce.solidBlockCollision() && NMSHacks.NMS_HACKS.collidesWithBlock(currentLocation, halfSize, increment, substeps, substep)) {
+        return true;
+      }
+      if (definition.damage != null) {
+        Entity hitEntity = NMSHacks.NMS_HACKS.collidesWithPlayer(location, halfSize, increment, this::isEnemyPlayer);
+        if (hitEntity != null) {
+          ((Player) hitEntity).damage(definition.damage, player);
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    private boolean isEnemyPlayer(Entity entity) {
+      if (!(entity instanceof Player victim)) {
+        return false;
+      }
+      var mpVictim = match.getPlayer(victim);
+      if (MatchPlayers.canInteract(mpVictim) && mpVictim.getParty() != shooterParty) {
+        return true;
+      }
+      return false;
+    }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
@@ -6,11 +6,11 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.FallingBlock;
 import org.bukkit.potion.PotionEffect;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -25,6 +25,7 @@ import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLFluentParser;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class ProjectileModule implements MapModule<ProjectileMatchModule> {
@@ -62,10 +63,10 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
             Node.fromChildOrAttr(projectileElement, "velocity"), Double.class, 1.0);
         ClickAction clickAction = XMLUtils.parseEnum(
             Node.fromAttr(projectileElement, "click"), ClickAction.class, ClickAction.BOTH);
-        Class<? extends Entity> entity =
-            XMLUtils.parseEntityTypeAttribute(projectileElement, "projectile", Arrow.class);
-        BlockMaterialData blockMaterial = entity.isAssignableFrom(FallingBlock.class)
-            ? XMLUtils.parseBlockMaterialData(Node.fromAttr(projectileElement, "material"))
+        ProjectileDefinition.ProjectileEntity entity =
+            parseProjectileEntity(projectileElement, factory.getParser());
+        BlockMaterialData blockMaterial = entity.requiresBlockMaterial()
+            ? XMLUtils.parseBlockMaterialData(Node.fromRequiredAttr(projectileElement, "material"))
             : null;
         Float power = XMLUtils.parseNumber(
             Node.fromChildOrAttr(projectileElement, "power"), Float.class, null);
@@ -97,6 +98,25 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
       }
 
       return projectiles.isEmpty() ? null : new ProjectileModule(ImmutableSet.copyOf(projectiles));
+    }
+
+    private static ProjectileDefinition.ProjectileEntity parseProjectileEntity(
+        final Element el, final XMLFluentParser parser) throws InvalidXMLException {
+      final String attributeName = "projectile";
+      final Class<? extends Entity> def = Arrow.class;
+      final Node node = Node.fromAttr(el, attributeName);
+      if (node == null) return new ProjectileDefinition.RealEntity(def);
+      final String entityText = node.getValue();
+      return switch (entityText.toLowerCase(Locale.ROOT)) {
+        case "block" ->
+          new ProjectileDefinition.BlockEntityType(
+              parser.parseFloat(el, "size").optional(1.0f),
+              parser.parseBool(el, "solid-block-collision").orTrue(),
+              parser.duration(el, "max-travel-time").optional(Duration.ofSeconds(1)));
+        default ->
+          new ProjectileDefinition.RealEntity(
+              XMLUtils.parseEntityTypeAttribute(el, attributeName, def));
+      };
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -94,6 +94,10 @@ public class XMLFluentParser {
     return number(Double.class, el, prop);
   }
 
+  public NumberBuilder<Float> parseFloat(Element el, String... prop) {
+    return number(Float.class, el, prop);
+  }
+
   public <T extends Number> NumberBuilder<T> number(Class<T> cls, Element el, String... prop) {
     return new NumberBuilder<>(cls, el, prop);
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/entities/ModernBlockEntity.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/entities/ModernBlockEntity.java
@@ -1,0 +1,56 @@
+package tc.oc.pgm.platform.modern.entities;
+
+import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
+
+import org.bukkit.Location;
+import org.bukkit.entity.BlockDisplay;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
+import org.joml.Matrix4f;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+import tc.oc.pgm.platform.modern.material.ModernBlockMaterialData;
+import tc.oc.pgm.util.bukkit.entities.BlockEntity;
+import tc.oc.pgm.util.material.BlockMaterialData;
+import tc.oc.pgm.util.platform.Supports;
+
+@Supports(value = PAPER, minVersion = "1.21.1")
+public class ModernBlockEntity implements BlockEntity.Factory {
+  @Override
+  public BlockEntity spawnBlockEntity(
+      Location center, BlockMaterialData blockMaterialData, float size, Vector velocity) {
+    Location corrected = center.clone();
+    corrected.setPitch(0);
+    corrected.setYaw(0);
+    final BlockDisplay entity = center.getWorld().spawn(corrected, BlockDisplay.class);
+    entity.setBlock(((ModernBlockMaterialData) blockMaterialData).getBlock());
+    entity.setTeleportDuration(1);
+
+    final Matrix4f translation =
+        new Matrix4f().translate(new Vector3f(-0.5f * size, -0.5f * size, -0.5f * size));
+
+    final Matrix4f rotationMatrix = new Matrix4f();
+    final Quaternionf rotation = new Quaternionf();
+    rotation.rotateLocalX((float) Math.toRadians(-center.getPitch()));
+    rotation.rotateLocalY((float) Math.toRadians(180 - center.getYaw()));
+    rotation.get(rotationMatrix);
+
+    final Matrix4f scaleMatrix = new Matrix4f().scale(size);
+    final Matrix4f transformationMatrix = rotationMatrix.mul(translation.mul(scaleMatrix));
+    entity.setTransformationMatrix(transformationMatrix);
+
+    return new Impl(entity);
+  }
+
+  private record Impl(Entity entity) implements BlockEntity {
+
+    public void teleport(Location center) {
+      entity.teleport(center);
+    }
+
+    @Override
+    public void remove() {
+      entity.remove();
+    }
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernNMSHacks.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernNMSHacks.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.HolderLookup;
@@ -46,8 +47,11 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.LevelSummary;
 import net.minecraft.world.level.storage.PrimaryLevelData;
 import net.minecraft.world.level.validation.ContentValidationException;
+import net.minecraft.world.phys.AABB;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Nameable;
 import org.bukkit.World;
@@ -75,7 +79,9 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
+
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.platform.modern.PgmBootstrap;
 import tc.oc.pgm.platform.modern.material.ModernBlockMaterialData;
@@ -450,5 +456,46 @@ public class ModernNMSHacks implements NMSHacks {
   @Override
   public int allocateEntityId() {
     return Bukkit.getUnsafe().nextEntityId();
+  }
+
+  @Override
+  public boolean collidesWithBlock(Location center, double halfSize, Vector delta, int substeps, Vector substep) {
+    Location pos = center.clone();
+    AABB AABB = new AABB(
+      pos.getX() - halfSize + Math.min(0, delta.getX()),
+      pos.getY() - halfSize + Math.min(0, delta.getY()),
+      pos.getZ() - halfSize + Math.min(0, delta.getZ()),
+
+      pos.getX() + halfSize + Math.max(0, delta.getX()),
+      pos.getY() + halfSize + Math.max(0, delta.getY()),
+      pos.getZ() + halfSize + Math.max(0, delta.getZ())
+    );
+    
+    CraftWorld world = (CraftWorld) pos.getWorld();
+    if (!world.getHandle().getLevel().noCollision(null, AABB)) {
+      for (int i = 0; i < substeps; i++) {
+        AABB = new AABB(
+          pos.getX() - halfSize,
+          pos.getY() - halfSize,
+          pos.getZ() - halfSize,
+
+          pos.getX() + halfSize,
+          pos.getY() + halfSize,
+          pos.getZ() + halfSize
+        );
+
+        if (!world.getHandle().getLevel().noCollision(null, AABB)) {
+        return true;
+        }
+        pos.add(substep);
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Entity collidesWithPlayer(Location center, double halfSize, Vector delta, Predicate<Entity> predicate) {
+    RayTraceResult result = center.getWorld().rayTraceEntities(center, delta.normalize(), delta.length(), halfSize, predicate);
+    return result != null ? result.getHitEntity() : null;
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/entities/SpBlockEntity.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/entities/SpBlockEntity.java
@@ -1,0 +1,59 @@
+package tc.oc.pgm.platform.sportpaper.entities;
+
+import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
+
+import net.minecraft.server.v1_8_R3.EntityArmorStand;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftArmorStand;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftFallingSand;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.util.bukkit.entities.BlockEntity;
+import tc.oc.pgm.util.material.BlockMaterialData;
+import tc.oc.pgm.util.platform.Supports;
+
+@Supports(SPORTPAPER)
+public class SpBlockEntity implements BlockEntity.Factory {
+  // We use a falling sand entity, which is 1 block high, so we want to lower actual positon by half
+  // of that
+  private static final double OFFSET = 0.5d;
+
+  @Override
+  public BlockEntity spawnBlockEntity(
+      Location center, BlockMaterialData blockMaterialData, float size, Vector velocity) {
+    center.setY(center.getY() - OFFSET);
+    var fallingBlock = blockMaterialData.spawnFallingBlock(center);
+    var stand = center.getWorld().spawn(center, ArmorStand.class);
+    stand.setCustomNameVisible(false);
+    stand.setVisible(false);
+    stand.setMarker(true);
+    stand.setBasePlate(false);
+    stand.setGravity(false);
+    stand.setPassenger(fallingBlock);
+
+    // Reset the original location
+    center.setY(center.getY() + OFFSET);
+
+    var nmsStand = ((CraftArmorStand) stand).getHandle();
+    var nmsFallingSand = ((CraftFallingSand) fallingBlock).getHandle();
+    // Noclip makes movement ignore all collisions (faster), which we don't need as we run our own
+    nmsStand.noclip = true;
+    nmsFallingSand.noclip = true;
+
+    return new Impl(stand, nmsStand);
+  }
+
+  private record Impl(ArmorStand bukkit, EntityArmorStand nms) implements BlockEntity {
+    @Override
+    public void teleport(Location l) {
+      // We NEED to use NMS move because bukkit's teleport does not work on entities with passengers
+      nms.move(l.getX() - nms.locX, l.getY() - nms.locY - OFFSET, l.getZ() - nms.locZ);
+    }
+
+    @Override
+    public void remove() {
+      bukkit.getPassenger().remove();
+      bukkit.remove();
+    }
+  }
+}

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpNMSHacks.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpNMSHacks.java
@@ -8,21 +8,22 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Predicate;
+
+import net.minecraft.server.v1_8_R3.AxisAlignedBB;
 import net.minecraft.server.v1_8_R3.ChunkSection;
 import net.minecraft.server.v1_8_R3.EntityArrow;
 import net.minecraft.server.v1_8_R3.EntityFireball;
 import net.minecraft.server.v1_8_R3.EntityFireworks;
 import net.minecraft.server.v1_8_R3.IBlockData;
 import net.minecraft.server.v1_8_R3.IDataManager;
+import net.minecraft.server.v1_8_R3.MovingObjectPosition;
 import net.minecraft.server.v1_8_R3.NBTTagCompound;
 import net.minecraft.server.v1_8_R3.ServerNBTManager;
+import net.minecraft.server.v1_8_R3.Vec3D;
 import net.minecraft.server.v1_8_R3.WorldData;
 import net.minecraft.server.v1_8_R3.WorldServer;
-import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
-import org.bukkit.Material;
-import org.bukkit.World;
-import org.bukkit.WorldCreator;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_8_R3.CraftChunk;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
@@ -228,5 +229,73 @@ public class SpNMSHacks implements NMSHacks {
   @Override
   public int allocateEntityId() {
     return Bukkit.allocateEntityId();
+  }
+
+  @Override
+  public boolean collidesWithBlock(Location center, double halfSize, Vector delta, int substeps, Vector substep) {
+    Location pos = center.clone();
+    
+    AxisAlignedBB AABB = new AxisAlignedBB(
+      pos.getX() - halfSize + Math.min(0, delta.getX()),
+      pos.getY() - halfSize + Math.min(0, delta.getY()),
+      pos.getZ() - halfSize + Math.min(0, delta.getZ()),
+
+      pos.getX() + halfSize + Math.max(0, delta.getX()),
+      pos.getY() + halfSize + Math.max(0, delta.getY()),
+      pos.getZ() + halfSize + Math.max(0, delta.getZ())
+    );
+    
+    net.minecraft.server.v1_8_R3.World world = ((org.bukkit.craftbukkit.v1_8_R3.CraftWorld) pos.getWorld()).getHandle();
+    if (!world.getCubes(null, AABB).isEmpty()) {
+      for (int i = 0; i < substeps; i++) {
+        AABB = new AxisAlignedBB(
+          pos.getX() - halfSize,
+          pos.getY() - halfSize,
+          pos.getZ() - halfSize,
+
+          pos.getX() + halfSize,
+          pos.getY() + halfSize,
+          pos.getZ() + halfSize
+        );
+
+        if (!world.getCubes(null, AABB).isEmpty()) {
+        return true;
+        }
+        pos.add(substep);
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Entity collidesWithPlayer(Location center, double halfSize, Vector delta, Predicate<Entity> predicate) {
+    Vector start = center.toVector();
+    Vector end = start.clone().add(delta);
+
+    AxisAlignedBB searchBox = new AxisAlignedBB(
+      Math.min(start.getX(), end.getX()), Math.min(start.getY(), end.getY()), Math.min(start.getZ(), end.getZ()),
+      Math.max(start.getX(), end.getX()), Math.max(start.getY(), end.getY()), Math.max(start.getZ(), end.getZ())
+    ).grow(halfSize, halfSize, halfSize);
+
+    net.minecraft.server.v1_8_R3.World world = ((org.bukkit.craftbukkit.v1_8_R3.CraftWorld) center.getWorld()).getHandle();
+    
+    List<net.minecraft.server.v1_8_R3.Entity> entities = world.getEntities(null, searchBox);
+
+    Vec3D vecStart = new Vec3D(start.getX(), start.getY(), start.getZ());
+    Vec3D vecEnd = new Vec3D(end.getX(), end.getY(), end.getZ());
+
+    for (net.minecraft.server.v1_8_R3.Entity entity : entities) {
+      if (!predicate.test(entity.getBukkitEntity())) continue;
+
+      AxisAlignedBB expandedBox = entity.getBoundingBox().grow(halfSize, halfSize, halfSize);
+      
+      MovingObjectPosition intercept = expandedBox.a(vecStart, vecEnd);
+
+      if (intercept != null) {
+        return entity.getBukkitEntity();
+      }
+    }
+
+    return null;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/entities/BlockEntity.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/entities/BlockEntity.java
@@ -1,0 +1,30 @@
+package tc.oc.pgm.util.bukkit.entities;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.util.material.BlockMaterialData;
+import tc.oc.pgm.util.platform.Platform;
+
+/**
+ * Implements a wrapper for block-like entities, used for projectiles. Modern implementations will
+ * use display entities, legacy (1.8) will use falling sand. <br>
+ *
+ * @implNote For this class, location is actually the center of the entity
+ */
+public interface BlockEntity {
+  BlockEntity.Factory FACTORY = Platform.get(BlockEntity.Factory.class);
+
+  static BlockEntity spawnBlockEntity(
+      Location center, BlockMaterialData blockMaterialData, float size, Vector velocity) {
+    return FACTORY.spawnBlockEntity(center, blockMaterialData, size, velocity);
+  }
+
+  void teleport(Location center);
+
+  void remove();
+
+  interface Factory {
+    BlockEntity spawnBlockEntity(
+        Location center, BlockMaterialData blockMaterialData, float size, Vector velocity);
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/NMSHacks.java
@@ -2,7 +2,10 @@ package tc.oc.pgm.util.nms;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Predicate;
+
 import org.bukkit.Chunk;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -57,4 +60,8 @@ public interface NMSHacks {
   int getMaxWorldSize(World world);
 
   int allocateEntityId();
+
+  boolean collidesWithBlock(Location center, double halfSize, Vector delta, int substeps, Vector substep);
+
+  Entity collidesWithPlayer(Location center, double halfSize, Vector delta, Predicate<Entity> predicate);
 }


### PR DESCRIPTION
This feature introduces display entities (specifically block display entities) as projectiles. This feature is only supported for modern PGM.

This can be done in XML, specifying "projectile" to be "BlockDisplay". Speed can be controlled with the "velocity" attribute, damage with the "damage" attribute, and cooldown with the "cooldown" attribute. In addition, the size of the projectile can be specified with the "scale" attribute, where 1 is the default size. The travel time can be specified with the "maxTravelTime" in seconds, where 1 second is the default travel time. Currently, these projectiles travel in a linear path with no falloff.

This is my first PR to PGM, so I understand if I missed some things. I hope I can fix these and make it usable! Thanks for the help.

Example projectile:
``` xml
<projectile
        id="laser"
        name="laser"
        projectile="Block"
        material="RED_STAINED_GLASS"
        velocity="0.5"
        damage="1"
        scale="0.2"
        throwable="false"
        max-travel-time="2s"
        cooldown="1s"/>
```