### PR TITLE
Add team-alias action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -46,7 +46,6 @@ import tc.oc.pgm.api.filter.Filterables;
 import tc.oc.pgm.api.filter.query.PartyQuery;
 import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.factory.MapFactory;
-import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.features.FeatureDefinitionContext;
@@ -62,6 +61,7 @@ import tc.oc.pgm.shops.ShopModule;
 import tc.oc.pgm.shops.menu.Payable;
 import tc.oc.pgm.structure.StructureDefinition;
 import tc.oc.pgm.teams.TeamFactory;
+import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
 import tc.oc.pgm.util.inventory.ItemMatcher;
@@ -419,22 +419,17 @@ public class ActionParser {
   }
 
   @MethodParser("team-alias")
-  public <T extends Filterable<?>> TeamAliasAction<T> parseTeamAliasAction(
-      Element el, Class<T> scope) throws InvalidXMLException {
-    scope = parseScope(el, scope);
+  public <T extends Filterable<?>> Action<?> parseTeamAliasAction(Element el, Class<T> scope)
+      throws InvalidXMLException {
     String alias = parser.string(el, "alias").required();
+    var action = new TeamAliasAction(alias);
+    var teamBuilder = parser.reference(TeamFactory.class, el, "team");
+    var team = scope == Party.class ? teamBuilder.orNull() : teamBuilder.required();
 
-    if (scope.getSimpleName().equals("Match")) {
-      var team = parser.reference(TeamFactory.class, el, "team").required();
-      return new TeamAliasAction.WithTeam<>(scope, alias, team);
-    } else if (scope.getSimpleName().equals("Party")) {
-      return new TeamAliasAction<>(scope, alias);
-    } else {
-      throw new InvalidXMLException(
-          "Wrong scope defined for action, scope must be " + Match.class.getSimpleName() + " or "
-              + Party.class.getSimpleName(),
-          el);
-    }
+    return team == null
+        ? action
+        : new ScopeSwitchAction<>(
+            scope, f -> f.moduleRequire(TeamMatchModule.class).getTeam(team.get()), null, action);
   }
 
   @MethodParser("take-payment")

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -19,24 +19,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
-import tc.oc.pgm.action.actions.ActionNode;
-import tc.oc.pgm.action.actions.DropFlagAction;
-import tc.oc.pgm.action.actions.EnchantItemAction;
-import tc.oc.pgm.action.actions.ExposedAction;
-import tc.oc.pgm.action.actions.FillAction;
-import tc.oc.pgm.action.actions.KillEntitiesAction;
-import tc.oc.pgm.action.actions.MessageAction;
-import tc.oc.pgm.action.actions.PasteStructureAction;
-import tc.oc.pgm.action.actions.PickupFlagAction;
-import tc.oc.pgm.action.actions.RepeatAction;
-import tc.oc.pgm.action.actions.ReplaceItemAction;
-import tc.oc.pgm.action.actions.ScopeSwitchAction;
-import tc.oc.pgm.action.actions.SetVariableAction;
-import tc.oc.pgm.action.actions.SoundAction;
-import tc.oc.pgm.action.actions.TakePaymentAction;
-import tc.oc.pgm.action.actions.TeleportAction;
-import tc.oc.pgm.action.actions.VelocityAction;
-import tc.oc.pgm.action.actions.WeatherAction;
+import tc.oc.pgm.action.actions.*;
 import tc.oc.pgm.action.replacements.Replacement;
 import tc.oc.pgm.action.replacements.ReplacementParser;
 import tc.oc.pgm.api.feature.FeatureValidation;
@@ -412,6 +395,15 @@ public class ActionParser {
         parser.filter(el, "filter").orNull(),
         parser.parseBool(el, "update").orTrue(),
         parser.parseBool(el, "events").orFalse());
+  }
+
+  @MethodParser("team-alias")
+  public TeamAliasAction parseTeamAliasAction(Element el, Class<?> scope)
+      throws InvalidXMLException {
+    String teamId = Node.fromRequiredAttr(el, "team-id").getValue();
+    String alias = Node.fromRequiredAttr(el, "alias").getValue();
+
+    return new TeamAliasAction(teamId, alias);
   }
 
   @MethodParser("take-payment")

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -19,7 +19,25 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Element;
 import org.jetbrains.annotations.Nullable;
