### PR TITLE
Resolve minor 1.21.10 migration issues; other cleanup

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
@@ -63,7 +63,7 @@ spotless {
     ratchetFrom = "origin/dev"
     java {
         removeUnusedImports()
-        palantirJavaFormat("2.80.0").style("GOOGLE").formatJavadoc(true)
+        palantirJavaFormat("2.81.0").style("GOOGLE").formatJavadoc(true)
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly("dev.pgm.paper:paper-api:1.8_1.21.8-SNAPSHOT")
+    compileOnly("dev.pgm.paper:paper-api:1.8_1.21.10-SNAPSHOT")
 
     implementation(project(":util"))
     runtimeOnly(project(":platform-sportpaper")) { exclude("*") }

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -130,7 +130,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
       getServer().getPluginManager().disablePlugin(this);
     }
     // Fix before any audiences have the chance of creating
-    ViaUtils.removeViaChatFacet();
+    if (Platform.isLegacy()) ViaUtils.removeViaChatFacet();
 
     Permissions.registerAll();
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernNMSHacks.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernNMSHacks.java
@@ -337,6 +337,10 @@ public class ModernNMSHacks implements NMSHacks {
     return serverLevel.getWorld();
   }
 
+  /**
+   * {@link io.papermc.paper.world.PaperWorldLoader#getLevelData} adapted for
+   * {@link ModernNMSHacks#createWorld}
+   */
   private static PaperWorldLoader.LevelDataResult getLevelData(
       final LevelStorageSource.LevelStorageAccess levelStorageAccess) {
     // Abort if level.dat is empty

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
@@ -87,7 +87,6 @@ public class ModernListener implements Listener {
   }
 
   @EventHandler(ignoreCancelled = true)
-  @SuppressWarnings("removal")
   public void onEntityDespawn(org.bukkit.event.entity.EntityRemoveEvent modernEvent) {
     if (modernEvent.getCause() == org.bukkit.event.entity.EntityRemoveEvent.Cause.OUT_OF_WORLD) {
       EntityDespawnInVoidEvent pgmEvent = new EntityDespawnInVoidEvent(modernEvent.getEntity());

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
@@ -94,6 +94,9 @@ class ModernMaterialParser {
     }
     text = text.toUpperCase(Locale.ROOT).replaceAll("\\s+", "_").replaceAll("\\W", "");
 
+    // 1.21.9 introduced copper chains, so chain was renamed accordingly
+    if (text.equals("CHAIN")) return Material.IRON_CHAIN;
+
     var legacy = Material.getMaterial("LEGACY_" + text);
     if (legacy != null) return legacy;
 

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly("dev.pgm.paper:paper-api:1.8_1.21.8-SNAPSHOT")
+    compileOnly("dev.pgm.paper:paper-api:1.8_1.21.10-SNAPSHOT")
     testImplementation("io.papermc.paper:paper-api:1.21.10-R0.1-SNAPSHOT")
     testImplementation("org.junit.jupiter:junit-jupiter:5.13.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
@@ -12,7 +12,7 @@ public class ViaUtils {
   public static final int VERSION_1_7 = 5;
   public static final int VERSION_1_8 = 47;
   public static final int VERSION_1_13 = 393;
-  public static final int VERSION_1_21_7 = 772;
+  public static final int VERSION_1_21_10 = 773;
 
   private static final boolean ENABLED = isViaLoaded();
 
@@ -37,7 +37,7 @@ public class ViaUtils {
     if (enabled()) {
       return Via.getAPI().getPlayerVersion(player.getUniqueId());
     } else {
-      return Platform.VARIANT == SPORTPAPER ? VERSION_1_8 : VERSION_1_21_7;
+      return Platform.VARIANT == SPORTPAPER ? VERSION_1_8 : VERSION_1_21_10;
     }
   }
 


### PR DESCRIPTION
- Use new intersect jar; very little changes between 1.21.8 intersect jar (still pending publishing)
- Only apply #1222 on legacy (modern is seemingly unaffected)
- Add comment linking to original `getLevelData` method in `PaperWorldLoader`
- Remove a no longer relevant removal warning suppression
- Use 1.21.10 protocol version in ViaUtils
- Update `ModernMaterialParser` to recognize chain being renamed to iron chain