### PR TITLE
Generate more fitting biomes for different dimensions in modern

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/chunk/NullChunkGenerator.java
+++ b/util/src/main/java/tc/oc/pgm/util/chunk/NullChunkGenerator.java
@@ -38,10 +38,18 @@ public class NullChunkGenerator extends ChunkGenerator {
 
     ChunkData chunkData = super.createChunkData(world);
 
-    // For everyblock in the chunk set the biome to plains
+    Biome newBiome;
+
+    switch (world.getEnvironment()) {
+      case NETHER -> newBiome = Biome.valueOf("NETHER_WASTES");
+      case THE_END -> newBiome = Biome.valueOf("THE_END");
+      default -> newBiome = Biome.PLAINS;
+    }
+
+    // For every block in the chunk set the biome
     for (int x = 0; x < 16; x++) {
       for (int z = 0; z < 16; z++) {
-        biome.setBiome(x, z, Biome.PLAINS);
+        biome.setBiome(x, z, newBiome);
       }
     }
     return chunkData;

--- a/util/src/main/java/tc/oc/pgm/util/chunk/NullChunkGenerator.java
+++ b/util/src/main/java/tc/oc/pgm/util/chunk/NullChunkGenerator.java
@@ -31,25 +31,24 @@ public class NullChunkGenerator extends ChunkGenerator {
 
   @Override
   public ChunkData generateChunkData(
-      World world, Random random, int chunkX, int chunkZ, BiomeGrid biome) {
+      World world, Random random, int chunkX, int chunkZ, BiomeGrid biomeGrid) {
     if (SKIP_BIOMES) {
-      return super.generateChunkData(world, random, chunkX, chunkZ, biome);
+      return super.generateChunkData(world, random, chunkX, chunkZ, biomeGrid);
     }
 
     ChunkData chunkData = super.createChunkData(world);
 
-    Biome newBiome;
-
-    switch (world.getEnvironment()) {
-      case NETHER -> newBiome = Biome.valueOf("NETHER_WASTES");
-      case THE_END -> newBiome = Biome.valueOf("THE_END");
-      default -> newBiome = Biome.PLAINS;
-    }
+    Biome biome =
+        switch (world.getEnvironment()) {
+          case NETHER -> Biome.valueOf("NETHER_WASTES");
+          case THE_END -> Biome.valueOf("THE_END");
+          default -> Biome.PLAINS;
+        };
 
     // For every block in the chunk set the biome
     for (int x = 0; x < 16; x++) {
       for (int z = 0; z < 16; z++) {
-        biome.setBiome(x, z, newBiome);
+        biomeGrid.setBiome(x, z, biome);
       }
     }
     return chunkData;


### PR DESCRIPTION
In modern, maps set in the Nether or The End generate empty chunks with the Plains biome. This means you need to leave more chunks than you normally would when pruning a map to prevent very noticeable sky color changes (specifically in the Nether)

<img width="300" alt="p_hell" src="https://github.com/user-attachments/assets/1b10095a-d589-4868-9f49-25ffb4d6efd5" />
<img width="300" alt="p_plains" src="https://github.com/user-attachments/assets/35b46c43-6102-45c0-aba1-7836d50e0382" />