-import tc.oc.pgm.action.actions.*;
+import tc.oc.pgm.action.actions.ActionNode;
+import tc.oc.pgm.action.actions.DropFlagAction;
+import tc.oc.pgm.action.actions.EnchantItemAction;
+import tc.oc.pgm.action.actions.ExposedAction;
+import tc.oc.pgm.action.actions.FillAction;
+import tc.oc.pgm.action.actions.KillEntitiesAction;
+import tc.oc.pgm.action.actions.MessageAction;
+import tc.oc.pgm.action.actions.PasteStructureAction;
+import tc.oc.pgm.action.actions.PickupFlagAction;
+import tc.oc.pgm.action.actions.RepeatAction;
+import tc.oc.pgm.action.actions.ReplaceItemAction;
+import tc.oc.pgm.action.actions.ScopeSwitchAction;
+import tc.oc.pgm.action.actions.SetVariableAction;
+import tc.oc.pgm.action.actions.SoundAction;
+import tc.oc.pgm.action.actions.TakePaymentAction;
+import tc.oc.pgm.action.actions.TeamAliasAction;
+import tc.oc.pgm.action.actions.TeleportAction;
+import tc.oc.pgm.action.actions.VelocityAction;
+import tc.oc.pgm.action.actions.WeatherAction;
 import tc.oc.pgm.action.replacements.Replacement;
 import tc.oc.pgm.action.replacements.ReplacementParser;
 import tc.oc.pgm.api.feature.FeatureValidation;
@@ -41,6 +59,7 @@ import tc.oc.pgm.modules.WeatherMatchModule;
 import tc.oc.pgm.shops.ShopModule;
 import tc.oc.pgm.shops.menu.Payable;
 import tc.oc.pgm.structure.StructureDefinition;
+import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.util.MethodParser;
 import tc.oc.pgm.util.MethodParsers;
 import tc.oc.pgm.util.inventory.ItemMatcher;
