### PR TITLE
fix: make death messages work on modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/death/DeathMessageBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/death/DeathMessageBuilder.java
@@ -33,6 +33,8 @@ import tc.oc.pgm.tracker.info.SpleefInfo;
 import tc.oc.pgm.util.bukkit.EntityTypes;
 import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.platform.Platform;
+import tc.oc.pgm.util.text.MinecraftComponent;
 import tc.oc.pgm.util.text.TextTranslations;
 
 public class DeathMessageBuilder {
@@ -209,8 +211,11 @@ public class DeathMessageBuilder {
     return false;
   }
 
-  private static final Set<EntityType> IGNORED_ENTITIES =
-      ImmutableSet.of(EntityTypes.COMPLEX_PART, EntityTypes.ENDER_CRYSTAL, EntityTypes.UNKNOWN);
+  private static final Set<EntityType> IGNORED_ENTITIES = ImmutableSet.of(
+      EntityTypes.COMPLEX_PART,
+      // Modern servers have a translation for the ender crystal
+      Platform.isModern() ? EntityTypes.UNKNOWN : EntityTypes.ENDER_CRYSTAL,
+      EntityTypes.UNKNOWN);
 
   boolean entity(EntityInfo entityInfo) {
     // Skip for entities that are weird and have no translations
@@ -218,28 +223,28 @@ public class DeathMessageBuilder {
 
     if (option("entity")) {
       weapon = entityInfo.getName();
-      option(entityInfo.getIdentifier());
+      option(makeEntityIdentifier(entityInfo));
       return true;
     }
     return false;
   }
 
   boolean insentient(@Nullable PhysicalInfo info) {
-    if (info instanceof PotionInfo) {
-      if (potion((PotionInfo) info)) {
+    if (info instanceof PotionInfo potionInfo) {
+      if (potion(potionInfo)) {
         return true;
       } else if (option("entity")) {
         // PotionInfo.getName returns a potion name,
         // which doesn't work outside a potion death message.
-        weapon = translatable("item.potion.name");
+        weapon = MinecraftComponent.material(Material.POTION);
         return true;
       }
-    } else if (info instanceof EntityInfo) {
-      return !(info instanceof MobInfo) && entity((EntityInfo) info);
-    } else if (info instanceof BlockInfo) {
-      return block((BlockInfo) info);
-    } else if (info instanceof ItemInfo) {
-      return item((ItemInfo) info);
+    } else if (info instanceof EntityInfo entityInfo) {
+      return !(info instanceof MobInfo) && entity(entityInfo);
+    } else if (info instanceof BlockInfo blockInfo) {
+      return block(blockInfo);
+    } else if (info instanceof ItemInfo itemInfo) {
+      return item(itemInfo);
     }
 
     return false;
@@ -248,15 +253,15 @@ public class DeathMessageBuilder {
   boolean mob(MobInfo mobInfo) {
     if (option("mob")) {
       mob = mobInfo.getName();
-      option(mobInfo.getIdentifier());
+      option(makeEntityIdentifier(mobInfo));
       return true;
     }
     return false;
   }
 
   boolean physical(@Nullable PhysicalInfo info) {
-    if (info instanceof MobInfo) {
-      return mob((MobInfo) info);
+    if (info instanceof MobInfo mobInfo) {
+      return mob(mobInfo);
     } else {
       return insentient(info);
     }
@@ -279,36 +284,23 @@ public class DeathMessageBuilder {
 
   void attack(@Nullable PhysicalInfo attacker, @Nullable PhysicalInfo weapon) throws NoMessage {
     player();
-    if (attacker instanceof MobInfo && !mob((MobInfo) attacker)) {
+    if (attacker instanceof MobInfo mobInfo && !mob(mobInfo)) {
       return;
     }
     insentient(weapon);
   }
 
   void generic(GenericDamageInfo info) throws NoMessage {
-    switch (info.getDamageType()) {
-      case CONTACT:
-        require("cactus");
-        break;
-      case DROWNING:
-        require("drown");
-        break;
-      case LIGHTNING:
-        require("lightning");
-        break;
-      case STARVATION:
-        require("starve");
-        break;
-      case SUFFOCATION:
-        require("suffocate");
-        break;
-      case CUSTOM:
-        require("generic");
-        break;
-      default:
-        require("unknown");
-        break;
-    }
+    require(
+        switch (info.getDamageType()) {
+          case CONTACT -> "cactus";
+          case DROWNING -> "drown";
+          case LIGHTNING -> "lightning";
+          case STARVATION -> "starve";
+          case SUFFOCATION -> "suffocate";
+          case CUSTOM -> "generic";
+          default -> "unknown";
+        });
   }
 
   void melee(MeleeInfo melee) throws NoMessage {
@@ -322,9 +314,9 @@ public class DeathMessageBuilder {
   }
 
   void projectile(ProjectileInfo projectile, Location distanceReference) throws NoMessage {
-    if (projectile.getProjectile() instanceof PotionInfo) {
+    if (projectile.getProjectile() instanceof PotionInfo potionInfo) {
       try {
-        magic((PotionInfo) projectile.getProjectile(), projectile.getShooter());
+        magic(potionInfo, projectile.getShooter());
         return;
       } catch (NoMessage ignored) {
         // If we can't generate a magic message (probably because it's part
@@ -335,8 +327,8 @@ public class DeathMessageBuilder {
     require("projectile");
 
     PhysicalInfo info = projectile.getProjectile();
-    if (info instanceof EntityInfo) {
-      switch (((EntityInfo) info).getEntityType()) {
+    if (info instanceof EntityInfo entityInfo) {
+      switch (entityInfo.getEntityType()) {
         case UNKNOWN:
         case ARROW:
         case WITHER_SKULL:
@@ -377,8 +369,8 @@ public class DeathMessageBuilder {
   void fire(FireInfo fire) throws NoMessage {
     require("fire");
     player();
-    if (!(fire.getIgniter() instanceof BlockInfo
-        && ((BlockInfo) fire.getIgniter()).getMaterial().getItemType() == Material.FIRE)) {
+    if (!(fire.getIgniter() instanceof BlockInfo igniter
+        && igniter.getMaterial().getItemType() == Material.FIRE)) {
       // "burned by fire" is redundant
       physical(fire.getIgniter());
     }
@@ -389,16 +381,16 @@ public class DeathMessageBuilder {
     require(fall.getTo().name().toLowerCase());
 
     TrackerInfo cause = fall.getCause();
-    if (cause instanceof SpleefInfo) {
+    if (cause instanceof SpleefInfo spleefInfo) {
       require("spleef");
-      DamageInfo breaker = ((SpleefInfo) cause).getBreaker();
-      if (breaker instanceof ExplosionInfo) {
-        explosion((ExplosionInfo) breaker, fall.getOrigin());
+      DamageInfo breaker = spleefInfo.getBreaker();
+      if (breaker instanceof ExplosionInfo explosionInfo) {
+        explosion(explosionInfo, fall.getOrigin());
       } else {
         player();
       }
-    } else if (cause instanceof DamageInfo) {
-      damage((DamageInfo) cause, fall.getOrigin());
+    } else if (cause instanceof DamageInfo damageInfo) {
+      damage(damageInfo, fall.getOrigin());
     } else if (fall.getTo() == FallInfo.To.GROUND) {
       setDistance(Trackers.distanceFromRanged(fall, victim.getBukkit().getLocation()));
 
@@ -421,34 +413,32 @@ public class DeathMessageBuilder {
   }
 
   void damage(DamageInfo info, Location location) throws NoMessage {
-    if (info instanceof MeleeInfo) {
-      melee((MeleeInfo) info);
-    } else if (info instanceof ProjectileInfo) {
-      projectile((ProjectileInfo) info, location);
-    } else if (info instanceof ExplosionInfo) {
-      explosion((ExplosionInfo) info, location);
-    } else if (info instanceof FireInfo) {
-      fire((FireInfo) info);
-    } else if (info instanceof PotionInfo) {
-      magic((PotionInfo) info, null);
-    } else if (info instanceof FallingBlockInfo) {
-      squash((FallingBlockInfo) info);
-    } else if (info instanceof BlockInfo) {
-      final Material material = ((BlockInfo) info).getMaterial().getItemType();
-      if (material == Material.ANVIL) {
-        squash((BlockInfo) info);
-      } else if (material == Material.CACTUS) {
-        cactus((BlockInfo) info);
-      } else {
-        suffocate((BlockInfo) info);
+    switch (info) {
+      case MeleeInfo meleeInfo -> melee(meleeInfo);
+      case ProjectileInfo projectileInfo -> projectile(projectileInfo, location);
+      case ExplosionInfo explosionInfo -> explosion(explosionInfo, location);
+      case FireInfo fireInfo -> fire(fireInfo);
+      case PotionInfo potionInfo -> magic(potionInfo, null);
+      case FallingBlockInfo fallingBlockInfo -> squash(fallingBlockInfo);
+      case BlockInfo blockInfo -> {
+        switch (blockInfo.getMaterial().getItemType()) {
+          case ANVIL -> squash(blockInfo);
+          case CACTUS -> cactus(blockInfo);
+          default -> suffocate(blockInfo);
+        }
       }
-    } else if (info instanceof FallInfo) {
-      fall((FallInfo) info);
-    } else if (info instanceof GenericDamageInfo) {
-      generic((GenericDamageInfo) info);
-    } else {
-      throw new NoMessage();
+      case FallInfo fallInfo -> fall(fallInfo);
+      case GenericDamageInfo genericDamageInfo -> generic(genericDamageInfo);
+      case null, default -> throw new NoMessage();
     }
+  }
+
+  // Converts an entity type into a legacy entity type name for translation purposes
+  private String makeEntityIdentifier(EntityInfo entityInfo) {
+    var entityType = entityInfo.getEntityType();
+    if (entityType == EntityType.CREEPER) return "Creeper";
+    else if (entityType == EntityTypes.PRIMED_TNT) return "PrimedTnt";
+    return entityInfo.getIdentifier();
   }
 
   void build(DamageInfo damageInfo) {

--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -318,9 +318,9 @@ public class PickerMatchModule implements MatchModule, Listener {
   public void checkInventoryClick(final InventoryClickEvent event) {
     if (event.getCurrentItem() == null
         || event.getCurrentItem().getItemMeta() == null
-        || event.getCurrentItem().getItemMeta().getDisplayName() == null) return;
-    if (event.getWhoClicked() instanceof Player) {
-      MatchPlayer player = match.getPlayer((Player) event.getWhoClicked());
+        || !event.getCurrentItem().getItemMeta().hasDisplayName()) return;
+    if (event.getWhoClicked() instanceof Player bukkitPlayer) {
+      MatchPlayer player = match.getPlayer(bukkitPlayer);
       if (player == null || !this.picking.contains(player)) return;
 
       this.handleInventoryClick(
@@ -348,8 +348,7 @@ public class PickerMatchModule implements MatchModule, Listener {
     if ((!right && !left) || InventoryUtils.isNothing(event.getClickedItem())) return;
 
     final ItemStack hand = event.getClickedItem();
-    String displayName = hand.getItemMeta().getDisplayName();
-    if (displayName == null) return;
+    if (!hand.getItemMeta().hasDisplayName()) return;
 
     final MatchPlayer player = event.getPlayer();
     if (!canUse(player)) return;

--- a/core/src/main/java/tc/oc/pgm/tracker/info/ItemInfo.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/ItemInfo.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.api.tracker.info.PhysicalInfo;
+import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.text.MinecraftComponent;
 
 public class ItemInfo extends OwnerInfoBase implements PhysicalInfo {
@@ -37,7 +38,7 @@ public class ItemInfo extends OwnerInfoBase implements PhysicalInfo {
   public Component getName() {
     if (getItem().hasItemMeta()) {
       String customName = getItem().getItemMeta().getDisplayName();
-      if (customName != null) {
+      if (!StringUtils.isNullOrEmpty(customName)) {
         return LegacyComponentSerializer.legacySection().deserialize(customName);
       }
     }

--- a/core/src/main/java/tc/oc/pgm/tracker/info/ProjectileInfo.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/ProjectileInfo.java
@@ -1,16 +1,18 @@
 package tc.oc.pgm.tracker.info;
 
-import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.api.tracker.info.DamageInfo;
 import tc.oc.pgm.api.tracker.info.PhysicalInfo;
 import tc.oc.pgm.api.tracker.info.PotionInfo;
 import tc.oc.pgm.api.tracker.info.RangedInfo;
+import tc.oc.pgm.util.text.MinecraftComponent;
 
 public class ProjectileInfo implements PhysicalInfo, DamageInfo, RangedInfo {
 
@@ -59,13 +61,13 @@ public class ProjectileInfo implements PhysicalInfo, DamageInfo, RangedInfo {
   }
 
   @Override
-  public net.kyori.adventure.text.Component getName() {
+  public Component getName() {
     if (customName != null) {
       return LegacyComponentSerializer.legacySection().deserialize(customName);
     } else if (getProjectile() instanceof PotionInfo) {
       // PotionInfo.getName returns a potion name,
       // which doesn't work outside a potion death message.
-      return translatable("item.potion.name");
+      return MinecraftComponent.material(Material.POTION);
     } else {
       return getProjectile().getName();
     }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMinecraftTranslator.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMinecraftTranslator.java
@@ -1,0 +1,27 @@
+package tc.oc.pgm.platform.modern.impl;
+
+import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
+
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.potion.PotionEffectType;
+import tc.oc.pgm.util.platform.Supports;
+import tc.oc.pgm.util.text.MinecraftComponent;
+
+@Supports(value = PAPER, minVersion = "1.21.8")
+public class ModernMinecraftTranslator implements MinecraftComponent.MinecraftTranslator {
+  @Override
+  public String getTranslationKey(Material material) {
+    return material.translationKey();
+  }
+
+  @Override
+  public String getTranslationKey(EntityType type) {
+    return type.translationKey();
+  }
+
+  @Override
+  public String getTranslationKey(PotionEffectType potionEffectType) {
+    return potionEffectType.translationKey();
+  }
+}

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMinecraftTranslator.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMinecraftTranslator.java
@@ -1,0 +1,42 @@
+package tc.oc.pgm.platform.sportpaper.impl;
+
+import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
+
+import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_8_R3.potion.CraftPotionEffectType;
+import org.bukkit.craftbukkit.v1_8_R3.util.CraftMagicNumbers;
+import org.bukkit.entity.EntityType;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionEffectTypeWrapper;
+import tc.oc.pgm.util.platform.Supports;
+import tc.oc.pgm.util.text.MinecraftComponent;
+
+@Supports(value = SPORTPAPER)
+public class SpMinecraftTranslator implements MinecraftComponent.MinecraftTranslator {
+  private static final String ENTITY_TYPE_FORMAT = "entity.%s.name";
+
+  @Override
+  public String getTranslationKey(Material material) {
+    var nmsItem = CraftMagicNumbers.getItem(material);
+    // This works with most items. Some multi-state items (e.g. dyes or banners) might produce a
+    // non-existent translation string, however.
+    return nmsItem.getName() + ".name";
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public String getTranslationKey(EntityType entityType) {
+    if (entityType == EntityType.MINECART_TNT)
+      return getTranslationKey(Material.EXPLOSIVE_MINECART);
+    return ENTITY_TYPE_FORMAT.formatted(entityType.getName());
+  }
+
+  @Override
+  public String getTranslationKey(PotionEffectType potionEffectType) {
+    var potionEffect = (CraftPotionEffectType)
+        (potionEffectType instanceof PotionEffectTypeWrapper wrapper
+            ? wrapper.getType()
+            : potionEffectType);
+    return potionEffect.getHandle().a();
+  }
+}

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMinecraftTranslator.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMinecraftTranslator.java
@@ -26,9 +26,13 @@ public class SpMinecraftTranslator implements MinecraftComponent.MinecraftTransl
   @Override
   @SuppressWarnings("deprecation")
   public String getTranslationKey(EntityType entityType) {
-    if (entityType == EntityType.MINECART_TNT)
-      return getTranslationKey(Material.EXPLOSIVE_MINECART);
-    return ENTITY_TYPE_FORMAT.formatted(entityType.getName());
+    return switch (entityType) {
+      case MINECART_TNT -> getTranslationKey(Material.EXPLOSIVE_MINECART);
+      case EGG -> getTranslationKey(Material.EGG);
+      // Not fully correct, but whatever
+      case FISHING_HOOK -> getTranslationKey(Material.FISHING_ROD);
+      default -> ENTITY_TYPE_FORMAT.formatted(entityType.getName());
+    };
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/StringUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/StringUtils.java
@@ -226,4 +226,8 @@ public final class StringUtils {
     String suffix = lastColors + substring(text, split, split + MAX_SUFFIX - lastColors.length());
     return new String[] {prefix, suffix};
   }
+
+  public static boolean isNullOrEmpty(String str) {
+    return str == null || str.isEmpty();
+  }
 }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -25,6 +25,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
+import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.platform.Platform;
 
 public final class InventoryUtils {
@@ -89,11 +90,10 @@ public final class InventoryUtils {
   }
 
   public static Collection<PotionEffect> getEffects(ItemStack potion) {
-    if (potion.getItemMeta() instanceof PotionMeta) {
-      PotionMeta meta = (PotionMeta) potion.getItemMeta();
+    if (potion.getItemMeta() instanceof PotionMeta meta) {
       if (meta.hasCustomEffects()) {
         return meta.getCustomEffects();
-      } else if (potion.getType() == Material.POTION) { // Sanity check, SpawnablePotionBukkit
+      } else if (Materials.POTIONS.matches(potion)) { // Sanity check, SpawnablePotionBukkit
         return INVENTORY_UTILS.getPotionEffects(potion);
       }
     }

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -46,6 +46,7 @@ public interface Materials {
           || m.name().endsWith("_AXE")
           || m.name().endsWith("_PICKAXE")
           || m.name().endsWith("_SHOVEL")
+          || m.name().endsWith("_SPADE") // 1.8 shovels
           || m.name().endsWith("_HOE"))
       .addAll(BOW, FLINT_AND_STEEL, SHEARS, STICK)
       .addNullable(Material.getMaterial("TRIDENT"))
@@ -66,6 +67,11 @@ public interface Materials {
   MaterialMatcher SOLID_EXCLUSIONS = MaterialMatcher.builder()
       .add(parse("SIGN_POST", "LEGACY_SIGN_POST")) // on modern, it's just *_SIGN
       .addAll(m -> m.name().endsWith("_PLATE") || m.name().endsWith("_SIGN"))
+      .build();
+
+  MaterialMatcher POTIONS = MaterialMatcher.builder()
+      .add(POTION)
+      .addAll(m -> m.name().endsWith("_POTION"))
       .build();
 
   static Material parse(String... names) {

--- a/util/src/main/java/tc/oc/pgm/util/text/MinecraftComponent.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/MinecraftComponent.java
@@ -2,72 +2,42 @@ package tc.oc.pgm.util.text;
 
 import static net.kyori.adventure.text.Component.translatable;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
-import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.potion.PotionEffectType;
-import tc.oc.pgm.util.StringUtils;
+import tc.oc.pgm.util.bukkit.EntityTypes;
+import tc.oc.pgm.util.platform.Platform;
 
 /** A singleton for accessing {@link Component} translations for Minecraft clients. */
 public final class MinecraftComponent {
+  private static final MinecraftTranslator TRANSLATOR = Platform.get(MinecraftTranslator.class);
+
   private MinecraftComponent() {}
-
-  private static final String ENTITY_KEY = "entity.%s.name";
-  private static final String MATERIAL_KEY = "item.%s.name";
-  private static final String POTION_KEY = "potion.%s";
-  private static final String WOOL_KEY = "tile.cloth.%s.name";
-
-  // TODO: Bukkit 1.13+ exposes NamespaceKey, which is significantly more accurate than this
-  private static final Map<Pattern, String> MATERIAL_REPLACEMENTS =
-      ImmutableMap.<Pattern, String>builder()
-          .put(Pattern.compile("_AXE"), "_HATCHET")
-          .put(Pattern.compile("_SPADE"), "_SHOVEL")
-          .build();
-
-  private static final Map<String, String> KEY_EXCEPTIONS =
-      ImmutableMap.<String, String>builder()
-          .put("entity.PrimedTnt.name", "tile.tnt.name") // "TNT" instead of "Block of TNT"
-          .put("entity.MinecartTNT.name", "item.minecartTnt.name")
-          .put("item.anvil.name", "tile.anvil.name")
-          .put("item.sand.name", "tile.sand.name")
-          .put("item.gravel.name", "tile.gravel.name")
-          .put("item.lava.name", "tile.lava.name")
-          .put("potion.speed", "potion.moveSpeed")
-          .put("potion.slow", "potion.moveSlowdown")
-          .put("potion.fastDigging", "potion.digSpeed")
-          .put("potion.slowDigging", "potion.digSlowdown")
-          .put("potion.damageResistance", "potion.resistance")
-          .build();
 
   /**
    * Gets a translated entity name.
    *
    * @param entity An entity type.
-   * @return An translated entity name.
+   * @return A translated entity name.
    */
   public static Component entity(EntityType entity) {
-    return getKey(ENTITY_KEY, entity.getName());
+    if (entity == EntityTypes.PRIMED_TNT)
+      // "TNT" instead of "Block of TNT" (1.8) / "Primed TNT" (1.21)
+      return translatable(TRANSLATOR.getTranslationKey(Material.TNT));
+    else return translatable(TRANSLATOR.getTranslationKey(entity));
   }
 
   /**
    * Gets a translated material name.
    *
-   * <p>Note: is highly inaccurate and is only guaranteed to work with weapons.
+   * <p>Note: won't work with some materials on 1.8 servers.
    *
    * @param material A material.
    * @return A material name.
    */
   public static Component material(Material material) {
-    String name = material.name();
-    for (Map.Entry<Pattern, String> entry : MATERIAL_REPLACEMENTS.entrySet()) {
-      name = entry.getKey().matcher(name).replaceAll(entry.getValue());
-    }
-
-    return getKey(MATERIAL_KEY, StringUtils.camelCase(name, true));
+    return translatable(TRANSLATOR.getTranslationKey(material));
   }
 
   /**
@@ -77,15 +47,14 @@ public final class MinecraftComponent {
    * @return A potion name.
    */
   public static Component potion(PotionEffectType potion) {
-    return getKey(POTION_KEY, StringUtils.camelCase(potion.getName()));
+    return translatable(TRANSLATOR.getTranslationKey(potion));
   }
 
-  public static Component wool(DyeColor color) {
-    return getKey(WOOL_KEY, StringUtils.camelCase(color.name()));
-  }
+  public interface MinecraftTranslator {
+    String getTranslationKey(Material material);
 
-  private static Component getKey(String format, String name) {
-    final String key = String.format(format, name);
-    return translatable(KEY_EXCEPTIONS.getOrDefault(key, key));
+    String getTranslationKey(EntityType entityType);
+
+    String getTranslationKey(PotionEffectType potionEffectType);
   }
 }


### PR DESCRIPTION
This pull request fixes some issues cropping up with death messages on modern servers:
- Item translations for nameless items show up correctly (a couple places that check for null item name were also replaced, as modern servers return an empty string for no item name)
- Un-ignored entity death messages for end crystals (they have a translation in modern Minecraft)
- Made splash potions without custom effects work in death messages
- Re-mapped creepers and primed TNT back to old entity name for translations

Along with some code cleanup, there are also some fixes and improvements for 1.8:
- Shovels are considered weapons again on 1.8
- Material and potion effect translations have been rewritten to use NMS
  - This allows PGM to make most materials translatable (and I believe all materials on modern servers)
  - No more clunky material/effect remapping!