### PR TITLE
Implement `damager` filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/tracker/info/DamageInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/tracker/info/DamageInfo.java
@@ -4,6 +4,12 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.player.ParticipantState;
 
 public interface DamageInfo extends TrackerInfo {
+
+  @Nullable
+  default PhysicalInfo getDamager() {
+    return null;
+  }
+
   @Nullable
   ParticipantState getAttacker();
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/damage/DamagerFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/damage/DamagerFilter.java
@@ -24,7 +24,7 @@ public class DamagerFilter extends QueryModifier<DamageQuery, EntityTypeQuery> {
       return new EntityTypeQuery() {
         @Override
         public Class<? extends Entity> getEntityType() {
-          return ((EntityInfo) damager).getEntityType().getEntityClass();
+          return ((EntityInfo) damager).getEntityClass();
         }
 
         @Override

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/damage/DamagerFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/damage/DamagerFilter.java
@@ -1,0 +1,43 @@
+package tc.oc.pgm.filters.matcher.damage;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.filter.query.DamageQuery;
+import tc.oc.pgm.api.filter.query.EntityTypeQuery;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.filters.modifier.QueryModifier;
+import tc.oc.pgm.tracker.info.EntityInfo;
+
+public class DamagerFilter extends QueryModifier<DamageQuery, EntityTypeQuery> {
+
+  public DamagerFilter(Filter child) {
+    super(child, DamageQuery.class, EntityTypeQuery.class);
+  }
+
+  @Nullable
+  @Override
+  protected EntityTypeQuery transformQuery(DamageQuery query) {
+    var damager = query.getDamageInfo().getDamager();
+    if (damager instanceof EntityInfo) {
+      return new EntityTypeQuery() {
+        @Override
+        public Class<? extends Entity> getEntityType() {
+          return ((EntityInfo) damager).getEntityType().getEntityClass();
+        }
+
+        @Override
+        public Event getEvent() {
+          return query.getEvent();
+        }
+
+        @Override
+        public Match getMatch() {
+          return query.getMatch();
+        }
+      };
+    }
+    return null;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/damage/DamagerQueryModifier.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/damage/DamagerQueryModifier.java
@@ -10,9 +10,9 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.filters.modifier.QueryModifier;
 import tc.oc.pgm.tracker.info.EntityInfo;
 
-public class DamagerFilter extends QueryModifier<DamageQuery, EntityTypeQuery> {
+public class DamagerQueryModifier extends QueryModifier<DamageQuery, EntityTypeQuery> {
 
-  public DamagerFilter(Filter child) {
+  public DamagerQueryModifier(Filter child) {
     super(child, DamageQuery.class, EntityTypeQuery.class);
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/damage/DamagerQueryModifier.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/damage/DamagerQueryModifier.java
@@ -20,11 +20,11 @@ public class DamagerQueryModifier extends QueryModifier<DamageQuery, EntityTypeQ
   @Override
   protected EntityTypeQuery transformQuery(DamageQuery query) {
     var damager = query.getDamageInfo().getDamager();
-    if (damager instanceof EntityInfo) {
+    if (damager instanceof EntityInfo entityInfo) {
       return new EntityTypeQuery() {
         @Override
         public Class<? extends Entity> getEntityType() {
-          return ((EntityInfo) damager).getEntityClass();
+          return entityInfo.getEntityClass();
         }
 
         @Override

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -31,7 +31,7 @@ import tc.oc.pgm.filters.matcher.block.MaterialFilter;
 import tc.oc.pgm.filters.matcher.block.StructuralLoadFilter;
 import tc.oc.pgm.filters.matcher.block.VoidFilter;
 import tc.oc.pgm.filters.matcher.damage.AttackerQueryModifier;
-import tc.oc.pgm.filters.matcher.damage.DamagerFilter;
+import tc.oc.pgm.filters.matcher.damage.DamagerQueryModifier;
 import tc.oc.pgm.filters.matcher.damage.RelationFilter;
 import tc.oc.pgm.filters.matcher.damage.VictimQueryModifier;
 import tc.oc.pgm.filters.matcher.entity.EntityTypeFilter;
@@ -269,8 +269,8 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
   }
 
   @MethodParser("damager")
-  public Filter damager(Element el) throws InvalidXMLException {
-    return new DamagerFilter(parseChild(el));
+  public DamagerQueryModifier damager(Element el) throws InvalidXMLException {
+    return new DamagerQueryModifier(parseChild(el));
   }
 
   @MethodParser("class")

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -31,6 +31,7 @@ import tc.oc.pgm.filters.matcher.block.MaterialFilter;
 import tc.oc.pgm.filters.matcher.block.StructuralLoadFilter;
 import tc.oc.pgm.filters.matcher.block.VoidFilter;
 import tc.oc.pgm.filters.matcher.damage.AttackerQueryModifier;
+import tc.oc.pgm.filters.matcher.damage.DamagerFilter;
 import tc.oc.pgm.filters.matcher.damage.RelationFilter;
 import tc.oc.pgm.filters.matcher.damage.VictimQueryModifier;
 import tc.oc.pgm.filters.matcher.entity.EntityTypeFilter;
@@ -265,6 +266,11 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
   @MethodParser("victim")
   public VictimQueryModifier parseVictim(Element el) throws InvalidXMLException {
     return new VictimQueryModifier(parseChild(el));
+  }
+
+  @MethodParser("damager")
+  public Filter damager(Element el) throws InvalidXMLException {
+    return new DamagerFilter(parseChild(el));
   }
 
   @MethodParser("class")

--- a/core/src/main/java/tc/oc/pgm/tracker/info/EntityInfo.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/EntityInfo.java
@@ -1,7 +1,5 @@
 package tc.oc.pgm.tracker.info;
 
-import static tc.oc.pgm.util.Assert.assertNotNull;
-
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.entity.Entity;
@@ -14,25 +12,18 @@ import tc.oc.pgm.util.text.MinecraftComponent;
 public class EntityInfo extends OwnerInfoBase implements PhysicalInfo {
 
   private final EntityType entityType;
+  private final Class<? extends Entity> entityClass;
   private final @Nullable String customName;
 
-  public EntityInfo(
-      EntityType entityType, @Nullable String customName, @Nullable ParticipantState owner) {
-    super(owner);
-    this.entityType = assertNotNull(entityType);
-    this.customName = customName;
-  }
-
-  public EntityInfo(EntityType entityType, @Nullable String customName) {
-    this(entityType, customName, null);
-  }
-
   public EntityInfo(Entity entity, @Nullable ParticipantState owner) {
-    this(entity.getType(), entity.getCustomName(), owner);
+    super(owner);
+    this.entityType = entity.getType();
+    this.entityClass = entity.getClass();
+    this.customName = entity.getCustomName();
   }
 
-  public EntityInfo(Entity entity) {
-    this(entity, null);
+  public Class<? extends Entity> getEntityClass() {
+    return entityClass;
   }
 
   public EntityType getEntityType() {

--- a/core/src/main/java/tc/oc/pgm/tracker/info/ExplosionInfo.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/ExplosionInfo.java
@@ -19,6 +19,10 @@ public class ExplosionInfo implements DamageInfo, RangedInfo, CauseInfo {
     this.explosive = assertNotNull(explosive);
   }
 
+  public @Nullable PhysicalInfo getDamager() {
+    return explosive;
+  }
+
   public PhysicalInfo getExplosive() {
     return explosive;
   }

--- a/core/src/main/java/tc/oc/pgm/tracker/info/FallingBlockInfo.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/FallingBlockInfo.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.FallingBlock;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.api.tracker.info.DamageInfo;
+import tc.oc.pgm.api.tracker.info.PhysicalInfo;
 import tc.oc.pgm.util.text.MinecraftComponent;
 
 public class FallingBlockInfo extends EntityInfo implements DamageInfo {
@@ -19,6 +20,11 @@ public class FallingBlockInfo extends EntityInfo implements DamageInfo {
 
   public FallingBlockInfo(FallingBlock entity) {
     this(entity, null);
+  }
+
+  @Override
+  public @Nullable PhysicalInfo getDamager() {
+    return this;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/tracker/info/GenericDamageInfo.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/GenericDamageInfo.java
@@ -24,6 +24,7 @@ public class GenericDamageInfo implements DamageInfo, CauseInfo {
     this(damageType, null);
   }
 
+  @Override
   public @Nullable PhysicalInfo getDamager() {
     return damager;
   }

--- a/core/src/main/java/tc/oc/pgm/tracker/info/ProjectileInfo.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/ProjectileInfo.java
@@ -32,6 +32,11 @@ public class ProjectileInfo implements PhysicalInfo, DamageInfo, RangedInfo {
     this.customName = customName;
   }
 
+  @Override
+  public @Nullable PhysicalInfo getDamager() {
+    return projectile;
+  }
+
   public PhysicalInfo getProjectile() {
     return projectile;
   }

--- a/core/src/main/java/tc/oc/pgm/tracker/info/ThrownPotionInfo.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/info/ThrownPotionInfo.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.ThrownPotion;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.player.ParticipantState;
+import tc.oc.pgm.api.tracker.info.PhysicalInfo;
 import tc.oc.pgm.api.tracker.info.PotionInfo;
 import tc.oc.pgm.util.inventory.InventoryUtils;
 import tc.oc.pgm.util.text.MinecraftComponent;
@@ -20,6 +21,11 @@ public class ThrownPotionInfo extends EntityInfo implements PotionInfo {
 
   public ThrownPotionInfo(ThrownPotion entity) {
     this(entity, null);
+  }
+
+  @Override
+  public @Nullable PhysicalInfo getDamager() {
+    return this;
   }
 
   @Override


### PR DESCRIPTION
Would close https://github.com/PGMDev/PGM/issues/1443

I'm not sure if I have adapted this correctly from ProjectAres. This has been tested with denying damage from arrows:

```xml
<damage>
    <deny>
        <damager>
            <entity>arrow</entity>
        </damager>
    </deny>
</damage>
```

Something like this does not work:

```xml
<damage>
    <deny>
        <damager>
            <entity>player</entity>
        </damager>
    </deny>
</damage>
```

The intended use case of this feature is filtering projectiles for Touchdown maps. This permits Touchdown maps to have bows while also maintaining the ability to pass the flag to others via actions and a snowball consumable without awkward workarounds, by filtering for only damage from snowballs.