### PR TITLE
Refresh WorldBorders once on match end

### DIFF
--- a/core/src/main/java/tc/oc/pgm/worldborder/WorldBorderMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/worldborder/WorldBorderMatchModule.java
@@ -16,6 +16,7 @@ import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.filters.query.MatchQuery;
 import tc.oc.pgm.goals.events.GoalEvent;
@@ -140,12 +141,20 @@ public class WorldBorderMatchModule implements MatchModule, Listener {
   private void freeze() {
     if (appliedBorder != null && appliedBorder.isMoving()) {
       match.getLogger().fine("Freezing border " + appliedBorder);
-      match.getWorld().getWorldBorder().setSize(match.getWorld().getWorldBorder().getSize(), 0);
+      match
+          .getWorld()
+          .getWorldBorder()
+          .setSize(match.getWorld().getWorldBorder().getSize(), 0);
     }
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onGoalComplete(GoalEvent event) {
+    update(event);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onMatchEnd(MatchFinishEvent event) {
     update(event);
   }
 }


### PR DESCRIPTION
Certain maps can have really tiny world borders on match end.
Refresh once to allow something like this to work:
```xml
<world-borders center="0.5,0.5">
    <world-border size="80"/>
    <world-border size="3" after="0s" duration="15s" damage="5" buffer="0"/>
    <world-border size="100" when="match-finished"/>
</world-borders>
```