### PR TITLE
Fix region command feedback for empty regions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
@@ -137,7 +137,10 @@ public class MapDevCommand {
     var pl = viewer.getBukkit();
     var world = pl.getWorld();
     var reg = region.getStatic(world);
-    if (!reg.getBounds().isBlockFinite()) {
+    var bounds = reg.getBounds();
+    if (bounds.isEmpty()) {
+      throw exception("Region is empty");
+    } else if (!bounds.isBlockFinite()) {
       throw exception("Region is not finite");
     }
 


### PR DESCRIPTION
Makes it so empty bounds passed to `/region` warns you about empty regions instead of displaying empty or wrong regions