### PR TITLE
Add lighting strike option to blitz module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzConfig.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzConfig.java
@@ -9,6 +9,7 @@ public class BlitzConfig {
 
   private final int lives;
   private final boolean broadcastLives;
+  private final boolean lightning;
   private final Filter filter;
   private final Filter scoreboardFilter;
   private final Filter joinFilter;
@@ -16,6 +17,7 @@ public class BlitzConfig {
   public BlitzConfig(
       int lives,
       boolean broadcastLives,
+      boolean lightning,
       Filter filter,
       Filter scoreboardFilter,
       Filter joinFilter) {
@@ -23,6 +25,7 @@ public class BlitzConfig {
 
     this.lives = lives;
     this.broadcastLives = broadcastLives;
+    this.lightning = lightning;
     this.filter = filter;
     this.scoreboardFilter = scoreboardFilter;
     this.joinFilter = joinFilter;
@@ -39,6 +42,10 @@ public class BlitzConfig {
 
   public boolean getBroadcastLives() {
     return this.broadcastLives;
+  }
+
+  public boolean getLightning() {
+    return this.lightning;
   }
 
   public Filter getFilter() {

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -140,15 +140,14 @@ public class BlitzMatchModule implements MatchModule, Listener {
 
   public void showLivesTitle(MatchPlayer matchPlayer) {
     int lives = this.lifeManager.getLives(matchPlayer.getId());
-    matchPlayer.showTitle(
-        title(
-            empty(),
+    matchPlayer.showTitle(title(
+        empty(),
+        translatable(
+            "blitz.livesRemaining",
+            NamedTextColor.RED,
             translatable(
-                "blitz.livesRemaining",
-                NamedTextColor.RED,
-                translatable(
-                    lives == 1 ? "misc.life" : "misc.lives", NamedTextColor.AQUA, text(lives))),
-            Title.Times.times(Duration.ZERO, fromTicks(60), fromTicks(20))));
+                lives == 1 ? "misc.life" : "misc.lives", NamedTextColor.AQUA, text(lives))),
+        Title.Times.times(Duration.ZERO, fromTicks(60), fromTicks(20))));
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
@@ -157,6 +156,10 @@ public class BlitzMatchModule implements MatchModule, Listener {
 
     World world = event.getMatch().getWorld();
     Location death = event.getDeathLocation();
+
+    if (this.config.getLightning()) {
+      world.strikeLightningEffect(death);
+    }
 
     double radius = 0.1;
     int n = 8;
@@ -184,15 +187,12 @@ public class BlitzMatchModule implements MatchModule, Listener {
     // Player leaving may have ended the match, causing a rejected execution.
     if (!match.isRunning()) return;
 
-    match
-        .getExecutor(MatchScope.RUNNING)
-        .execute(
-            () -> {
-              ImmutableSet.copyOf(match.getParticipants()).stream()
-                  .filter(participating -> isPlayerEliminated(participating.getId()))
-                  .forEach(participating -> match.setParty(participating, match.getDefaultParty()));
+    match.getExecutor(MatchScope.RUNNING).execute(() -> {
+      ImmutableSet.copyOf(match.getParticipants()).stream()
+          .filter(participating -> isPlayerEliminated(participating.getId()))
+          .forEach(participating -> match.setParty(participating, match.getDefaultParty()));
 
-              match.calculateVictory();
-            });
+      match.calculateVictory();
+    });
   }
 }

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzModule.java
@@ -58,6 +58,7 @@ public class BlitzModule implements MapModule<BlitzMatchModule> {
 
       int lives = Integer.MAX_VALUE;
       boolean broadcastLives = false;
+      boolean lightning = false;
       Filter filter = null;
       Filter scoreboardFilter = null;
       Filter joinFilter = null;
@@ -65,19 +66,18 @@ public class BlitzModule implements MapModule<BlitzMatchModule> {
       FilterParser filters = factory.getFilters();
       for (Element blitzEl : blitzElements) {
         broadcastLives = XMLUtils.parseBoolean(blitzEl.getChild("broadcastLives"), true);
-        lives =
-            XMLUtils.parseNumberInRange(
-                Node.fromChildOrAttr(blitzEl, "lives"), Integer.class, Range.atLeast(1), 1);
+        lightning = XMLUtils.parseBoolean(Node.fromChildOrAttr(blitzEl, "lightning"), false);
+        lives = XMLUtils.parseNumberInRange(
+            Node.fromChildOrAttr(blitzEl, "lives"), Integer.class, Range.atLeast(1), 1);
         filter = filters.parseProperty(blitzEl, "filter", StaticFilter.ALLOW);
-        scoreboardFilter =
-            filters.parseProperty(
-                blitzEl, "scoreboard-filter", StaticFilter.ALLOW, DynamicFilterValidation.PARTY);
+        scoreboardFilter = filters.parseProperty(
+            blitzEl, "scoreboard-filter", StaticFilter.ALLOW, DynamicFilterValidation.PARTY);
         joinFilter = filters.parseProperty(blitzEl, "join-filter", StaticFilter.DENY);
       }
 
       if (lives != Integer.MAX_VALUE) {
-        return new BlitzModule(
-            new BlitzConfig(lives, broadcastLives, filter, scoreboardFilter, joinFilter));
+        return new BlitzModule(new BlitzConfig(
+            lives, broadcastLives, lightning, filter, scoreboardFilter, joinFilter));
       }
 
       return null;


### PR DESCRIPTION
Adds a simple `lightning` attribute to the `<blitz>` module. This produces a lightning strike on the player's death location when they are eliminated (no lives left), the same way a [smoke effect](https://github.com/PGMDev/PGM/blob/8263eab3c3f0324a12b888863a0b6ae2f789dbfc/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java#L168) is produced.

Implemented according to [Pablo's comment](https://github.com/PGMDev/PGM/issues/1217#issuecomment-2953632887) here. At Warzone, we intend to use this for Survival Games maps, but can of course be used for any other Blitz maps.

(Other changes in the code are due to the formatter Spotless)