### PR TITLE
Fix Nether/End Portals working on Modern

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
@@ -13,10 +13,12 @@ import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityPoseChangeEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.event.entity.EntitySpawnEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.world.WorldLoadEvent;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.event.block.BlockFallEvent;
@@ -96,5 +98,12 @@ public class ModernListener implements Listener {
   @EventHandler
   public void onMatchLoad(WorldLoadEvent event) {
     event.getWorld().setGameRule(GameRule.DO_IMMEDIATE_RESPAWN, true);
+  }
+
+  @EventHandler(priority = EventPriority.HIGH)
+  public void onPlayerTeleport(final PlayerTeleportEvent event) {
+    switch (event.getCause()) {
+      case NETHER_PORTAL, END_PORTAL -> event.setCancelled(true);
+    }
   }
 }


### PR DESCRIPTION
End portals and Nether portals work on modern.

Cancelling the teleport event when the cause is a nether or end portal fixes that.