@@ -400,10 +419,10 @@ public class ActionParser {
   @MethodParser("team-alias")
   public TeamAliasAction parseTeamAliasAction(Element el, Class<?> scope)
       throws InvalidXMLException {
-    String teamId = Node.fromRequiredAttr(el, "team-id").getValue();
-    String alias = Node.fromRequiredAttr(el, "alias").getValue();
+    String alias = parser.string(el, "alias").required();
+    var team = parser.reference(TeamFactory.class, el, "team").required();
 
-    return new TeamAliasAction(teamId, alias);
+    return new TeamAliasAction(team, alias);
   }
 
   @MethodParser("take-payment")

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -46,6 +46,8 @@ import tc.oc.pgm.api.filter.Filterables;
 import tc.oc.pgm.api.filter.query.PartyQuery;
 import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.features.XMLFeatureReference;
@@ -417,12 +419,22 @@ public class ActionParser {
   }
 
   @MethodParser("team-alias")
-  public TeamAliasAction parseTeamAliasAction(Element el, Class<?> scope)
-      throws InvalidXMLException {
+  public <T extends Filterable<?>> TeamAliasAction<T> parseTeamAliasAction(
+      Element el, Class<T> scope) throws InvalidXMLException {
+    scope = parseScope(el, scope);
     String alias = parser.string(el, "alias").required();
-    var team = parser.reference(TeamFactory.class, el, "team").required();
 
-    return new TeamAliasAction(team, alias);
+    if (scope.getSimpleName().equals("Match")) {
+      var team = parser.reference(TeamFactory.class, el, "team").required();
+      return new TeamAliasAction.WithTeam<>(scope, alias, team);
+    } else if (scope.getSimpleName().equals("Party")) {
+      return new TeamAliasAction<>(scope, alias);
+    } else {
+      throw new InvalidXMLException(
+          "Wrong scope defined for action, scope must be " + Match.class.getSimpleName() + " or "
+              + Party.class.getSimpleName(),
+          el);
+    }
   }
 
   @MethodParser("take-payment")

--- a/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
@@ -1,33 +1,22 @@
 package tc.oc.pgm.action.actions;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.teams.TeamFactory;
 
 public class TeamAliasAction extends AbstractAction<Match> {
-  private final String teamId;
+  private final FeatureReference<TeamFactory> team;
   private final String alias;
 
-  public TeamAliasAction(String teamId, String alias) {
+  public TeamAliasAction(FeatureReference<TeamFactory> team, String alias) {
     super(Match.class);
-    this.teamId = teamId;
+    this.team = team;
     this.alias = alias;
   }
 
   @Override
   public void trigger(Match match) {
-    List<Party> teamsList = new ArrayList<>(match.getParties());
-
-    for (Party team : teamsList) {
-      if (team instanceof Team) {
-        String teamId = ((Team) team).getId();
-        if (Objects.equals(teamId, this.teamId)) {
-          team.setName(this.alias);
-        }
-      }
-    }
+    match.getFeatureContext().get(team.get().getId(), Team.class).setName(this.alias);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
@@ -1,0 +1,33 @@
+package tc.oc.pgm.action.actions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.teams.Team;
+
+public class TeamAliasAction extends AbstractAction<Match> {
+  private final String teamId;
+  private final String alias;
+
+  public TeamAliasAction(String teamId, String alias) {
+    super(Match.class);
+    this.teamId = teamId;
+    this.alias = alias;
+  }
+
+  @Override
+  public void trigger(Match match) {
+    List<Party> teamsList = new ArrayList<>(match.getParties());
+
+    for (Party team : teamsList) {
+      if (team instanceof Team) {
+        String teamId = ((Team) team).getId();
+        if (Objects.equals(teamId, this.teamId)) {
+          team.setName(this.alias);
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
@@ -1,45 +1,17 @@
 package tc.oc.pgm.action.actions;
 
-import tc.oc.pgm.api.feature.FeatureReference;
-import tc.oc.pgm.filters.Filterable;
-import tc.oc.pgm.match.MatchImpl;
-import tc.oc.pgm.match.PartyImpl;
-import tc.oc.pgm.teams.Team;
-import tc.oc.pgm.teams.TeamFactory;
+import tc.oc.pgm.api.party.Party;
 
-public class TeamAliasAction<T extends Filterable<?>> extends AbstractAction<T> {
+public class TeamAliasAction extends AbstractAction<Party> {
   protected final String alias;
 
-  public TeamAliasAction(Class<T> scope, String alias) {
-    super(scope);
+  public TeamAliasAction(String alias) {
+    super(Party.class);
     this.alias = alias;
   }
 
   @Override
-  public void trigger(T scope) {
-    if (scope instanceof PartyImpl) {
-      ((PartyImpl) scope).getParty().setName(this.alias);
-    }
-  }
-  ;
-
-  public static class WithTeam<T extends Filterable<?>> extends TeamAliasAction<T> {
-    private final FeatureReference<TeamFactory> team;
-
-    public WithTeam(Class<T> scope, String alias, FeatureReference<TeamFactory> team) {
-      super(scope, alias);
-      this.team = team;
-    }
-
-    @Override
-    public void trigger(T scope) {
-      if (scope instanceof MatchImpl) {
-        ((MatchImpl) scope)
-            .getFeatureContext()
-            .get(team.get().getId(), Team.class)
-            .setName(this.alias);
-      }
-    }
-    ;
+  public void trigger(Party party) {
+    party.setName(this.alias);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
@@ -1,22 +1,45 @@
 package tc.oc.pgm.action.actions;
 
 import tc.oc.pgm.api.feature.FeatureReference;
-import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.match.MatchImpl;
+import tc.oc.pgm.match.PartyImpl;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamFactory;
 
-public class TeamAliasAction extends AbstractAction<Match> {
-  private final FeatureReference<TeamFactory> team;
-  private final String alias;
+public class TeamAliasAction<T extends Filterable<?>> extends AbstractAction<T> {
+  protected final String alias;
 
-  public TeamAliasAction(FeatureReference<TeamFactory> team, String alias) {
-    super(Match.class);
-    this.team = team;
+  public TeamAliasAction(Class<T> scope, String alias) {
+    super(scope);
     this.alias = alias;
   }
 
   @Override
-  public void trigger(Match match) {
-    match.getFeatureContext().get(team.get().getId(), Team.class).setName(this.alias);
+  public void trigger(T scope) {
+    if (scope instanceof PartyImpl) {
+      ((PartyImpl) scope).getParty().setName(this.alias);
+    }
+  }
+  ;
+
+  public static class WithTeam<T extends Filterable<?>> extends TeamAliasAction<T> {
+    private final FeatureReference<TeamFactory> team;
+
+    public WithTeam(Class<T> scope, String alias, FeatureReference<TeamFactory> team) {
+      super(scope, alias);
+      this.team = team;
+    }
+
+    @Override
+    public void trigger(T scope) {
+      if (scope instanceof MatchImpl) {
+        ((MatchImpl) scope)
+            .getFeatureContext()
+            .get(team.get().getId(), Team.class)
+            .setName(this.alias);
+      }
+    }
+    ;
   }
 }


### PR DESCRIPTION
While working on a map, I thought it would be useful to dynamically change team names. I knew this was already possible in PGM using a command, so I decided it might be a good idea to add an XML action that performs the same task.

The code works, but there are still some missing checks (e.g. verifying whether the `team-id` actually corresponds to a defined team, or if the `alias` is already in use). I decided to leave those out for now and wait for feedback on the idea before refining the implementation.

To use it, simply define:

```xml
<team-alias team-id="red-team" alias="Attackers" />
```