### PR TITLE
fix: don't despawn shopkeeper mobs on modern servers

### DIFF
--- a/core/src/main/java/tc/oc/pgm/shops/ShopKeeper.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopKeeper.java
@@ -6,6 +6,7 @@ import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
@@ -52,6 +53,9 @@ public class ShopKeeper {
     keeper.setCustomName(getName());
     keeper.setCustomNameVisible(true);
     keeper.setMetadata(METADATA_KEY, new FixedMetadataValue(PGM.get(), shop.getId()));
+    if (keeper instanceof LivingEntity livingEntity) {
+      livingEntity.setRemoveWhenFarAway(false);
+    }
     NMS_HACKS.freezeEntity(keeper);
   }
 


### PR DESCRIPTION
Sets entity persistence to prevent mob-based shops from despawning on modern servers. On 1.8, the despawning logic is disabled by disabling mob AI, but the flag is set there as well, just in case.