### PR TITLE
fix: correct wind charge behavior in modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blockdrops/BlockDropsMatchModule.java
@@ -68,7 +68,9 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
   }
 
   public static boolean causesDrops(final Event event) {
-    return event instanceof BlockBreakEvent || event instanceof EntityExplodeEvent;
+    return event instanceof BlockBreakEvent
+        || (event instanceof EntityExplodeEvent explodeEvent
+            && MISC_UTILS.isDestructiveExplosion(explodeEvent));
   }
 
   @EventHandler(priority = EventPriority.LOW)
@@ -169,8 +171,7 @@ public class BlockDropsMatchModule implements MatchModule, Listener {
       boolean explosion = false;
       MatchPlayer player = ParticipantBlockTransformEvent.getParticipant(event);
 
-      if (event.getCause() instanceof EntityExplodeEvent) {
-        EntityExplodeEvent explodeEvent = (EntityExplodeEvent) event.getCause();
+      if (event.getCause() instanceof EntityExplodeEvent explodeEvent) {
         explosion = true;
         yield = explodeEvent.getYield();
 

--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -383,7 +383,13 @@ public class BlockTransformListener implements Listener {
     for (Block block : event.blockList()) {
       if (block.getType() != Material.TNT) {
         // Don't cancel the explosion when individual blocks are cancelled
-        callEvent(event, block.getState(), BlockStates.toAir(block), playerState)
+        callEvent(
+                event,
+                block.getState(),
+                MISC_UTILS.isDestructiveExplosion(event)
+                    ? BlockStates.toAir(block)
+                    : block.getState(),
+                playerState)
             .setPropagate(false);
       }
     }

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTMatchModule.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.tnt;
 
+import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
+
 import java.util.Random;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -114,13 +116,11 @@ public class TNTMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void dispenserNukes(BlockTransformEvent event) {
     BlockState oldState = event.getOldState();
-    if (oldState instanceof Dispenser
+    if (oldState instanceof Dispenser dispenser
         && this.properties.dispenserNukeLimit > 0
         && this.properties.dispenserNukeMultiplier > 0
-        && event.getCause() instanceof EntityExplodeEvent) {
-
-      EntityExplodeEvent explodeEvent = (EntityExplodeEvent) event.getCause();
-      Dispenser dispenser = (Dispenser) oldState;
+        && event.getCause() instanceof EntityExplodeEvent explodeEvent
+        && MISC_UTILS.isDestructiveExplosion(explodeEvent)) {
       int tntLimit =
           Math.round(this.properties.dispenserNukeLimit / this.properties.dispenserNukeMultiplier);
       int tntCount = 0;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
@@ -10,6 +10,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.NbtUtils;
+import org.bukkit.ExplosionResult;
 import org.bukkit.Location;
 import org.bukkit.Registry;
 import org.bukkit.Sound;
@@ -30,6 +31,7 @@ import org.bukkit.event.EventException;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.inventory.ItemStack;
@@ -131,5 +133,11 @@ public class ModernMiscUtil implements MiscUtils {
       return weapon != null && weapon.containsEnchantment(Enchantment.POWER);
     }
     return false;
+  }
+
+  @Override
+  public boolean isDestructiveExplosion(EntityExplodeEvent ev) {
+    return ev.getExplosionResult() == ExplosionResult.DESTROY
+        || ev.getExplosionResult() == ExplosionResult.DESTROY_WITH_DECAY;
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMiscUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMiscUtil.java
@@ -28,6 +28,7 @@ import org.bukkit.event.EventException;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.inventory.ItemStack;
@@ -118,5 +119,11 @@ public class SpMiscUtil implements MiscUtils {
   public boolean isPowerEnchanted(Projectile proj) {
     // Arrows with damage > 2 are from power bows.
     return proj instanceof Arrow arrow && arrow.spigot().getDamage() > 2.0D;
+  }
+
+  @Override
+  public boolean isDestructiveExplosion(EntityExplodeEvent ev) {
+    // All explosions in 1.8 are destructive
+    return true;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
@@ -17,6 +17,7 @@ import org.bukkit.event.EventException;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.inventory.ItemStack;
@@ -61,4 +62,6 @@ public interface MiscUtils {
   default void initScoreboardTeam(Team team, NamedTextColor color) {}
 
   boolean isPowerEnchanted(Projectile proj);
+
+  boolean isDestructiveExplosion(EntityExplodeEvent ev);
 }


### PR DESCRIPTION
Makes it so wind charges and other non-destructive explosions:
- don't break blocks with custom drops
- don't count as a core/monument touch
- don't set off dispenser nukes

That said, it might not be 100% desirable to call a `BlockTransformEvent` for non-destructive explosions, as the non-destructive `ExplosionResult`s either won't do anything with the blocks (value of `KEEP`) or ~~will fire collateral block physics events~~ (value of `TRIGGER_BLOCK` - e. g. wind charges). Currently, they're fired without a state change.