### PR TITLE
Disable leaving after a match ends

### DIFF
--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -165,8 +165,7 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
 
     // Can't leave if the match is over
     if (match.isFinished()) {
-      leaving.sendWarning(
-              translatable("join.err.afterFinish"));
+      leaving.sendWarning(translatable("join.err.afterFinish"));
       return false;
     }
 

--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -170,6 +170,7 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
       return false;
     }
 
+
     if (leaving.getParty() instanceof ObserverParty) {
       leaving.sendWarning(
           translatable("join.err.alreadyJoined.team", leaving.getParty().getName()));

--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -170,7 +170,6 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
       return false;
     }
 
-
     if (leaving.getParty() instanceof ObserverParty) {
       leaving.sendWarning(
           translatable("join.err.alreadyJoined.team", leaving.getParty().getName()));

--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -163,6 +163,13 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
   public boolean leave(MatchPlayer leaving, JoinRequest request) {
     if (cancelQueuedJoin(leaving)) return true;
 
+    // Can't leave if the match is over
+    if (match.isFinished()) {
+      leaving.sendWarning(
+              translatable("join.err.afterFinish"));
+      return false;
+    }
+
     if (leaving.getParty() instanceof ObserverParty) {
       leaving.sendWarning(
           translatable("join.err.alreadyJoined.team", leaving.getParty().getName()));


### PR DESCRIPTION
Certain players like to leave matches after they end but before Stats pops up so they have a Obs name tag when it shows up.

This PR disables leaving after a match ends.