### PR TITLE
Voted pool minor improvements

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapInfo.java
@@ -13,6 +13,9 @@ import tc.oc.pgm.util.text.TextTranslations;
 /** Basic information about a map. The most bare-bones part is in {@link VariantInfo} */
 public interface MapInfo extends VariantInfo.Forwarding, Comparable<MapInfo>, Cloneable {
 
+  /** @return The id of the default variant of the map * */
+  String getBaseId();
+
   /** @return The map variant info for this map */
   VariantInfo getVariant();
 

--- a/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapInfoImpl.java
@@ -126,6 +126,11 @@ public class MapInfoImpl implements MapInfo {
   }
 
   @Override
+  public String getBaseId() {
+    return variants.get(DEFAULT_VARIANT).getId();
+  }
+
+  @Override
   public VariantInfo getVariant() {
     return variant;
   }

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
@@ -51,7 +51,7 @@ public class VotingPool extends MapPool {
   }
 
   private Map<MapInfo, VoteData> buildMapScores(ToDoubleFunction<MapInfo> weight) {
-    var ids = maps.stream().map(MapInfo::getId).toList();
+    var ids = maps.stream().map(MapInfo::getBaseId).toList();
     var persisted = PGM.get().getDatastore().getMapData(ids, constants.defaultScore());
     return Collections.unmodifiableMap(maps.stream()
         .collect(Collectors.toMap(
@@ -59,7 +59,7 @@ public class VotingPool extends MapPool {
             m -> VoteData.of(
                 weight.applyAsDouble(m),
                 constants.defaultScore(),
-                persisted.get(m.getId()),
+                persisted.get(m.getBaseId()),
                 constants.persistScores()))));
   }
 
@@ -152,8 +152,8 @@ public class VotingPool extends MapPool {
               // If there is a restart queued, don't start a vote
               if (RestartManager.isQueued()) return;
 
-              currentPoll =
-                  new MapPoll(match, mapPicker.getMaps(manager.getVoteOptions(), mapScores));
+              currentPoll = new MapPoll(
+                  match, mapPicker.getMaps(match.getMap(), manager.getVoteOptions(), mapScores));
             },
             5,
             TimeUnit.SECONDS);

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/MapPoll.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/MapPoll.java
@@ -164,7 +164,7 @@ public class MapPoll {
     VOTE_BOOK_TAG.set(personalDummyVoteBook, VOTE_BOOK_METADATA);
     ItemMeta meta = personalDummyVoteBook.getItemMeta();
 
-    meta.setDisplayName(TextTranslations.translateLegacy(VOTE_BOOK_TITLE, viewer.getBukkit()));
+    meta.setDisplayName(TextTranslations.translateLegacy(VOTE_BOOK_TITLE, viewer));
 
     personalDummyVoteBook.setItemMeta(meta);
 
@@ -186,9 +186,7 @@ public class MapPoll {
     boolean added = votes.add(player.getId());
     if (!added) votes.remove(player.getId());
 
-    if (match.get() != null) {
-      match.get().callEvent(new MatchPlayerVoteEvent(player, vote, added));
-    }
+    player.getMatch().callEvent(new MatchPlayerVoteEvent(player, vote, added));
 
     return added;
   }
@@ -198,7 +196,7 @@ public class MapPoll {
     return votes.entrySet().stream()
         .max(Comparator.comparingInt(e -> countVotes(e.getValue())))
         .map(Map.Entry::getKey)
-        .orElse(null);
+        .orElseThrow();
   }
 
   /**
@@ -251,8 +249,10 @@ public class MapPoll {
     running = false;
     MapInfo picked = getMostVotedMap();
     Match match = this.match.get();
-    if (match != null) match.getPlayers().forEach(player -> announceWinner(player, picked));
-    if (picked != null) match.callEvent(new MatchVoteFinishEvent(match, picked));
+    if (match != null) {
+      match.getPlayers().forEach(player -> announceWinner(player, picked));
+      match.callEvent(new MatchVoteFinishEvent(match, picked));
+    }
     return picked;
   }
 

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.rotation.vote;
 
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -77,19 +78,32 @@ public class MapVotePicker {
    * @return list of maps to include in the vote
    */
   public List<MapInfo> getMaps(VotePoolOptions options, Map<MapInfo, VoteData> scores) {
-    if (options.shouldOverride())
-      return getMaps(new ArrayList<>(), options.getCustomVoteMapsWeighted());
-
-    List<MapInfo> maps = new ArrayList<>(options.getCustomVoteMaps());
-    return getMaps(maps, scores);
+    return getMaps(null, options, scores);
   }
 
-  protected List<MapInfo> getMaps(@Nullable List<MapInfo> selected, Map<MapInfo, VoteData> scores) {
+  /**
+   * Get a list of maps to vote on, given voting options and map of scores
+   *
+   * @param options custom voting options currently available
+   * @param scores maps and their respective scores
+   * @return list of maps to include in the vote
+   */
+  public List<MapInfo> getMaps(
+      @Nullable MapInfo prevMap, VotePoolOptions options, Map<MapInfo, VoteData> scores) {
+    if (options.shouldOverride())
+      return getMaps(null, new ArrayList<>(), options.getCustomVoteMapsWeighted());
+
+    List<MapInfo> maps = new ArrayList<>(options.getCustomVoteMaps());
+    return getMaps(prevMap, maps, scores);
+  }
+
+  protected List<MapInfo> getMaps(
+      @Nullable MapInfo prevMap, @Nullable List<MapInfo> selected, Map<MapInfo, VoteData> scores) {
     if (selected == null) selected = new ArrayList<>();
 
-    List<MapInfo> unmodifiable = Collections.unmodifiableList(selected);
+    List<MapInfo> previousMaps = prependedUnmodifiableList(prevMap, selected);
     while (selected.size() < constants.voteOptions()) {
-      MapInfo map = getMap(unmodifiable, scores);
+      MapInfo map = getMap(previousMaps, scores);
 
       if (map == null) break; // Ran out of maps!
       selected.add(map);
@@ -98,11 +112,11 @@ public class MapVotePicker {
     return selected;
   }
 
-  public MapInfo getMap(List<MapInfo> selected, Map<MapInfo, VoteData> mapScores) {
+  public MapInfo getMap(List<MapInfo> previousMaps, Map<MapInfo, VoteData> mapScores) {
     NavigableMap<Double, MapInfo> cumulativeScores = new TreeMap<>();
     double maxWeight = 0;
     for (Map.Entry<MapInfo, VoteData> map : mapScores.entrySet()) {
-      double weight = getWeight(selected, map.getKey(), map.getValue());
+      double weight = getWeight(previousMaps, map.getKey(), map.getValue());
       if (weight > MINIMUM_WEIGHT) cumulativeScores.put(maxWeight += weight, map.getKey());
     }
     Map.Entry<Double, MapInfo> selectedMap =
@@ -113,19 +127,20 @@ public class MapVotePicker {
   /**
    * Get the weight for a specific map, given it's score
    *
-   * @param selected The list of selected maps so far
+   * @param previousMaps The list of maps that played previous or are already selected for the vote
    * @param map The map being considered
    * @param data The vote data of the map, from player votes and config
    * @return random weight for the map
    */
-  public double getWeight(@Nullable List<MapInfo> selected, @NotNull MapInfo map, VoteData data) {
-    if ((selected != null && selected.contains(map))
+  public double getWeight(
+      @Nullable List<MapInfo> previousMaps, @NotNull MapInfo map, VoteData data) {
+    if ((previousMaps != null && previousMaps.contains(map))
         || data.getScore() <= constants.scoreMinToVote()
         || data.isOnCooldown(constants)) return 0;
 
     var context = new MapVoteContext(
         data.getScore(),
-        getRepeatedGamemodes(selected, map),
+        getRepeatedGamemodes(previousMaps, map),
         map.getMaxPlayers().stream().mapToInt(i -> i).sum(),
         manager.getActivePlayers(null));
 
@@ -155,5 +170,21 @@ public class MapVotePicker {
     static Set<String> variables() {
       return new MapVoteContext(0, 0, 0, 0).getVariables();
     }
+  }
+
+  private static <T> List<T> prependedUnmodifiableList(@Nullable T prepend, List<T> list) {
+    return prepend == null
+        ? Collections.unmodifiableList(list)
+        : new AbstractList<>() {
+          @Override
+          public T get(int index) {
+            return index == 0 ? prepend : list.get(index - 1);
+          }
+
+          @Override
+          public int size() {
+            return list.size() + 1;
+          }
+        };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/VoteData.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/VoteData.java
@@ -26,7 +26,7 @@ public class VoteData {
   }
 
   public static VoteData of(double weight, double score, MapInfo map, boolean persist) {
-    return of(weight, score, PGM.get().getDatastore().getMapData(map.getId(), score), persist);
+    return of(weight, score, PGM.get().getDatastore().getMapData(map.getBaseId(), score), persist);
   }
 
   public void setScore(double score) {


### PR DESCRIPTION
Makes a few relatively minor fixes to voted pools:
 - The map scores/length will always persist under the base id of the map (the id of the default variant)
   - This fixes a situation where a variant may have played (staff set it,or it was sponsored), and then PGM gives another variant of the same map in the votebook.
 - Map selection for voted pools now takes into account the map that just played.
   - Before, pgm would weigh following options of the vote if they were of the same gamemode, so 2nd option was less likely to be a repeated gamemode of 1st option. Now this list of "previous" contains the currently played map too. So if a CTW just finished playing, the vote is less likely to contain CTW options. Same for rage, bridge, or any other gamemode.