### PR TITLE
Drop flag if banner is not in helmet slot

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
+++ b/core/src/main/java/tc/oc/pgm/api/player/MatchPlayer.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.Tickable;
@@ -264,7 +265,7 @@ public interface MatchPlayer
    */
   GameMode getGameMode();
 
-  @Override
+  @UnknownNullability
   PlayerInventory getInventory();
 
   World getWorld();

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -68,8 +68,8 @@ public class Carried extends Spawned implements Missing {
   public Carried(Flag flag, Post post, MatchPlayer carrier, Location dropLocation) {
     super(flag, post);
     this.carrier = carrier;
-    this.dropLocations.add(
-        dropLocation); // Need an initial dropLocation in case the carrier never generates ones
+    // Need an initial dropLocation in case the carrier never generates ones
+    this.dropLocations.add(dropLocation);
   }
 
   @Override
@@ -208,6 +208,10 @@ public class Carried extends Spawned implements Missing {
           this.flag.getDefinition().getPointsPerSecond() / 20D,
           ScoreCause.FLAG_CARRIED_TICK);
     }
+
+    if (!isFlag(carrier.getInventory().getHelmet())) {
+      this.dropFlag();
+    }
   }
 
   @Override
@@ -293,7 +297,7 @@ public class Carried extends Spawned implements Missing {
   }
 
   protected boolean isFlag(ItemStack stack) {
-    return stack.isSimilar(this.flag.getBannerItem());
+    return stack != null && stack.isSimilar(this.flag.getBannerItem());
   }
 
   @Override


### PR DESCRIPTION
Makes it so when holding a flag, if by any way the banner is dropped from the helmet slot, the flag is dropped.
Things that could cause this include:
 - Applying a (pgm) kit that clears or modifies the helmet
 - Commands like /replaceitem (or /hat in modified servers)
 - Any other kind of plugin interaction that replaces inventory slots