### PR TITLE
Support item matcher in itemmods

### DIFF
--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyModule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyModule.java
@@ -14,6 +14,7 @@ import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.util.inventory.ItemMatcher;
 import tc.oc.pgm.util.inventory.tag.ItemTag;
 import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -21,24 +22,30 @@ import tc.oc.pgm.util.xml.XMLUtils;
 
 public class ItemModifyModule implements MapModule<ItemModifyMatchModule> {
   private static final ItemTag<Boolean> APPLIED = ItemTag.newBoolean("custom-meta-applied");
+  private final MaterialMatcher matcher;
   private final List<ItemRule> rules;
 
   public ItemModifyModule(List<ItemRule> rules) {
     this.rules = rules;
+    var builder = MaterialMatcher.builder();
+    rules.forEach(r -> builder.add(r.items));
+    this.matcher = builder.build();
   }
 
   public boolean applyRules(ItemStack stack) {
-    if (stack == null || stack.getType() == Material.AIR || APPLIED.has(stack)) {
+    if (stack == null
+        || stack.getType() == Material.AIR
+        || !matcher.matches(stack)
+        || APPLIED.has(stack)) {
       return false;
-    } else {
-      APPLIED.set(stack, true);
-      for (ItemRule rule : rules) {
-        if (rule.matches(stack)) {
-          rule.apply(stack);
-        }
-      }
-      return true;
     }
+    APPLIED.set(stack, true);
+    for (ItemRule rule : rules) {
+      if (rule.matches(stack)) {
+        rule.apply(stack);
+      }
+    }
+    return true;
   }
 
   @Override
@@ -52,15 +59,23 @@ public class ItemModifyModule implements MapModule<ItemModifyMatchModule> {
         throws InvalidXMLException {
       List<ItemRule> rules = new ArrayList<>();
       for (Element elRule : XMLUtils.flattenElements(doc.getRootElement(), "item-mods", "rule")) {
-        MaterialMatcher items =
-            XMLUtils.parseMaterialMatcher(XMLUtils.getRequiredUniqueChild(elRule, "match"));
+        var match = XMLUtils.getRequiredUniqueChild(elRule, "match");
+        ItemMatcher itemMatcher;
+        MaterialMatcher materialMatcher;
+        if (match.getChild("matcher") != null) {
+          itemMatcher = factory.getKits().parseItemMatcher(match, "matcher");
+          materialMatcher = itemMatcher.getMaterialMatcher();
+        } else {
+          itemMatcher = null;
+          materialMatcher = XMLUtils.parseMaterialMatcher(match);
+        }
 
         // Always use a PotionMeta so the rule can have potion effects, though it will only apply
         // those to potion items
         PotionMeta meta = (PotionMeta) Bukkit.getItemFactory().getItemMeta(Material.POTION);
         factory.getKits().parseItemMeta(XMLUtils.getRequiredUniqueChild(elRule, "modify"), meta);
 
-        ItemRule rule = new ItemRule(items, meta);
+        ItemRule rule = new ItemRule(materialMatcher, itemMatcher, meta);
         rules.add(rule);
       }
 

--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemRule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemRule.java
@@ -10,20 +10,24 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.inventory.InventoryUtils;
+import tc.oc.pgm.util.inventory.ItemMatcher;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
 public class ItemRule {
   final MaterialMatcher items;
+  final @Nullable ItemMatcher matcher;
   final PotionMeta meta;
 
-  public ItemRule(MaterialMatcher items, PotionMeta meta) {
+  public ItemRule(MaterialMatcher items, @Nullable ItemMatcher matcher, PotionMeta meta) {
     this.items = items;
+    this.matcher = matcher;
     this.meta = meta;
   }
 
   public boolean matches(ItemStack stack) {
-    return items.matches(stack);
+    return items.matches(stack) && (matcher == null || matcher.matches(stack));
   }
 
   public void apply(ItemStack stack) {
@@ -40,7 +44,7 @@ public class ItemRule {
       }
 
       Set<ItemFlag> flags = this.meta.getItemFlags();
-      meta.addItemFlags(flags.toArray(new ItemFlag[flags.size()]));
+      meta.addItemFlags(flags.toArray(new ItemFlag[0]));
 
       InventoryUtils.addEnchantments(meta, this.meta.getEnchants());
 

--- a/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.util.inventory;
 import com.google.common.collect.Range;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.material.Materials;
 
 public class ItemMatcher {
@@ -31,6 +32,10 @@ public class ItemMatcher {
 
     this.amount = amount;
     this.base = stripMeta(base);
+  }
+
+  public MaterialMatcher getMaterialMatcher() {
+    return MaterialMatcher.builder().add(base, ignoreDurability).build();
   }
 
   private ItemStack stripMeta(final ItemStack item) {

--- a/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
@@ -64,10 +64,6 @@ public interface MaterialMatcher {
     return builder().addAll(materials).build();
   }
 
-  static MaterialMatcher ofMatchers(Collection<? extends MaterialMatcher> matchers) {
-    return CompoundMaterialMatcher.of(matchers);
-  }
-
   static MaterialMatcher parse(Element el) throws InvalidXMLException {
     return MaterialMatcher.builder().parse(new Node(el)).build();
   }
@@ -239,7 +235,7 @@ public interface MaterialMatcher {
       List<MaterialMatcher> materialMatchers = new ArrayList<>(materials.size() + matchers.size());
       if (!materials.isEmpty()) materialMatchers.add(MaterialMatcher.of(materials));
       if (!matchers.isEmpty()) materialMatchers.addAll(matchers);
-      return MaterialMatcher.ofMatchers(materialMatchers);
+      return CompoundMaterialMatcher.of(materialMatchers);
     }
   }
 }


### PR DESCRIPTION
Allows for item-mods to have a `matcher` subelement for `match` which is an item matcher definition, such as those found in holding/carrying filters or replace-item/enchant-item actions.

eg:

```xml
<item-mods>
    <rule>
        <match ignore-metadata="true">
            <matcher material="bow" amount="1"/>
        </match>
        <modify show-enchantments="false" unbreakable="true">
            <enchantment level="2">infinity</enchantment>
        </modify>
    </rule>
</item-mods>
```

Do note: item-mods still apply JUST ONCE whenever the item is first observed (eg: when a chest is opened, or when the kit is created), so things like trying to modify the item when it gets to a certain durability, or if it gets enchanted with something after the fact is not and will not be supported.


This is more of a prototype because it was requested by a mapdev, but i'm not convinced this actually solves their intended use-case which was modifying punch bows in chests, as itemmods can only add not remove stuff. Also not convinced on the xml name for it, but we can't really use `material` or `item` as either of those are already interpreted as being materials for the material matcher.