### PR TITLE
fix: fix iron doors chopping off in modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/WorldProblemListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/WorldProblemListener.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.listeners;
 
+import static tc.oc.pgm.util.material.MaterialUtils.MATERIAL_UTILS;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 
 import com.google.common.collect.HashMultimap;
@@ -46,10 +47,9 @@ public class WorldProblemListener implements Listener {
     if (str != null) {
       int value = Integer.parseInt(str);
       if (value > RANDOM_TICK_SPEED_LIMIT) {
-        broadcastDeveloperWarning(
-            "Gamerule 'randomTickSpeed' is set to "
-                + value
-                + " for this world (normal value is 3). This may overload the server.");
+        broadcastDeveloperWarning("Gamerule 'randomTickSpeed' is set to "
+            + value
+            + " for this world (normal value is 3). This may overload the server.");
       }
     }
   }
@@ -60,15 +60,18 @@ public class WorldProblemListener implements Listener {
     block36Locations.remove(event.getWorld());
   }
 
-  @SuppressWarnings("deprecation")
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void repairChunk(ChunkLoadEvent event) {
     if (this.repairedChunks.put(event.getWorld(), event.getChunk())) {
-      // Replace formerly invisible half-iron-door blocks with barriers
-      for (Block ironDoor : NMS_HACKS.getBlocks(event.getChunk(), Materials.IRON_DOOR)) {
-        BlockFace half = (ironDoor.getData() & 8) == 0 ? BlockFace.DOWN : BlockFace.UP;
-        if (ironDoor.getRelative(half.getOppositeFace()).getType() != Materials.IRON_DOOR) {
-          ironDoor.setType(Material.BARRIER, false);
+      // Set by modern platform on 1.13+ worlds - we want to treat only the older worlds
+      if (!event.getWorld().hasMetadata("is-post-flattening")) {
+        // Replace formerly invisible half-iron-door blocks with barriers
+        for (Block ironDoor : NMS_HACKS.getBlocks(event.getChunk(), Materials.IRON_DOOR)) {
+          BlockFace half =
+              MATERIAL_UTILS.isUpperHalfOfDoor(ironDoor) ? BlockFace.UP : BlockFace.DOWN;
+          if (ironDoor.getRelative(half.getOppositeFace()).getType() != Materials.IRON_DOOR) {
+            ironDoor.setType(Material.BARRIER, false);
+          }
         }
       }
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernNMSHacks.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernNMSHacks.java
@@ -64,6 +64,7 @@ import org.bukkit.generator.WorldInfo;
 import org.bukkit.inventory.DoubleChestInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.platform.modern.PgmBootstrap;
@@ -299,7 +300,8 @@ public class ModernNMSHacks implements NMSHacks {
     }
 
     // If the world is < 1.18-exp.1, replace dimension type
-    boolean isOld = summary.levelVersion().minecraftVersion().version() < DataVersions.V1_18_EXP_1;
+    var dataVersion = summary.levelVersion().minecraftVersion().version();
+    boolean isOld = dataVersion < DataVersions.V1_18_EXP_1;
     if (isOld && actualDimension == LevelStem.OVERWORLD) {
       var dimReg = console.registryAccess().lookupOrThrow(Registries.DIMENSION_TYPE);
       var dimHolder = dimReg.getOrThrow(PgmBootstrap.LEGACY_OVERWORLD);
@@ -336,6 +338,11 @@ public class ModernNMSHacks implements NMSHacks {
     if (server.getWorld(name) == null) {
       return null;
     }
+
+    if (dataVersion >= DataVersions.V1_13)
+      serverLevel
+          .getWorld()
+          .setMetadata("is-post-flattening", new FixedMetadataValue(BukkitUtils.getPlugin(), true));
 
     console.addLevel(serverLevel);
     console.initWorld(

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
@@ -9,8 +9,11 @@ import java.util.Set;
 import org.bukkit.Bukkit;
 import org.bukkit.ChunkSnapshot;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Door;
 import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 import org.bukkit.entity.GlowItemFrame;
 import org.bukkit.entity.Hanging;
@@ -145,6 +148,12 @@ public class ModernMaterialUtils implements MaterialUtils {
   @Override
   public MaterialMatcher.Builder matcherBuilder() {
     return new MaterialMatcherBuilderImpl();
+  }
+
+  @Override
+  public boolean isUpperHalfOfDoor(Block block) {
+    return block.getState().getBlockData() instanceof Door door
+        && door.getHalf() == Bisected.Half.TOP;
   }
 
   private static class MaterialMatcherBuilderImpl extends MaterialMatcher.BuilderImpl

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
@@ -19,6 +19,7 @@ import org.bukkit.entity.LeashHitch;
 import org.bukkit.entity.Painting;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.Door;
 import org.bukkit.util.BlockVector;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.block.BlockData;
@@ -155,6 +156,11 @@ public class SpMaterialUtils implements MaterialUtils {
   @Override
   public MaterialMatcher.Builder matcherBuilder() {
     return new MaterialMatcherBuilderImpl();
+  }
+
+  @Override
+  public boolean isUpperHalfOfDoor(org.bukkit.block.Block block) {
+    return block.getState().getData() instanceof Door door && door.isTopHalf();
   }
 
   private static class MaterialMatcherBuilderImpl extends MaterialMatcher.BuilderImpl

--- a/util/src/main/java/tc/oc/pgm/util/material/MaterialUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/MaterialUtils.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import org.bukkit.ChunkSnapshot;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Hanging;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
@@ -57,4 +58,6 @@ public interface MaterialUtils {
   boolean hasBlockStates(Material material);
 
   MaterialMatcher.Builder matcherBuilder();
+
+  boolean isUpperHalfOfDoor(Block block);
 }


### PR DESCRIPTION
Fixes an issue where iron doors would get chopped off on modern servers due to Block#getData returning unreliable and/or contradicting data there, causing the block to be treated as an "invisible half-iron-door" and get replaced with a barrier.

![A screenshot of Raid FFA showing an errorneously placed barrier block](https://github.com/user-attachments/assets/63b93b75-5d0b-4402-b2ce-eea693e9696a)

Additionally, this PR exempts >=1.13 worlds (based on the data version in level.dat) from the aforementioned behavior; those worlds are not loadable on 1.8 by default and as such I think it's reasonable to assume that the map author isn't using a half door to create an invisible barrier.