### PR TITLE
fix(rage): determine projectile eligibility using used weapon on modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/rage/RageMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/rage/RageMatchModule.java
@@ -2,9 +2,9 @@ package tc.oc.pgm.rage;
 
 import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 
-import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -17,7 +17,6 @@ import tc.oc.pgm.util.bukkit.Enchantments;
 
 @ListenerScope(MatchScope.RUNNING)
 public class RageMatchModule implements MatchModule, Listener {
-
   public RageMatchModule(Match match) {}
 
   @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -28,12 +27,10 @@ public class RageMatchModule implements MatchModule, Listener {
   }
 
   private boolean isRage(Entity damager) {
-    if (damager instanceof Player) {
-      Player player = (Player) damager;
+    if (damager instanceof Player player) {
       return player.getItemInHand().containsEnchantment(Enchantments.SHARPNESS);
-    } else if (damager instanceof Arrow) {
-      Arrow arrow = (Arrow) damager; // Arrows with damage > 2 are from power bows.
-      return arrow.getShooter() instanceof Player && MISC_UTILS.getArrowDamage(arrow) > 2.0D;
+    } else if (damager instanceof Projectile proj) {
+      return proj.getShooter() instanceof Player && MISC_UTILS.isPowerEnchanted(proj);
     }
     return false;
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
@@ -17,9 +17,12 @@ import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.AbstractArrow;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventException;
@@ -111,5 +114,15 @@ public class ModernMiscUtil implements MiscUtils {
   public void initScoreboardTeam(Team team, NamedTextColor color) {
     team.color(color);
     team.setOption(Team.Option.COLLISION_RULE, Team.OptionStatus.NEVER);
+  }
+
+  @Override
+  public boolean isPowerEnchanted(Projectile proj) {
+    if (proj instanceof AbstractArrow arrow) {
+      // We can leverage the used weapon data to determine if the arrow was shot from a power bow
+      var weapon = arrow.getWeapon();
+      return weapon != null && weapon.containsEnchantment(Enchantment.POWER);
+    }
+    return false;
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMiscUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMiscUtil.java
@@ -21,6 +21,7 @@ import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventException;
@@ -110,5 +111,11 @@ public class SpMiscUtil implements MiscUtils {
   @SuppressWarnings("PatternValidation")
   public Key getSound(Sound enumConstant) {
     return key(CraftSound.getSound(enumConstant));
+  }
+
+  @Override
+  public boolean isPowerEnchanted(Projectile proj) {
+    // Arrows with damage > 2 are from power bows.
+    return proj instanceof Arrow arrow && arrow.spigot().getDamage() > 2.0D;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
@@ -11,6 +11,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventException;
@@ -59,4 +60,6 @@ public interface MiscUtils {
   Key getSound(Sound constant);
 
   default void initScoreboardTeam(Team team, NamedTextColor color) {}
+
+  boolean isPowerEnchanted(Projectile proj);
 }


### PR DESCRIPTION
In modern Minecraft, `AbstractArrow#getDamage()` (and by extension, `MiscUtils#getArrowDamage`) returns the base damage before applying any enchantment multipliers. However, we can leverage the item stack in `AbstractArrow#getWeapon()` to determine if the weapon used has a power enchantment and act accordingly.

This also enables the rage module to work with thrown tridents if they're enchanted with Power I.