### PR TITLE
fix: fix exceptions when interacting with decorated pots as obs in modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
@@ -435,7 +435,7 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
 
     if (realInventory instanceof PlayerInventory) {
       previewPlayerInventory(viewer, (PlayerInventory) realInventory);
-    } else {
+    } else if (INVENTORY_UTILS.isViewable(realInventory)) {
       Inventory fakeInventory;
       fakeInventory = NMS_HACKS.createFakeInventory(viewer, realInventory);
       fakeInventory.setContents(realInventory.getContents());

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernInventoryUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernInventoryUtil.java
@@ -14,6 +14,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -86,5 +87,10 @@ public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatfor
   @SuppressWarnings("removal")
   public Set<Material> getCanPlaceOn(ItemMeta itemMeta) {
     return itemMeta.getCanPlaceOn();
+  }
+
+  @Override
+  public boolean isViewable(Inventory inventory) {
+    return inventory.getType().isCreatable();
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpInventoryUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpInventoryUtil.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.Potion;
@@ -69,5 +70,11 @@ public class SpInventoryUtil implements InventoryUtils.InventoryUtilsPlatform {
   @Override
   public Set<Material> getCanPlaceOn(ItemMeta itemMeta) {
     return itemMeta.getCanPlaceOn();
+  }
+
+  @Override
+  public boolean isViewable(Inventory inventory) {
+    // All inventories in 1.8 are viewable
+    return true;
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -195,5 +195,7 @@ public final class InventoryUtils {
     void setCanPlaceOn(ItemMeta itemMeta, Set<Material> materials);
 
     Set<Material> getCanPlaceOn(ItemMeta itemMeta);
+
+    boolean isViewable(Inventory inventory);
   }
 }


### PR DESCRIPTION
Prevents opening non-creatable inventories such as decorated pots, jukeboxes, and composters, and others as an observer - trying to create such inventories throws an exception.