### PR TITLE
fix: make tool repair work better with arrows on modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyMatchModule.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.itemmeta;
 
+import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 import static tc.oc.pgm.util.nms.Packets.PLAYERS;
 
@@ -99,7 +100,7 @@ public class ItemModifyMatchModule implements MatchModule, Listener {
 
     if (applyRules(itemStack)) {
       event.setCancelled(true);
-      PLAYERS.fakePlayerItemPickup(event.getPlayer(), item);
+      PLAYERS.fakePlayerItemPickup(event.getPlayer(), MISC_UTILS.getFakePickupEntity(event));
       event.getPlayer().getInventory().addItem(itemStack);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/modules/ToolRepairMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ToolRepairMatchModule.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.modules;
 
+import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 import static tc.oc.pgm.util.nms.Packets.PLAYERS;
 
 import com.google.common.collect.Iterables;
@@ -36,7 +37,7 @@ public class ToolRepairMatchModule implements MatchModule, Listener {
     ItemStack pickup = item.getItemStack();
 
     event.setCancelled(true);
-    PLAYERS.fakePlayerItemPickup(event.getPlayer(), item);
+    PLAYERS.fakePlayerItemPickup(event.getPlayer(), MISC_UTILS.getFakePickupEntity(event));
 
     int hitsLeft = pickup.getType().getMaxDurability() - pickup.getDurability() + 1;
     stack.setDurability((short) Math.max(stack.getDurability() - hitsLeft, 0));

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
@@ -33,6 +33,8 @@ import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerPickupArrowEvent;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -139,5 +141,11 @@ public class ModernMiscUtil implements MiscUtils {
   public boolean isDestructiveExplosion(EntityExplodeEvent ev) {
     return ev.getExplosionResult() == ExplosionResult.DESTROY
         || ev.getExplosionResult() == ExplosionResult.DESTROY_WITH_DECAY;
+  }
+
+  @Override
+  public Entity getFakePickupEntity(PlayerPickupItemEvent ev) {
+    if (ev instanceof PlayerPickupArrowEvent arrowEvent) return arrowEvent.getArrow();
+    return ev.getItem();
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernPlayerPackets.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernPlayerPackets.java
@@ -23,6 +23,7 @@ import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -62,15 +63,17 @@ public class ModernPlayerPackets implements PlayerPackets, PacketSender {
   }
 
   @Override
-  public void fakePlayerItemPickup(Player player, Item item) {
+  public void fakePlayerItemPickup(Player player, Entity entity) {
     float pitch = (((float) (Math.random() - Math.random()) * 0.7F + 1.0F) * 2.0F);
-    item.getWorld().playSound(item.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.2F, pitch);
+    entity.getWorld().playSound(entity.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.2F, pitch);
 
     var packet = new ClientboundTakeItemEntityPacket(
-        item.getEntityId(), player.getEntityId(), item.getItemStack().getAmount());
+        entity.getEntityId(),
+        player.getEntityId(),
+        entity instanceof Item item ? item.getItemStack().getAmount() : 1);
 
-    sendToViewers(packet, player, false);
-    item.remove();
+    sendToViewers(packet, entity, false);
+    entity.remove();
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMiscUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMiscUtil.java
@@ -30,6 +30,7 @@ import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -125,5 +126,10 @@ public class SpMiscUtil implements MiscUtils {
   public boolean isDestructiveExplosion(EntityExplodeEvent ev) {
     // All explosions in 1.8 are destructive
     return true;
+  }
+
+  @Override
+  public Entity getFakePickupEntity(PlayerPickupItemEvent ev) {
+    return ev.getItem();
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/packets/SpPlayerPackets.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/packets/SpPlayerPackets.java
@@ -17,7 +17,7 @@ import net.minecraft.server.v1_8_R3.PacketPlayOutWorldBorder;
 import net.minecraft.server.v1_8_R3.WorldBorder;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
-import org.bukkit.entity.Item;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.util.bukkit.ViaUtils;
@@ -71,11 +71,12 @@ public class SpPlayerPackets implements PlayerPackets, PacketSender {
   }
 
   @Override
-  public void fakePlayerItemPickup(Player player, Item item) {
+  public void fakePlayerItemPickup(Player player, Entity entity) {
     float pitch = (((float) (Math.random() - Math.random()) * 0.7F + 1.0F) * 2.0F);
-    item.getWorld().playSound(item.getLocation(), org.bukkit.Sound.ITEM_PICKUP, 0.2F, pitch);
-    sendToViewers(new PacketPlayOutCollect(item.getEntityId(), player.getEntityId()), item, false);
-    item.remove();
+    entity.getWorld().playSound(entity.getLocation(), org.bukkit.Sound.ITEM_PICKUP, 0.2F, pitch);
+    sendToViewers(
+        new PacketPlayOutCollect(entity.getEntityId(), player.getEntityId()), entity, false);
+    entity.remove();
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
@@ -19,6 +19,7 @@ import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -64,4 +65,6 @@ public interface MiscUtils {
   boolean isPowerEnchanted(Projectile proj);
 
   boolean isDestructiveExplosion(EntityExplodeEvent ev);
+
+  Entity getFakePickupEntity(PlayerPickupItemEvent ev);
 }

--- a/util/src/main/java/tc/oc/pgm/util/nms/packets/PlayerPackets.java
+++ b/util/src/main/java/tc/oc/pgm/util/nms/packets/PlayerPackets.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.util.nms.packets;
 
-import org.bukkit.entity.Item;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -9,7 +9,7 @@ public interface PlayerPackets {
 
   void showBorderWarning(Player player, boolean show);
 
-  void fakePlayerItemPickup(Player player, Item item);
+  void fakePlayerItemPickup(Player player, Entity entity);
 
   void sendLegacyHelmet(Player player, ItemStack item);
 


### PR DESCRIPTION
It turns out that picking up arrows needs special handling on modern, in particular, the item and arrow entities have been decoupled, so everything involving faking the item pickup has to be done on the arrow entity instead.

This fixes the issue with "infinite pickup" on maps that have arrows (or tridents) in tool repair.