### PR TITLE
Add flexibility to inline filters and actions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -148,7 +148,7 @@ public class ActionParser {
     return action;
   }
 
-  private static final String EXPRESSION = "[^=\\]]+";
+  private static final String EXPRESSION = "[^=]+";
   private static final Pattern INLINE_SET =
       Pattern.compile("(%VAR%)(?:\\[(%IDX%)])?\\s*:=\\s*(%EXP%)"
           .replace("%VAR%", VariableParser.VARIABLE_ID.pattern())

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FeatureFilterParser.java
@@ -22,6 +22,7 @@ import tc.oc.pgm.filters.operator.DenyFilter;
 import tc.oc.pgm.filters.operator.InverseFilter;
 import tc.oc.pgm.filters.operator.OneFilter;
 import tc.oc.pgm.util.MethodParser;
+import tc.oc.pgm.util.math.Formula;
 import tc.oc.pgm.util.parser.ParsingNode;
 import tc.oc.pgm.util.parser.SyntaxException;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -29,6 +30,7 @@ import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 import tc.oc.pgm.variables.Variable;
 import tc.oc.pgm.variables.VariableParser;
+import tc.oc.pgm.variables.VariablesModule;
 
 public class FeatureFilterParser extends FilterParser {
 
@@ -90,8 +92,9 @@ public class FeatureFilterParser extends FilterParser {
   }
 
   private static final Pattern INLINE_VARIABLE =
-      Pattern.compile("(%VAR%)(?:\\[(\\d+)])?\\s*=\\s*(%RANGE%|%NUM%)"
+      Pattern.compile("(?:(%VAR%)(?:\\[(\\d+)])?|(%EXPR%))\\s*=\\s*(%RANGE%|%NUM%)"
           .replace("%VAR%", VariableParser.VARIABLE_ID.pattern())
+          .replace("%EXPR%", "[^=]+")
           .replace("%RANGE%", XMLUtils.RANGE_DOTTED.pattern())
           .replace("%NUM%", "-?\\d*\\.?\\d+"));
 
@@ -108,13 +111,22 @@ public class FeatureFilterParser extends FilterParser {
     // Parse variable filter
     Matcher match = INLINE_VARIABLE.matcher(text);
     if (match.matches()) {
-      Variable<?> variable = features.resolve(node, match.group(1), Variable.class);
-      Integer index =
-          match.group(2) == null ? null : XMLUtils.parseNumber(node, match.group(2), Integer.class);
-      Range<Double> range = XMLUtils.parseNumericRange(node, match.group(3), Double.class);
-      return VariableFilter.of(variable, index, range, node);
-    }
+      Range<Double> range = XMLUtils.parseNumericRange(node, match.group(4), Double.class);
 
+      var varName = match.group(1);
+      if (varName != null) {
+        Variable<?> variable = features.resolve(node, match.group(1), Variable.class);
+        Integer index = match.group(2) == null
+            ? null
+            : XMLUtils.parseNumber(node, match.group(2), Integer.class);
+        return VariableFilter.of(variable, index, range, node);
+      } else {
+        var variables = factory.needModule(VariablesModule.class);
+        var expr = match.group(3);
+        var scope = variables.deriveScope(expr);
+        return VariableFilter.of(Formula.of(expr, variables.getContext(scope)), scope, range);
+      }
+    }
     return null;
   }
 
@@ -127,8 +139,8 @@ public class FeatureFilterParser extends FilterParser {
       case "not" -> new InverseFilter(buildChild(node, parsed));
       case "deny" -> new DenyFilter(buildChild(node, parsed));
       case "allow" -> new AllowFilter(buildChild(node, parsed));
-      default -> throw new SyntaxException(
-          "Unknown inline filter type " + parsed.getBase(), parsed);
+      default ->
+        throw new SyntaxException("Unknown inline filter type " + parsed.getBase(), parsed);
     };
   }
 

--- a/core/src/main/java/tc/oc/pgm/variables/VariablesModule.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariablesModule.java
@@ -52,6 +52,19 @@ public class VariablesModule implements MapModule<VariablesMatchModule> {
     return (Formula.ContextFactory<T>) variablesByScope.get(scope);
   }
 
+  public Class<? extends Filterable<?>> deriveScope(String expression) {
+    var vars = Formula.getUsedVariables(expression, getContext(Filterables.SCOPES.getLast()));
+
+    for (Class<? extends Filterable<?>> scope : Filterables.SCOPES) {
+      if (variablesByScope.get(scope).vars.keySet().containsAll(vars)) return scope;
+    }
+
+    vars.removeAll(variablesByScope.get(Filterables.SCOPES.getLast()).vars.keySet());
+
+    throw new IllegalStateException(
+        "Expression '" + expression + "' uses variables not found in any scope: " + vars);
+  }
+
   private record Context<T extends Filterable<?>>(
       ImmutableSet<String> variables, ImmutableSet<String> arrays, Map<String, Variable<?>> vars)
       implements Formula.ContextFactory<T> {
@@ -85,10 +98,10 @@ public class VariablesModule implements MapModule<VariablesMatchModule> {
 
     @Override
     public ExpressionContext withContext(T scope) {
-      Map<String, Double> variableCache = new HashMap<>();
-      Map<String, Function> arrayCache = new HashMap<>();
-
       return new ExpressionContext() {
+        private final Map<String, Double> variableCache = new HashMap<>();
+        private final Map<String, Function> arrayCache = new HashMap<>();
+
         @Override
         public Set<String> getVariables() {
           return variables;

--- a/util/src/main/java/tc/oc/pgm/util/math/AddedFunctions.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/AddedFunctions.java
@@ -1,6 +1,8 @@
 package tc.oc.pgm.util.math;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import net.objecthunter.exp4j.function.Function;
 
 class AddedFunctions {
@@ -46,4 +48,7 @@ class AddedFunctions {
           return count >= 1;
         }
       });
+
+  public static final Map<String, Function> BY_NAME =
+      ALL.stream().collect(Collectors.toUnmodifiableMap(Function::getName, f -> f));
 }

--- a/util/src/main/java/tc/oc/pgm/util/math/Formula.java
+++ b/util/src/main/java/tc/oc/pgm/util/math/Formula.java
@@ -1,13 +1,18 @@
 package tc.oc.pgm.util.math;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.ToDoubleFunction;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;
 import net.objecthunter.exp4j.ExpressionContext;
 import net.objecthunter.exp4j.function.Function;
+import net.objecthunter.exp4j.shuntingyard.ShuntingYard;
+import net.objecthunter.exp4j.tokenizer.FunctionToken;
+import net.objecthunter.exp4j.tokenizer.VariableToken;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 
 public interface Formula<T> extends ToDoubleFunction<T> {
@@ -34,23 +39,31 @@ public interface Formula<T> extends ToDoubleFunction<T> {
     }
   }
 
-  static <T> Formula<T> of(String expression, ContextFactory<T> context)
+  static <T> ExpFormula<T> of(String expression, ContextFactory<T> context)
       throws IllegalArgumentException {
     Expression exp = new ExpressionBuilder(expression)
         .variables(context.getVariables())
         .functions(AddedFunctions.ALL)
-        .functions(context.getArrays().stream()
-            .map(str -> new Function(str, 1) {
-              @Override
-              public double apply(double... doubles) {
-                throw new UnsupportedOperationException(
-                    "Cannot get array value without replacement!");
-              }
-            })
-            .collect(Collectors.toList()))
+        .functions(
+            context.getArrays().stream().<Function>map(ArrayPlaceholder::new).toList())
         .build();
 
     return new ExpFormula<>(exp, context);
+  }
+
+  static Set<String> getUsedVariables(String expr, ContextFactory<?> context)
+      throws IllegalArgumentException {
+    var fn = new HashMap<>(AddedFunctions.BY_NAME);
+    context.getArrays().forEach(arr -> fn.put(arr, new ArrayPlaceholder(arr)));
+
+    var result = new HashSet<String>();
+    for (var token : ShuntingYard.convertToRPN(expr, fn, Map.of(), context.getVariables(), false)) {
+      if (token instanceof VariableToken vt) result.add(vt.getName());
+      else if (token instanceof FunctionToken ft) {
+        if (ft.getFunction() instanceof ArrayPlaceholder a) result.add(a.getName());
+      }
+    }
+    return result;
   }
 
   default <R> Formula<R> map(java.util.function.Function<R, T> mapper) {
@@ -62,18 +75,22 @@ public interface Formula<T> extends ToDoubleFunction<T> {
     return applyAsDouble(value);
   }
 
-  class ExpFormula<T> implements Formula<T> {
-    private final Expression expression;
-    private final ContextFactory<T> context;
-
-    private ExpFormula(Expression expression, ContextFactory<T> context) {
-      this.expression = expression;
-      this.context = context;
-    }
-
+  record ExpFormula<T>(Expression expression, ContextFactory<T> context) implements Formula<T> {
     @Override
     public double applyAsDouble(T value) {
       return expression.setExpressionContext(context.withContext(value)).evaluate();
+    }
+  }
+
+  class ArrayPlaceholder extends Function {
+    private ArrayPlaceholder(String name) {
+      super(name, 1);
+    }
+
+    @Override
+    public double apply(double... doubles) {
+      throw new UnsupportedOperationException(
+          "Function can only be ran after replacement with a context");
     }
   }
 


### PR DESCRIPTION
### State prior to this pr

Prior to this change, inline variable filters would have to be in the form of `filter="variable[0] = 5..`  where `0` MUST be a constant. This could be mitigated by using an actually declared filter such as  `<variable id="idx-over-5" value="variable[i]">5..</variable>` but declaring them separately is messy.

### What becomes possible

This allows arbitrary expressions within the filter itself like `filter="variable[i * 5] + j = 5..`, and the scope will be derived automatically from your used variables.

### Warning note
Using `(` is problematic because both PGM inline filter combining (eg: all, any) and math expression formulas are fighting to parse it. The suggested workaround is using `[` for math leaving `(` for PGM.

Eg: `filter="all(any(max(5, i) + max(5, j) = 5..), alive), red-team)"` will give you issues as PGM can't currently tell that `max(5, i)` is part of the expression `max(5, i) + max(5, j) = 5..` should be parsed as a whole.
Solution is to use: `filter="all(any(max[5, i] + max[5, j] = 5..), alive), red-team)"` instead.

### Inline action fix
Inline actions just get a small fix where nested indexes were broken, so `idx[someVar[j] + 5] := 6` didn't work because pgm took the first `]` as the end of the index expression, leading it to try to parse `someVar[j` instead of `someVar[j] + 5` as the index. That's now resolved.



