### PR TITLE
Make player class components more interactive

### DIFF
--- a/core/src/main/java/tc/oc/pgm/classes/PlayerClass.java
+++ b/core/src/main/java/tc/oc/pgm/classes/PlayerClass.java
@@ -7,15 +7,17 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.util.material.ItemMaterialData;
 
-public class PlayerClass {
+public class PlayerClass implements ComponentLike {
   private final String name;
   private final String familyName;
   private final @Nullable String description;
@@ -60,7 +62,8 @@ public class PlayerClass {
     return this.longdescription;
   }
 
-  public Component getComponent() {
+  @Override
+  public @NotNull Component asComponent() {
     TextComponent.Builder component =
         text().content(this.name).color(NamedTextColor.GOLD).decoration(TextDecoration.BOLD, true);
 

--- a/core/src/main/java/tc/oc/pgm/classes/PlayerClass.java
+++ b/core/src/main/java/tc/oc/pgm/classes/PlayerClass.java
@@ -1,9 +1,15 @@
 package tc.oc.pgm.classes;
 
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.event.HoverEvent.showText;
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.kits.Kit;
@@ -52,6 +58,19 @@ public class PlayerClass {
 
   public @Nullable String getLongDescription() {
     return this.longdescription;
+  }
+
+  public Component getComponent() {
+    TextComponent.Builder component =
+        text().content(this.name).color(NamedTextColor.GOLD).decoration(TextDecoration.BOLD, true);
+
+    String desc = this.description != null ? this.description : this.longdescription;
+    if (desc != null) {
+      component.hoverEvent(showText(
+          text(this.name + ": ", NamedTextColor.GOLD).append(text(desc, NamedTextColor.GRAY))));
+    }
+
+    return component.build();
   }
 
   public boolean isSticky() {

--- a/core/src/main/java/tc/oc/pgm/command/ClassCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ClassCommand.java
@@ -31,13 +31,12 @@ public final class ClassCommand {
     if (newClass == null) {
       player.sendMessage(translatable("match.class.current", NamedTextColor.GREEN)
           .append(space())
-          .append(currentClass.getComponent()));
+          .append(currentClass));
       player.sendMessage(translatable("match.class.view", NamedTextColor.GOLD));
     } else {
       classes.setPlayerClass(player.getId(), newClass);
 
-      player.sendMessage(
-          translatable("match.class.ok", NamedTextColor.GREEN, newClass.getComponent()));
+      player.sendMessage(translatable("match.class.ok", NamedTextColor.GREEN, newClass));
       if (player.isParticipating()) {
         player.sendMessage(translatable("match.class.queue", NamedTextColor.GREEN));
       }

--- a/core/src/main/java/tc/oc/pgm/command/ClassCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ClassCommand.java
@@ -3,6 +3,8 @@ package tc.oc.pgm.command;
 import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.event.ClickEvent.runCommand;
+import static net.kyori.adventure.text.event.HoverEvent.showText;
 
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -27,19 +29,15 @@ public final class ClassCommand {
     final PlayerClass currentClass = classes.getSelectedClass(player.getId());
 
     if (newClass == null) {
-      player.sendMessage(
-          translatable("match.class.current", NamedTextColor.GREEN)
-              .append(space())
-              .append(text(currentClass.getName(), NamedTextColor.GOLD, TextDecoration.BOLD)));
+      player.sendMessage(translatable("match.class.current", NamedTextColor.GREEN)
+          .append(space())
+          .append(currentClass.getComponent()));
       player.sendMessage(translatable("match.class.view", NamedTextColor.GOLD));
     } else {
       classes.setPlayerClass(player.getId(), newClass);
 
       player.sendMessage(
-          translatable(
-              "match.class.ok",
-              NamedTextColor.GREEN,
-              text(newClass.getName(), NamedTextColor.GOLD, TextDecoration.UNDERLINED)));
+          translatable("match.class.ok", NamedTextColor.GREEN, newClass.getComponent()));
       if (player.isParticipating()) {
         player.sendMessage(translatable("match.class.queue", NamedTextColor.GREEN));
       }
@@ -51,11 +49,10 @@ public final class ClassCommand {
   public void classList(ClassMatchModule classes, MatchPlayer player) {
     final PlayerClass currentClass = classes.getSelectedClass(player.getId());
 
-    player.sendMessage(
-        TextFormatter.horizontalLineHeading(
-            player.getBukkit(),
-            translatable("match.class.title").color(NamedTextColor.GOLD),
-            NamedTextColor.RED));
+    player.sendMessage(TextFormatter.horizontalLineHeading(
+        player.getBukkit(),
+        translatable("match.class.title").color(NamedTextColor.GOLD),
+        NamedTextColor.RED));
 
     int i = 1;
     for (PlayerClass cls : classes.getClasses()) {
@@ -71,8 +68,11 @@ public final class ClassCommand {
         color = NamedTextColor.RED;
       }
 
-      result.append(
-          text(cls.getName(), color).decoration(TextDecoration.UNDERLINED, cls == currentClass));
+      result.append(text(cls.getName(), color)
+          .decoration(TextDecoration.UNDERLINED, cls == currentClass)
+          .hoverEvent(showText(translatable(
+              "match.class.select", NamedTextColor.GRAY, text(cls.getName(), NamedTextColor.GOLD))))
+          .clickEvent(runCommand("/class " + cls.getName())));
 
       if (cls.getDescription() != null) {
         result.append(text(" - ", NamedTextColor.DARK_PURPLE)).append(text(cls.getDescription()));

--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -1,7 +1,5 @@
 package tc.oc.pgm.picker;
 
-import static net.kyori.adventure.key.Key.key;
-import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static tc.oc.pgm.util.Assert.assertTrue;
 
@@ -673,8 +671,9 @@ public class PickerMatchModule implements MatchModule, Listener {
         if (cls != cmm.getSelectedClass(player.getId())) {
           if (cmm.getCanChangeClass(player.getId())) {
             cmm.setPlayerClass(player.getId(), cls);
-            player.sendMessage(translatable(
-                "match.class.ok", NamedTextColor.GOLD, text(name, NamedTextColor.GREEN)));
+
+            player.sendMessage(
+                translatable("match.class.ok", NamedTextColor.GREEN, cls.getComponent()));
             scheduleRefresh(player);
           } else {
             player.sendMessage(translatable("match.class.sticky", NamedTextColor.RED));

--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -672,8 +672,7 @@ public class PickerMatchModule implements MatchModule, Listener {
           if (cmm.getCanChangeClass(player.getId())) {
             cmm.setPlayerClass(player.getId(), cls);
 
-            player.sendMessage(
-                translatable("match.class.ok", NamedTextColor.GREEN, cls.getComponent()));
+            player.sendMessage(translatable("match.class.ok", NamedTextColor.GREEN, cls));
             scheduleRefresh(player);
           } else {
             player.sendMessage(translatable("match.class.sticky", NamedTextColor.RED));

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -41,6 +41,9 @@ match.class.ok = You have selected {0}
 
 match.class.queue = Changes will take effect on next spawn.
 
+# {0} = class name
+match.class.select = Click to select {0}
+
 match.class.sticky = You may not change classes because your current class is sticky.
 
 match.class.notEnabled = Classes are not enabled on this map.
@@ -210,4 +213,3 @@ admin.end.unknownError = Match could not be ended at this time.
 admin.end.announce = {0} has ended the match.
 
 admin.setPool.activeCycle = You may not adjust the pool while match is cycling.
-


### PR DESCRIPTION
Adds more interactivity to Class messages

For `/classes`
- Makes it so each entry can be clicked to select that class

For `/class` and the class message from PickerMatchModule
- Adds a hover in the format: `Class Name: Description`
- No click action

Also standardized the response message for class selection. (The coloring was flipped)