### PR TITLE
Fix leak on quitting players in modern

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/bukkit/LeavingPlayers.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/LeavingPlayers.java
@@ -1,0 +1,32 @@
+package tc.oc.pgm.util.bukkit;
+
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import java.util.Set;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class LeavingPlayers implements Listener {
+  private static final LeavingPlayers INSTANCE = new LeavingPlayers();
+
+  private final Set<Player> recentlyDisconnected = new ReferenceOpenHashSet<>();
+
+  private LeavingPlayers() {
+    Bukkit.getPluginManager().registerEvents(this, BukkitUtils.getPlugin());
+  }
+
+  public static boolean contains(Player player) {
+    return INSTANCE.recentlyDisconnected.contains(player);
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST)
+  public void onPlayerQuit(PlayerQuitEvent event) {
+    if (recentlyDisconnected.isEmpty())
+      Bukkit.getScheduler()
+          .scheduleSyncDelayedTask(BukkitUtils.getPlugin(), recentlyDisconnected::clear);
+    recentlyDisconnected.add(event.getPlayer());
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/OnlinePlayerMapAdapter.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/OnlinePlayerMapAdapter.java
@@ -21,7 +21,7 @@ public class OnlinePlayerMapAdapter<V> extends ListeningMapAdapter<Player, V> im
 
   @Override
   public boolean isValid(Player key) {
-    return key.isOnline();
+    return key.isOnline() && !LeavingPlayers.contains(key);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/OnlinePlayerUUIDMapAdapter.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/OnlinePlayerUUIDMapAdapter.java
@@ -22,7 +22,7 @@ public class OnlinePlayerUUIDMapAdapter<V> extends ListeningMapAdapter<UUID, V>
 
   public boolean isValid(UUID key) {
     Player player = Bukkit.getPlayer(key);
-    return player != null && player.isOnline();
+    return player != null && player.isOnline() && !LeavingPlayers.contains(player);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)


### PR DESCRIPTION
Currently modern throws a player close inventory event AFTER the player quit event, causing players in the AFK tracker to be removed from the activity map, then re-added and memory leaked.
This seems like a more reliable way to track leaving players to avoid them being ever added to online map adapters.