### PR TITLE
Admin chat audit message improvements

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/FinishCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/FinishCommand.java
@@ -1,23 +1,31 @@
 package tc.oc.pgm.command;
 
+import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.util.player.PlayerComponent.player;
 import static tc.oc.pgm.util.text.TextException.exception;
 
+import org.bukkit.command.CommandSender;
 import org.incendo.cloud.annotations.Argument;
 import org.incendo.cloud.annotations.Command;
 import org.incendo.cloud.annotations.CommandDescription;
 import org.incendo.cloud.annotations.Permission;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.channels.ChatManager;
 import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.util.named.NameStyle;
 
 public final class FinishCommand {
 
   @Command("finish|end [team]")
   @CommandDescription("End the match")
   @Permission(Permissions.STOP)
-  public void end(Match match, @Argument("team") Team team) {
+  public void end(CommandSender sender, Match match, @Argument("team") Team team) {
     if (!match.finish(team)) {
       throw exception("admin.end.unknownError");
+    } else {
+      ChatManager.broadcastAdminMessage(
+          translatable("admin.end.announce", player(sender, NameStyle.FANCY)));
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/command/JoinCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/JoinCommand.java
@@ -1,5 +1,8 @@
 package tc.oc.pgm.command;
 
+import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.util.player.PlayerComponent.player;
+
 import org.incendo.cloud.annotation.specifier.FlagYielding;
 import org.incendo.cloud.annotations.Argument;
 import org.incendo.cloud.annotations.Command;
@@ -10,8 +13,10 @@ import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.channels.ChatManager;
 import tc.oc.pgm.join.JoinMatchModule;
 import tc.oc.pgm.join.JoinRequest;
+import tc.oc.pgm.util.named.NameStyle;
 
 public final class JoinCommand {
 
@@ -29,7 +34,15 @@ public final class JoinCommand {
     }
 
     if (force && player.getBukkit().hasPermission(Permissions.JOIN_FORCE)) {
-      joiner.forceJoin(player, (Competitor) team);
+      final Party oldParty = player.getParty();
+      if (joiner.forceJoin(player, (Competitor) team)) {
+        ChatManager.broadcastAdminMessage(translatable(
+            "join.ok.force.announce",
+            player(player, NameStyle.FANCY),
+            player.getName(NameStyle.FANCY),
+            player.getParty().getName(),
+            oldParty.getName()));
+      }
     } else {
       joiner.join(player, (Competitor) team);
     }

--- a/core/src/main/java/tc/oc/pgm/command/MapOrderCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapOrderCommand.java
@@ -2,6 +2,8 @@ package tc.oc.pgm.command;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.event.ClickEvent.runCommand;
+import static net.kyori.adventure.text.event.HoverEvent.showText;
 import static tc.oc.pgm.api.Permissions.DEV;
 import static tc.oc.pgm.api.map.Phase.DEVELOPMENT;
 import static tc.oc.pgm.command.util.ParserConstants.CURRENT;
@@ -86,7 +88,10 @@ public final class MapOrderCommand {
   }
 
   public static void sendSetNextMessage(@NotNull MapInfo map, CommandSender sender) {
-    Component mapName = text(map.getName(), NamedTextColor.GOLD);
+    Component mapName = text(map.getName(), NamedTextColor.GOLD)
+        .hoverEvent(showText(translatable(
+            "command.maps.hover", NamedTextColor.GRAY, map.getStyledName(MapNameStyle.COLOR))))
+        .clickEvent(runCommand("/map " + map.getName()));
     ChatManager.broadcastAdminMessage(
         translatable("map.setNext", NamedTextColor.GRAY, player(sender), mapName));
   }

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -207,6 +207,7 @@ admin.start.unknownState = Match could not be started at this time.
 admin.start.announce = {0} set the match to start in {1}
 
 admin.end.unknownError = Match could not be ended at this time.
+admin.end.announce = {0} has ended the match.
 
 admin.setPool.activeCycle = You may not adjust the pool while match is cycling.
 


### PR DESCRIPTION
Adds:
- admin chat audit messages for `/end` and `/join -f`
- map info click to set-next admin chat audit messages

