### PR TITLE
Rollback the breaking change for now

### DIFF
--- a/core/src/main/java/tc/oc/pgm/variables/VariablesModule.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariablesModule.java
@@ -29,7 +29,6 @@ import tc.oc.pgm.variables.types.MaxBuildVariable;
 import tc.oc.pgm.variables.types.PlayerVariable;
 import tc.oc.pgm.variables.types.ScoreVariable;
 import tc.oc.pgm.variables.types.TimeLimitVariable;
-import tc.oc.pgm.variables.types.WorldTimeVariable;
 
 public class VariablesModule implements MapModule<VariablesMatchModule> {
 
@@ -143,7 +142,8 @@ public class VariablesModule implements MapModule<VariablesMatchModule> {
         features.addFeature(null, "score", ScoreVariable.INSTANCE);
         features.addFeature(null, "timelimit", TimeLimitVariable.INSTANCE);
         features.addFeature(null, "maxbuildheight", MaxBuildVariable.INSTANCE);
-        features.addFeature(null, "worldtime", WorldTimeVariable.INSTANCE);
+        // TODO: support fallback feature ids being overriden without being a breaking change
+        // features.addFeature(null, "worldtime", WorldTimeVariable.INSTANCE);
         for (var component : PlayerVariable.Component.values()) {
           String key = "player." + component.name().toLowerCase(Locale.ROOT);
           features.addFeature(null, key, PlayerVariable.of(component));


### PR DESCRIPTION
#1505 added a breaking change by introducing a new default id, meaning if any map is using "worldtime" for anything in their xml, they'd break.

Ideally we'd want to allow for "fallback ids" to be supported, so pgm defines worldtime but if any other module defines something else with that name, they can have it, without breaking. This would allow to add more default ids in the future without being a breaking change.