### PR TITLE
Add normalization to mutable cuboid region

### DIFF
--- a/core/src/main/java/tc/oc/pgm/regions/Bounds.java
+++ b/core/src/main/java/tc/oc/pgm/regions/Bounds.java
@@ -42,6 +42,21 @@ public class Bounds implements Cloneable {
     return new Bounds(this);
   }
 
+  public Bounds normalizedClone() {
+    Vector min = this.getMin();
+    Vector max = this.getMax();
+
+    double minX = Math.min(min.getX(), max.getX());
+    double minY = Math.min(min.getY(), max.getY());
+    double minZ = Math.min(min.getZ(), max.getZ());
+
+    double maxX = Math.max(min.getX(), max.getX());
+    double maxY = Math.max(min.getY(), max.getY());
+    double maxZ = Math.max(min.getZ(), max.getZ());
+
+    return new Bounds(new Vector(minX, minY, minZ), new Vector(maxX, maxY, maxZ));
+  }
+
   public static Bounds unbounded() {
     return new Bounds(
         new Vector(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY),

--- a/core/src/main/java/tc/oc/pgm/regions/CuboidRegion.java
+++ b/core/src/main/java/tc/oc/pgm/regions/CuboidRegion.java
@@ -1,6 +1,9 @@
 package tc.oc.pgm.regions;
 
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
 import java.util.Random;
+import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.api.region.RegionDefinition;
 
@@ -66,6 +69,24 @@ public class CuboidRegion implements RegionDefinition.HardStatic {
 
     public Vector getMutableMax() {
       return bounds.max;
+    }
+
+    @Override
+    public boolean contains(Vector point) {
+      Bounds b = this.bounds.normalizedClone();
+
+      return point.getX() >= b.getMin().getX()
+          && point.getX() <= b.getMax().getX()
+          && point.getY() >= b.getMin().getY()
+          && point.getY() <= b.getMax().getY()
+          && point.getZ() >= b.getMin().getZ()
+          && point.getZ() <= b.getMax().getZ();
+    }
+
+    @Override
+    public Iterator<BlockVector> getBlockVectorIterator() {
+      Bounds normalized = this.bounds.normalizedClone();
+      return Iterators.filter(normalized.getBlockIterator(), this::contains);
     }
   }
 


### PR DESCRIPTION
While working on the XML for a map, I used a `cuboid` region variable that moves to random positions and applies a `<fill/>` action. This worked fine.

However, when applying the same logic in another map, it stopped working entirely. The region appeared to be set correctly when using `/region`, but the automatic glass fill that occurs when running that command also didn’t work. This indicated that the issue was not with `<fill/>` itself, the region behaved as if it contained zero blocks.

After inspecting the code and running several tests, I found that `Region.getBlockVectorIterator()` was returning an empty iterator. When comparing the dynamically assigned coordinates to the working map, it seemed that normalizing would make it work. The underlying issue seems to be that the mutable cuboid can end up with inverted bounds (max < min). Neither the iterator nor `contains()` operate correctly this way.

By normalizing the bounds before iterating and before checking containment, the region once again produces valid block positions and behaves correctly.

To avoid altering behavior of existing static regions, the normalization is applied only inside `CuboidRegion.Mutable`, by overriding `contains()` and `getBlockVectorIterator()`. Based on my testing, this fully resolves the issue without impacting other region types.