### PR TITLE
Update adventure and adventure-platform

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
@@ -23,9 +23,9 @@ repositories {
 
 dependencies {
     api("org.jdom:jdom2:2.0.6.1")
-    api("net.kyori:adventure-api:4.18.0")
-    api("net.kyori:adventure-text-serializer-plain:4.18.0")
-    api("net.kyori:adventure-platform-bukkit:4.3.4")
+    api("net.kyori:adventure-api:4.21.0")
+    api("net.kyori:adventure-text-serializer-plain:4.21.0")
+    api("net.kyori:adventure-platform-bukkit:4.4.0")
     api("org.incendo:cloud-core:2.0.0")
     api("org.incendo:cloud-annotations:2.0.0")
     api("org.incendo:cloud-paper:2.0.0-beta.10")


### PR DESCRIPTION
Unblocks https://github.com/PGMDev/PGM/pull/1494

Draft because it won't actually be used on modern since Paper's copy of Adventure takes precedence, so we either need to wait until we update to a newer version of Paper or figure something else out (relocating Adventure and then solving issues that arise from that if it's possible?).