### PR TITLE
THE crawling filter

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/PlatformFilters.java
+++ b/core/src/main/java/tc/oc/pgm/filters/PlatformFilters.java
@@ -9,4 +9,6 @@ public interface PlatformFilters {
   Filter gliding();
 
   Filter riptiding();
+
+  Filter crawling();
 }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -395,6 +395,11 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
     return PLATFORM_FILTERS.riptiding();
   }
 
+  @MethodParser("crawling")
+  public Filter parseCrawling(Element el) throws InvalidXMLException {
+    return PLATFORM_FILTERS.crawling();
+  }
+
   @MethodParser("flying")
   public FlyingFilter parseFlying(Element el) throws InvalidXMLException {
     return FlyingFilter.INSTANCE;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/filters/CrawlingFilter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/filters/CrawlingFilter.java
@@ -13,6 +13,7 @@ import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
 public class CrawlingFilter extends ParticipantFilter {
   public static final FilterDefinition INSTANCE = new CrawlingFilter();
 
+
   @Override
   public Collection<Class<? extends Event>> getRelevantEvents() {
     return Collections.singleton(PlayerCoarseMoveEvent.class);

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/filters/CrawlingFilter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/filters/CrawlingFilter.java
@@ -1,0 +1,25 @@
+package tc.oc.pgm.platform.modern.filters;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.bukkit.entity.Pose;
+import org.bukkit.event.Event;
+import tc.oc.pgm.api.filter.FilterDefinition;
+import tc.oc.pgm.api.filter.query.PlayerQuery;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.filters.matcher.player.ParticipantFilter;
+import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
+
+public class CrawlingFilter extends ParticipantFilter {
+  public static final FilterDefinition INSTANCE = new CrawlingFilter();
+
+  @Override
+  public Collection<Class<? extends Event>> getRelevantEvents() {
+    return Collections.singleton(PlayerCoarseMoveEvent.class);
+  }
+
+  @Override
+  protected boolean matches(PlayerQuery query, MatchPlayer player) {
+    return player.getBukkit().getPose() == Pose.SWIMMING && !player.getBukkit().isInWater();
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/filters/ModernPlatformFilters.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/filters/ModernPlatformFilters.java
@@ -17,4 +17,9 @@ public class ModernPlatformFilters implements PlatformFilters {
   public Filter riptiding() {
     return RiptidingFilter.INSTANCE;
   }
+
+  @Override
+  public Filter crawling() {
+    return CrawlingFilter.INSTANCE;
+  }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/filters/SpPlatformFilters.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/filters/SpPlatformFilters.java
@@ -20,4 +20,10 @@ public class SpPlatformFilters implements PlatformFilters {
     // Riptiding is not possible in 1.8
     return StaticFilter.DENY;
   }
+
+  @Override
+  public Filter crawling() {
+    // Crawling is not possible in 1.8
+    return StaticFilter.DENY;
+  }
 }


### PR DESCRIPTION
It's over for walkcels. We are now entering the crawling revolution. 
Think you can bypass filters by crawling? Think again! This PR introduces THE `<crawling/>` filter
Ex:
```xml
<filters>
    <crawling id="the-crawler"/>
</filters>
<actions>
    <trigger filter="the-crawler">
        <action>
            <message text="`lTHE CRAWLER IS HERE!"/>
        </action>
    </trigger>
</actions>