### PR TITLE
Fix lack of redirect for xml region ref

### DIFF
--- a/core/src/main/java/tc/oc/pgm/regions/XMLRegionReference.java
+++ b/core/src/main/java/tc/oc/pgm/regions/XMLRegionReference.java
@@ -144,6 +144,11 @@ public class XMLRegionReference extends XMLFeatureReference<RegionDefinition>
   }
 
   @Override
+  public boolean isDynamic() {
+    return get().isDynamic();
+  }
+
+  @Override
   public Collection<Class<? extends Event>> getRelevantEvents() {
     return get().getRelevantEvents();
   }


### PR DESCRIPTION
XmlRegionReference was not redirecting isDynamic, which meant it defaulted to Filter's implementation instead of the referred's implementation, causing inconsistencies with variable regions.


Example from @TTtie:  

This didn't work (because its directly the region):
```xml
<variables>
    <cuboid id="cube" min="390,0,280" max="420,10,300" />
</variables>
<actions>
    <trigger filter="cube" scope="player">
        <action>
            <message text="You're in the cube" />
        </action>
    </trigger>
</actions>
```
While this did work (because it uses a reference):
```xml
<variables>
    <cuboid id="cube" min="390,0,280" max="420,10,300" />
</variables>
<actions>
    <trigger scope="player">
        <filter>
            <region id="cube" />
        </filter>
        <action>
            <message text="You're in the cube" />
        </action>
    </trigger>
</actions>
```
This is because variable regions are *not* dynamic, as there is no way to detect players suddently being in the region as the result of the region having moved/resized

