### PR TITLE
Add license linking exception

### DIFF
--- a/LICENSE_LINKING
+++ b/LICENSE_LINKING
@@ -1,0 +1,18 @@
+"MINECRAFT" LINKING EXCEPTION TO THE AGPL
+
+Linking this mod statically or dynamically with other modules is making a
+combined work based on this mod. Thus, the terms and conditions of the GNU
+Affero General Public License cover the whole combination.
+
+In addition, as a special exception, the copyright holders of this mod give you
+permission to combine this mod with free software programs or libraries that
+are released under the GNU LGPL, GPL and with code included in the standard release
+of Minecraft under All Rights Reserved (or modified versions of such code, with
+unchanged license). You may copy and distribute such a system following the
+terms of the GNU AGPL for this mod and the licenses of the other code concerned.
+
+Note that people who make modified versions of this mod are not obligated to
+grant this special exception for their modified versions; it is their choice
+whether to do so. The GNU Affero General Public License gives permission to
+release a modified version without this exception; this exception also makes it
+possible to release a modified version which carries forward this exception.


### PR DESCRIPTION
As per #1513 , we're adding a linking exception to the AGPL licence that governs PGM, and everyone who submitted patches to PGM has agreed.