### PR TITLE
Add missing getHandlers method to PlayerChangePartyEvent

### DIFF
--- a/core/src/main/java/tc/oc/pgm/events/PlayerChangePartyEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerChangePartyEvent.java
@@ -34,4 +34,9 @@ public class PlayerChangePartyEvent extends PlayerPartyChangeEventBase {
   public static HandlerList getHandlerList() {
     return handlers;
   }
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
 }


### PR DESCRIPTION
`getHandlers` is missing from `PlayerChangePartyEvent`


```bash
[02:33:11 ERROR]: Could not pass event PlayerJoinEvent to PGM v0.16-SNAPSHOT (git-6dc89cc0)
java.lang.AbstractMethodError: Receiver class tc.oc.pgm.events.PlayerChangePartyEvent does not define or inherit an implementation of the resolved method 'abstract org.bukkit.event.HandlerList getHandlers()' of abstract class org.bukkit.event.Event.
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:45) ~[paper-1.21.10.jar:1.21.10-113-9fc21bc]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.10.jar:1.21.10-113-9fc21bc]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.10-R0.1-SNAPSHOT.jar:?]
        at PGM.jar/tc.oc.pgm.match.MatchImpl.callEvent(MatchImpl.java:245) ~[PGM.jar:?]
        at PGM.jar/tc.oc.pgm.match.MatchImpl.setOrClearPlayerParty(MatchImpl.java:560) ~[PGM.jar:?]
        at PGM.jar/tc.oc.pgm.match.MatchImpl.setParty(MatchImpl.java:470) ~[PGM.jar:?]
        at PGM.jar/tc.oc.pgm.api.match.Match.setParty(Match.java:372) ~[PGM.jar:?]
        at PGM.jar/tc.oc.pgm.match.MatchImpl.addPlayer(MatchImpl.java:450) ~[PGM.jar:?]
        at PGM.jar/tc.oc.pgm.listeners.PGMListener.addPlayerOnJoin(PGMListener.java:109) ~[PGM.jar:?]
```