### PR TITLE
Fix attributes breaking backwards compatibility

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/attribute/Attributes.java
+++ b/util/src/main/java/tc/oc/pgm/util/attribute/Attributes.java
@@ -5,29 +5,17 @@ import java.util.Map;
 import org.bukkit.attribute.Attribute;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
-import tc.oc.pgm.util.platform.Platform;
 
 public class Attributes {
 
   private static final Map<String, Attribute> BY_NAME = new HashMap<>(Attribute.values().length);
 
   static {
-    parse("GENERIC_MAX_HEALTH", "MAX_HEALTH");
-    parse("GENERIC_FOLLOW_RANGE", "FOLLOW_RANGE");
-    parse("GENERIC_MOVEMENT_SPEED", "MOVEMENT_SPEED");
-    parse("GENERIC_ATTACK_DAMAGE", "ATTACK_DAMAGE");
     parse("HORSE_JUMP_STRENGTH", "GENERIC_JUMP_STRENGTH", "JUMP_STRENGTH");
     parse("ZOMBIE_SPAWN_REINFORCEMENTS", "SPAWN_REINFORCEMENTS");
-    if (Platform.isModern()) {
-      parse("GENERIC_FLYING_SPEED", "FLYING_SPEED");
-      parse("GENERIC_ATTACK_SPEED", "ATTACK_SPEED");
-      parse("GENERIC_ARMOR", "ARMOR");
-      parse("GENERIC_ARMOR_TOUGHNESS", "ARMOR_TOUGHNESS");
-      parse("GENERIC_LUCK", "LUCK");
-    }
 
     for (Attribute value : Attribute.values()) {
-      if (value != null) BY_NAME.put(StringUtils.simplify(value.name()), value);
+      if (value != null) BY_NAME.put(simplifyAttributeKey(value.name()), value);
     }
   }
 
@@ -37,12 +25,19 @@ public class Attributes {
   private static Attribute parse(String... names) {
     Attribute type = BukkitUtils.parse(Attribute::valueOf, names);
     for (String name : names) {
-      BY_NAME.put(StringUtils.simplify(name), type);
+      BY_NAME.put(simplifyAttributeKey(name), type);
     }
     return type;
   }
 
   public static Attribute getByName(String name) {
-    return BY_NAME.get(StringUtils.simplify(name));
+    return BY_NAME.get(simplifyAttributeKey(name));
+  }
+
+  private static String simplifyAttributeKey(String name) {
+    var split = name.split("[._]", 2);
+    if ("generic".equalsIgnoreCase(split[0]) || "player".equalsIgnoreCase(split[0]))
+      name = split.length > 1 ? split[1] : "";
+    return StringUtils.simplify(name);
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -1047,9 +1047,6 @@ public final class XMLUtils {
     var attribute = Attributes.getByName(text);
     if (attribute != null) return attribute;
 
-    attribute = Attributes.getByName("generic" + text);
-    if (attribute != null) return attribute;
-
     throw new InvalidXMLException("Unknown attribute '" + text + "'", node);
   }
 
@@ -1064,8 +1061,8 @@ public final class XMLUtils {
       case "add" -> AttributeModifier.Operation.ADD_NUMBER;
       case "base" -> AttributeModifier.Operation.ADD_SCALAR;
       case "multiply" -> AttributeModifier.Operation.MULTIPLY_SCALAR_1;
-      default -> throw new InvalidXMLException(
-          "Unknown attribute modifier operation '" + text + "'", node);
+      default ->
+        throw new InvalidXMLException("Unknown attribute modifier operation '" + text + "'", node);
     };
   }
 


### PR DESCRIPTION
Allows `generic.whatever` to always work no matter if included or excluded, since the `generic.` prefix will always be stripped. The same goes for `generic_*`,  `player.*` or `player_*`