### PR TITLE
Pull and display player component based on what team that player spent the most time on

### DIFF
--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -381,11 +381,12 @@ public class StatsMatchModule implements MatchModule, Listener {
   }
 
   private Component getPlayerComponent(UUID uuid) {
+    var mp = match.getPlayer(uuid);
     var player = player(uuid, NameStyle.VERBOSE);
 
-    if (player != PlayerComponent.UNKNOWN
-        && match.getPlayer(uuid) != null
-        && !match.getPlayer(uuid).isObserving()) return player;
+    if (mp != null && mp.getCompetitor() != null && player != PlayerComponent.UNKNOWN) {
+      return player;
+    }
     return stats.column(uuid).values().stream()
         .max(Comparator.comparing(PlayerStats::getTimePlayed))
         .map(PlayerStats::getPlayerComponent)

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -382,15 +382,17 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   private Component getPlayerComponent(UUID uuid) {
     var mp = match.getPlayer(uuid);
-    var player = player(uuid, NameStyle.VERBOSE);
-    if (mp != null && mp.getCompetitor() != null && player != PlayerComponent.UNKNOWN) {
-      return player;
+    Component player = null;
+
+    if (mp != null && mp.getCompetitor() != null) {
+      player = player(uuid, NameStyle.VERBOSE);
+      if (player != PlayerComponent.UNKNOWN) return player;
     }
 
     return stats.column(uuid).values().stream()
         .max(Comparator.comparing(PlayerStats::getTimePlayed))
         .map(PlayerStats::getPlayerComponent)
-        .orElse(player);
+        .orElse(player != null ? player : player(uuid, NameStyle.VERBOSE));
   }
 
   /** Formats raw damage to damage relative to the amount of hearths the player would have broken */

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -77,6 +77,7 @@ import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.tracker.TrackerMatchModule;
 import tc.oc.pgm.tracker.info.ProjectileInfo;
 import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.player.PlayerComponent;
 import tc.oc.pgm.util.text.TextFormatter;
 import tc.oc.pgm.util.usernames.UsernameResolvers;
 import tc.oc.pgm.wool.MonumentWool;
@@ -354,7 +355,8 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   private Component getMessage(AggStat<?> agg, boolean best, boolean own) {
     Component who = empty();
-    if (best) who = translatable("misc.authorship", agg.type.makeNumber(agg.value), credit(agg));
+    if (best)
+      who = translatable("misc.authorship", agg.type.makeNumber(agg.value), credit(agg.players));
     if (own)
       who = who.append(virtual(Player.class, p -> {
         if (agg.players.contains(p.getUniqueId()) || hasNoStats(p.getUniqueId())) return empty();
@@ -367,25 +369,25 @@ public class StatsMatchModule implements MatchModule, Listener {
     return agg.type.component(who);
   }
 
-  private Component credit(AggStat<?> agg) {
-    if (agg.players.size() >= 10)
+  private Component credit(Set<UUID> players) {
+    if (players.size() >= 10)
       return translatable("objective.credit.many", NamedTextColor.GRAY, TextDecoration.ITALIC);
 
-    var list = list(
-        Collections2.transform(
-            agg.players, player -> this.getPlayerComponent(player, (StatType.Builtin) agg.type)),
-        null);
-    if (agg.players.size() > 3)
+    var list = list(Collections2.transform(players, this::getPlayerComponent), null);
+    if (players.size() > 3)
       return translatable("match.stats.severalPlayers", NamedTextColor.GRAY, TextDecoration.ITALIC)
           .hoverEvent(list);
     return list;
   }
 
-  private Component getPlayerComponent(UUID uuid, StatType.Builtin type) {
+  private Component getPlayerComponent(UUID uuid) {
     var player = player(uuid, NameStyle.VERBOSE);
 
+    if (player != PlayerComponent.UNKNOWN
+        && match.getPlayer(uuid).getBukkit().isOnline()
+        && !match.getPlayer(uuid).isObserving()) return player;
     return stats.column(uuid).values().stream()
-        .max(Comparator.comparingDouble(playerStat -> playerStat.getStat(type).doubleValue()))
+        .max(Comparator.comparing(PlayerStats::getTimePlayed))
         .map(PlayerStats::getPlayerComponent)
         .orElse(player);
   }

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -77,7 +77,6 @@ import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.tracker.TrackerMatchModule;
 import tc.oc.pgm.tracker.info.ProjectileInfo;
 import tc.oc.pgm.util.named.NameStyle;
-import tc.oc.pgm.util.player.PlayerComponent;
 import tc.oc.pgm.util.text.TextFormatter;
 import tc.oc.pgm.util.usernames.UsernameResolvers;
 import tc.oc.pgm.wool.MonumentWool;
@@ -382,17 +381,12 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   private Component getPlayerComponent(UUID uuid) {
     var mp = match.getPlayer(uuid);
-    Component player = null;
-
-    if (mp != null && mp.getCompetitor() != null) {
-      player = player(uuid, NameStyle.VERBOSE);
-      if (player != PlayerComponent.UNKNOWN) return player;
-    }
+    if (mp != null && mp.getCompetitor() != null) return mp.getName();
 
     return stats.column(uuid).values().stream()
         .max(Comparator.comparing(PlayerStats::getTimePlayed))
         .map(PlayerStats::getPlayerComponent)
-        .orElse(player != null ? player : player(uuid, NameStyle.VERBOSE));
+        .orElseGet(() -> player(uuid, NameStyle.VERBOSE));
   }
 
   /** Formats raw damage to damage relative to the amount of hearths the player would have broken */

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -384,7 +384,7 @@ public class StatsMatchModule implements MatchModule, Listener {
     var player = player(uuid, NameStyle.VERBOSE);
 
     if (player != PlayerComponent.UNKNOWN
-        && match.getPlayer(uuid).getBukkit().isOnline()
+        && match.getPlayer(uuid) != null
         && !match.getPlayer(uuid).isObserving()) return player;
     return stats.column(uuid).values().stream()
         .max(Comparator.comparing(PlayerStats::getTimePlayed))

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -383,10 +383,10 @@ public class StatsMatchModule implements MatchModule, Listener {
   private Component getPlayerComponent(UUID uuid) {
     var mp = match.getPlayer(uuid);
     var player = player(uuid, NameStyle.VERBOSE);
-
     if (mp != null && mp.getCompetitor() != null && player != PlayerComponent.UNKNOWN) {
       return player;
     }
+
     return stats.column(uuid).values().stream()
         .max(Comparator.comparing(PlayerStats::getTimePlayed))
         .map(PlayerStats::getPlayerComponent)

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -77,7 +77,6 @@ import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.tracker.TrackerMatchModule;
 import tc.oc.pgm.tracker.info.ProjectileInfo;
 import tc.oc.pgm.util.named.NameStyle;
-import tc.oc.pgm.util.player.PlayerComponent;
 import tc.oc.pgm.util.text.TextFormatter;
 import tc.oc.pgm.util.usernames.UsernameResolvers;
 import tc.oc.pgm.wool.MonumentWool;
@@ -355,8 +354,7 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   private Component getMessage(AggStat<?> agg, boolean best, boolean own) {
     Component who = empty();
-    if (best)
-      who = translatable("misc.authorship", agg.type.makeNumber(agg.value), credit(agg.players));
+    if (best) who = translatable("misc.authorship", agg.type.makeNumber(agg.value), credit(agg));
     if (own)
       who = who.append(virtual(Player.class, p -> {
         if (agg.players.contains(p.getUniqueId()) || hasNoStats(p.getUniqueId())) return empty();
@@ -369,22 +367,25 @@ public class StatsMatchModule implements MatchModule, Listener {
     return agg.type.component(who);
   }
 
-  private Component credit(Set<UUID> players) {
-    if (players.size() >= 10)
+  private Component credit(AggStat<?> agg) {
+    if (agg.players.size() >= 10)
       return translatable("objective.credit.many", NamedTextColor.GRAY, TextDecoration.ITALIC);
 
-    var list = list(Collections2.transform(players, this::getPlayerComponent), null);
-    if (players.size() > 3)
+    var list = list(
+        Collections2.transform(
+            agg.players, player -> this.getPlayerComponent(player, (StatType.Builtin) agg.type)),
+        null);
+    if (agg.players.size() > 3)
       return translatable("match.stats.severalPlayers", NamedTextColor.GRAY, TextDecoration.ITALIC)
           .hoverEvent(list);
     return list;
   }
 
-  private Component getPlayerComponent(UUID uuid) {
+  private Component getPlayerComponent(UUID uuid, StatType.Builtin type) {
     var player = player(uuid, NameStyle.VERBOSE);
-    if (player != PlayerComponent.UNKNOWN) return player;
+
     return stats.column(uuid).values().stream()
-        .max(Comparator.comparing(PlayerStats::getTimePlayed))
+        .max(Comparator.comparingDouble(playerStat -> playerStat.getStat(type).doubleValue()))
         .map(PlayerStats::getPlayerComponent)
         .orElse(player);
   }


### PR DESCRIPTION
In the stats roll up, show player's team color based on what team they spent the most time on

In a long CTW defense match, there are instances where a defender disconnects cause people have to touch grass. But that defender might have had the top kill streak or top kills. When the match ends their name shows as disconnected. It would be nice to see their team color so we know where their contributions helped most.