### PR TITLE
Add ``worldtime`` variable

### DIFF
--- a/core/src/main/java/tc/oc/pgm/variables/VariableParser.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariableParser.java
@@ -28,6 +28,7 @@ import tc.oc.pgm.variables.types.PlayerVariable;
 import tc.oc.pgm.variables.types.ScoreVariable;
 import tc.oc.pgm.variables.types.TeamVariableAdapter;
 import tc.oc.pgm.variables.types.TimeLimitVariable;
+import tc.oc.pgm.variables.types.WorldTimeVariable;
 
 public class VariableParser {
   // The limitation is due to them being used in exp4j formulas for.
@@ -130,5 +131,10 @@ public class VariableParser {
       factory.getFeatures().addFeature(el, subId, variable.getComponent(component));
     }
     return variable;
+  }
+
+  @MethodParser("worldtime")
+  public Variable<Match> parseWorldTime(Element el) {
+    return WorldTimeVariable.INSTANCE;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/variables/VariablesModule.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariablesModule.java
@@ -29,6 +29,7 @@ import tc.oc.pgm.variables.types.MaxBuildVariable;
 import tc.oc.pgm.variables.types.PlayerVariable;
 import tc.oc.pgm.variables.types.ScoreVariable;
 import tc.oc.pgm.variables.types.TimeLimitVariable;
+import tc.oc.pgm.variables.types.WorldTimeVariable;
 
 public class VariablesModule implements MapModule<VariablesMatchModule> {
 
@@ -142,6 +143,7 @@ public class VariablesModule implements MapModule<VariablesMatchModule> {
         features.addFeature(null, "score", ScoreVariable.INSTANCE);
         features.addFeature(null, "timelimit", TimeLimitVariable.INSTANCE);
         features.addFeature(null, "maxbuildheight", MaxBuildVariable.INSTANCE);
+        features.addFeature(null, "worldtime", WorldTimeVariable.INSTANCE);
         for (var component : PlayerVariable.Component.values()) {
           String key = "player." + component.name().toLowerCase(Locale.ROOT);
           features.addFeature(null, key, PlayerVariable.of(component));

--- a/core/src/main/java/tc/oc/pgm/variables/types/WorldTimeVariable.java
+++ b/core/src/main/java/tc/oc/pgm/variables/types/WorldTimeVariable.java
@@ -1,0 +1,24 @@
+package tc.oc.pgm.variables.types;
+
+import tc.oc.pgm.api.match.Match;
+
+public class WorldTimeVariable extends AbstractVariable<Match> {
+
+  public static final WorldTimeVariable INSTANCE = new WorldTimeVariable();
+
+  public WorldTimeVariable() {
+    super(Match.class);
+  }
+
+  @Override
+  protected double getValueImpl(Match match) {
+    long val = match.getWorld().getTime();
+    return (double) val;
+  }
+
+  @Override
+  protected void setValueImpl(Match match, double value) {
+    long val = (long) value;
+    match.getWorld().setTime(val);
+  }
+}


### PR DESCRIPTION
Adds a variable that allows mapmakers to change the time of the world during a match (for instance, as an objective is completed). It is 

Example: 
```xml
<actions>
    <action id="set-daytime" scope="match" expose="true">
        <set var="worldtime" value="6000"/> <!-- Sets the world time to 6000 -->
    </action>
    <action id="set-nighttime" scope="match" expose="true">
        <set var="worldtime" value="18000"/> <!-- Sets the world time to 18000 -->
    </action>
    <action id="add-time" scope="match" expose="true">
        <set var="worldtime" value="worldtime+1000"/> <!-- Adds 1000 to the current world time -->
    </action>
    <action id="remove-time" scope="match" expose="true">
        <set var="worldtime" value="worldtime-1000"/>
    </action>
</actions>
```

I went with `worldtime` instead of `world-time` to keep in line with `timelimit` and `maxbuildheight` (and so that the default ID matched the variable type)