### PR TITLE
feat: allow quoting inline filters using single quotes

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/parser/StringReader.java
+++ b/util/src/main/java/tc/oc/pgm/util/parser/StringReader.java
@@ -22,8 +22,8 @@ public class StringReader {
    * @return The next word read in full.
    */
   public String readText() {
-    int quoteChar = pollFor('"', '\'');
-    boolean quoted = quoteChar != -1;
+    char quoteChar = pollQuote();
+    boolean quoted = quoteChar != 0;
 
     for (int i = nextIdx; i < string.length(); i++) {
       char ch = string.charAt(i);
@@ -92,24 +92,22 @@ public class StringReader {
   }
 
   /**
-   * Peeks at the next char ignoring whitespace, if it's one of {@param chs}, polls it and returns
-   * the matching character
+   * Peeks at the next char ignoring whitespace, if it's one of " or ', polls it and returns the
+   * quote character that was found
    *
-   * @param chs The characters to expect next
-   * @return one of {@param chs} if it is the next char, and it was skipped. -1 otherwise.
+   * @return one of " or ' if it is the next char, and it was skipped, 0 otherwise.
    */
-  public int pollFor(char... chs) {
+  public char pollQuote() {
     for (int i = nextIdx; i < string.length(); i++) {
       char currChar = string.charAt(i);
-      for (char ch : chs) {
-        if (currChar == ch) {
-          nextIdx = i + 1;
-          return ch;
-        }
+      if (currChar == '"' || currChar == '\'') {
+        nextIdx = i + 1;
+        return currChar;
+      } else if (!Character.isWhitespace(currChar)) {
+        return 0;
       }
-      if (!Character.isWhitespace(currChar)) return -1;
     }
-    return -1;
+    return 0;
   }
 
   public String substring(int start, int end) {

--- a/util/src/main/java/tc/oc/pgm/util/parser/StringReader.java
+++ b/util/src/main/java/tc/oc/pgm/util/parser/StringReader.java
@@ -15,20 +15,22 @@ public class StringReader {
 
   /**
    * Reads a text (arbitrary string) as defined below: Any character is eligible, except for '(' ','
-   * ')' and any whitespace char. You may use a quoted string "string" for any char except " being
-   * eligible. Either of them may be escaped by using \, and \ can be escaped by \\.
+   * ')' and any whitespace char. You may use a quoted string "string" or 'string' for any char
+   * except " (or ', respectively) being eligible. Either of them may be escaped by using \, and \
+   * can be escaped by \\.
    *
    * @return The next word read in full.
    */
   public String readText() {
-    boolean quoted = pollIf('"');
+    int quoteChar = pollFor('"', '\'');
+    boolean quoted = quoteChar != -1;
 
     for (int i = nextIdx; i < string.length(); i++) {
       char ch = string.charAt(i);
       if (ch == '\\') {
         // Skip the next char, it's been escaped
         i++;
-      } else if (quoted ? ch == '"' : ch == '(' || ch == ',' || ch == ')' || ch == ' ') {
+      } else if (quoted ? ch == quoteChar : ch == '(' || ch == ',' || ch == ')' || ch == ' ') {
         if (nextIdx == i)
           throw new SyntaxException("Invalid text, expected at least one char", nextIdx);
 
@@ -87,6 +89,27 @@ public class StringReader {
       }
     }
     return false;
+  }
+
+  /**
+   * Peeks at the next char ignoring whitespace, if it's one of {@param chs}, polls it and returns
+   * the matching character
+   *
+   * @param chs The characters to expect next
+   * @return one of {@param chs} if it is the next char, and it was skipped. -1 otherwise.
+   */
+  public int pollFor(char... chs) {
+    for (int i = nextIdx; i < string.length(); i++) {
+      char currChar = string.charAt(i);
+      for (char ch : chs) {
+        if (currChar == ch) {
+          nextIdx = i + 1;
+          return ch;
+        }
+      }
+      if (!Character.isWhitespace(currChar)) return -1;
+    }
+    return -1;
   }
 
   public String substring(int start, int end) {


### PR DESCRIPTION
This PR allows using single quotes to quote a filter during inline filter parsing:
```xml
<filter id="all('variable = value', ...)" />
<filter id='all(&apos;variable = value&apos;, ...)' />
```

in addition to the currently supported:
```xml
<filter id="all(&quot;variable = value&quot;, ...)" />
<filter id="all(variable\ =\ value, ...)" />
<filter id='all("variable = value", ...)' /> <!-- legal, but very few maps use single quotes for XML attribute values -->
```