### PR TITLE
Fix unsharable items and flags dropping on leave

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -22,7 +22,6 @@ import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -51,6 +50,7 @@ import tc.oc.pgm.goals.TouchableGoal;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalEvent;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
+import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.points.AngleProvider;
 import tc.oc.pgm.points.PointProvider;
 import tc.oc.pgm.points.StaticAngleProvider;
@@ -126,6 +126,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     this.bannerData = COLOR_UTILS.createBanner(banner);
     this.bannerData.setName(getComponentName());
     this.bannerItem = this.getBannerData().createItem();
+    ItemTags.PREVENT_SHARING.set(this.bannerItem, true);
 
     this.bannerLocation = getLocationWithYaw(banner, bannerData.getFacing());
     this.bannerYawProvider = new StaticAngleProvider(this.bannerLocation.getYaw());
@@ -467,11 +468,6 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
         listener.playSound(otherSound);
       }
     }
-  }
-
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-  public void onPlayerDeath(PlayerDeathEvent event) {
-    event.getDrops().removeIf(itemStack -> itemStack.isSimilar(this.getBannerItem()));
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
@@ -11,6 +11,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
@@ -159,6 +160,14 @@ public class KitMatchModule implements MatchModule, Listener {
       sendLockWarning(event.getPlayer());
     } else if (isUnshareable(event.getItemDrop().getItemStack())) {
       event.getItemDrop().remove();
+    }
+  }
+
+  @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+  public void processItemRemoval(ItemSpawnEvent event) {
+    ItemStack item = event.getEntity().getItemStack();
+    if (isUnshareable(item)) {
+      event.setCancelled(true);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -254,14 +254,16 @@ public class PGMListener implements Listener {
     MatchPlayer quitter = event.getPlayer();
     if (!quitter.isAlive()) return;
 
+    var world = quitter.getBukkit().getWorld();
+    var location = quitter.getBukkit().getLocation();
     for (ItemStack item : quitter.getInventory().getContents()) {
       if (item == null || item.getType() == Material.AIR) continue;
-      quitter.getBukkit().getWorld().dropItemNaturally(quitter.getBukkit().getLocation(), item);
+      world.dropItemNaturally(location, item);
     }
 
     for (ItemStack armor : quitter.getInventory().getArmorContents()) {
       if (armor == null || armor.getType() == Material.AIR) continue;
-      quitter.getBukkit().getWorld().dropItemNaturally(quitter.getBukkit().getLocation(), armor);
+      world.dropItemNaturally(location, armor);
     }
   }
 


### PR DESCRIPTION
The code that drops all items when you leave, was causing unsharable items (and flags) to drop on leave or /obs.
This makes unsharable items also get deleted on item spawn event (not just item drop event) to account for this, and flags have been made unsharable so they receive the same behavior without needing additional listeners.