### PR TITLE
Allow using regions in `teleport` action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -36,6 +36,7 @@ import tc.oc.pgm.action.actions.SoundAction;
 import tc.oc.pgm.action.actions.TakePaymentAction;
 import tc.oc.pgm.action.actions.TeamAliasAction;
 import tc.oc.pgm.action.actions.TeleportAction;
+import tc.oc.pgm.action.actions.TeleportRegionAction;
 import tc.oc.pgm.action.actions.VelocityAction;
 import tc.oc.pgm.action.actions.WeatherAction;
 import tc.oc.pgm.action.replacements.Replacement;
@@ -48,6 +49,7 @@ import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.features.XMLFeatureReference;
 import tc.oc.pgm.filters.Filterable;
@@ -456,12 +458,28 @@ public class ActionParser {
   @MethodParser("teleport")
   public Action<? super MatchPlayer> parseTeleport(Element el, Class<?> scope)
       throws InvalidXMLException {
-    var xFormula = parser.formula(MatchPlayer.class, el, "x").required();
-    var yFormula = parser.formula(MatchPlayer.class, el, "y").required();
-    var zFormula = parser.formula(MatchPlayer.class, el, "z").required();
 
     var pitchFormula = parser.formula(MatchPlayer.class, el, "pitch").optional();
     var yawFormula = parser.formula(MatchPlayer.class, el, "yaw").optional();
+
+    if (el.getAttribute("region") != null) {
+      Region.Static region = parser.staticRegion(el, "region").randomPoints().orNull();
+      if (region == null) {
+        throw new InvalidXMLException("Unknown region: " + el.getAttributeValue("region"), el);
+      }
+      return new TeleportRegionAction(region, pitchFormula, yawFormula);
+    }
+
+    if (el.getAttribute("x") == null
+        || el.getAttribute("y") == null
+        || el.getAttribute("z") == null) {
+      throw new InvalidXMLException(
+          "Teleport requires either attributes x, y and z, or a region", el);
+    }
+
+    var xFormula = parser.formula(MatchPlayer.class, el, "x").required();
+    var yFormula = parser.formula(MatchPlayer.class, el, "y").required();
+    var zFormula = parser.formula(MatchPlayer.class, el, "z").required();
 
     return new TeleportAction(xFormula, yFormula, zFormula, pitchFormula, yawFormula);
   }

--- a/core/src/main/java/tc/oc/pgm/action/actions/TeleportRegionAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TeleportRegionAction.java
@@ -3,37 +3,31 @@ package tc.oc.pgm.action.actions;
 import java.util.Optional;
 import org.bukkit.Location;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.util.Vector;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.util.math.Formula;
 
-public class TeleportAction extends AbstractAction<MatchPlayer> {
+public class TeleportRegionAction extends AbstractAction<MatchPlayer> {
 
-  private final Formula<MatchPlayer> xformula;
-  private final Formula<MatchPlayer> yformula;
-  private final Formula<MatchPlayer> zformula;
+  private final Region.Static region;
   private final Optional<Formula<MatchPlayer>> pitchFormula;
   private final Optional<Formula<MatchPlayer>> yawFormula;
 
-  public TeleportAction(
-      Formula<MatchPlayer> xformula,
-      Formula<MatchPlayer> yformula,
-      Formula<MatchPlayer> zformula,
+  public TeleportRegionAction(
+      Region.Static region,
       Optional<Formula<MatchPlayer>> pitchFormula,
       Optional<Formula<MatchPlayer>> yawFormula) {
     super(MatchPlayer.class);
-    this.xformula = xformula;
-    this.yformula = yformula;
-    this.zformula = zformula;
+    this.region = region;
     this.pitchFormula = pitchFormula;
     this.yawFormula = yawFormula;
   }
 
   @Override
   public void trigger(MatchPlayer player) {
-    Location location = player.getLocation();
-    location.setX(xformula.applyAsDouble(player));
-    location.setY(yformula.applyAsDouble(player));
-    location.setZ(zformula.applyAsDouble(player));
+    Vector vec = region.getRandom(player.getMatch().getRandom());
+    Location location = new Location(player.getWorld(), vec.getX(), vec.getY(), vec.getZ());
 
     pitchFormula.ifPresent(f -> location.setPitch((float) f.applyAsDouble(player)));
     yawFormula.ifPresent(f -> location.setYaw((float) f.applyAsDouble(player)));


### PR DESCRIPTION
Allows specifying regions as destinations for `<teleport/>` actions. This is useful if you've already defined those regions for other things elsewhere in the code, or if you're not using formulas and just want to define a destination as a point with the usual `"x,y,z"` format instead of the unique `x="" y="" z=""` of the teleport action (either manually or when using constants).

```xml
<teleport region="first-checkpoint"/>
<teleport region="second-checkpoint" yaw="90" pitch="0"/>
```