### PR TITLE
fix(platform/modern): disable respawn anchors in legacy overworld

### DIFF
--- a/platform/platform-modern/src/main/resources/pgm_compat_datapack/data/pgm/dimension_type/legacy_overworld.json
+++ b/platform/platform-modern/src/main/resources/pgm_compat_datapack/data/pgm/dimension_type/legacy_overworld.json
@@ -2,7 +2,7 @@
   "ultrawarm": false,
   "natural": true,
   "piglin_safe": false,
-  "respawn_anchor_works": true,
+  "respawn_anchor_works": false,
   "bed_works": true,
   "has_raids": true,
   "has_skylight": true,


### PR DESCRIPTION
Disables respawn anchors in legacy overworld as those aren't supposed to work in the modern overworld either.