### PR TITLE
Implement ``weather`` action and allow for weather control

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -445,7 +445,7 @@ public class ActionParser {
 
   @MethodParser("weather")
   public WeatherAction parseWeather(Element el, Class<?> scope) throws InvalidXMLException {
-    return new WeatherAction(
+    return WeatherAction.of(
         parser.parseEnum(WeatherMatchModule.WeatherType.class, el, "state").required());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -36,6 +36,7 @@ import tc.oc.pgm.action.actions.SoundAction;
 import tc.oc.pgm.action.actions.TakePaymentAction;
 import tc.oc.pgm.action.actions.TeleportAction;
 import tc.oc.pgm.action.actions.VelocityAction;
+import tc.oc.pgm.action.actions.WeatherAction;
 import tc.oc.pgm.api.feature.FeatureValidation;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.Filterables;
@@ -50,6 +51,7 @@ import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.matcher.player.ParticipatingFilter;
 import tc.oc.pgm.filters.operator.AllFilter;
 import tc.oc.pgm.kits.Kit;
+import tc.oc.pgm.modules.WeatherMatchModule;
 import tc.oc.pgm.shops.ShopModule;
 import tc.oc.pgm.shops.menu.Payable;
 import tc.oc.pgm.structure.StructureDefinition;
@@ -439,5 +441,11 @@ public class ActionParser {
     var update = parser.parseBool(el, "update").orTrue();
 
     return new PasteStructureAction<>(scope, xFormula, yFormula, zFormula, structure, update);
+  }
+
+  @MethodParser("weather")
+  public WeatherAction parseWeather(Element el, Class<?> scope) throws InvalidXMLException {
+    return new WeatherAction(
+        parser.parseEnum(WeatherMatchModule.WeatherType.class, el, "state").required());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/WeatherAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/WeatherAction.java
@@ -1,0 +1,18 @@
+package tc.oc.pgm.action.actions;
+
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.modules.WeatherMatchModule;
+
+public class WeatherAction extends AbstractAction<Match> {
+
+  private final Enum state;
+
+  public WeatherAction(Enum state) {
+    super(Match.class);
+    this.state = state;
+  }
+
+  public void trigger(Match match) {
+    match.getModule(WeatherMatchModule.class).setWeather(state);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/action/actions/WeatherAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/WeatherAction.java
@@ -5,9 +5,9 @@ import tc.oc.pgm.modules.WeatherMatchModule;
 
 public class WeatherAction extends AbstractAction<Match> {
 
-  private final Enum state;
+  private final WeatherMatchModule.WeatherType state;
 
-  public WeatherAction(Enum state) {
+  public WeatherAction(WeatherMatchModule.WeatherType state) {
     super(Match.class);
     this.state = state;
   }

--- a/core/src/main/java/tc/oc/pgm/action/actions/WeatherAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/WeatherAction.java
@@ -1,18 +1,35 @@
 package tc.oc.pgm.action.actions;
 
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.modules.WeatherMatchModule;
+import tc.oc.pgm.modules.WeatherMatchModule.WeatherType;
 
 public class WeatherAction extends AbstractAction<Match> {
+  private static final Map<WeatherType, WeatherAction> INSTANCES;
 
-  private final WeatherMatchModule.WeatherType state;
+  static {
+    var values = new EnumMap<WeatherType, WeatherAction>(WeatherType.class);
+    for (WeatherType component : WeatherType.values()) {
+      values.put(component, new WeatherAction(component));
+    }
+    INSTANCES = Collections.unmodifiableMap(values);
+  }
 
-  public WeatherAction(WeatherMatchModule.WeatherType state) {
+  private final WeatherType state;
+
+  private WeatherAction(WeatherType state) {
     super(Match.class);
     this.state = state;
   }
 
+  public static WeatherAction of(WeatherType state) {
+    return INSTANCES.get(state);
+  }
+
   public void trigger(Match match) {
-    match.getModule(WeatherMatchModule.class).setWeather(state);
+    match.moduleRequire(WeatherMatchModule.class).setWeather(state);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -94,6 +94,7 @@ import tc.oc.pgm.modules.SoundsMatchModule;
 import tc.oc.pgm.modules.SpectateMatchModule;
 import tc.oc.pgm.modules.ToolRepairMatchModule;
 import tc.oc.pgm.modules.ToolRepairModule;
+import tc.oc.pgm.modules.WeatherMatchModule;
 import tc.oc.pgm.modules.WorldTimeModule;
 import tc.oc.pgm.observers.ObserverToolsMatchModule;
 import tc.oc.pgm.picker.PickerMatchModule;
@@ -225,6 +226,7 @@ public final class Modules {
     register(PlayerTimeMatchModule.class, PlayerTimeMatchModule::new);
     register(SpectateMatchModule.class, SpectateMatchModule::new);
     register(DamageHistoryMatchModule.class, DamageHistoryMatchModule::new);
+    register(WeatherMatchModule.class, WeatherMatchModule::new);
 
     register(ProjectileTrailMatchModule.class, ProjectileTrailMatchModule::new);
 

--- a/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
@@ -37,7 +37,6 @@ import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.vehicle.VehicleDamageEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
-import org.bukkit.event.weather.WeatherChangeEvent;
 import org.bukkit.event.world.PortalCreateEvent;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
@@ -149,11 +148,6 @@ public class EventFilterMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onPortalCreate(final PortalCreateEvent event) {
-    cancelAlways(event, event.getWorld());
-  }
-
-  @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-  public void onWeatherChange(final WeatherChangeEvent event) {
     cancelAlways(event, event.getWorld());
   }
 

--- a/core/src/main/java/tc/oc/pgm/modules/WeatherMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/WeatherMatchModule.java
@@ -25,41 +25,36 @@ public class WeatherMatchModule implements MatchModule, Listener {
 
   public WeatherMatchModule(Match match) {
     this.match = match;
-    this.shouldChange = shouldChange;
   }
 
   public void setWeather(WeatherMatchModule.WeatherType state) {
     shouldChange = true;
     World world = match.getWorld();
     switch (state) {
-      case WeatherType.CLEAR:
-        world.setStorm(false);
-        break;
-      case WeatherType.RAIN:
+      case WeatherType.CLEAR -> world.setStorm(false);
+      case WeatherType.RAIN -> {
         world.setStorm(true);
         world.setThundering(false);
         world.setThunderDuration(0);
-        break;
-      case WeatherType.THUNDER:
+      }
+      case WeatherType.THUNDER -> {
         world.setStorm(true);
         world.setThundering(true);
-        break;
-      default:
-        break;
+      }
     }
     shouldChange = false;
   }
 
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onWeatherChange(final WeatherChangeEvent event) {
-    if ((match.getWorld() == event.getWorld()) && !shouldChange) {
+    if (match.getWorld() == event.getWorld() && !shouldChange) {
       event.setCancelled(true);
     }
   }
 
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onThunderChange(ThunderChangeEvent event) {
-    if ((match.getWorld() == event.getWorld()) && !shouldChange) {
+    if (match.getWorld() == event.getWorld() && !shouldChange) {
       event.setCancelled(true);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/modules/WeatherMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/WeatherMatchModule.java
@@ -28,7 +28,7 @@ public class WeatherMatchModule implements MatchModule, Listener {
     this.shouldChange = shouldChange;
   }
 
-  public void setWeather(Enum state) {
+  public void setWeather(WeatherMatchModule.WeatherType state) {
     shouldChange = true;
     World world = match.getWorld();
     switch (state) {
@@ -52,14 +52,14 @@ public class WeatherMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onWeatherChange(final WeatherChangeEvent event) {
-    if ((match.getWorld() != event.getWorld()) || !shouldChange) {
+    if ((match.getWorld() == event.getWorld()) && !shouldChange) {
       event.setCancelled(true);
     }
   }
 
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onThunderChange(ThunderChangeEvent event) {
-    if ((match.getWorld() != event.getWorld()) || !shouldChange) {
+    if ((match.getWorld() == event.getWorld()) && !shouldChange) {
       event.setCancelled(true);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/modules/WeatherMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/WeatherMatchModule.java
@@ -1,0 +1,66 @@
+package tc.oc.pgm.modules;
+
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.weather.ThunderChangeEvent;
+import org.bukkit.event.weather.WeatherChangeEvent;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.events.ListenerScope;
+
+@ListenerScope(MatchScope.LOADED)
+public class WeatherMatchModule implements MatchModule, Listener {
+
+  public enum WeatherType {
+    CLEAR,
+    RAIN,
+    THUNDER;
+  }
+
+  private final Match match;
+  private boolean shouldChange = false;
+
+  public WeatherMatchModule(Match match) {
+    this.match = match;
+    this.shouldChange = shouldChange;
+  }
+
+  public void setWeather(Enum state) {
+    shouldChange = true;
+    World world = match.getWorld();
+    switch (state) {
+      case WeatherType.CLEAR:
+        world.setStorm(false);
+        break;
+      case WeatherType.RAIN:
+        world.setStorm(true);
+        world.setThundering(false);
+        world.setThunderDuration(0);
+        break;
+      case WeatherType.THUNDER:
+        world.setStorm(true);
+        world.setThundering(true);
+        break;
+      default:
+        break;
+    }
+    shouldChange = false;
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+  public void onWeatherChange(final WeatherChangeEvent event) {
+    if ((match.getWorld() != event.getWorld()) || !shouldChange) {
+      event.setCancelled(true);
+    }
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+  public void onThunderChange(ThunderChangeEvent event) {
+    if ((match.getWorld() != event.getWorld()) || !shouldChange) {
+      event.setCancelled(true);
+    }
+  }
+}


### PR DESCRIPTION
Adds a ``weather`` action that allows map authors to change the world's weather during a match (for instance, every X minutes). Aside from aesthetic uses, this can be especially useful in newer versions where rain affects things like riptide tridents.

```xml
<action id="set-rain" scope="match" expose="true">
    <weather state="rain"/>
</action>
<action id="set-thunder" scope="match" expose="true">
    <weather state="thunder"/>
</action>
<action id="set-clear" scope="match" expose="true">
    <weather state="clear"/>
</action>
```

Also fixes thunder actually being able to end on its own on existing maps, as it uses a different counter.