### PR TITLE
Add custom banner support to kits

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -24,8 +24,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.bukkit.*;
+
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
+import org.bukkit.FireworkEffect;
 import org.bukkit.FireworkEffect.Type;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.block.banner.PatternType;

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -445,7 +445,6 @@ public abstract class KitParser {
     ItemStack itemStack = parseItem(el, Materials.BANNER);
     DyeColor color = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(el, "base-color"));
     COLOR_UTILS.setColor(itemStack, color);
-    
     BannerMeta meta = (BannerMeta) itemStack.getItemMeta();
 
     for (Element layerEl : el.getChildren("layer")) {

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.FireworkEffect;
@@ -449,7 +448,10 @@ public abstract class KitParser {
     patterns.add(new org.bukkit.block.banner.Pattern(color, PatternType.BASE));
     for (Element elLayer : el.getChildren("layer")) {
       DyeColor layerColor = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(elLayer, "color"));
-      String patternString = XMLUtils.getRequiredAttribute(elLayer, "pattern").getValue();
+      String patternString = XMLUtils.getRequiredAttribute(elLayer, "pattern")
+          .getValue()
+          .toUpperCase()
+          .replace(" ", "_");
       PatternType patternType = PatternType.valueOf(patternString);
       org.bukkit.block.banner.Pattern pattern =
           new org.bukkit.block.banner.Pattern(layerColor, patternType);

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -443,10 +443,10 @@ public abstract class KitParser {
 
   public ItemStack parseBanner(Element el) throws InvalidXMLException {
     ItemStack itemStack = parseItem(el, Materials.BANNER);
-    BannerMeta meta = (BannerMeta) itemStack.getItemMeta();
-
     DyeColor color = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(el, "base-color"));
     COLOR_UTILS.setColor(itemStack, color);
+    
+    BannerMeta meta = (BannerMeta) itemStack.getItemMeta();
 
     for (Element layerEl : el.getChildren("layer")) {
       DyeColor layerColor = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(layerEl, "color"));

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -24,16 +24,15 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.bukkit.Color;
-import org.bukkit.FireworkEffect;
+import org.bukkit.*;
 import org.bukkit.FireworkEffect.Type;
-import org.bukkit.GameMode;
-import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.block.banner.PatternType;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.FireworkMeta;
@@ -73,7 +72,8 @@ import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public abstract class KitParser {
-  private static final Set<String> ITEM_TYPES = Set.of("item", "book", "head", "firework");
+  private static final Set<String> ITEM_TYPES =
+      Set.of("item", "book", "head", "firework", "banner");
 
   protected final MapFactory factory;
   protected final Set<Kit> kits = new HashSet<>();
@@ -281,6 +281,7 @@ public abstract class KitParser {
       case "book" -> parseBook(el);
       case "head" -> parseHead(el);
       case "firework" -> parseFirework(el);
+      case "banner" -> parseBanner(el);
       default -> null;
     };
   }
@@ -433,6 +434,25 @@ public abstract class KitParser {
       colors.add(XMLUtils.parseHexColor(node));
     }
     return colors;
+  }
+
+  public ItemStack parseBanner(Element el) throws InvalidXMLException {
+    ItemStack itemStack = parseItem(el, Materials.BANNER);
+    BannerMeta meta = (BannerMeta) itemStack.getItemMeta();
+    DyeColor color = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(el, "base-color"));
+    List<org.bukkit.block.banner.Pattern> patterns = new ArrayList<>();
+    patterns.add(new org.bukkit.block.banner.Pattern(color, PatternType.BASE));
+    for (Element elLayer : el.getChildren("layer")) {
+      DyeColor layerColor = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(elLayer, "color"));
+      String patternString = XMLUtils.getRequiredAttribute(elLayer, "pattern").getValue();
+      PatternType patternType = PatternType.valueOf(patternString);
+      org.bukkit.block.banner.Pattern pattern =
+          new org.bukkit.block.banner.Pattern(layerColor, patternType);
+      patterns.add(pattern);
+    }
+    meta.setPatterns(patterns);
+    itemStack.setItemMeta(meta);
+    return itemStack;
   }
 
   public ItemMatcher parseItemMatcher(Element parent) throws InvalidXMLException {
@@ -588,7 +608,7 @@ public abstract class KitParser {
       case HIDE_UNBREAKABLE -> "unbreakable";
       case HIDE_DESTROYS -> "can-destroy";
       case HIDE_PLACED_ON -> "can-place-on";
-        //noinspection UnnecessaryDefault: newer versions do have extra branches
+      //noinspection UnnecessaryDefault: newer versions do have extra branches
       default -> {
         if (flag == InventoryUtils.HIDE_ADDITIONAL_FLAG) yield "other";
         yield flag.name().replace("HIDE_", "").toLowerCase().replace("_", "-");

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.kits;
 
 import static tc.oc.pgm.util.attribute.AttributeUtils.ATTRIBUTE_UTILS;
 import static tc.oc.pgm.util.inventory.InventoryUtils.INVENTORY_UTILS;
+import static tc.oc.pgm.util.material.ColorUtils.COLOR_UTILS;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 
 import com.google.common.base.Splitter;
@@ -443,21 +444,17 @@ public abstract class KitParser {
   public ItemStack parseBanner(Element el) throws InvalidXMLException {
     ItemStack itemStack = parseItem(el, Materials.BANNER);
     BannerMeta meta = (BannerMeta) itemStack.getItemMeta();
+
     DyeColor color = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(el, "base-color"));
-    List<org.bukkit.block.banner.Pattern> patterns = new ArrayList<>();
-    patterns.add(new org.bukkit.block.banner.Pattern(color, PatternType.BASE));
-    for (Element elLayer : el.getChildren("layer")) {
-      DyeColor layerColor = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(elLayer, "color"));
-      String patternString = XMLUtils.getRequiredAttribute(elLayer, "pattern")
-          .getValue()
-          .toUpperCase()
-          .replace(" ", "_");
-      PatternType patternType = PatternType.valueOf(patternString);
-      org.bukkit.block.banner.Pattern pattern =
-          new org.bukkit.block.banner.Pattern(layerColor, patternType);
-      patterns.add(pattern);
+    COLOR_UTILS.setColor(itemStack, color);
+
+    for (Element layerEl : el.getChildren("layer")) {
+      DyeColor layerColor = XMLUtils.parseDyeColor(XMLUtils.getRequiredAttribute(layerEl, "color"));
+      PatternType patternType =
+          XMLUtils.parsePatternType(XMLUtils.getRequiredAttribute(layerEl, "pattern"));
+      meta.addPattern(new org.bukkit.block.banner.Pattern(layerColor, patternType));
     }
-    meta.setPatterns(patterns);
+
     itemStack.setItemMeta(meta);
     return itemStack;
   }

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/PatternTypes.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/PatternTypes.java
@@ -1,0 +1,40 @@
+package tc.oc.pgm.util.bukkit;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.bukkit.block.banner.PatternType;
+import tc.oc.pgm.util.StringUtils;
+
+public class PatternTypes {
+  private static final Map<String, PatternType> BY_NAME = new HashMap<>();
+
+  static {
+    for (PatternType value : PatternType.values()) {
+      BY_NAME.put(StringUtils.simplify(value.name()), value);
+    }
+  }
+
+  public static final PatternType CIRCLE = parse("CIRCLE", "CIRCLE_MIDDLE");
+  public static final PatternType DIAGONAL_UP_LEFT =
+      parse("DIAGONAL_UP_LEFT", "DIAGONAL_LEFT_MIRROR");
+  public static final PatternType DIAGONAL_UP_RIGHT =
+      parse("DIAGONAL_UP_RIGHT", "DIAGONAL_RIGHT_MIRROR");
+  public static final PatternType HALF_HORIZONTAL_BOTTOM =
+      parse("HALF_HORIZONTAL_BOTTOM", "HALF_HORIZONTAL_MIRROR");
+  public static final PatternType HALF_VERTICAL_RIGHT =
+      parse("HALF_VERTICAL_RIGHT", "HALF_VERTICAL_MIRROR");
+  public static final PatternType RHOMBUS = parse("RHOMBUS", "RHOMBUS_MIDDLE");
+  public static final PatternType SMALL_STRIPES = parse("SMALL_STRIPES", "STRIPE_SMALL");
+
+  private static PatternType parse(String... names) {
+    PatternType type = BukkitUtils.parse(PatternType::valueOf, names);
+    for (String name : names) {
+      BY_NAME.put(StringUtils.simplify(name), type);
+    }
+    return type;
+  }
+
+  public static PatternType getByName(String name) {
+    return BY_NAME.get(StringUtils.simplify(name));
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -32,7 +32,7 @@ public interface Materials {
   Material BOOK_AND_QUILL = parse("BOOK_AND_QUILL", "WRITABLE_BOOK");
   Material EYE_OF_ENDER = parse("EYE_OF_ENDER", "ENDER_EYE");
   Material FIREWORK = parse("FIREWORK", "FIREWORK_ROCKET");
-  Material BANNER = parse("BANNER");
+  Material BANNER = parse("BANNER", "LEGACY_BANNER");
   Material WATCH = parse("WATCH", "CLOCK");
   Material DYE = parse("INK_SACK", "BLACK_DYE");
   Material IRON_DOOR = parse("IRON_DOOR_BLOCK", "IRON_DOOR");

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -32,6 +32,7 @@ public interface Materials {
   Material BOOK_AND_QUILL = parse("BOOK_AND_QUILL", "WRITABLE_BOOK");
   Material EYE_OF_ENDER = parse("EYE_OF_ENDER", "ENDER_EYE");
   Material FIREWORK = parse("FIREWORK", "FIREWORK_ROCKET");
+  Material BANNER = parse("BANNER");
   Material WATCH = parse("WATCH", "CLOCK");
   Material DYE = parse("INK_SACK", "BLACK_DYE");
   Material IRON_DOOR = parse("IRON_DOOR_BLOCK", "IRON_DOOR");

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -14,6 +14,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
 import org.bukkit.*;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.block.banner.PatternType;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.potion.PotionEffect;
@@ -33,6 +34,7 @@ import tc.oc.pgm.util.attribute.Attributes;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.bukkit.DyeColors;
 import tc.oc.pgm.util.bukkit.Enchantments;
+import tc.oc.pgm.util.bukkit.PatternTypes;
 import tc.oc.pgm.util.bukkit.PotionEffects;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.ItemMaterialData;
@@ -1144,5 +1146,17 @@ public final class XMLUtils {
       throw new InvalidXMLException("Invalid color format '" + rawColor + "'", node);
     }
     return Color.fromRGB(Integer.parseInt(rawColor, 16));
+  }
+
+  public static PatternType parsePatternType(Attribute attr, String text)
+      throws InvalidXMLException {
+    var patternType = PatternTypes.getByName(text);
+    if (patternType != null) return patternType;
+
+    throw new InvalidXMLException("Unknown pattern type '" + text + "'", attr);
+  }
+
+  public static PatternType parsePatternType(Attribute attr) throws InvalidXMLException {
+    return parsePatternType(attr, attr.getValue());
   }
 }


### PR DESCRIPTION

This is my humble PR that brings banner support to PGM.  My current PGM experience is limited by the lack of banner support. There are plentiful use cases for custom banners.

 Think of the children. The children who go everyday without banner support. The children that only play on PGM servers. The children that MAY not know that banners can be much more than a wall decoration. Banners can be a symbol, an idea, a glimpse of hope in the world. Without banners what is the point of PGM? 

As PGM-ers we should encourage our users to maximize their creativity. 

How does one use such an AWESOME AND HIGHLY DEMANDED PGM feature? Its simple:
```xml
<kits>
	<kit id="banner-kit">
		<banner base-color="white" slot="8" name="awesome custom banner">
			<layer color="red" pattern="half horizontal mirror"/>
			<layer color="red" pattern="HALF_HORIZONTAL"/>
			<layer color="light_blue" pattern="STRIPE_middle"/>
			<layer color="red" pattern="HaLF VertIcAL"/>
			<layer color="black" pattern="triangles bottom"/>
			<layer color="black" pattern="border"/>
			<layer color="light_blue" pattern="stripe_middle"/>
			<layer color="red" pattern="STRIPE_LEFT"/>
			<layer color="black" pattern="TRIANGLES_BOTTOM"/>
			<layer color="black" pattern="border"/>
			<layer color="black" pattern="STRIPE TOP"/>
		</banner>
	</kit>
</kits>
```
A full list of banner patterns can be found [here](https://helpch.at/docs/1.8/index.html?org/bukkit/block/banner/PatternType.html)


<img width="1065" height="508" alt="image" src="https://github.com/user-attachments/assets/dad93487-f7b7-445c-a030-a292b30caa46" />
<img width="295" height="599" alt="image" src="https://github.com/user-attachments/assets/dc73447e-d89c-4e4d-9327-ff623d6ffaee" />
