### PR TITLE
Add drop-flag and pickup-flag actions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -20,12 +20,14 @@ import org.bukkit.inventory.ItemStack;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.action.actions.ActionNode;
+import tc.oc.pgm.action.actions.DropFlagAction;
 import tc.oc.pgm.action.actions.EnchantItemAction;
 import tc.oc.pgm.action.actions.ExposedAction;
 import tc.oc.pgm.action.actions.FillAction;
 import tc.oc.pgm.action.actions.KillEntitiesAction;
 import tc.oc.pgm.action.actions.MessageAction;
 import tc.oc.pgm.action.actions.PasteStructureAction;
+import tc.oc.pgm.action.actions.PickupFlagAction;
 import tc.oc.pgm.action.actions.RepeatAction;
 import tc.oc.pgm.action.actions.ReplaceItemAction;
 import tc.oc.pgm.action.actions.ScopeSwitchAction;
@@ -50,6 +52,7 @@ import tc.oc.pgm.filters.Filterable;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.matcher.player.ParticipatingFilter;
 import tc.oc.pgm.filters.operator.AllFilter;
+import tc.oc.pgm.flag.FlagDefinition;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.modules.WeatherMatchModule;
 import tc.oc.pgm.shops.ShopModule;
@@ -460,5 +463,16 @@ public class ActionParser {
   public WeatherAction parseWeather(Element el, Class<?> scope) throws InvalidXMLException {
     return WeatherAction.of(
         parser.parseEnum(WeatherMatchModule.WeatherType.class, el, "state").required());
+  }
+
+  @MethodParser("drop-flag")
+  public DropFlagAction parseDropFlag(Element el, Class<?> scope) throws InvalidXMLException {
+    return new DropFlagAction(parser.reference(FlagDefinition.class, el, "flag").required());
+  }
+
+  @MethodParser("pickup-flag")
+  public PickupFlagAction parsePickupFlag(Element el, Class<?> scope) throws InvalidXMLException {
+    return new PickupFlagAction(
+        parser.reference(FlagDefinition.class, el, "flag").required());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/DropFlagAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/DropFlagAction.java
@@ -1,0 +1,22 @@
+package tc.oc.pgm.action.actions;
+
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.flag.Flag;
+import tc.oc.pgm.flag.FlagDefinition;
+
+public class DropFlagAction extends AbstractAction<Match> {
+  private final FeatureReference<? extends FlagDefinition> flag;
+
+  public DropFlagAction(FeatureReference<? extends FlagDefinition> flag) {
+    super(Match.class);
+    this.flag = flag;
+  }
+
+  @Override
+  public void trigger(Match match) {
+    final Flag flag = this.flag.get().getGoal(match);
+    if (flag == null) return;
+    flag.dropFlag();
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/action/actions/PickupFlagAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/PickupFlagAction.java
@@ -1,0 +1,22 @@
+package tc.oc.pgm.action.actions;
+
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.flag.Flag;
+import tc.oc.pgm.flag.FlagDefinition;
+
+public class PickupFlagAction extends AbstractAction<MatchPlayer> {
+  private final FeatureReference<? extends FlagDefinition> flag;
+
+  public PickupFlagAction(FeatureReference<? extends FlagDefinition> flag) {
+    super(MatchPlayer.class);
+    this.flag = flag;
+  }
+
+  @Override
+  public void trigger(MatchPlayer matchPlayer) {
+    final Flag flag = this.flag.get().getGoal(matchPlayer.getMatch());
+    if (flag == null) return;
+    flag.pickupFlag(matchPlayer, matchPlayer.getLocation());
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -355,6 +355,14 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     }
   }
 
+  public boolean pickupFlag(MatchPlayer carrier, Location location) {
+    return this.state.pickupFlag(carrier, location);
+  }
+
+  public void dropFlag() {
+    this.state.dropFlag();
+  }
+
   public boolean canPickup(Query query, Post post) {
     return getDefinition().getPickupFilter().query(query).isAllowed()
         && post.getPickupFilter().query(query).isAllowed();

--- a/core/src/main/java/tc/oc/pgm/flag/state/BaseState.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/BaseState.java
@@ -21,14 +21,17 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.flag.Flag;
+import tc.oc.pgm.flag.FlagMatchModule;
 import tc.oc.pgm.flag.Post;
 import tc.oc.pgm.flag.event.FlagCaptureEvent;
+import tc.oc.pgm.flag.event.FlagPickupEvent;
 import tc.oc.pgm.flag.event.FlagStateChangeEvent;
 import tc.oc.pgm.goals.events.GoalEvent;
 import tc.oc.pgm.spawns.events.ParticipantDespawnEvent;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.TimeUtils;
+import tc.oc.pgm.util.bukkit.Sounds;
 
 /** Base class for all {@link Flag} states */
 public abstract class BaseState implements Runnable, State {
@@ -37,6 +40,7 @@ public abstract class BaseState implements Runnable, State {
   protected final Post post;
   protected final Instant enterTime;
   protected @Nullable Long remainingTicks;
+  protected @Nullable MatchPlayer pickingUp;
   private Future<?> task;
 
   protected BaseState(Flag flag, Post post) {
@@ -57,16 +61,15 @@ public abstract class BaseState implements Runnable, State {
    * throw an exception. Care must be taken that any events fired cannot cause another transition
    * for this flag. Transitioning other flags is OK.
    *
-   * <p>If this state wants to immediately transition, it should return zero from {@link
-   * #getDuration}, which will cause {@link #finishCountdown} to be called after this method
+   * <p>If this state wants to immediately transition, it should return zero from
+   * {@link #getDuration}, which will cause {@link #finishCountdown} to be called after this method
    * returns.
    */
   public void enterState() {
-    this.task =
-        this.flag
-            .getMatch()
-            .getExecutor(MatchScope.LOADED)
-            .scheduleWithFixedDelay(this, TimeUtils.TICK, TimeUtils.TICK, TimeUnit.MILLISECONDS);
+    this.task = this.flag
+        .getMatch()
+        .getExecutor(MatchScope.LOADED)
+        .scheduleWithFixedDelay(this, TimeUtils.TICK, TimeUtils.TICK, TimeUnit.MILLISECONDS);
   }
 
   public void leaveState() {
@@ -75,6 +78,38 @@ public abstract class BaseState implements Runnable, State {
       this.task = null;
     }
   }
+
+  protected boolean canPickup(MatchPlayer player) {
+    if (this.pickingUp != null) return false; // Prevent infinite recursion
+
+    for (Flag flag : this.flag.getMatch().getModule(FlagMatchModule.class).getFlags()) {
+      if (flag.isCarrying(player)) return false;
+    }
+
+    return this.flag.canPickup(player, this.post);
+  }
+
+  public boolean pickupFlag(MatchPlayer carrier, Location location) {
+    if (!this.canPickup(carrier)) return false;
+
+    try {
+      this.pickingUp = carrier;
+      FlagPickupEvent event = new FlagPickupEvent(this.flag, carrier, location);
+      this.flag.getMatch().callEvent(event);
+      if (event.isCancelled()) return false;
+    } finally {
+      this.pickingUp = null;
+    }
+
+    this.flag.playStatusSound(Sounds.FLAG_PICKUP_OWN, Sounds.FLAG_PICKUP);
+    this.flag.touch(carrier.getParticipantState());
+
+    this.flag.transition(new Carried(this.flag, this.post, carrier, location));
+
+    return true;
+  }
+
+  public void dropFlag() {}
 
   @Override
   public Iterable<Location> getProximityLocations(ParticipantState player) {
@@ -139,7 +174,8 @@ public abstract class BaseState implements Runnable, State {
 
   @Override
   public boolean isCarrying(MatchPlayer player) {
-    return false;
+    // This allows CarryingFlagFilter to match and cancel the pickup before it actually happens
+    return player == this.pickingUp;
   }
 
   @Override
@@ -148,9 +184,8 @@ public abstract class BaseState implements Runnable, State {
     return matchPlayer != null && isCarrying(matchPlayer);
   }
 
-  @Override
   public boolean isCarrying(Party party) {
-    return false;
+    return this.pickingUp != null && party == this.pickingUp.getParty();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -215,12 +215,12 @@ public class Carried extends Spawned implements Missing {
 
   @Override
   public boolean isCarrying(MatchPlayer player) {
-    return this.carrier == player;
+    return carrier() == player;
   }
 
   @Override
   public boolean isCarrying(Party party) {
-    return this.carrier.getParty() == party;
+    return carrier().getParty() == party;
   }
 
   @Override
@@ -228,7 +228,8 @@ public class Carried extends Spawned implements Missing {
     return player != this.carrier.getBukkit();
   }
 
-  protected void dropFlag() {
+  @Override
+  public void dropFlag() {
     for (Location dropLocation : this.dropLocations) {
       if (this.flag.canDrop(new PlayerQuery(null, carrier, dropLocation))) {
         this.flag.transition(new Dropped(this.flag, this.post, dropLocation, this.carrier));
@@ -281,6 +282,10 @@ public class Carried extends Spawned implements Missing {
 
     FlagCaptureEvent event = new FlagCaptureEvent(this.flag, this.carrier, net);
     this.flag.getMatch().callEvent(event);
+  }
+
+  private MatchPlayer carrier() {
+    return pickingUp != null ? this.pickingUp : carrier;
   }
 
   public MatchPlayer getCarrier() {

--- a/core/src/main/java/tc/oc/pgm/flag/state/Dropped.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Dropped.java
@@ -44,6 +44,18 @@ public class Dropped extends Uncarried implements Missing {
   }
 
   @Override
+  protected void placeBanner() {
+    if (Duration.ZERO.equals(this.getDuration())) return;
+    super.placeBanner();
+  }
+
+  @Override
+  protected void breakBanner() {
+    if (Duration.ZERO.equals(this.getDuration())) return;
+    super.breakBanner();
+  }
+
+  @Override
   public void enterState() {
     super.enterState();
 

--- a/core/src/main/java/tc/oc/pgm/flag/state/Uncarried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Uncarried.java
@@ -13,16 +13,12 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.BlockTransformEvent;
-import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.flag.Flag;
-import tc.oc.pgm.flag.FlagMatchModule;
 import tc.oc.pgm.flag.Post;
-import tc.oc.pgm.flag.event.FlagPickupEvent;
 import tc.oc.pgm.hologram.Hologram;
 import tc.oc.pgm.hologram.HologramMatchModule;
 import tc.oc.pgm.util.block.BlockStates;
-import tc.oc.pgm.util.bukkit.Sounds;
 import tc.oc.pgm.util.material.Materials;
 
 /** Base class for flag states in which the banner is placed on the ground somewhere as a block */
@@ -32,7 +28,6 @@ public abstract class Uncarried extends Spawned {
   protected final BlockState oldBlock;
   protected final BlockState oldBase;
   protected final Hologram hologram;
-  private @Nullable MatchPlayer pickingUp;
 
   public Uncarried(Flag flag, Post post, @Nullable Location location) {
     super(flag, post);
@@ -95,36 +90,6 @@ public abstract class Uncarried extends Spawned {
     super.leaveState();
   }
 
-  @Override
-  public boolean isCarrying(MatchPlayer player) {
-    // This allows CarryingFlagFilter to match and cancel the pickup before it actually happens
-    return player == this.pickingUp || super.isCarrying(player);
-  }
-
-  @Override
-  public boolean isCarrying(Party party) {
-    return (this.pickingUp != null && party == this.pickingUp.getParty())
-        || super.isCarrying(party);
-  }
-
-  protected boolean pickupFlag(MatchPlayer carrier) {
-    try {
-      this.pickingUp = carrier;
-      FlagPickupEvent event = new FlagPickupEvent(this.flag, carrier, this.location);
-      this.flag.getMatch().callEvent(event);
-      if (event.isCancelled()) return false;
-    } finally {
-      this.pickingUp = null;
-    }
-
-    this.flag.playStatusSound(Sounds.FLAG_PICKUP_OWN, Sounds.FLAG_PICKUP);
-    this.flag.touch(carrier.getParticipantState());
-
-    this.flag.transition(new Carried(this.flag, this.post, carrier, this.location));
-
-    return true;
-  }
-
   protected boolean inPickupRange(Player player) {
     Location playerLoc = player.getLocation();
     Location flagLoc = this.getLocation();
@@ -142,16 +107,6 @@ public abstract class Uncarried extends Spawned {
     return false;
   }
 
-  protected boolean canPickup(MatchPlayer player) {
-    if (this.pickingUp != null) return false; // Prevent infinite recursion
-
-    for (Flag flag : this.flag.getMatch().getModule(FlagMatchModule.class).getFlags()) {
-      if (flag.isCarrying(player)) return false;
-    }
-
-    return this.flag.canPickup(player, this.post);
-  }
-
   @Override
   public void onEvent(PlayerMoveEvent event) {
     super.onEvent(event);
@@ -159,7 +114,7 @@ public abstract class Uncarried extends Spawned {
     if (player == null || !player.canInteract() || player.getBukkit().isDead()) return;
 
     if (this.inPickupRange(player.getBukkit()) && this.canPickup(player)) {
-      this.pickupFlag(player);
+      this.pickupFlag(player, this.location);
     }
   }
 


### PR DESCRIPTION
Adds actions for transferring flags

```xml
<action id="pickup-red-flag" scope="player" expose="true">
    <pickup-flag flag="red-flag"/>
</action>

<action id="drop-red-flag" scope="match" expose="true">
    <drop-flag flag="red-flag"/>
</action>
```

Internally this means that flags can now transition from any state (bar Completed) to Carried. There shouldn't be any illegal transitions that become possible with this, but I could be missing something