### PR TITLE
Cleanup some flag and match messages

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -43,6 +43,7 @@ import tc.oc.pgm.flag.post.PostDefinition;
 import tc.oc.pgm.flag.state.BaseState;
 import tc.oc.pgm.flag.state.Captured;
 import tc.oc.pgm.flag.state.Completed;
+import tc.oc.pgm.flag.state.Dropped;
 import tc.oc.pgm.flag.state.Returned;
 import tc.oc.pgm.flag.state.Spawned;
 import tc.oc.pgm.flag.state.State;
@@ -217,7 +218,8 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
 
   public boolean canDrop(LocationQuery query) {
     return canDropAt(query.getLocation())
-        && getDefinition().getDropFilter().query(query).isAllowed();
+        && getDefinition().getDropFilter().query(query).isAllowed()
+        && !(this.state instanceof Dropped);
   }
 
   public boolean canDropAt(Location location) {

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -74,7 +74,7 @@ public class Carried extends Spawned implements Missing {
 
   @Override
   public boolean isRecoverable() {
-    return true;
+    return this.flag.getMatch().isRunning();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/flag/state/Dropped.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Dropped.java
@@ -99,7 +99,7 @@ public class Dropped extends Uncarried implements Missing {
 
   @Override
   public boolean isRecoverable() {
-    return true;
+    return this.flag.getMatch().isRunning();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/flag/state/Respawning.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Respawning.java
@@ -10,6 +10,7 @@ import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.flag.Flag;
@@ -54,7 +55,8 @@ public class Respawning extends Spawned implements Returning {
   public void enterState() {
     super.enterState();
 
-    if (Duration.ZERO.equals(respawnTime)) return;
+    if (Duration.ZERO.equals(respawnTime) || !this.flag.getMatch().isRunning()) return;
+
     // Respawn is delayed
     String postName = this.post.getPostName();
 
@@ -82,6 +84,11 @@ public class Respawning extends Spawned implements Returning {
     }
 
     this.flag.transition(new Returned(this.flag, this.post, this.respawnTo));
+  }
+
+  @Override
+  protected boolean canSeeParticles(Player player) {
+    return this.flag.getMatch().isRunning();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
@@ -24,7 +24,6 @@ import tc.oc.pgm.channels.ChatManager;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalTouchEvent;
 import tc.oc.pgm.spawns.events.ParticipantDespawnEvent;
-import tc.oc.pgm.util.Audience;
 
 /**
  * A {@link Goal} that may be 'touched' by players, meaning the player has made some tangible
@@ -190,7 +189,6 @@ public abstract class TouchableGoal<T extends ProximityGoalDefinition> extends P
     if (!hasShowOption(ShowOption.SHOW_MESSAGES)) return;
 
     Component message = getTouchMessage(toucher, false);
-    Audience.console().sendMessage(message);
 
     if (shouldShowTouched(toucher.getParty())) {
       if (showEnemyTouches())

--- a/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MatchAnnouncer.java
@@ -62,23 +62,28 @@ public class MatchAnnouncer implements Listener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onMatchEnd(final MatchFinishEvent event) {
     final Match match = event.getMatch();
+    final Collection<Competitor> winners = event.getWinners();
+    final boolean singleWinner = winners.size() == 1;
 
-    // broadcast match finish message
+    Component title;
+    if (winners.isEmpty()) {
+      title = translatable("broadcast.gameOver");
+    } else if (singleWinner) {
+      title = translatable(
+          Iterables.getOnlyElement(winners).isNamePlural()
+              ? "broadcast.gameOver.teamWinners"
+              : "broadcast.gameOver.teamWinner",
+          TextFormatter.nameList(winners, NameStyle.FANCY, NamedTextColor.WHITE));
+    } else {
+      // 2 or more winners, show "Tied!" as the title
+      title = translatable("broadcast.gameOver.tied", NamedTextColor.YELLOW);
+    }
+
+    // Broadcast match finish titles to participants
     for (MatchPlayer viewer : match.getPlayers()) {
-      Component title = null, subtitle = empty();
-      final Collection<Competitor> winners = event.getWinners();
-      final boolean singleWinner = winners.size() == 1;
-      if (winners.isEmpty()) {
-        title = translatable("broadcast.gameOver");
-      } else {
-        if (singleWinner) {
-          title = translatable(
-              Iterables.getOnlyElement(winners).isNamePlural()
-                  ? "broadcast.gameOver.teamWinners"
-                  : "broadcast.gameOver.teamWinner",
-              TextFormatter.nameList(winners, NameStyle.FANCY, NamedTextColor.WHITE));
-        }
+      Component subtitle = empty();
 
+      if (!winners.isEmpty()) {
         // Use stream here instead of #contains to avoid unchecked cast
         if (winners.stream().anyMatch(w -> w == viewer.getParty())) {
           // Winner
@@ -98,10 +103,7 @@ public class MatchAnnouncer implements Listener {
         }
       }
 
-      if (title == null) {
-        // 2 or more winners, show "Tied!" as the title
-        title = translatable("broadcast.gameOver.tied", NamedTextColor.YELLOW);
-
+      if (subtitle == empty()) {
         // If 2 or 3 winners we show the winners as the subtitle
         if (winners.size() <= 3) {
           subtitle = TextFormatter.nameList(winners, NameStyle.FANCY, NamedTextColor.WHITE);
@@ -111,10 +113,12 @@ public class MatchAnnouncer implements Listener {
       final Title.Times titleTimes = Title.Times.times(Duration.ZERO, fromTicks(40), fromTicks(40));
       viewer.showTitle(title(title, subtitle, titleTimes));
 
-      viewer.sendMessage(title);
-
       if (viewer.getParty() instanceof Competitor || !singleWinner) viewer.sendMessage(subtitle);
     }
+
+    // Broadcast match finish message to the match
+    // This includes console
+    match.sendMessage(title);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)


### PR DESCRIPTION
1. Only drop flag if it's removed as helmet if the current state is `Carried`; when we don't do this you can see that the flag is "dropped" twice in KotF: once when the match ends and then again after that, which is noticeable as duplicate messages.
2. Don't bother sending the "Flag will respawn in n seconds" message if the match is over, and also don't bother showing the flag particle beam either, if the flag is in the `Respawning` state when the match is over.
3. Don't send the flag pickup message to console twice; `ChatManager.broadcastMessage` and friends already do this.
4. Send match winner message to console.