### PR TITLE
fix(platform/modern): allow invisible players to be hidden

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernPlayerUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernPlayerUtils.java
@@ -171,7 +171,7 @@ public class ModernPlayerUtils implements PlayerUtils {
   }
 
   private boolean updateMetadata(Player player, boolean set, String key) {
-    if (player.hasMetadata(key)) return false;
+    if (player.hasMetadata(key) == set) return false;
 
     if (set) player.setMetadata(key, TRUE);
     else player.removeMetadata(key, BukkitUtils.getPlugin());


### PR DESCRIPTION
This patch corrects the logic in `ModernPlayerUtils#updateMetadata` to allow for unsetting player metadata - making hiding invisible players or showing potion particles work again 🙈