### PR TITLE
Implement hearts scoring display

### DIFF
--- a/core/src/main/java/tc/oc/pgm/score/ScoreDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreDefinition.java
@@ -34,6 +34,7 @@ public record ScoreDefinition(
     },
     CIRCLE("\u2B24", 16), // ⬤
     SQUARE("\u2b1b", 16), // ⬛
+    HEART("\u2764",16), // ❤
     PIPE("|", 24);
 
     public final String symbol;

--- a/core/src/main/java/tc/oc/pgm/score/ScoreDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreDefinition.java
@@ -34,7 +34,7 @@ public record ScoreDefinition(
     },
     CIRCLE("\u2B24", 16), // ⬤
     SQUARE("\u2b1b", 16), // ⬛
-    HEART("\u2764",16), // ❤
+    HEART("\u2764", 16), // ❤
     PIPE("|", 24);
 
     public final String symbol;


### PR DESCRIPTION
a small change that implements the option for maps to use hearts as a score display method. The intent are to use these as health bars for future maps with a team elimination format such as 4 team bridge and 4 team flag assault maps (see img).
-# (Am currently working on a map that would use this feature if accepted) 

<img width="124" height="104" alt="image" src="https://github.com/user-attachments/assets/893150ea-6443-4d57-832c-b659af9d8176" />

