### PR TITLE
Treewide cleanup and use of modern Java features

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,6 @@ repositories {
 
 dependencies {
     implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.3.1")
-    implementation("com.diffplug.gradle.spotless:com.diffplug.gradle.spotless.gradle.plugin:8.2.0")
+    implementation("com.diffplug.gradle.spotless:com.diffplug.gradle.spotless.gradle.plugin:8.2.1")
     implementation("de.skuzzle.restrictimports:de.skuzzle.restrictimports.gradle.plugin:3.0.0")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,6 @@ repositories {
 
 dependencies {
     implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.3.1")
-    implementation("com.diffplug.gradle.spotless:com.diffplug.gradle.spotless.gradle.plugin:8.1.0")
+    implementation("com.diffplug.gradle.spotless:com.diffplug.gradle.spotless.gradle.plugin:8.2.0")
     implementation("de.skuzzle.restrictimports:de.skuzzle.restrictimports.gradle.plugin:3.0.0")
 }

--- a/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
@@ -69,7 +69,7 @@ spotless {
         removeUnusedImports()
         trimTrailingWhitespace()
         formatAnnotations()
-        palantirJavaFormat("2.85.0").style("GOOGLE").formatJavadoc(true)
+        palantirJavaFormat("2.86.0").style("GOOGLE").formatJavadoc(true)
     }
 }
 

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -21,8 +21,6 @@ import java.nio.file.Paths;
 import java.text.Normalizer;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -39,7 +37,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
@@ -394,14 +392,11 @@ public final class PGMConfig implements Config {
     }
 
     // Will be sorted based on priority, in ascending order
-    Collections.sort(groups, new Comparator<String>() {
-      @Override
-      public int compare(String o1, String o2) {
-        try {
-          return Integer.parseInt(o1.split("\\|")[0]) - Integer.parseInt(o2.split("\\|")[0]);
-        } catch (Throwable t) {
-          return 0;
-        }
+    groups.sort((o1, o2) -> {
+      try {
+        return Integer.parseInt(o1.split("\\|")[0]) - Integer.parseInt(o2.split("\\|")[0]);
+      } catch (Throwable t) {
+        return 0;
       }
     });
 
@@ -774,13 +769,13 @@ public final class PGMConfig implements Config {
 
   private static class Flair implements Config.Flair {
 
-    private String prefix;
-    private String suffix;
-    private String displayName;
-    private String description;
-    private String clickLink;
-    private Component prefixOverride;
-    private Component suffixOverride;
+    private final String prefix;
+    private final String suffix;
+    private final String displayName;
+    private final String description;
+    private final String clickLink;
+    private final Component prefixOverride;
+    private final Component suffixOverride;
 
     public Flair(ConfigurationSection config) {
       final String prefix = config.getString("prefix");
@@ -847,7 +842,7 @@ public final class PGMConfig implements Config {
   public static class Moderation {
 
     public static boolean isRuleLinkVisible() {
-      return getRulesLink().length() > 0;
+      return !getRulesLink().isEmpty();
     }
 
     public static String getRulesLink() {
@@ -863,7 +858,7 @@ public final class PGMConfig implements Config {
     }
 
     public static boolean isAppealVisible() {
-      return getAppealMessage().length() > 0;
+      return !getAppealMessage().isEmpty();
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/api/event/BlockTransformEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/event/BlockTransformEvent.java
@@ -155,8 +155,7 @@ public class BlockTransformEvent extends GeneralizedEvent {
         || event instanceof PlayerBucketEmptyEvent
         || event instanceof PlayerBucketFillEvent) return true;
 
-    if (event instanceof BlockIgniteEvent) {
-      BlockIgniteEvent igniteEvent = (BlockIgniteEvent) event;
+    if (event instanceof BlockIgniteEvent igniteEvent) {
       if (igniteEvent.getCause() == BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL
           && igniteEvent.getIgnitingEntity() != null) {
         return true;

--- a/core/src/main/java/tc/oc/pgm/api/feature/FeatureInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/feature/FeatureInfo.java
@@ -10,5 +10,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface FeatureInfo {
   /** A readable name for the type of feature (used for database documents and error messages) */
-  public String name();
+  String name();
 }

--- a/core/src/main/java/tc/oc/pgm/api/filter/Filter.java
+++ b/core/src/main/java/tc/oc/pgm/api/filter/Filter.java
@@ -34,15 +34,13 @@ public interface Filter extends FeatureDefinition {
    * <p>{@link #respondsTo(Class)} can be used to ensure that this method will not throw.
    */
   default boolean response(Query query) {
-    switch (query(query)) {
-      case ALLOW:
-        return true;
-      case DENY:
-        return false;
-      default:
+    return switch (query(query)) {
+      case ALLOW -> true;
+      case DENY -> false;
+      default ->
         throw new UnsupportedOperationException(
             "Filter " + this + " did not respond to the query " + query);
-    }
+    };
   }
 
   /**
@@ -59,8 +57,8 @@ public interface Filter extends FeatureDefinition {
    * Does this filter support dynamic notifications?
    *
    * <p>If this returns true, then any change in the response of this filter to a query that passes
-   * {@link #respondsTo(Class)} must notify {@link FilterListener}s registered through {@link
-   * tc.oc.pgm.filters.FilterMatchModule}.
+   * {@link #respondsTo(Class)} must notify {@link FilterListener}s registered through
+   * {@link tc.oc.pgm.filters.FilterMatchModule}.
    *
    * <p>This method should NOT account for the behavior of any {@link #dependencies()}, as that is
    * done automatically by the calling code. This method can return true as long as it does NOT

--- a/core/src/main/java/tc/oc/pgm/api/integration/Integration.java
+++ b/core/src/main/java/tc/oc/pgm/api/integration/Integration.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.channels.Channel;
 import tc.oc.pgm.api.player.MatchPlayer;
 
@@ -18,13 +18,13 @@ public final class Integration {
   private Integration() {}
 
   private static final AtomicReference<FriendIntegration> FRIENDS =
-      new AtomicReference<FriendIntegration>(new NoopFriendIntegration());
+      new AtomicReference<>(new NoopFriendIntegration());
   private static final AtomicReference<NickIntegration> NICKS =
-      new AtomicReference<NickIntegration>(new NoopNickIntegration());
+      new AtomicReference<>(new NoopNickIntegration());
   private static final AtomicReference<PunishmentIntegration> PUNISHMENTS =
-      new AtomicReference<PunishmentIntegration>(new NoopPunishmentIntegration());
+      new AtomicReference<>(new NoopPunishmentIntegration());
   private static final AtomicReference<VanishIntegration> VANISH =
-      new AtomicReference<VanishIntegration>(new NoopVanishIntegration());
+      new AtomicReference<>(new NoopVanishIntegration());
   private static final AtomicReference<SquadIntegration> SQUAD =
       new AtomicReference<>(new NoopSquadIntegration());
   private static Set<Channel<?>> CHANNELS = new HashSet<>();

--- a/core/src/main/java/tc/oc/pgm/api/map/MapContext.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapContext.java
@@ -3,7 +3,7 @@ package tc.oc.pgm.api.map;
 import tc.oc.pgm.api.module.ModuleContext;
 
 /** A {@link MapInfo} that is "loaded" with its {@link MapModule}s and a {@link MapSource}. */
-public interface MapContext extends ModuleContext<MapModule> {
+public interface MapContext extends ModuleContext<MapModule<?>> {
 
   /**
    * Get an immutable {@link MapInfo} which doesn't hold strong references to the context.

--- a/core/src/main/java/tc/oc/pgm/api/match/MatchPhase.java
+++ b/core/src/main/java/tc/oc/pgm/api/match/MatchPhase.java
@@ -8,8 +8,8 @@ import tc.oc.pgm.api.player.MatchPlayer;
 public enum MatchPhase {
 
   /**
-   * The {@link Match} is loaded, but no countdown has been queued for it to transition to {@link
-   * MatchPhase#STARTING}.
+   * The {@link Match} is loaded, but no countdown has been queued for it to transition to
+   * {@link MatchPhase#STARTING}.
    */
   IDLE,
 
@@ -38,18 +38,12 @@ public enum MatchPhase {
    * @return Whether the transition is allowed.
    */
   public boolean canTransitionTo(MatchPhase next) {
-    switch (this) {
-      case IDLE:
-        return next == STARTING || next == RUNNING;
-      case STARTING:
-        return next == RUNNING || next == IDLE || next == STARTING;
-      case RUNNING:
-        return next == FINISHED;
-      case FINISHED:
-        return false;
-      default:
-        throw new IllegalStateException("Unknown transition state for " + next);
-    }
+    return switch (this) {
+      case IDLE -> next == STARTING || next == RUNNING;
+      case STARTING -> next == RUNNING || next == IDLE || next == STARTING;
+      case RUNNING -> next == FINISHED;
+      case FINISHED -> false;
+    };
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/api/match/event/MatchVoteFinishEvent.java
+++ b/core/src/main/java/tc/oc/pgm/api/match/event/MatchVoteFinishEvent.java
@@ -1,15 +1,15 @@
 package tc.oc.pgm.api.match.event;
 
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.match.Match;
 
 public class MatchVoteFinishEvent extends MatchEvent {
 
-  private @Nullable MapInfo pickedMap;
+  private final @Nullable MapInfo pickedMap;
 
-  public MatchVoteFinishEvent(Match match, MapInfo pickedMap) {
+  public MatchVoteFinishEvent(Match match, @Nullable MapInfo pickedMap) {
     super(match);
     this.pickedMap = pickedMap;
   }

--- a/core/src/main/java/tc/oc/pgm/api/module/ModuleGraph.java
+++ b/core/src/main/java/tc/oc/pgm/api/module/ModuleGraph.java
@@ -8,7 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Stack;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
 
 /** A dependency graph for {@link Module}s and their {@link ModuleFactory}s. */
@@ -73,7 +73,7 @@ public abstract class ModuleGraph<M extends Module, F extends ModuleFactory<M>>
     }
 
     if (!errors.isEmpty()) {
-      throw errors.get(0);
+      throw errors.getFirst();
     }
   }
 
@@ -154,7 +154,7 @@ public abstract class ModuleGraph<M extends Module, F extends ModuleFactory<M>>
       }
     }
 
-    @Nullable M module;
+    M module;
     try {
       module = createModule(factory);
     } catch (ModuleLoadException e) {

--- a/core/src/main/java/tc/oc/pgm/api/module/exception/ModuleLoadException.java
+++ b/core/src/main/java/tc/oc/pgm/api/module/exception/ModuleLoadException.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.api.module.exception;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.module.Module;
 
 /** When a {@link Module} or its factory is unable to load. */
@@ -8,7 +8,8 @@ public class ModuleLoadException extends RuntimeException {
 
   private final @Nullable Class<? extends Module> key;
 
-  public ModuleLoadException(Class<? extends Module> key, String message, Throwable cause) {
+  public ModuleLoadException(
+      @Nullable Class<? extends Module> key, String message, Throwable cause) {
     super(getFullMessage(message, key), cause);
     this.key = key;
   }

--- a/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/blitz/BlitzMatchModule.java
@@ -20,7 +20,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.Gamemode;
 import tc.oc.pgm.api.match.Match;
@@ -90,8 +90,7 @@ public class BlitzMatchModule implements MatchModule, Listener {
   public void handleDeath(final MatchPlayerDeathEvent event) {
     MatchPlayer victim = event.getVictim();
     if (config.getFilter().query(victim).isDenied()) return;
-    if (victim.getParty() instanceof Competitor) {
-      Competitor competitor = (Competitor) victim.getParty();
+    if (victim.getParty() instanceof Competitor competitor) {
 
       int lives = this.lifeManager.addLives(event.getVictim().getId(), -1);
 

--- a/core/src/main/java/tc/oc/pgm/classes/ClassMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/classes/ClassMatchModule.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
@@ -40,14 +40,7 @@ public class ClassMatchModule implements MatchModule, Listener {
     this.classes = assertNotNull(classes, "classes");
     this.defaultClass = assertNotNull(defaultClass, "default class");
 
-    this.classesByName =
-        Sets.newTreeSet(
-            new Comparator<PlayerClass>() {
-              @Override
-              public int compare(PlayerClass o1, PlayerClass o2) {
-                return o1.getName().compareTo(o2.getName());
-              }
-            });
+    this.classesByName = Sets.newTreeSet(Comparator.comparing(PlayerClass::getName));
     this.classesByName.addAll(this.classes.values());
   }
 

--- a/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
+++ b/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -100,11 +101,20 @@ public class ClassModule implements MapModule<ClassMatchModule> {
       if (family == null)
         throw new InvalidXMLException("Unable to determine family for classes", doc);
 
+      Set<String> usedNames = Sets.newHashSet();
+
       ImmutableMap.Builder<String, PlayerClass> builder = ImmutableMap.builder();
       PlayerClass defaultClass = null;
 
       for (Element classEl : classElements) {
         PlayerClass cls = parseClass(classEl, factory.getKits(), family);
+
+        usedNames.add(cls.getName().toLowerCase());
+        if (usedNames.contains(cls.getName().toLowerCase())) {
+          throw new InvalidXMLException(
+              "Class already registered to \" + cls.getName() + \"; skipping second instance",
+              classEl);
+        }
 
         String classFamily = classEl.getAttributeValue("family");
         if (!family.equals(classFamily)) {

--- a/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
+++ b/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -15,7 +14,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
@@ -86,8 +85,7 @@ public class ClassModule implements MapModule<ClassMatchModule> {
       for (Element classEl : classElements) {
         String classFamily = classEl.getAttributeValue("family");
         if (classFamily != null) {
-          Integer num = familyFrequency.get(classFamily);
-          familyFrequency.put(classFamily, (num != null ? num.intValue() : 0) + 1);
+          familyFrequency.compute(classFamily, (k, num) -> (num != null ? num : 0) + 1);
         }
       }
 
@@ -102,28 +100,17 @@ public class ClassModule implements MapModule<ClassMatchModule> {
       if (family == null)
         throw new InvalidXMLException("Unable to determine family for classes", doc);
 
-      Set<String> usedNames = Sets.newHashSet();
       ImmutableMap.Builder<String, PlayerClass> builder = ImmutableMap.builder();
       PlayerClass defaultClass = null;
 
       for (Element classEl : classElements) {
         PlayerClass cls = parseClass(classEl, factory.getKits(), family);
 
-        if (usedNames.contains(cls.getName().toLowerCase())) {
-          throw new InvalidXMLException(
-              "Class already registered to \" + cls.getName() + \"; skipping second instance",
-              classEl);
-        }
-
         String classFamily = classEl.getAttributeValue("family");
-        if (family == null) {
-          family = classFamily;
-        } else {
-          if (!family.equals(classFamily)) {
-            throw new InvalidXMLException(
-                "Family was determined to be '" + family + "' but class specified '" + classFamily,
-                classEl);
-          }
+        if (!family.equals(classFamily)) {
+          throw new InvalidXMLException(
+              "Family was determined to be '" + family + "' but class specified '" + classFamily,
+              classEl);
         }
 
         if (XMLUtils.parseBoolean(classEl.getAttribute("default"), false)) {

--- a/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
+++ b/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
@@ -109,12 +109,13 @@ public class ClassModule implements MapModule<ClassMatchModule> {
       for (Element classEl : classElements) {
         PlayerClass cls = parseClass(classEl, factory.getKits(), family);
 
-        usedNames.add(cls.getName().toLowerCase());
         if (usedNames.contains(cls.getName().toLowerCase())) {
           throw new InvalidXMLException(
               "Class already registered to \" + cls.getName() + \"; skipping second instance",
               classEl);
         }
+
+        usedNames.add(cls.getName().toLowerCase());
 
         String classFamily = classEl.getAttributeValue("family");
         if (!family.equals(classFamily)) {

--- a/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
+++ b/core/src/main/java/tc/oc/pgm/classes/ClassModule.java
@@ -24,6 +24,7 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.kits.KitModule;
 import tc.oc.pgm.kits.KitParser;
+import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.material.ItemMaterialData;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -109,13 +110,11 @@ public class ClassModule implements MapModule<ClassMatchModule> {
       for (Element classEl : classElements) {
         PlayerClass cls = parseClass(classEl, factory.getKits(), family);
 
-        if (usedNames.contains(cls.getName().toLowerCase())) {
+        if (!usedNames.add(StringUtils.normalize(cls.getName()))) {
           throw new InvalidXMLException(
               "Class already registered to \" + cls.getName() + \"; skipping second instance",
               classEl);
         }
-
-        usedNames.add(cls.getName().toLowerCase());
 
         String classFamily = classEl.getAttributeValue("family");
         if (!family.equals(classFamily)) {

--- a/core/src/main/java/tc/oc/pgm/classes/PlayerClass.java
+++ b/core/src/main/java/tc/oc/pgm/classes/PlayerClass.java
@@ -12,8 +12,8 @@ import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.util.material.ItemMaterialData;
 
@@ -63,7 +63,7 @@ public class PlayerClass implements ComponentLike {
   }
 
   @Override
-  public @NotNull Component asComponent() {
+  public @NonNull Component asComponent() {
     TextComponent.Builder component =
         text().content(this.name).color(NamedTextColor.GOLD).decoration(TextDecoration.BOLD, true);
 
@@ -118,8 +118,7 @@ public class PlayerClass implements ComponentLike {
   public boolean equals(Object obj) {
     if (this == obj) return true;
     if (obj == null) return false;
-    if (!(obj instanceof PlayerClass)) return false;
-    PlayerClass other = (PlayerClass) obj;
+    if (!(obj instanceof PlayerClass other)) return false;
     if (!this.name.equals(other.name)) return false;
     if (!this.familyName.equals(other.familyName)) return false;
     if (this.description == null) {

--- a/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MatchCommand.java
@@ -23,7 +23,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.annotations.Command;
 import org.incendo.cloud.annotations.CommandDescription;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchPhase;
@@ -51,21 +51,17 @@ public final class MatchCommand {
     boolean haveGameInfo =
         match.getPhase() == MatchPhase.RUNNING || match.getPhase() == MatchPhase.FINISHED;
 
-    viewer.sendMessage(
-        TextFormatter.horizontalLineHeading(
-            sender,
-            translatable("match.title")
-                .append(text(" #" + match.getId()))
-                .color(NamedTextColor.YELLOW),
-            NamedTextColor.WHITE,
-            TextFormatter.MAX_CHAT_WIDTH));
+    viewer.sendMessage(TextFormatter.horizontalLineHeading(
+        sender,
+        translatable("match.title").append(text(" #" + match.getId())).color(NamedTextColor.YELLOW),
+        NamedTextColor.WHITE,
+        TextFormatter.MAX_CHAT_WIDTH));
 
     if (haveGameInfo) {
       // show match time
-      viewer.sendMessage(
-          translatable("match.info.time", NamedTextColor.DARK_PURPLE)
-              .append(text(": ", NamedTextColor.DARK_PURPLE))
-              .append(clock(match.getDuration()).color(NamedTextColor.GOLD)));
+      viewer.sendMessage(translatable("match.info.time", NamedTextColor.DARK_PURPLE)
+          .append(text(": ", NamedTextColor.DARK_PURPLE))
+          .append(clock(match.getDuration()).color(NamedTextColor.GOLD)));
     }
 
     TeamMatchModule tmm = match.getModule(TeamMatchModule.class);
@@ -80,9 +76,8 @@ public final class MatchCommand {
         if (teamName.endsWith(" Team")) teamName = teamName.substring(0, teamName.length() - 5);
 
         msg.append(text(teamName, TextFormatter.convert(team.getColor())))
-            .append(
-                text(": ", NamedTextColor.GRAY)
-                    .append(text(getNonVanishedCount(team.getPlayers()), NamedTextColor.WHITE)));
+            .append(text(": ", NamedTextColor.GRAY)
+                .append(text(getNonVanishedCount(team.getPlayers()), NamedTextColor.WHITE)));
 
         if (team.getMaxPlayers() != Integer.MAX_VALUE) {
           msg.append(text("/" + team.getMaxPlayers(), NamedTextColor.GRAY));
@@ -91,25 +86,20 @@ public final class MatchCommand {
         teamCountParts.add(msg.build());
       }
     } else if (ffamm != null) {
-      teamCountParts.add(
-          text()
-              .append(
-                  translatable("match.info.players", NamedTextColor.YELLOW)
-                      .append(text(": ", NamedTextColor.GRAY))
-                      .append(text(match.getParticipants().size(), NamedTextColor.WHITE))
-                      .append(text("/" + ffamm.getMaxPlayers(), NamedTextColor.GRAY)))
-              .build());
+      teamCountParts.add(text()
+          .append(translatable("match.info.players", NamedTextColor.YELLOW)
+              .append(text(": ", NamedTextColor.GRAY))
+              .append(text(match.getParticipants().size(), NamedTextColor.WHITE))
+              .append(text("/" + ffamm.getMaxPlayers(), NamedTextColor.GRAY)))
+          .build());
     }
 
-    teamCountParts.add(
-        text()
-            .append(
-                text(
-                    TextTranslations.translate("match.info.observers", sender),
-                    NamedTextColor.AQUA))
-            .append(text(": ", NamedTextColor.GRAY))
-            .append(text(getNonVanishedCount(match.getObservers()), NamedTextColor.WHITE))
-            .build());
+    teamCountParts.add(text()
+        .append(
+            text(TextTranslations.translate("match.info.observers", sender), NamedTextColor.AQUA))
+        .append(text(": ", NamedTextColor.GRAY))
+        .append(text(getNonVanishedCount(match.getObservers()), NamedTextColor.WHITE))
+        .build());
 
     viewer.sendMessage(
         join(JoinConfiguration.separator(text(" | ", NamedTextColor.DARK_GRAY)), teamCountParts));
@@ -117,7 +107,7 @@ public final class MatchCommand {
     if (!haveGameInfo) return;
 
     GoalMatchModule gmm = match.getModule(GoalMatchModule.class);
-    if (gmm != null && tmm != null && gmm.getGoalsByCompetitor().size() > 0) {
+    if (gmm != null && tmm != null && !gmm.getGoalsByCompetitor().isEmpty()) {
       Multimap<Team, Component> teamGoalTexts = LinkedHashMultimap.create();
       Map<Goal<?>, Component> sharedGoalTexts = new LinkedHashMap<>();
 
@@ -143,18 +133,18 @@ public final class MatchCommand {
             translatable("match.info.goals").append(text(":")).color(NamedTextColor.DARK_PURPLE));
 
         // Team goals
-        for (Map.Entry<Team, Collection<Component>> entry : teamGoalTexts.asMap().entrySet()) {
+        for (Map.Entry<Team, Collection<Component>> entry :
+            teamGoalTexts.asMap().entrySet()) {
           Team team = entry.getKey();
           Collection<Component> goalTexts = entry.getValue();
 
-          viewer.sendMessage(
-              text()
-                  .append(space())
-                  .append(space())
-                  .append(team.getName())
-                  .append(text(": ", NamedTextColor.GRAY))
-                  .append(join(JoinConfiguration.separator(text("  ")), goalTexts))
-                  .build());
+          viewer.sendMessage(text()
+              .append(space())
+              .append(space())
+              .append(team.getName())
+              .append(text(": ", NamedTextColor.GRAY))
+              .append(join(JoinConfiguration.separator(text("  ")), goalTexts))
+              .build());
         }
         // Shared goals
         viewer.sendMessage(join(JoinConfiguration.separator(text("  ")), sharedGoalTexts.values()));
@@ -183,13 +173,11 @@ public final class MatchCommand {
       Goal<?> goal, @Nullable Competitor competitor, Party viewingParty) {
     TextComponent.Builder sb = text().append(space());
 
-    sb.append(
-        goal.renderSidebarStatusText(competitor, viewingParty)
-            .color(goal.renderSidebarStatusColor(competitor, viewingParty)));
+    sb.append(goal.renderSidebarStatusText(competitor, viewingParty)
+        .color(goal.renderSidebarStatusColor(competitor, viewingParty)));
 
     sb.append(space());
-    if (goal instanceof ProximityGoal) {
-      ProximityGoal<?> proxGoal = (ProximityGoal<?>) goal;
+    if (goal instanceof ProximityGoal<?> proxGoal) {
       Component proximity = proxGoal.renderProximity(competitor, viewingParty);
       if (proximity != empty()) {
         TextColor proximityColor = proxGoal.renderProximityColor(competitor, viewingParty);
@@ -198,9 +186,8 @@ public final class MatchCommand {
       }
     }
 
-    sb.append(
-        goal.renderSidebarLabelText(competitor, viewingParty)
-            .color(goal.renderSidebarLabelColor(competitor, viewingParty)));
+    sb.append(goal.renderSidebarLabelText(competitor, viewingParty)
+        .color(goal.renderSidebarLabelColor(competitor, viewingParty)));
 
     return sb.build();
   }

--- a/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ModeCommand.java
@@ -41,7 +41,7 @@ public final class ModeCommand {
     TextComponent.Builder builder = text()
         .append(translatable("command.nextMode", NamedTextColor.DARK_PURPLE).append(space()));
 
-    ModeChangeCountdown next = countdowns.get(0);
+    ModeChangeCountdown next = countdowns.getFirst();
     Duration timeLeft = modes.getCountdown().getTimeLeft(next);
 
     if (timeLeft == null) {

--- a/core/src/main/java/tc/oc/pgm/command/ProximityCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/ProximityCommand.java
@@ -12,7 +12,6 @@ import org.incendo.cloud.annotations.CommandDescription;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.goals.Goal;
 import tc.oc.pgm.goals.GoalMatchModule;
-import tc.oc.pgm.goals.ProximityGoal;
 import tc.oc.pgm.goals.ProximityMetric;
 import tc.oc.pgm.goals.ShowOption;
 import tc.oc.pgm.goals.TouchableGoal;
@@ -37,9 +36,8 @@ public final class ProximityCommand {
       boolean teamHeader = false;
 
       for (Goal<?> goal : gmm.getGoals(team)) {
-        if (goal instanceof TouchableGoal && goal.hasShowOption(ShowOption.SHOW_INFO)) {
-          TouchableGoal touchable = (TouchableGoal) goal;
-          ProximityGoal proximity = (ProximityGoal) goal;
+        if (goal instanceof TouchableGoal<?> touchable
+            && goal.hasShowOption(ShowOption.SHOW_INFO)) {
 
           if (!teamHeader) {
             lines.add(TextTranslations.translateLegacy(team.getName(), player.getBukkit()));
@@ -56,16 +54,15 @@ public final class ProximityCommand {
             line += ChatColor.RED + " UNTOUCHED";
           }
 
-          if (proximity.isProximityRelevant(team)) {
-            ProximityMetric metric = proximity.getProximityMetric(team);
+          if (touchable.isProximityRelevant(team)) {
+            ProximityMetric metric = touchable.getProximityMetric(team);
             if (metric != null) {
-              line +=
-                  ChatColor.GRAY
-                      + " "
-                      + metric.description()
-                      + ": "
-                      + ChatColor.AQUA
-                      + String.format("%.2f", proximity.getMinimumDistance(team));
+              line += ChatColor.GRAY
+                  + " "
+                  + metric.description()
+                  + ": "
+                  + ChatColor.AQUA
+                  + String.format("%.2f", touchable.getMinimumDistance(team));
             }
           }
 

--- a/core/src/main/java/tc/oc/pgm/command/util/CommandKeys.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/CommandKeys.java
@@ -9,11 +9,11 @@ import tc.oc.pgm.rotation.pools.MapPoolType;
 public class CommandKeys {
 
   // Keep the current match in a key, avoids excessive lookups, one in each parser/injector.
-  public static final CloudKey<Match> MATCH = CloudKey.of("_pgm_match_", new TypeToken<Match>() {});
+  public static final CloudKey<Match> MATCH = CloudKey.of("_pgm_match_", new TypeToken<>() {});
 
   public static final CloudKey<SettingKey> SETTING_KEY =
-      CloudKey.of("_pgm_setting_key_param_", new TypeToken<SettingKey>() {});
+      CloudKey.of("_pgm_setting_key_param_", new TypeToken<>() {});
 
   public static final CloudKey<MapPoolType> POOL_TYPE =
-      CloudKey.of("_pgm_pool_type_param_", new TypeToken<MapPoolType>() {});
+      CloudKey.of("_pgm_pool_type_param_", new TypeToken<>() {});
 }

--- a/core/src/main/java/tc/oc/pgm/command/util/CommandKeys.java
+++ b/core/src/main/java/tc/oc/pgm/command/util/CommandKeys.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.command.util;
 
-import io.leangen.geantyref.TypeToken;
 import org.incendo.cloud.key.CloudKey;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.setting.SettingKey;
@@ -9,11 +8,11 @@ import tc.oc.pgm.rotation.pools.MapPoolType;
 public class CommandKeys {
 
   // Keep the current match in a key, avoids excessive lookups, one in each parser/injector.
-  public static final CloudKey<Match> MATCH = CloudKey.of("_pgm_match_", new TypeToken<>() {});
+  public static final CloudKey<Match> MATCH = CloudKey.of("_pgm_match_", Match.class);
 
   public static final CloudKey<SettingKey> SETTING_KEY =
-      CloudKey.of("_pgm_setting_key_param_", new TypeToken<>() {});
+      CloudKey.of("_pgm_setting_key_param_", SettingKey.class);
 
   public static final CloudKey<MapPoolType> POOL_TYPE =
-      CloudKey.of("_pgm_pool_type_param_", new TypeToken<>() {});
+      CloudKey.of("_pgm_pool_type_param_", MapPoolType.class);
 }

--- a/core/src/main/java/tc/oc/pgm/controlpoint/events/CapturingTeamChangeEvent.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/events/CapturingTeamChangeEvent.java
@@ -1,18 +1,18 @@
 package tc.oc.pgm.controlpoint.events;
 
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.controlpoint.ControlPoint;
 
 public class CapturingTeamChangeEvent extends ControlPointEvent {
   private static final HandlerList handlers = new HandlerList();
-  @Nullable private final Competitor oldTeam;
-  @Nullable private final Competitor newTeam;
+  private final @Nullable Competitor oldTeam;
+  private final @Nullable Competitor newTeam;
 
   public CapturingTeamChangeEvent(
-      Match match, ControlPoint hill, Competitor oldTeam, Competitor newTeam) {
+      Match match, ControlPoint hill, @Nullable Competitor oldTeam, @Nullable Competitor newTeam) {
     super(match, hill);
     this.oldTeam = oldTeam;
     this.newTeam = newTeam;

--- a/core/src/main/java/tc/oc/pgm/controlpoint/events/ControllerChangeEvent.java
+++ b/core/src/main/java/tc/oc/pgm/controlpoint/events/ControllerChangeEvent.java
@@ -1,18 +1,21 @@
 package tc.oc.pgm.controlpoint.events;
 
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.controlpoint.ControlPoint;
 
 public class ControllerChangeEvent extends ControlPointEvent {
   private static final HandlerList handlers = new HandlerList();
-  @Nullable private final Competitor oldController;
-  @Nullable private final Competitor newController;
+  private final @Nullable Competitor oldController;
+  private final @Nullable Competitor newController;
 
   public ControllerChangeEvent(
-      Match match, ControlPoint hill, Competitor oldController, Competitor newController) {
+      Match match,
+      ControlPoint hill,
+      @Nullable Competitor oldController,
+      @Nullable Competitor newController) {
     super(match, hill);
     this.oldController = oldController;
     this.newController = newController;

--- a/core/src/main/java/tc/oc/pgm/core/CoreConvertMonitor.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreConvertMonitor.java
@@ -12,7 +12,7 @@ public class CoreConvertMonitor implements Runnable {
 
   public CoreConvertMonitor(CoreMatchModule parent) {
     this.parent = parent;
-    this.nextMaterial = getNext(parent.cores.iterator().next());
+    this.nextMaterial = getNext(parent.cores.getFirst());
   }
 
   @Override
@@ -30,7 +30,7 @@ public class CoreConvertMonitor implements Runnable {
           .append(text(name + " CORE MODE", NamedTextColor.RED))
           .append(text(" < < < <", NamedTextColor.DARK_AQUA))
           .build());
-      this.nextMaterial = getNext(parent.cores.iterator().next());
+      this.nextMaterial = getNext(parent.cores.getFirst());
     }
   }
 
@@ -41,11 +41,9 @@ public class CoreConvertMonitor implements Runnable {
   }
 
   public static String getName(Material material) {
-    switch (material) {
-      case GOLD_BLOCK:
-        return "GOLD";
-      default:
-        return null;
+    if (material == Material.GOLD_BLOCK) {
+      return "GOLD";
     }
+    return null;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/core/CoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/core/CoreModule.java
@@ -44,7 +44,7 @@ public class CoreModule implements MapModule<CoreMatchModule> {
   protected final List<CoreFactory> coreFactories;
 
   public CoreModule(List<CoreFactory> coreFactories) {
-    assert coreFactories.size() > 0;
+    assert !coreFactories.isEmpty();
     this.coreFactories = coreFactories;
   }
 
@@ -161,7 +161,7 @@ public class CoreModule implements MapModule<CoreMatchModule> {
       }
 
       // only produce a valid core module if there are cores to handle
-      if (coreFactories.size() > 0) {
+      if (!coreFactories.isEmpty()) {
         return new CoreModule(coreFactories);
       } else {
         return null;

--- a/core/src/main/java/tc/oc/pgm/crafting/CraftingModule.java
+++ b/core/src/main/java/tc/oc/pgm/crafting/CraftingModule.java
@@ -15,7 +15,7 @@ import org.bukkit.inventory.ShapelessRecipe;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
@@ -53,23 +53,13 @@ public class CraftingModule implements MapModule<CraftingMatchModule> {
         }
 
         for (Element elRecipe : XMLUtils.getChildren(elCrafting, "shapeless", "shaped", "smelt")) {
-          Recipe recipe;
-          switch (elRecipe.getName()) {
-            case "shapeless":
-              recipe = parseShapelessRecipe(factory, elRecipe);
-              break;
-
-            case "shaped":
-              recipe = parseShapedRecipe(factory, elRecipe);
-              break;
-
-            case "smelt":
-              recipe = parseSmeltingRecipe(factory, elRecipe);
-              break;
-
-            default:
-              throw new IllegalStateException();
-          }
+          Recipe recipe =
+              switch (elRecipe.getName()) {
+                case "shapeless" -> parseShapelessRecipe(factory, elRecipe);
+                case "shaped" -> parseShapedRecipe(factory, elRecipe);
+                case "smelt" -> parseSmeltingRecipe(factory, elRecipe);
+                default -> throw new IllegalStateException();
+              };
 
           customRecipes.add(recipe);
           if (XMLUtils.parseBoolean(elRecipe.getAttribute("override"), false)) {
@@ -132,7 +122,7 @@ public class CraftingModule implements MapModule<CraftingMatchModule> {
             throw new InvalidXMLException(
                 "Shape must have no more than 3 columns (" + row + ")", elShape);
           }
-        } else if (row.length() != rows.get(0).length()) {
+        } else if (row.length() != rows.getFirst().length()) {
           throw new InvalidXMLException("All rows must be the same width", elShape);
         }
 
@@ -143,7 +133,7 @@ public class CraftingModule implements MapModule<CraftingMatchModule> {
         throw new InvalidXMLException("Shape must have at least one row", elShape);
       }
 
-      recipe.shape(rows.toArray(new String[rows.size()]));
+      recipe.shape(rows.toArray(new String[0]));
       Set<Character> keys = recipe
           .getIngredientMap()
           .keySet(); // All shape symbols are present and mapped to null at this point

--- a/core/src/main/java/tc/oc/pgm/damage/DamageMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/damage/DamageMatchModule.java
@@ -23,7 +23,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.vehicle.VehicleDamageEvent;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.action.Action;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.DamageQuery;
@@ -76,8 +76,7 @@ public class DamageMatchModule implements MatchModule, Listener {
    */
   public static boolean isAllowedSelfDamage(DamageInfo damageInfo) {
     // Disable self-damage with arrows
-    if (damageInfo instanceof ProjectileInfo) {
-      ProjectileInfo projectileInfo = (ProjectileInfo) damageInfo;
+    if (damageInfo instanceof ProjectileInfo projectileInfo) {
       if (projectileInfo.getProjectile() instanceof EntityInfo
           && ((EntityInfo) projectileInfo.getProjectile()).getEntityType() == EntityType.ARROW) {
         return false;
@@ -145,16 +144,14 @@ public class DamageMatchModule implements MatchModule, Listener {
 
   /** Query whether the given damage is both allowed and incentivized for the attacker. */
   public Filter.QueryResponse queryHostile(ParticipantState victim, DamageInfo damageInfo) {
-    switch (PlayerRelation.get(victim, damageInfo.getAttacker())) {
-      case SELF:
-      case ALLY:
+    return switch (PlayerRelation.get(victim, damageInfo.getAttacker())) {
+      case SELF, ALLY ->
         // Players don't want to hurt themselves or their teammates
-        return Filter.QueryResponse.DENY;
-
-      default:
+        Filter.QueryResponse.DENY;
+      default ->
         // They also don't want to waste time trying to inflict damage that will be filtered out
-        return queryRules(null, victim, damageInfo);
-    }
+        queryRules(null, victim, damageInfo);
+    };
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
+++ b/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
@@ -6,7 +6,6 @@ import com.google.common.cache.LoadingCache;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
-import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.map.MapActivity;
 import tc.oc.pgm.api.map.MapData;
@@ -26,30 +25,13 @@ public class CacheDatastore implements Datastore {
 
   public CacheDatastore(Datastore datastore) {
     this.datastore = datastore;
-    this.usernames = CacheBuilder.newBuilder().softValues().build(new CacheLoader<>() {
-      @Override
-      public Username load(@NonNull UUID id) {
-        return datastore.getUsername(id);
-      }
-    });
-    this.settings = CacheBuilder.newBuilder().build(new CacheLoader<>() {
-      @Override
-      public Settings load(@NonNull UUID id) {
-        return datastore.getSettings(id);
-      }
-    });
-    this.skins = CacheBuilder.newBuilder().build(new CacheLoader<>() {
-      @Override
-      public Skin load(@NonNull UUID id) {
-        return datastore.getSkin(id);
-      }
-    });
-    this.activities = CacheBuilder.newBuilder().build(new CacheLoader<>() {
-      @Override
-      public MapActivity load(@NonNull String name) {
-        return datastore.getMapActivity(name);
-      }
-    });
+    this.usernames =
+        CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getUsername));
+    this.settings =
+        CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getSettings));
+    this.skins = CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getSkin));
+    this.activities =
+        CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getMapActivity));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
+++ b/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
@@ -25,13 +25,10 @@ public class CacheDatastore implements Datastore {
 
   public CacheDatastore(Datastore datastore) {
     this.datastore = datastore;
-    this.usernames =
-        CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getUsername));
-    this.settings =
-        CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getSettings));
-    this.skins = CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getSkin));
-    this.activities =
-        CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getMapActivity));
+    this.usernames = CacheBuilder.newBuilder().build(CacheLoader.from(datastore::getUsername));
+    this.settings = CacheBuilder.newBuilder().build(CacheLoader.from(datastore::getSettings));
+    this.skins = CacheBuilder.newBuilder().build(CacheLoader.from(datastore::getSkin));
+    this.activities = CacheBuilder.newBuilder().build(CacheLoader.from(datastore::getMapActivity));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
+++ b/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
@@ -6,6 +6,7 @@ import com.google.common.cache.LoadingCache;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.map.MapActivity;
 import tc.oc.pgm.api.map.MapData;
@@ -25,29 +26,27 @@ public class CacheDatastore implements Datastore {
 
   public CacheDatastore(Datastore datastore) {
     this.datastore = datastore;
-    this.usernames = CacheBuilder.newBuilder()
-        .softValues()
-        .build(new CacheLoader<UUID, Username>() {
-          @Override
-          public Username load(UUID id) {
-            return datastore.getUsername(id);
-          }
-        });
-    this.settings = CacheBuilder.newBuilder().build(new CacheLoader<UUID, Settings>() {
+    this.usernames = CacheBuilder.newBuilder().softValues().build(new CacheLoader<>() {
       @Override
-      public Settings load(UUID id) {
+      public Username load(@NonNull UUID id) {
+        return datastore.getUsername(id);
+      }
+    });
+    this.settings = CacheBuilder.newBuilder().build(new CacheLoader<>() {
+      @Override
+      public Settings load(@NonNull UUID id) {
         return datastore.getSettings(id);
       }
     });
-    this.skins = CacheBuilder.newBuilder().build(new CacheLoader<UUID, Skin>() {
+    this.skins = CacheBuilder.newBuilder().build(new CacheLoader<>() {
       @Override
-      public Skin load(UUID id) {
+      public Skin load(@NonNull UUID id) {
         return datastore.getSkin(id);
       }
     });
-    this.activities = CacheBuilder.newBuilder().build(new CacheLoader<String, MapActivity>() {
+    this.activities = CacheBuilder.newBuilder().build(new CacheLoader<>() {
       @Override
-      public MapActivity load(String name) {
+      public MapActivity load(@NonNull String name) {
         return datastore.getMapActivity(name);
       }
     });

--- a/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
+++ b/core/src/main/java/tc/oc/pgm/db/CacheDatastore.java
@@ -25,7 +25,8 @@ public class CacheDatastore implements Datastore {
 
   public CacheDatastore(Datastore datastore) {
     this.datastore = datastore;
-    this.usernames = CacheBuilder.newBuilder().build(CacheLoader.from(datastore::getUsername));
+    this.usernames =
+        CacheBuilder.newBuilder().softValues().build(CacheLoader.from(datastore::getUsername));
     this.settings = CacheBuilder.newBuilder().build(CacheLoader.from(datastore::getSettings));
     this.skins = CacheBuilder.newBuilder().build(CacheLoader.from(datastore::getSkin));
     this.activities = CacheBuilder.newBuilder().build(CacheLoader.from(datastore::getMapActivity));

--- a/core/src/main/java/tc/oc/pgm/db/SqlUsernameResolver.java
+++ b/core/src/main/java/tc/oc/pgm/db/SqlUsernameResolver.java
@@ -38,14 +38,8 @@ public class SqlUsernameResolver extends AbstractBatchingUsernameResolver {
     CompletableFuture.allOf(futures).join();
   }
 
-  private static class SingleSelect implements ThreadSafeConnection.Query {
-    private final UUID uuid;
-    private final CompletableFuture<UsernameResponse> future;
-
-    public SingleSelect(UUID uuid, CompletableFuture<UsernameResponse> future) {
-      this.uuid = uuid;
-      this.future = future;
-    }
+  private record SingleSelect(UUID uuid, CompletableFuture<UsernameResponse> future)
+      implements ThreadSafeConnection.Query {
 
     @Override
     public String getFormat() {
@@ -69,14 +63,8 @@ public class SqlUsernameResolver extends AbstractBatchingUsernameResolver {
     }
   }
 
-  private static class BatchSelect implements ThreadSafeConnection.Query {
-    private final List<UUID> uuids;
-    private final BiConsumer<UUID, UsernameResponse> completion;
-
-    public BatchSelect(List<UUID> uuids, BiConsumer<UUID, UsernameResponse> completion) {
-      this.uuids = uuids;
-      this.completion = completion;
-    }
+  private record BatchSelect(List<UUID> uuids, BiConsumer<UUID, UsernameResponse> completion)
+      implements ThreadSafeConnection.Query {
 
     @Override
     public String getFormat() {

--- a/core/src/main/java/tc/oc/pgm/death/DeathMessageMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/death/DeathMessageMatchModule.java
@@ -50,10 +50,10 @@ public class DeathMessageMatchModule implements MatchModule, Listener {
       boolean show = involved
           || isStaff
           || switch (viewer.getSettings().getValue(SettingKey.DEATH)) {
-            case DEATH_OWN -> false;
             case DEATH_FRIENDS -> isFriendInvolved(viewer.getBukkit(), event);
-            case DEATH_SQUAD -> isFriendInvolved(viewer.getBukkit(), event)
-                || isSquadInvolved(viewer.getBukkit(), event);
+            case DEATH_SQUAD ->
+              isFriendInvolved(viewer.getBukkit(), event)
+                  || isSquadInvolved(viewer.getBukkit(), event);
             case DEATH_ALL -> true;
             default -> false;
           };

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -26,8 +26,8 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Firework;
 import org.bukkit.util.BlockVector;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
@@ -129,7 +129,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
 
   // Remove @Nullable
   @Override
-  public @NotNull Team getOwner() {
+  public @NonNull Team getOwner() {
     Team owner = super.getOwner();
     if (owner == null) {
       throw new IllegalStateException("destroyable " + getId() + " has no owner");
@@ -403,7 +403,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
       if (player != null && player.getParty() == this.getOwner()) {
         return "objective.damageOwn";
       }
-    } else if (deltaHealth > 0) {
+    } else {
       // Repair
       if (player != null && player.getParty() != this.getOwner()) {
         return "objective.repairOther";
@@ -486,7 +486,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return StringUtils.percentage(this.getCompletion());
   }
 
-  @NotNull
+  @NonNull
   @Override
   public String renderPreciseCompletion() {
     return this.getBreaks() + "/" + this.getBreaksRequired();
@@ -537,11 +537,11 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     return this.isDestroyed() && this.canComplete(team);
   }
 
-  public @NotNull List<DestroyableHealthChange> getEvents() {
+  public @NonNull List<DestroyableHealthChange> getEvents() {
     return ImmutableList.copyOf(this.events);
   }
 
-  public @NotNull ImmutableList<DestroyableContribution> getContributions() {
+  public @NonNull ImmutableList<DestroyableContribution> getContributions() {
     if (this.contributions != null) {
       return this.contributions;
     }

--- a/core/src/main/java/tc/oc/pgm/enderchest/DropoffFallback.java
+++ b/core/src/main/java/tc/oc/pgm/enderchest/DropoffFallback.java
@@ -4,5 +4,5 @@ package tc.oc.pgm.enderchest;
 public enum DropoffFallback {
   KEEP,
   DELETE,
-  AUTO;
+  AUTO
 }

--- a/core/src/main/java/tc/oc/pgm/enderchest/EnderChestMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/enderchest/EnderChestMatchModule.java
@@ -46,7 +46,6 @@ public class EnderChestMatchModule implements MatchModule, Listener {
   @EventHandler
   public void onParticipantLeave(PlayerPartyChangeEvent event) {
     if (!isEnabled()) return;
-    if (dropoffs.isEmpty()) return;
     Party oldParty = event.getOldParty();
     if (!(oldParty instanceof Competitor)) return;
 
@@ -62,8 +61,17 @@ public class EnderChestMatchModule implements MatchModule, Listener {
     }
 
     if (!dropped) {
-      if (fallback == DropoffFallback.DELETE) {
-        enderchest.clear();
+      switch (fallback) {
+        case AUTO:
+          if (dropoffs.isEmpty()) {
+            enderchest.clear();
+          }
+          break;
+        case DELETE:
+          enderchest.clear();
+          break;
+        default:
+          break;
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/enderchest/EnderChestMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/enderchest/EnderChestMatchModule.java
@@ -62,17 +62,8 @@ public class EnderChestMatchModule implements MatchModule, Listener {
     }
 
     if (!dropped) {
-      switch (fallback) {
-        case AUTO:
-          if (dropoffs.isEmpty()) {
-            enderchest.clear();
-          }
-          break;
-        case DELETE:
-          enderchest.clear();
-          break;
-        default:
-          break;
+      if (fallback == DropoffFallback.DELETE) {
+        enderchest.clear();
       }
     }
   }

--- a/core/src/main/java/tc/oc/pgm/events/FeatureChangeEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/FeatureChangeEvent.java
@@ -6,14 +6,14 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.event.MatchEvent;
 
 public class FeatureChangeEvent extends MatchEvent {
-  private final Feature feature;
+  private final Feature<?> feature;
 
-  public FeatureChangeEvent(Match match, Feature feature) {
+  public FeatureChangeEvent(Match match, Feature<?> feature) {
     super(match);
     this.feature = feature;
   }
 
-  public Feature getFeature() {
+  public Feature<?> getFeature() {
     return feature;
   }
 

--- a/core/src/main/java/tc/oc/pgm/events/MapPoolAdjustEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/MapPoolAdjustEvent.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.rotation.pools.MapPool;
 
@@ -53,11 +53,11 @@ public class MapPoolAdjustEvent extends Event {
     return forced;
   }
 
-  public CommandSender getSender() {
+  public @Nullable CommandSender getSender() {
     return sender;
   }
 
-  public Duration getTimeLimit() {
+  public @Nullable Duration getTimeLimit() {
     return timeLimit;
   }
 

--- a/core/src/main/java/tc/oc/pgm/events/PlayerJoinMatchEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerJoinMatchEvent.java
@@ -22,7 +22,7 @@ import tc.oc.pgm.join.JoinRequest;
  */
 public class PlayerJoinMatchEvent extends PlayerJoinPartyEvent {
 
-  private List<Component> extraLines = Lists.newArrayList();
+  private final List<Component> extraLines = Lists.newArrayList();
 
   public PlayerJoinMatchEvent(MatchPlayer player, Party newParty, JoinRequest request) {
     super(player, null, assertNotNull(newParty), request);

--- a/core/src/main/java/tc/oc/pgm/events/PlayerLeavePartyEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerLeavePartyEvent.java
@@ -16,7 +16,7 @@ public class PlayerLeavePartyEvent extends PlayerPartyChangeEventBase {
     return oldParty;
   }
 
-  private static HandlerList handlers = new HandlerList();
+  private static final HandlerList handlers = new HandlerList();
 
   @Override
   public HandlerList getHandlers() {

--- a/core/src/main/java/tc/oc/pgm/fallingblocks/FallingBlocksMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/fallingblocks/FallingBlocksMatchModule.java
@@ -19,7 +19,7 @@ import org.bukkit.entity.FallingBlock;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -287,7 +287,6 @@ public class FallingBlocksMatchModule implements MatchModule, Listener, Tickable
         this.blockDisturbersByTick.put(tick, blockDisturbers);
       }
 
-      Block block = blockState.getBlock();
       if (!blockDisturbers.containsKey(pos)) {
         blockDisturbers.put(pos, disturber);
       }

--- a/core/src/main/java/tc/oc/pgm/fallingblocks/FallingBlocksRule.java
+++ b/core/src/main/java/tc/oc/pgm/fallingblocks/FallingBlocksRule.java
@@ -3,7 +3,7 @@ package tc.oc.pgm.fallingblocks;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.filters.query.BlockQuery;
 import tc.oc.pgm.util.material.Materials;
@@ -26,14 +26,11 @@ public class FallingBlocksRule {
   }
 
   public boolean canFall(BlockState block) {
-    switch (this.fall.query(new BlockQuery(block))) {
-      case ALLOW:
-        return true;
-      case DENY:
-        return false;
-      default:
-        return block.getType().hasGravity();
-    }
+    return switch (this.fall.query(new BlockQuery(block))) {
+      case ALLOW -> true;
+      case DENY -> false;
+      default -> block.getType().hasGravity();
+    };
   }
 
   public boolean canSupport(BlockState supporter) {

--- a/core/src/main/java/tc/oc/pgm/features/XMLFeatureReference.java
+++ b/core/src/main/java/tc/oc/pgm/features/XMLFeatureReference.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.features;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -26,7 +27,7 @@ public class XMLFeatureReference<T extends FeatureDefinition> implements Feature
   }
 
   public XMLFeatureReference(
-      FeatureDefinitionContext context, Node node, @Nullable String id, Class<T> type) {
+      FeatureDefinitionContext context, @NonNull Node node, @Nullable String id, Class<T> type) {
     this.context = context;
     this.node = node;
     this.id = id != null ? id : node.getValueNormalize();

--- a/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/filters/FilterMatchModule.java
@@ -91,7 +91,7 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
    * Create the FilterMatchModule
    *
    * @param match the match this module exists in
-   * @param filterContext the context where all {@link Filters} for the relevant match can be found.
+   * @param filterContext the context where all {@link Filter} for the relevant match can be found.
    *     Important to find {@link ReactorFactory}s
    */
   public FilterMatchModule(Match match, ContextStore<? super Filter> filterContext) {
@@ -422,18 +422,19 @@ public class FilterMatchModule implements MatchModule, FilterDispatcher, Tickabl
         result = (l, e) -> {
           try {
             final Object o = handle.invoke(e);
-            if (o instanceof Player) {
-              MatchPlayer mp = this.match.getPlayer((Player) o);
-              if (mp != null) invalidate(mp);
-              else match.getLogger().warning("MatchPlayer not found for player " + o);
-            } else if (o instanceof Filterable) {
-              this.invalidate((Filterable<?>) o);
-            } else if (o instanceof Entity) {
-              // No-op, non-player entities can be returned from events and should just be ignored
-              match.getLogger().finer("Non-player entity was filtered " + o.getClass());
-            } else {
-              throw new IllegalStateException(
-                  "A cached MethodHandle returned a non-expected type. Was: " + o.getClass());
+            switch (o) {
+              case Player player -> {
+                MatchPlayer mp = this.match.getPlayer(player);
+                if (mp != null) invalidate(mp);
+                else match.getLogger().warning("MatchPlayer not found for player " + player);
+              }
+              case Filterable<?> filterable -> this.invalidate(filterable);
+              case Entity entity ->
+                // No-op, non-player entities can be returned from events and should just be ignored
+                match.getLogger().finer("Non-player entity was filtered " + entity.getClass());
+              default ->
+                throw new IllegalStateException(
+                    "A cached MethodHandle returned a non-expected type. Was: " + o.getClass());
             }
           } catch (Throwable t) {
             match.getLogger().log(Level.SEVERE, "Error extracting Filterable for " + e, t);

--- a/core/src/main/java/tc/oc/pgm/filters/operator/AllowFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/AllowFilter.java
@@ -20,9 +20,9 @@ public class AllowFilter extends SingleFilterFunction {
 
   @Override
   public QueryResponse query(Query query) {
-    if (filter.query(query) == QueryResponse.ALLOW) {
-      return QueryResponse.ALLOW;
-    }
-    return QueryResponse.ABSTAIN;
+    return switch (filter.query(query)) {
+      case ALLOW -> QueryResponse.ALLOW;
+      default -> QueryResponse.ABSTAIN;
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/AllowFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/AllowFilter.java
@@ -20,11 +20,9 @@ public class AllowFilter extends SingleFilterFunction {
 
   @Override
   public QueryResponse query(Query query) {
-    switch (filter.query(query)) {
-      case ALLOW:
-        return QueryResponse.ALLOW;
-      default:
-        return QueryResponse.ABSTAIN;
+    if (filter.query(query) == QueryResponse.ALLOW) {
+      return QueryResponse.ALLOW;
     }
+    return QueryResponse.ABSTAIN;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/DenyFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/DenyFilter.java
@@ -18,9 +18,9 @@ public class DenyFilter extends SingleFilterFunction {
 
   @Override
   public QueryResponse query(Query query) {
-    if (filter.query(query) == QueryResponse.ALLOW) {
-      return QueryResponse.DENY;
-    }
-    return QueryResponse.ABSTAIN;
+    return switch (filter.query(query)) {
+      case ALLOW -> QueryResponse.DENY;
+      default -> QueryResponse.ABSTAIN;
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/DenyFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/DenyFilter.java
@@ -18,11 +18,9 @@ public class DenyFilter extends SingleFilterFunction {
 
   @Override
   public QueryResponse query(Query query) {
-    switch (filter.query(query)) {
-      case ALLOW:
-        return QueryResponse.DENY;
-      default:
-        return QueryResponse.ABSTAIN;
+    if (filter.query(query) == QueryResponse.ALLOW) {
+      return QueryResponse.DENY;
     }
+    return QueryResponse.ABSTAIN;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/FilterNode.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/FilterNode.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.filters.operator;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.FilterDefinition;
@@ -58,12 +57,10 @@ public class FilterNode implements FilterDefinition {
   }
 
   public static FilterNode allow(Filter child) {
-    return new FilterNode(
-        Collections.emptyList(), Collections.singletonList(child), Collections.emptyList());
+    return new FilterNode(List.of(), List.of(child), List.of());
   }
 
   public static FilterNode deny(Filter child) {
-    return new FilterNode(
-        Collections.emptyList(), Collections.emptyList(), Collections.singletonList(child));
+    return new FilterNode(List.of(), List.of(), List.of(child));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/FilterNode.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/FilterNode.java
@@ -59,15 +59,11 @@ public class FilterNode implements FilterDefinition {
 
   public static FilterNode allow(Filter child) {
     return new FilterNode(
-        Collections.<Filter>emptyList(),
-        Collections.singletonList(child),
-        Collections.<Filter>emptyList());
+        Collections.emptyList(), Collections.singletonList(child), Collections.emptyList());
   }
 
   public static FilterNode deny(Filter child) {
     return new FilterNode(
-        Collections.<Filter>emptyList(),
-        Collections.<Filter>emptyList(),
-        Collections.singletonList(child));
+        Collections.emptyList(), Collections.emptyList(), Collections.singletonList(child));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/operator/InverseFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/InverseFilter.java
@@ -12,13 +12,10 @@ public class InverseFilter extends SingleFilterFunction {
 
   @Override
   public QueryResponse query(Query query) {
-    switch (this.filter.query(query)) {
-      case ALLOW:
-        return QueryResponse.DENY;
-      case DENY:
-        return QueryResponse.ALLOW;
-      default:
-        return QueryResponse.ABSTAIN;
-    }
+    return switch (this.filter.query(query)) {
+      case ALLOW -> QueryResponse.DENY;
+      case DENY -> QueryResponse.ALLOW;
+      default -> QueryResponse.ABSTAIN;
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
@@ -69,7 +69,7 @@ public class LegacyFilterParser extends FilterParser {
   }
 
   protected List<Filter> parseParents(Element el) throws InvalidXMLException {
-    List<Filter> parents = new ArrayList<Filter>();
+    List<Filter> parents = new ArrayList<>();
     if (el.getAttribute("parents") == null) {
       return parents;
     }

--- a/core/src/main/java/tc/oc/pgm/filters/query/EntityQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/EntityQuery.java
@@ -7,7 +7,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 
@@ -50,10 +50,8 @@ public class EntityQuery extends Query implements tc.oc.pgm.api.filter.query.Ent
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof EntityQuery)) return false;
-    EntityQuery query = (EntityQuery) o;
-    if (!entity.equals(query.entity)) return false;
-    return true;
+    if (!(o instanceof EntityQuery query)) return false;
+    return entity.equals(query.entity);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/query/EntitySpawnQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/EntitySpawnQuery.java
@@ -5,7 +5,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class EntitySpawnQuery extends EntityQuery
     implements tc.oc.pgm.api.filter.query.EntitySpawnQuery {
@@ -26,11 +26,9 @@ public class EntitySpawnQuery extends EntityQuery
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof EntitySpawnQuery)) return false;
+    if (!(o instanceof EntitySpawnQuery query)) return false;
     if (!super.equals(o)) return false;
-    EntitySpawnQuery query = (EntitySpawnQuery) o;
-    if (spawnReason != query.spawnReason) return false;
-    return true;
+    return spawnReason == query.spawnReason;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/query/MatchQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/MatchQuery.java
@@ -3,7 +3,7 @@ package tc.oc.pgm.filters.query;
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 
 public class MatchQuery extends Query implements tc.oc.pgm.api.filter.query.MatchQuery {
@@ -23,10 +23,8 @@ public class MatchQuery extends Query implements tc.oc.pgm.api.filter.query.Matc
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof MatchQuery)) return false;
-    MatchQuery query = (MatchQuery) o;
-    if (!match.equals(query.match)) return false;
-    return true;
+    if (!(o instanceof MatchQuery query)) return false;
+    return match.equals(query.match);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/query/MaterialQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/MaterialQuery.java
@@ -5,7 +5,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import java.util.HashMap;
 import java.util.Map;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.util.material.MaterialData;
 
 public class MaterialQuery extends Query implements tc.oc.pgm.api.filter.query.MaterialQuery {
@@ -26,10 +26,8 @@ public class MaterialQuery extends Query implements tc.oc.pgm.api.filter.query.M
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof MaterialQuery)) return false;
-    MaterialQuery query = (MaterialQuery) o;
-    if (!material.equals(query.material)) return false;
-    return true;
+    if (!(o instanceof MaterialQuery query)) return false;
+    return material.equals(query.material);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/query/PartyQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/PartyQuery.java
@@ -3,7 +3,7 @@ package tc.oc.pgm.filters.query;
 import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
 
@@ -29,10 +29,8 @@ public class PartyQuery extends Query implements tc.oc.pgm.api.filter.query.Part
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PartyQuery)) return false;
-    PartyQuery query = (PartyQuery) o;
-    if (!party.equals(query.party)) return false;
-    return true;
+    if (!(o instanceof PartyQuery query)) return false;
+    return party.equals(query.party);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/filters/query/PlayerQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/PlayerQuery.java
@@ -9,7 +9,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.PlayerInventory;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -75,8 +75,7 @@ public class PlayerQuery extends Query implements tc.oc.pgm.api.filter.query.Pla
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PlayerQuery)) return false;
-    PlayerQuery query = (PlayerQuery) o;
+    if (!(o instanceof PlayerQuery query)) return false;
     return Objects.equals(player, query.player);
   }
 

--- a/core/src/main/java/tc/oc/pgm/filters/query/PlayerStateQuery.java
+++ b/core/src/main/java/tc/oc/pgm/filters/query/PlayerStateQuery.java
@@ -8,7 +8,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.Inventory;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
@@ -67,10 +67,8 @@ public class PlayerStateQuery extends Query implements PlayerQuery {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PlayerStateQuery)) return false;
-    PlayerStateQuery query = (PlayerStateQuery) o;
-    if (!playerState.equals(query.playerState)) return false;
-    return true;
+    if (!(o instanceof PlayerStateQuery query)) return false;
+    return playerState.equals(query.playerState);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/flag/post/CompositePost.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/CompositePost.java
@@ -1,7 +1,7 @@
 package tc.oc.pgm.flag.post;
 
 import com.google.common.collect.ImmutableList;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 
 public class CompositePost extends PostDefinition {
@@ -19,7 +19,7 @@ public class CompositePost extends PostDefinition {
 
     this.sequential = sequential;
     this.posts = posts;
-    this.fallback = fallback != null ? fallback : posts.get(0);
+    this.fallback = fallback != null ? fallback : posts.getFirst();
   }
 
   public boolean isSequential() {

--- a/core/src/main/java/tc/oc/pgm/flag/post/RandomOrderPostResolver.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/RandomOrderPostResolver.java
@@ -40,8 +40,9 @@ public class RandomOrderPostResolver implements PostResolver {
   }
 
   private SinglePost findNext(Flag flag) {
-    GoalQuery query = new GoalQuery(flag);
-    if (next != null && next.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) return next;
+    GoalQuery<?> query = new GoalQuery<>(flag);
+    if (next != null && next.getRespawnFilter().query(new GoalQuery<>(flag)).isAllowed())
+      return next;
 
     Collections.shuffle(posts);
     for (SinglePost post : posts) {

--- a/core/src/main/java/tc/oc/pgm/flag/post/SequentialPostResolver.java
+++ b/core/src/main/java/tc/oc/pgm/flag/post/SequentialPostResolver.java
@@ -12,7 +12,7 @@ public class SequentialPostResolver implements PostResolver {
   public SequentialPostResolver(ImmutableList<SinglePost> posts, SinglePost fallback) {
     this.posts = posts;
     this.fallback = fallback;
-    this.currentIdx = posts.get(0) == fallback ? 0 : -1;
+    this.currentIdx = posts.getFirst() == fallback ? 0 : -1;
   }
 
   @Override
@@ -25,7 +25,7 @@ public class SequentialPostResolver implements PostResolver {
   public SinglePost peekNext(Flag flag) {
     for (int offset = 1; offset < posts.size(); offset++) {
       final SinglePost post = posts.get((currentIdx + offset) % posts.size());
-      if (post.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) return post;
+      if (post.getRespawnFilter().query(new GoalQuery<>(flag)).isAllowed()) return post;
     }
     return fallback;
   }
@@ -34,7 +34,7 @@ public class SequentialPostResolver implements PostResolver {
   public SinglePost getNext(Flag flag) {
     for (int offset = 1; offset < posts.size(); offset++) {
       final SinglePost post = posts.get((currentIdx + offset) % posts.size());
-      if (post.getRespawnFilter().query(new GoalQuery(flag)).isAllowed()) {
+      if (post.getRespawnFilter().query(new GoalQuery<>(flag)).isAllowed()) {
         this.currentIdx = (currentIdx + offset) % posts.size();
         return post;
       }

--- a/core/src/main/java/tc/oc/pgm/gamerules/GameRulesModule.java
+++ b/core/src/main/java/tc/oc/pgm/gamerules/GameRulesModule.java
@@ -17,7 +17,7 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 
 public class GameRulesModule implements MapModule<GameRulesMatchModule> {
 
-  private Map<String, String> gameRules;
+  private final Map<String, String> gameRules;
 
   private GameRulesModule(Map<String, String> gamerules) {
     this.gameRules = gamerules;

--- a/core/src/main/java/tc/oc/pgm/goals/Goal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/Goal.java
@@ -6,7 +6,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.feature.Feature;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.match.Match;
@@ -34,13 +34,13 @@ public interface Goal<T extends GoalDefinition> extends Feature<T> {
   boolean isCompleted(Competitor team);
 
   default boolean isCompleted(Optional<? extends Competitor> competitor) {
-    return competitor.isPresent() ? isCompleted(competitor.get()) : isCompleted();
+    return competitor.map(this::isCompleted).orElseGet(this::isCompleted);
   }
 
   /**
    * Returns true if this goal can be completed by multiple teams (e.g. a capture point). Currently,
-   * this affects how the goal is displayed on the scoreboard, and how it interacts with {@link
-   * GoalFilter}.
+   * this affects how the goal is displayed on the scoreboard, and how it interacts with
+   * {@link GoalFilter}.
    */
   boolean isShared();
 

--- a/core/src/main/java/tc/oc/pgm/goals/GoalMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/goals/GoalMatchModule.java
@@ -52,32 +52,32 @@ public class GoalMatchModule implements MatchModule, Listener {
   }
 
   protected final Match match;
-  protected final List<Goal> goals = new ArrayList<>();
-  protected final Multimap<Competitor, Goal> goalsByCompetitor = ArrayListMultimap.create();
-  protected final Multimap<Goal, Competitor> competitorsByGoal = HashMultimap.create();
+  protected final List<Goal<?>> goals = new ArrayList<>();
+  protected final Multimap<Competitor, Goal<?>> goalsByCompetitor = ArrayListMultimap.create();
+  protected final Multimap<Goal<?>, Competitor> competitorsByGoal = HashMultimap.create();
   protected final Map<Competitor, GoalProgress> progressByCompetitor = new HashMap<>();
 
   private GoalMatchModule(Match match) {
     this.match = match;
   }
 
-  public Collection<Goal> getGoals() {
+  public Collection<Goal<?>> getGoals() {
     return Collections.unmodifiableCollection(goals);
   }
 
-  public Collection<Goal> getGoals(Competitor competitor) {
+  public Collection<Goal<?>> getGoals(Competitor competitor) {
     return Collections.unmodifiableCollection(goalsByCompetitor.get(competitor));
   }
 
-  public Collection<Competitor> getCompetitors(Goal goal) {
+  public Collection<Competitor> getCompetitors(Goal<?> goal) {
     return competitorsByGoal.get(goal);
   }
 
-  public Multimap<Competitor, Goal> getGoalsByCompetitor() {
+  public Multimap<Competitor, Goal<?>> getGoalsByCompetitor() {
     return goalsByCompetitor;
   }
 
-  public Multimap<Goal, Competitor> getCompetitorsByGoal() {
+  public Multimap<Goal<?>, Competitor> getCompetitorsByGoal() {
     return competitorsByGoal;
   }
 
@@ -107,7 +107,7 @@ public class GoalMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onMatchLoad(MatchLoadEvent event) {
-    for (Goal goal : goals) {
+    for (Goal<?> goal : goals) {
       for (Competitor competitor : match.getCompetitors()) {
         addCompetitorGoal(competitor, goal);
       }
@@ -118,7 +118,7 @@ public class GoalMatchModule implements MatchModule, Listener {
   public void onCompetitorAdd(CompetitorAddEvent event) {
     match.getLogger().fine("Competitor added " + event.getCompetitor());
 
-    for (Goal goal : goals) {
+    for (Goal<?> goal : goals) {
       addCompetitorGoal(event.getCompetitor(), goal);
     }
   }
@@ -126,15 +126,15 @@ public class GoalMatchModule implements MatchModule, Listener {
   @EventHandler
   public void onCompetitorRemove(CompetitorRemoveEvent event) {
     goalsByCompetitor.removeAll(event.getCompetitor());
-    for (Goal goal : ImmutableSet.copyOf(competitorsByGoal.keySet())) {
+    for (Goal<?> goal : ImmutableSet.copyOf(competitorsByGoal.keySet())) {
       competitorsByGoal.remove(goal, event.getCompetitor());
     }
   }
 
   @SuppressWarnings("unchecked")
-  public <T extends Goal> Multimap<Competitor, T> getGoals(Class<T> filterClass) {
+  public <T extends Goal<?>> Multimap<Competitor, T> getGoals(Class<T> filterClass) {
     Multimap<Competitor, T> filteredGoals = ArrayListMultimap.create();
-    for (Entry<Competitor, Goal> entry : this.goalsByCompetitor.entries()) {
+    for (Entry<Competitor, Goal<?>> entry : this.goalsByCompetitor.entries()) {
       if (filterClass.isInstance(entry.getValue())) {
         filteredGoals.put(entry.getKey(), (T) entry.getValue());
       }

--- a/core/src/main/java/tc/oc/pgm/goals/GoalProgress.java
+++ b/core/src/main/java/tc/oc/pgm/goals/GoalProgress.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
 
@@ -82,9 +82,9 @@ public class GoalProgress implements Comparable<GoalProgress> {
         if (goal.isCompleted(competitor)) {
           completed++;
         } else {
-          if (goal instanceof ProximityGoal) {
-            ProximityGoal proximity = (ProximityGoal) goal;
-            TouchableGoal touchable = goal instanceof TouchableGoal ? (TouchableGoal) goal : null;
+          if (goal instanceof ProximityGoal<?> proximity) {
+            TouchableGoal<?> touchable =
+                goal instanceof TouchableGoal ? (TouchableGoal<?>) goal : null;
 
             if (touchable != null && touchable.hasTouched(competitor)) {
               touched++;
@@ -97,8 +97,7 @@ public class GoalProgress implements Comparable<GoalProgress> {
               }
             }
 
-            if (goal instanceof IncrementalGoal) {
-              IncrementalGoal incrementalGoal = (IncrementalGoal) goal;
+            if (goal instanceof IncrementalGoal<?> incrementalGoal) {
               progress.add(incrementalGoal.getCompletion());
             } else if (touchable != null && touchable.hasTouched(competitor)) {
               // A touched, non-incremental goal is worth 50% completion
@@ -109,7 +108,7 @@ public class GoalProgress implements Comparable<GoalProgress> {
       }
     }
 
-    Collections.sort(progress, Collections.reverseOrder());
+    progress.sort(Collections.reverseOrder());
     Collections.sort(completionProximity);
     Collections.sort(touchProximity);
 
@@ -121,7 +120,7 @@ public class GoalProgress implements Comparable<GoalProgress> {
   }
 
   @Override
-  public int compareTo(@NotNull GoalProgress that) {
+  public int compareTo(@NonNull GoalProgress that) {
     // This team has more completed goals, so they take the lead
     if (this.completed > that.completed) return -1;
     if (this.completed < that.completed) return 1;

--- a/core/src/main/java/tc/oc/pgm/goals/GoalsVictoryCondition.java
+++ b/core/src/main/java/tc/oc/pgm/goals/GoalsVictoryCondition.java
@@ -33,7 +33,7 @@ public class GoalsVictoryCondition implements VictoryCondition {
   public boolean isCompleted(Match match) {
     GoalMatchModule gmm = match.needModule(GoalMatchModule.class);
     competitors:
-    for (Map.Entry<Competitor, Collection<Goal>> entry :
+    for (Map.Entry<Competitor, Collection<Goal<?>>> entry :
         gmm.getGoalsByCompetitor().asMap().entrySet()) {
       boolean someRequired = false;
       for (Goal<?> goal : entry.getValue()) {

--- a/core/src/main/java/tc/oc/pgm/goals/ProximityMetric.java
+++ b/core/src/main/java/tc/oc/pgm/goals/ProximityMetric.java
@@ -1,13 +1,13 @@
 package tc.oc.pgm.goals;
 
 import org.jdom2.Element;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class ProximityMetric {
-  public static enum Type {
+  public enum Type {
     CLOSEST_PLAYER("closest player"),
     CLOSEST_BLOCK("closest block"),
     CLOSEST_KILL("closest kill"),
@@ -47,8 +47,7 @@ public class ProximityMetric {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ProximityMetric)) return false;
-    ProximityMetric that = (ProximityMetric) o;
+    if (!(o instanceof ProximityMetric that)) return false;
     return this.type == that.type && this.horizontal == that.horizontal;
   }
 
@@ -68,9 +67,8 @@ public class ProximityMetric {
       throws InvalidXMLException {
     if (!prefix.isEmpty()) prefix = prefix + "-";
 
-    ProximityMetric.Type type =
-        XMLUtils.parseEnum(
-            Node.fromAttr(el, prefix + "proximity-metric"), ProximityMetric.Type.class, def.type);
+    ProximityMetric.Type type = XMLUtils.parseEnum(
+        Node.fromAttr(el, prefix + "proximity-metric"), ProximityMetric.Type.class, def.type);
 
     // If proximity metric is none, use null proximity so that it doesn't try to get tracked nor
     // shows in the scoreboard

--- a/core/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/TouchableGoal.java
@@ -5,7 +5,6 @@ import static net.kyori.adventure.text.Component.translatable;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -13,7 +12,7 @@ import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.party.Competitor;
@@ -151,15 +150,8 @@ public abstract class TouchableGoal<T extends ProximityGoalDefinition> extends P
 
   public void resetTouches(Competitor team) {
     if (touchingCompetitors.remove(team)) {
-      for (Iterator<ParticipantState> iterator = touchingPlayers.iterator(); iterator.hasNext(); ) {
-        if (iterator.next().getParty() == team) iterator.remove();
-        ;
-      }
-      for (Iterator<ParticipantState> iterator = recentTouchingPlayers.iterator();
-          iterator.hasNext(); ) {
-        if (iterator.next().getParty() == team) iterator.remove();
-        ;
-      }
+      touchingPlayers.removeIf(participantState -> participantState.getParty() == team);
+      recentTouchingPlayers.removeIf(participantState -> participantState.getParty() == team);
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/goals/events/GoalCompleteEvent.java
+++ b/core/src/main/java/tc/oc/pgm/goals/events/GoalCompleteEvent.java
@@ -13,13 +13,13 @@ public class GoalCompleteEvent extends GoalEvent {
   private final boolean isGood;
   private final ImmutableList<? extends Contribution> contributions;
 
-  public GoalCompleteEvent(Match match, Goal goal, Competitor competitor, boolean isGood) {
-    this(match, goal, competitor, isGood, ImmutableList.<Contribution>of());
+  public GoalCompleteEvent(Match match, Goal<?> goal, Competitor competitor, boolean isGood) {
+    this(match, goal, competitor, isGood, ImmutableList.of());
   }
 
   public GoalCompleteEvent(
       Match match,
-      Goal goal,
+      Goal<?> goal,
       Competitor competitor,
       boolean isGood,
       List<? extends Contribution> contributions) {

--- a/core/src/main/java/tc/oc/pgm/goals/events/GoalEvent.java
+++ b/core/src/main/java/tc/oc/pgm/goals/events/GoalEvent.java
@@ -1,27 +1,29 @@
 package tc.oc.pgm.goals.events;
 
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.event.MatchEvent;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.goals.Goal;
 
 public abstract class GoalEvent extends MatchEvent {
-  private final Goal goal;
-  @Nullable private final Competitor competitor;
+  private final Goal<?> goal;
 
-  protected GoalEvent(Match match, Goal goal, @Nullable Competitor competitor) {
+  @Nullable
+  private final Competitor competitor;
+
+  protected GoalEvent(Match match, Goal<?> goal, @Nullable Competitor competitor) {
     super(match);
     this.goal = goal;
     this.competitor = competitor;
   }
 
-  protected GoalEvent(Goal goal, @Nullable Competitor competitor) {
+  protected GoalEvent(Goal<?> goal, @Nullable Competitor competitor) {
     this(goal.getMatch(), goal, competitor);
   }
 
-  public Goal getGoal() {
+  public Goal<?> getGoal() {
     return goal;
   }
 

--- a/core/src/main/java/tc/oc/pgm/goals/events/GoalProximityChangeEvent.java
+++ b/core/src/main/java/tc/oc/pgm/goals/events/GoalProximityChangeEvent.java
@@ -2,7 +2,7 @@ package tc.oc.pgm.goals.events;
 
 import org.bukkit.Location;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.goals.ProximityGoal;
 
@@ -12,7 +12,7 @@ public class GoalProximityChangeEvent extends GoalEvent {
   private final double newDistance;
 
   public GoalProximityChangeEvent(
-      ProximityGoal goal,
+      ProximityGoal<?> goal,
       Competitor team,
       @Nullable Location location,
       double oldDistance,

--- a/core/src/main/java/tc/oc/pgm/goals/events/GoalStatusChangeEvent.java
+++ b/core/src/main/java/tc/oc/pgm/goals/events/GoalStatusChangeEvent.java
@@ -1,18 +1,18 @@
 package tc.oc.pgm.goals.events;
 
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.goals.Goal;
 import tc.oc.pgm.teams.Team;
 
 public class GoalStatusChangeEvent extends GoalEvent {
 
-  public GoalStatusChangeEvent(Match match, Goal goal, @Nullable Team team) {
+  public GoalStatusChangeEvent(Match match, Goal<?> goal, @Nullable Team team) {
     super(match, goal, team);
   }
 
-  public GoalStatusChangeEvent(Match match, Goal goal) {
+  public GoalStatusChangeEvent(Match match, Goal<?> goal) {
     this(match, goal, null);
   }
 

--- a/core/src/main/java/tc/oc/pgm/goals/events/GoalTouchEvent.java
+++ b/core/src/main/java/tc/oc/pgm/goals/events/GoalTouchEvent.java
@@ -4,15 +4,15 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 
 import java.time.Instant;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.ParticipantState;
 import tc.oc.pgm.goals.TouchableGoal;
 
 /** Raised when a player touches a goal. */
 public class GoalTouchEvent extends GoalEvent {
-  private final TouchableGoal goal;
+  private final TouchableGoal<?> goal;
   private final @Nullable Competitor competitor;
   private final boolean firstForCompetitor;
   private final @Nullable ParticipantState player;
@@ -33,7 +33,7 @@ public class GoalTouchEvent extends GoalEvent {
    * @param time The time at which the touch occurred.
    */
   public GoalTouchEvent(
-      TouchableGoal goal,
+      TouchableGoal<?> goal,
       @Nullable Competitor competitor,
       boolean firstForCompetitor,
       @Nullable ParticipantState player,
@@ -51,7 +51,7 @@ public class GoalTouchEvent extends GoalEvent {
     this.time = assertNotNull(time, "Time");
   }
 
-  public GoalTouchEvent(TouchableGoal goal, Instant time) {
+  public GoalTouchEvent(TouchableGoal<?> goal, Instant time) {
     this(goal, null, false, null, false, false, time);
   }
 
@@ -60,7 +60,7 @@ public class GoalTouchEvent extends GoalEvent {
   }
 
   @Override
-  public @NotNull Competitor getCompetitor() { // remove @Nullable
+  public @NonNull Competitor getCompetitor() { // remove @Nullable
     //noinspection ConstantConditions
     return super.getCompetitor();
   }
@@ -82,7 +82,7 @@ public class GoalTouchEvent extends GoalEvent {
   }
 
   @Override
-  public TouchableGoal getGoal() {
+  public TouchableGoal<?> getGoal() {
     return this.goal;
   }
 

--- a/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
+++ b/core/src/main/java/tc/oc/pgm/integrations/SimpleVanishIntegration.java
@@ -50,15 +50,14 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
     this.vanishedPlayers = Lists.newArrayList();
     this.matchManager = matchManager;
     this.hotbarFlash = false;
-    this.hotbarTask =
-        tasks.scheduleAtFixedRate(
-            () -> {
-              getOnlineVanished().forEach(p -> sendHotbarVanish(p, hotbarFlash));
-              hotbarFlash = !hotbarFlash; // Toggle boolean so we get a nice flashing effect
-            },
-            0,
-            1,
-            TimeUnit.SECONDS);
+    this.hotbarTask = tasks.scheduleAtFixedRate(
+        () -> {
+          getOnlineVanished().forEach(p -> sendHotbarVanish(p, hotbarFlash));
+          hotbarFlash = !hotbarFlash; // Toggle boolean so we get a nice flashing effect
+        },
+        0,
+        1,
+        TimeUnit.SECONDS);
 
     // Register listener
     PGM.get().getServer().getPluginManager().registerEvents(this, PGM.get());
@@ -172,7 +171,7 @@ public class SimpleVanishIntegration implements VanishIntegration, Listener {
   public void onUnvanish(PlayerVanishEvent event) {
     // If player joined via "vanish" subdomain, but unvanishes while online
     // stop tracking them for auto-vanish removal
-    if (!event.isVanished() && tempVanish.contains(event.getPlayer().getId())) {
+    if (!event.isVanished()) {
       tempVanish.remove(event.getPlayer().getId());
     }
   }

--- a/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
@@ -147,8 +147,7 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void updateMonitoredClick(final InventoryClickEvent event) {
-    if (event.getWhoClicked() instanceof Player) {
-      Player player = (Player) event.getWhoClicked();
+    if (event.getWhoClicked() instanceof Player player) {
 
       boolean playerInventory =
           event.getInventory().getType() == InventoryType.CRAFTING; // cb bug fix
@@ -170,8 +169,7 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
         // this is how we determine if we have a match
         if (inventory.getViewers().isEmpty()
             || tracker.getWatched().getViewers().isEmpty()
-            || inventory.getViewers().size() > tracker.getWatched().getViewers().size())
-          continue invLoop;
+            || inventory.getViewers().size() > tracker.getWatched().getViewers().size()) continue;
 
         for (int i = 0; i < inventory.getViewers().size(); i++) {
           if (!inventory
@@ -232,8 +230,7 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void updateMonitoredHealth(final EntityRegainHealthEvent event) {
-    if (event.getEntity() instanceof Player) {
-      Player player = (Player) event.getEntity();
+    if (event.getEntity() instanceof Player player) {
       if (player.getHealth() == player.getMaxHealth()) return;
       this.scheduleCheck((Player) event.getEntity());
     }
@@ -379,7 +376,7 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
     }
 
     // potions
-    boolean hasPotions = holder.getActivePotionEffects().size() > 0;
+    boolean hasPotions = !holder.getActivePotionEffects().isEmpty();
     ItemStack potions = new ItemStack(hasPotions ? Material.POTION : Material.GLASS_BOTTLE);
     ItemMeta potionMeta = potions.getItemMeta();
     potionMeta.setDisplayName(ChatColor.AQUA.toString()

--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemRule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemRule.java
@@ -40,7 +40,7 @@ public class ItemRule {
       }
 
       Set<ItemFlag> flags = this.meta.getItemFlags();
-      meta.addItemFlags(flags.toArray(new ItemFlag[flags.size()]));
+      meta.addItemFlags(flags.toArray(new ItemFlag[0]));
 
       InventoryUtils.addEnchantments(meta, this.meta.getEnchants());
 

--- a/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/join/JoinMatchModule.java
@@ -8,7 +8,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
@@ -130,34 +130,34 @@ public class JoinMatchModule implements MatchModule, Listener, JoinHandler {
   }
 
   @Override
-  public boolean join(MatchPlayer joining, JoinRequest request, @NotNull JoinResult result) {
+  public boolean join(MatchPlayer joining, JoinRequest request, @NonNull JoinResult result) {
     if (result.isSuccess()) {
       requests.put(joining.getBukkit(), request);
     }
 
-    switch (result.getOption()) {
-      case QUEUED:
+    return switch (result.getOption()) {
+      case QUEUED -> {
         queueToJoin(joining);
-        return true;
-
-      case MATCH_STARTED:
+        yield true;
+      }
+      case MATCH_STARTED -> {
         joining.sendWarning(translatable("join.err.afterStart"));
-        return true;
-
-      case MATCH_FINISHED:
+        yield true;
+      }
+      case MATCH_FINISHED -> {
         joining.sendWarning(translatable("join.err.afterFinish"));
-        return true;
-
-      case NO_PERMISSION:
+        yield true;
+      }
+      case NO_PERMISSION -> {
         joining.sendWarning(translatable("join.err.noPermission"));
-        return true;
-
-      case VANISHED:
+        yield true;
+      }
+      case VANISHED -> {
         joining.sendWarning(translatable("join.err.vanish"));
-        return true;
-    }
-
-    return handler.join(joining, request, result);
+        yield true;
+      }
+      default -> handler.join(joining, request, result);
+    };
   }
 
   public boolean leave(MatchPlayer leaving, JoinRequest request) {

--- a/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
@@ -122,8 +122,7 @@ public class KitMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onGrenadeLaunch(final ProjectileLaunchEvent event) {
-    if (event.getEntity().getShooter() instanceof Player) {
-      Player player = (Player) event.getEntity().getShooter();
+    if (event.getEntity().getShooter() instanceof Player player) {
       ItemStack stack = player.getItemInHand();
 
       if (stack != null) {

--- a/core/src/main/java/tc/oc/pgm/kits/KitModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitModule.java
@@ -12,7 +12,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Document;
 import org.jdom2.Element;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.action.ActionModule;
 import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.api.filter.Filter;
@@ -108,8 +108,7 @@ public class KitModule implements MapModule<KitMatchModule> {
       }
 
       // Apply any item-mods rules to item kits
-      if (kit instanceof ItemKit) {
-        ItemKit itKit = (ItemKit) kit;
+      if (kit instanceof ItemKit itKit) {
         for (ItemStack is : Iterables.concat(itKit.getSlotItems().values(), itKit.getFreeItems())) {
           if (!hasTnt && is.getType() == Material.TNT && is.getAmount() >= 16) {
             hasTnt = true;

--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -21,7 +21,6 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.Event;
-import org.bukkit.event.EventException;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -50,7 +49,7 @@ import org.bukkit.material.Door;
 import org.bukkit.plugin.EventExecutor;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.match.Match;
@@ -99,49 +98,45 @@ public class BlockTransformListener implements Listener {
               method.getParameterTypes()[0].asSubclass(Event.class);
 
           for (final EventPriority priority : EventPriority.values()) {
-            EventExecutor executor = new EventExecutor() {
-              @Override
-              public void execute(Listener listener, Event event) throws EventException {
-                // REMOVED: Ignore the event if it was fron a non-Match world
-                // if (event instanceof Physical
-                //    && PGM.get().getMatchManager().getMatch(((Physical) event).getWorld())
-                // ==
-                // null)
-                //  return;
+            EventExecutor executor = (listener, event) -> {
+              // if (event instanceof Physical
+              //    && PGM.get().getMatchManager().getMatch(((Physical) event).getWorld())
+              // ==
+              // null)
+              //  return;
 
-                if (!Events.isCancelled(event)) {
-                  // At the first priority level, call the event handler method.
-                  // If it decides to generate a BlockTransformEvent, it will be stored in
-                  // currentEvents.
-                  if (priority == EventPriority.LOWEST) {
-                    if (eventClass.isInstance(event)) {
-                      try {
-                        method.invoke(listener, event);
-                      } catch (InvocationTargetException ex) {
-                        throw MISC_UTILS.createEventException(ex.getCause(), event);
-                      } catch (Throwable t) {
-                        throw MISC_UTILS.createEventException(t, event);
-                      }
+              if (!Events.isCancelled(event)) {
+                // At the first priority level, call the event handler method.
+                // If it decides to generate a BlockTransformEvent, it will be stored in
+                // currentEvents.
+                if (priority == EventPriority.LOWEST) {
+                  if (eventClass.isInstance(event)) {
+                    try {
+                      method.invoke(listener, event);
+                    } catch (InvocationTargetException ex) {
+                      throw MISC_UTILS.createEventException(ex.getCause(), event);
+                    } catch (Throwable t) {
+                      throw MISC_UTILS.createEventException(t, event);
                     }
                   }
                 }
+              }
 
-                // Check for cached events and dispatch them at the current priority level
-                // only.
-                // The BTE needs to be dispatched even after it's cancelled, because we DO
-                // have
-                // listeners that depend on receiving cancelled events e.g. WoolMatchModule.
-                for (BlockTransformEvent bte : currentEvents.get(event)) {
-                  Events.callEvent(bte, priority);
-                }
+              // Check for cached events and dispatch them at the current priority level
+              // only.
+              // The BTE needs to be dispatched even after it's cancelled, because we DO
+              // have
+              // listeners that depend on receiving cancelled events e.g. WoolMatchModule.
+              for (BlockTransformEvent bte : currentEvents.get(event)) {
+                Events.callEvent(bte, priority);
+              }
 
-                // After dispatching the last priority level, clean up the cached events and
-                // do
-                // post-event stuff.
-                // This needs to happen even if the event is cancelled.
-                if (priority == EventPriority.MONITOR) {
-                  finishCauseEvent(event);
-                }
+              // After dispatching the last priority level, clean up the cached events and
+              // do
+              // post-event stuff.
+              // This needs to happen even if the event is cancelled.
+              if (priority == EventPriority.MONITOR) {
+                finishCauseEvent(event);
               }
             };
 
@@ -489,18 +484,18 @@ public class BlockTransformListener implements Listener {
 
   private byte getPistonDirectionByte(BlockFace face) {
     return switch (face) {
-      default -> 0; // down included
       case UP -> 1;
       case NORTH -> 2;
       case SOUTH -> 3;
       case WEST -> 4;
       case EAST -> 5;
+      default -> 0; // down included
     };
   }
 
   @EventWrapper
   public void onBlockPistonRetract(final BlockPistonRetractEvent event) {
-    this.onPistonMove(event, event.getBlocks(), new HashMap<Block, BlockState>());
+    this.onPistonMove(event, event.getBlocks(), new HashMap<>());
   }
 
   // -----------------------------

--- a/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -42,14 +42,12 @@ public class ChatDispatcher {
     Collection<MatchPlayer> viewers = channel.getBroadcastViewers(null);
     channel.broadcastMessage(message, null);
 
-    sound.ifPresent(s -> {
-      viewers.stream()
-          .filter(player -> {
-            SettingValue settingValue = player.getSettings().getValue(SettingKey.SOUNDS);
-            return settingValue.equals(SettingValue.SOUNDS_ALL)
-                || settingValue.equals(SettingValue.SOUNDS_CHAT);
-          })
-          .forEach(player -> player.playSound(s));
-    });
+    sound.ifPresent(s -> viewers.stream()
+        .filter(player -> {
+          SettingValue settingValue = player.getSettings().getValue(SettingKey.SOUNDS);
+          return settingValue.equals(SettingValue.SOUNDS_ALL)
+              || settingValue.equals(SettingValue.SOUNDS_CHAT);
+        })
+        .forEach(player -> player.playSound(s)));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/listeners/JoinLeaveAnnouncer.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/JoinLeaveAnnouncer.java
@@ -105,7 +105,7 @@ public class JoinLeaveAnnouncer implements Listener {
     return value.equals(SettingValue.JOIN_FRIENDS) && Integration.isFriend(a, b);
   }
 
-  public static enum JoinVisibility {
+  public enum JoinVisibility {
     ALL, // When player is not vanished, show everyone
     STAFF, // When player is vanished and actually joins/quits, show staff only
     NONSTAFF; // When player toggles vanish, show non-staff (fake broadcast)

--- a/core/src/main/java/tc/oc/pgm/listeners/MotdListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/MotdListener.java
@@ -48,15 +48,11 @@ public class MotdListener implements Listener {
   }
 
   private ChatColor getPhaseColor(MatchPhase phase) {
-    switch (phase) {
-      case STARTING:
-        return ChatColor.YELLOW;
-      case RUNNING:
-        return ChatColor.GREEN;
-      case FINISHED:
-        return ChatColor.RED;
-      default:
-        return ChatColor.GRAY;
-    }
+    return switch (phase) {
+      case STARTING -> ChatColor.YELLOW;
+      case RUNNING -> ChatColor.GREEN;
+      case FINISHED -> ChatColor.RED;
+      default -> ChatColor.GRAY;
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/listeners/ServerPingDataListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ServerPingDataListener.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.ServerListPingEvent;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.map.Contributor;
@@ -47,9 +48,9 @@ public class ServerPingDataListener implements Listener {
     this.matchCache = CacheBuilder.newBuilder()
         .weakKeys()
         .expireAfterWrite(5L, TimeUnit.SECONDS)
-        .build(new CacheLoader<Match, JsonObject>() {
+        .build(new CacheLoader<>() {
           @Override
-          public JsonObject load(Match match) throws Exception {
+          public JsonObject load(@NonNull Match match) {
             JsonObject jsonObject = new JsonObject();
             serializeMatch(match, jsonObject);
             return jsonObject;

--- a/core/src/main/java/tc/oc/pgm/listeners/ServerPingDataListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/ServerPingDataListener.java
@@ -18,7 +18,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.ServerListPingEvent;
-import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.map.Contributor;
@@ -48,14 +47,11 @@ public class ServerPingDataListener implements Listener {
     this.matchCache = CacheBuilder.newBuilder()
         .weakKeys()
         .expireAfterWrite(5L, TimeUnit.SECONDS)
-        .build(new CacheLoader<>() {
-          @Override
-          public JsonObject load(@NonNull Match match) {
-            JsonObject jsonObject = new JsonObject();
-            serializeMatch(match, jsonObject);
-            return jsonObject;
-          }
-        });
+        .build(CacheLoader.from(match -> {
+          JsonObject jsonObject = new JsonObject();
+          serializeMatch(match, jsonObject);
+          return jsonObject;
+        }));
   }
 
   @EventHandler

--- a/core/src/main/java/tc/oc/pgm/loot/LootableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/loot/LootableMatchModule.java
@@ -24,7 +24,7 @@ import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.InventoryQuery;
 import tc.oc.pgm.api.match.Match;
@@ -72,21 +72,23 @@ public class LootableMatchModule implements MatchModule, Listener {
    * InventoryHolder is not something that we should be filling.
    */
   private static @Nullable Predicate<Filter> filterPredicate(InventoryHolder holder) {
-    if (holder instanceof DoubleChest doubleChest) {
-      return filter -> !filter
-              .query(new BlockQuery((Chest) doubleChest.getLeftSide()))
-              .isDenied()
-          || !filter.query(new BlockQuery((Chest) doubleChest.getRightSide())).isDenied();
-    } else if (holder instanceof BlockState) {
-      return filter -> !filter.query(new BlockQuery((BlockState) holder)).isDenied();
-    } else if (holder instanceof Entity && !(holder instanceof Player)) {
-      return filter -> !filter.query(new EntityQuery((Entity) holder)).isDenied();
-    } else {
-      // This happens with crafting inventories, and possibly other transient inventory types
-      // Pretty sure we never want to fill an inventory held by the player, or one we don't know
-      // about
-      return null;
-    }
+    return switch (holder) {
+      case DoubleChest doubleChest ->
+        filter -> !filter
+                .query(new BlockQuery((Chest) doubleChest.getLeftSide()))
+                .isDenied()
+            || !filter.query(new BlockQuery((Chest) doubleChest.getRightSide())).isDenied();
+      case BlockState blockState ->
+        filter -> !filter.query(new BlockQuery(blockState)).isDenied();
+      case Entity entity
+      when !(holder instanceof Player) ->
+        filter -> !filter.query(new EntityQuery(entity)).isDenied();
+      case null, default ->
+        // This happens with crafting inventories, and possibly other transient inventory types
+        // Pretty sure we never want to fill an inventory held by the player, or one we don't know
+        // about
+        null;
+    };
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/tc/oc/pgm/map/MapContextImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapContextImpl.java
@@ -12,7 +12,7 @@ import tc.oc.pgm.api.map.MapModule;
 public class MapContextImpl implements MapContext {
 
   private final MapInfo info;
-  private final List<MapModule> modules;
+  private final List<MapModule<?>> modules;
 
   public MapContextImpl(MapInfoImpl info, Collection<MapModule<?>> modules) {
     this.info = info;
@@ -27,12 +27,12 @@ public class MapContextImpl implements MapContext {
   }
 
   @Override
-  public Collection<MapModule> getModules() {
+  public Collection<MapModule<?>> getModules() {
     return modules;
   }
 
   @Override
-  public <N extends MapModule> N getModule(Class<? extends N> key) {
+  public <N extends MapModule<?>> N getModule(Class<? extends N> key) {
     throw new UnsupportedOperationException(
         "Not allowed to query for specific modules in " + getClass().getSimpleName());
   }

--- a/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFactoryImpl.java
@@ -101,9 +101,7 @@ public class MapFactoryImpl extends ModuleGraph<MapModule<?>, MapModuleFactory<?
       throw e;
     } catch (IOException e) {
       throw new MapException(source, info, "Unable to read map document", e);
-    } catch (InvalidXMLException e) {
-      throw new MapException(source, info, e.getMessage(), e);
-    } catch (ModuleLoadException e) {
+    } catch (InvalidXMLException | ModuleLoadException e) {
       throw new MapException(source, info, e.getMessage(), e);
     } catch (JDOMParseException e) {
       // Set base uri so when error is displayed it shows what XML caused the issue

--- a/core/src/main/java/tc/oc/pgm/map/contrib/PlayerContributor.java
+++ b/core/src/main/java/tc/oc/pgm/map/contrib/PlayerContributor.java
@@ -5,7 +5,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import com.google.common.base.Objects;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.api.player.Username;
@@ -28,7 +28,7 @@ public class PlayerContributor implements Contributor {
   }
 
   @Override
-  public String getContribution() {
+  public @Nullable String getContribution() {
     return contribution;
   }
 
@@ -49,8 +49,7 @@ public class PlayerContributor implements Contributor {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof PlayerContributor)) return false;
-    final PlayerContributor o = (PlayerContributor) obj;
+    if (!(obj instanceof PlayerContributor o)) return false;
     return this.id.equals(o.getId()) && Objects.equal(this.contribution, o.getContribution());
   }
 

--- a/core/src/main/java/tc/oc/pgm/map/contrib/PseudonymContributor.java
+++ b/core/src/main/java/tc/oc/pgm/map/contrib/PseudonymContributor.java
@@ -7,7 +7,7 @@ import com.google.common.base.Objects;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.map.Contributor;
 import tc.oc.pgm.util.named.NameStyle;
 
@@ -22,7 +22,7 @@ public class PseudonymContributor implements Contributor {
   }
 
   @Override
-  public String getContribution() {
+  public @Nullable String getContribution() {
     return contribution;
   }
 
@@ -43,15 +43,14 @@ public class PseudonymContributor implements Contributor {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof PseudonymContributor)) return false;
-    final PseudonymContributor o = (PseudonymContributor) obj;
+    if (!(obj instanceof PseudonymContributor o)) return false;
     return this.name.equals(o.name) && Objects.equal(this.contribution, o.contribution);
   }
 
   @Override
   public int hashCode() {
     int hash = 7;
-    hash = 31 * hash + (int) this.name.hashCode();
+    hash = 31 * hash + this.name.hashCode();
     hash = 31 * hash + (contribution == null ? 0 : contribution.hashCode());
     return hash;
   }

--- a/core/src/main/java/tc/oc/pgm/map/source/SystemMapSource.java
+++ b/core/src/main/java/tc/oc/pgm/map/source/SystemMapSource.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.map.MapSource;
 import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
@@ -37,8 +37,9 @@ class SystemMapSource implements MapSource {
   }
 
   private File getDirectory(String subdir) throws MapMissingException {
-    final File dir =
-        subdir == null ? getAbsoluteDir().toFile() : getAbsoluteDir().resolve(subdir).toFile();
+    final File dir = subdir == null
+        ? getAbsoluteDir().toFile()
+        : getAbsoluteDir().resolve(subdir).toFile();
 
     if (!dir.exists()) {
       throw new MapMissingException(dir.getPath(), "Unable to find map folder (was it moved?)");
@@ -131,8 +132,7 @@ class SystemMapSource implements MapSource {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof SystemMapSource)) return false;
-    SystemMapSource other = (SystemMapSource) obj;
+    if (!(obj instanceof SystemMapSource other)) return false;
     return dir.equals(other.dir) && Objects.equals(variant, other.variant);
   }
 

--- a/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
@@ -27,6 +27,7 @@ import org.bukkit.Difficulty;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapContext;
 import tc.oc.pgm.api.map.WorldInfo;
@@ -150,7 +151,8 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
   }
 
   @Override
-  public Match get(long duration, TimeUnit unit) throws InterruptedException, ExecutionException {
+  public Match get(long duration, @NonNull TimeUnit unit)
+      throws InterruptedException, ExecutionException {
     return future.get();
   }
 
@@ -199,9 +201,7 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
   }
 
   /** Stage #1: ensures that a {@link MapContext} is loaded. */
-  private static class InitMapStage implements Stage {
-    private final String mapId;
-
+  private record InitMapStage(String mapId) implements Stage {
     private InitMapStage(String mapId) {
       this.mapId = assertNotNull(mapId);
     }
@@ -256,10 +256,7 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
   }
 
   /** Stage #3: initializes the {@link World} on the main thread. */
-  private static class InitWorldStage implements Stage, Revertable {
-    private final MapContext map;
-    private final String worldName;
-
+  private record InitWorldStage(MapContext map, String worldName) implements Stage, Revertable {
     private InitWorldStage(MapContext map, String worldName) {
       this.map = assertNotNull(map);
       this.worldName = assertNotNull(worldName);

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -31,8 +31,8 @@ import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.filter.query.PlayerQuery;
@@ -453,7 +453,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
   }
 
   @Override
-  public @NotNull Audience audience() {
+  public @NonNull Audience audience() {
     return audience;
   }
 
@@ -508,8 +508,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof MatchPlayer)) return false;
-    final MatchPlayer o = (MatchPlayer) obj;
+    if (!(obj instanceof MatchPlayer o)) return false;
     return this.id.equals(o.getId()) && this.match.equals(o.getMatch());
   }
 

--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerStateImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerStateImpl.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
@@ -19,19 +19,19 @@ import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.named.NameStyle;
 
 public class MatchPlayerStateImpl implements MatchPlayerState {
-  private final @NotNull Match match;
-  private final @NotNull String username;
-  private final @NotNull UUID uuid;
-  private final @NotNull Party party;
+  private final @NonNull Match match;
+  private final @NonNull String username;
+  private final @NonNull UUID uuid;
+  private final @NonNull Party party;
   private final boolean dead;
   private final boolean vanished;
   private final @Nullable String nick;
 
   // Excluded from equals/hashcode
-  private final @NotNull Vector location;
-  private final @NotNull Audience audience;
+  private final @NonNull Vector location;
+  private final @NonNull Audience audience;
 
-  protected MatchPlayerStateImpl(@NotNull MatchPlayer player) {
+  protected MatchPlayerStateImpl(@NonNull MatchPlayer player) {
     this.match = assertNotNull(player).getMatch();
     this.username = assertNotNull(player.getBukkit().getName());
     this.uuid = assertNotNull(player.getId());
@@ -45,22 +45,22 @@ public class MatchPlayerStateImpl implements MatchPlayerState {
   }
 
   @Override
-  public @NotNull Match getMatch() {
+  public @NonNull Match getMatch() {
     return match;
   }
 
   @Override
-  public @NotNull Party getParty() {
+  public @NonNull Party getParty() {
     return party;
   }
 
   @Override
-  public @NotNull UUID getId() {
+  public @NonNull UUID getId() {
     return uuid;
   }
 
   @Override
-  public @NotNull Location getLocation() {
+  public @NonNull Location getLocation() {
     return location.toLocation(match.getWorld());
   }
 
@@ -80,7 +80,7 @@ public class MatchPlayerStateImpl implements MatchPlayerState {
   }
 
   @Override
-  @NotNull
+  @NonNull
   public Audience audience() {
     return audience;
   }
@@ -109,9 +109,7 @@ public class MatchPlayerStateImpl implements MatchPlayerState {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof MatchPlayerStateImpl)) return false;
-
-    MatchPlayerStateImpl that = (MatchPlayerStateImpl) o;
+    if (!(o instanceof MatchPlayerStateImpl that)) return false;
 
     if (isDead() != that.isDead()) return false;
     if (isVanished() != that.isVanished()) return false;

--- a/core/src/main/java/tc/oc/pgm/match/PartyImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/PartyImpl.java
@@ -14,7 +14,8 @@ import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.party.event.PartyRenameEvent;
@@ -71,7 +72,7 @@ public abstract class PartyImpl implements Party, Audience {
   }
 
   @Override
-  public Audience audience() {
+  public @NonNull Audience audience() {
     return this.audience;
   }
 

--- a/core/src/main/java/tc/oc/pgm/match/QueuedParty.java
+++ b/core/src/main/java/tc/oc/pgm/match/QueuedParty.java
@@ -63,7 +63,7 @@ public class QueuedParty extends PartyImpl {
       if (PGM.get().getConfiguration().canPriorityKick()) {
         // If priority kicking is enabled, might as well join the high
         // priority players first so nobody actually gets kicked.
-        Collections.sort(this.memberOrder, new Order());
+        this.memberOrder.sort(new Order());
       }
     }
     return this.memberOrder;

--- a/core/src/main/java/tc/oc/pgm/menu/PagedInventoryMenu.java
+++ b/core/src/main/java/tc/oc/pgm/menu/PagedInventoryMenu.java
@@ -129,7 +129,7 @@ public abstract class PagedInventoryMenu extends InventoryMenu {
         c -> getInventory().open(player, page));
   }
 
-  private final ItemStack getPageIcon(String text, int page) {
+  private ItemStack getPageIcon(String text, int page) {
     return getNamedItem(text, PAGE_MATERIAL, page);
   }
 

--- a/core/src/main/java/tc/oc/pgm/modes/ModeChangeCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/modes/ModeChangeCountdown.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.countdowns.CountdownContext;
 import tc.oc.pgm.countdowns.MatchCountdown;
@@ -43,7 +44,7 @@ public class ModeChangeCountdown extends MatchCountdown implements Comparable<Mo
    * @param that The mode to compare to.
    */
   @Override
-  public int compareTo(ModeChangeCountdown that) {
+  public int compareTo(@NonNull ModeChangeCountdown that) {
     boolean running = this.getMatch().isRunning();
 
     Duration d1 = running ? this.context.getTimeLeft(this) : this.getMode().getAfter();

--- a/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
@@ -38,7 +38,7 @@ import org.bukkit.event.vehicle.VehicleDamageEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
 import org.bukkit.event.world.PortalCreateEvent;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
@@ -128,18 +128,11 @@ public class EventFilterMatchModule implements MatchModule, Listener {
 
   @Nullable
   ClickType convertClick(Action action, Player player) {
-    switch (action) {
-      case LEFT_CLICK_BLOCK:
-      case LEFT_CLICK_AIR:
-        return ClickType.LEFT;
-
-      case RIGHT_CLICK_BLOCK:
-      case RIGHT_CLICK_AIR:
-        return convertClick(ClickType.RIGHT, player);
-
-      default:
-        return null;
-    }
+    return switch (action) {
+      case LEFT_CLICK_BLOCK, LEFT_CLICK_AIR -> ClickType.LEFT;
+      case RIGHT_CLICK_BLOCK, RIGHT_CLICK_AIR -> convertClick(ClickType.RIGHT, player);
+      default -> null;
+    };
   }
 
   // -------------------------------------------------------------
@@ -288,8 +281,7 @@ public class EventFilterMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void onDamage(final EntityDamageEvent event) {
     cancelUnlessInteracting(event, event.getEntity());
-    if (event instanceof EntityDamageByEntityEvent) {
-      EntityDamageByEntityEvent entityEvent = (EntityDamageByEntityEvent) event;
+    if (event instanceof EntityDamageByEntityEvent entityEvent) {
       if (cancelUnlessInteracting(event, entityEvent.getDamager())) {
         MatchPlayer player = match.getPlayer(entityEvent.getDamager());
         if (player == null) return;

--- a/core/src/main/java/tc/oc/pgm/modules/ItemKeepMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ItemKeepMatchModule.java
@@ -48,7 +48,6 @@ public class ItemKeepMatchModule implements MatchModule, Listener {
    * NOTE: Must be called before
    * {@link tc.oc.pgm.tracker.trackers.DeathTracker#onPlayerDeath(PlayerDeathEvent)}
    */
-  @SuppressWarnings("deprecation")
   @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
   public void processPlayerDeath(PlayerDeathEvent event) {
     MatchPlayer player = this.match.getPlayer(event.getEntity());

--- a/core/src/main/java/tc/oc/pgm/modules/MobsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/MobsMatchModule.java
@@ -1,9 +1,10 @@
 package tc.oc.pgm.modules;
 
+import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.Filter.QueryResponse;
 import tc.oc.pgm.api.match.Match;
@@ -17,7 +18,7 @@ public class MobsMatchModule implements MatchModule, Listener {
   private final Match match;
   private final @Nullable Filter mobsFilter;
 
-  public MobsMatchModule(Match match, Filter mobsFilter) {
+  public MobsMatchModule(Match match, @Nullable Filter mobsFilter) {
     this.match = match;
     this.mobsFilter = mobsFilter;
   }
@@ -47,17 +48,15 @@ public class MobsMatchModule implements MatchModule, Listener {
     }
 
     // Always allow armor stands since they are not really mobs.
-    switch (event.getEntityType()) {
-      case ARMOR_STAND:
-        return;
+    if (event.getEntityType() == EntityType.ARMOR_STAND) {
+      return;
     }
 
     if (this.mobsFilter == null) {
       event.setCancelled(true);
     } else {
-      final QueryResponse response =
-          this.mobsFilter.query(
-              new EntitySpawnQuery(event, event.getEntity(), event.getSpawnReason()));
+      final QueryResponse response = this.mobsFilter.query(
+          new EntitySpawnQuery(event, event.getEntity(), event.getSpawnReason()));
       event.setCancelled(response.isDenied());
     }
   }

--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
@@ -83,8 +83,7 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
       }
 
       // Save some special properties of Arrows
-      if (oldEntity instanceof Arrow) {
-        Arrow arrow = (Arrow) oldEntity;
+      if (oldEntity instanceof Arrow arrow) {
         newProjectile.setMetadata("critical", new FixedMetadataValue(plugin, arrow.isCritical()));
         newProjectile.setMetadata(
             "knockback", new FixedMetadataValue(plugin, arrow.getKnockbackStrength()));
@@ -139,10 +138,9 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
 
         // If the projectile is not an arrow, play an impact sound.
         if (event.getEntity() instanceof Player
-            && (projectile instanceof Projectile && !(projectile instanceof Arrow))) {
-          Projectile customProjectile = (Projectile) projectile;
-          if (customProjectile.getShooter() instanceof Player) {
-            Player bukkitShooter = (Player) customProjectile.getShooter();
+            && (projectile instanceof Projectile customProjectile
+                && !(projectile instanceof Arrow))) {
+          if (customProjectile.getShooter() instanceof Player bukkitShooter) {
             MatchPlayer shooter = match.getPlayer(bukkitShooter);
             if (shooter != null && event.getEntity() != null) {
               shooter.playSound(Sounds.PROJECTILE_HIT);

--- a/core/src/main/java/tc/oc/pgm/modules/PlayerTimeMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/PlayerTimeMatchModule.java
@@ -35,13 +35,10 @@ public class PlayerTimeMatchModule implements MatchModule, Listener {
   }
 
   private static long getPreferencedTime(MatchPlayer player) {
-    switch (player.getSettings().getValue(SettingKey.TIME)) {
-      case TIME_DARK:
-        return 18000; // Midnight
-      case TIME_LIGHT:
-        return 6000; // Midday
-      default:
-        return player.getWorld().getFullTime();
-    }
+    return switch (player.getSettings().getValue(SettingKey.TIME)) {
+      case TIME_DARK -> 18000; // Midnight
+      case TIME_LIGHT -> 6000; // Midday
+      default -> player.getWorld().getFullTime();
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modules/SpectateMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/SpectateMatchModule.java
@@ -4,11 +4,9 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -73,8 +71,7 @@ public class SpectateMatchModule implements MatchModule, Listener {
   public List<MatchPlayer> getSpectating(UUID player) {
     final Collection<UUID> list = spectators.get(player);
     if (list == null) return ImmutableList.of();
-    return Collections.unmodifiableList(
-        list.stream().map(match::getPlayer).filter(Objects::nonNull).collect(Collectors.toList()));
+    return list.stream().map(match::getPlayer).filter(Objects::nonNull).toList();
   }
 
   /** Get the {@link MatchPlayer}s currently spectating the given {@link MatchPlayer}, if any. */

--- a/core/src/main/java/tc/oc/pgm/modules/WeatherMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/WeatherMatchModule.java
@@ -17,7 +17,7 @@ public class WeatherMatchModule implements MatchModule, Listener {
   public enum WeatherType {
     CLEAR,
     RAIN,
-    THUNDER;
+    THUNDER
   }
 
   private final Match match;

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
@@ -41,12 +41,7 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
   private NameDecorationProvider provider;
   private final LoadingCache<UUID, DecorationCacheEntry> decorationCache = CacheBuilder.newBuilder()
       .expireAfterAccess(15, TimeUnit.MINUTES)
-      .build(new CacheLoader<>() {
-        @Override
-        public DecorationCacheEntry load(@NonNull UUID uuid) {
-          return new DecorationCacheEntry(uuid);
-        }
-      });
+      .build(CacheLoader.from(DecorationCacheEntry::new));
 
   public NameDecorationRegistryImpl(@Nullable NameDecorationProvider provider) {
     setProvider(provider);

--- a/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/namedecorations/NameDecorationRegistryImpl.java
@@ -21,8 +21,8 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.NameDecorationChangeEvent;
 import tc.oc.pgm.api.party.Party;
@@ -39,16 +39,14 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
   private final MetadataValue METADATA_VALUE = new FixedMetadataValue(PGM.get(), this);
 
   private NameDecorationProvider provider;
-  private final LoadingCache<UUID, DecorationCacheEntry> decorationCache =
-      CacheBuilder.newBuilder()
-          .expireAfterAccess(15, TimeUnit.MINUTES)
-          .build(
-              new CacheLoader<UUID, DecorationCacheEntry>() {
-                @Override
-                public DecorationCacheEntry load(@NotNull UUID uuid) {
-                  return new DecorationCacheEntry(uuid);
-                }
-              });
+  private final LoadingCache<UUID, DecorationCacheEntry> decorationCache = CacheBuilder.newBuilder()
+      .expireAfterAccess(15, TimeUnit.MINUTES)
+      .build(new CacheLoader<>() {
+        @Override
+        public DecorationCacheEntry load(@NonNull UUID uuid) {
+          return new DecorationCacheEntry(uuid);
+        }
+      });
 
   public NameDecorationRegistryImpl(@Nullable NameDecorationProvider provider) {
     setProvider(provider);
@@ -107,10 +105,9 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
   public Component getDecoratedNameComponent(Player player, ChatColor partyColor) {
     return text()
         .append(getPrefixComponent(player.getUniqueId()))
-        .append(
-            text(
-                player.getName(),
-                partyColor == null ? NamedTextColor.WHITE : TextFormatter.convert(partyColor)))
+        .append(text(
+            player.getName(),
+            partyColor == null ? NamedTextColor.WHITE : TextFormatter.convert(partyColor)))
         .append(getSuffixComponent(player.getUniqueId()))
         .build();
   }
@@ -144,7 +141,7 @@ public class NameDecorationRegistryImpl implements NameDecorationRegistry, Liste
   }
 
   @Override
-  @NotNull
+  @NonNull
   public NameDecorationProvider getProvider() {
     return provider;
   }

--- a/core/src/main/java/tc/oc/pgm/observers/ObserverToolsMenu.java
+++ b/core/src/main/java/tc/oc/pgm/observers/ObserverToolsMenu.java
@@ -15,13 +15,12 @@ import tc.oc.pgm.observers.tools.SettingsTool;
 
 public class ObserverToolsMenu extends InventoryMenu {
 
-  private List<MenuItem> items;
+  private final List<MenuItem> items;
 
   public ObserverToolsMenu(MatchPlayer viewer) {
     super("setting.title", NamedTextColor.AQUA, 1, viewer);
-    this.items =
-        Lists.newArrayList(
-            new FlySpeedTool(), new NightVisionTool(), new SettingsTool(), new GamemodeTool());
+    this.items = Lists.newArrayList(
+        new FlySpeedTool(), new NightVisionTool(), new SettingsTool(), new GamemodeTool());
     open();
   }
 

--- a/core/src/main/java/tc/oc/pgm/observers/tools/FlySpeedTool.java
+++ b/core/src/main/java/tc/oc/pgm/observers/tools/FlySpeedTool.java
@@ -53,7 +53,7 @@ public class FlySpeedTool implements MenuItem {
     private final TextColor color;
     private final float value;
 
-    private static FlySpeed[] speeds = values();
+    private static final FlySpeed[] speeds = values();
 
     FlySpeed(TextColor color, float value) {
       this.color = color;

--- a/core/src/main/java/tc/oc/pgm/observers/tools/GamemodeTool.java
+++ b/core/src/main/java/tc/oc/pgm/observers/tools/GamemodeTool.java
@@ -57,21 +57,17 @@ public class GamemodeTool implements MenuItem {
   }
 
   private Component getToggleMessage() {
-    Component command =
-        text("/tools", NamedTextColor.AQUA)
-            .hoverEvent(showText(translatable("setting.gamemode.hover", NamedTextColor.GRAY)))
-            .clickEvent(runCommand("/tools"));
+    Component command = text("/tools", NamedTextColor.AQUA)
+        .hoverEvent(showText(translatable("setting.gamemode.hover", NamedTextColor.GRAY)))
+        .clickEvent(runCommand("/tools"));
     return translatable("setting.gamemode.warning", NamedTextColor.GRAY, command);
   }
 
   private GameMode getOppositeMode(GameMode mode) {
-    switch (mode) {
-      case CREATIVE:
-        return GameMode.SPECTATOR;
-      case SPECTATOR:
-        return GameMode.CREATIVE;
-      default:
-        return mode;
-    }
+    return switch (mode) {
+      case CREATIVE -> GameMode.SPECTATOR;
+      case SPECTATOR -> GameMode.CREATIVE;
+      default -> mode;
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/payload/track/Track.java
+++ b/core/src/main/java/tc/oc/pgm/payload/track/Track.java
@@ -41,19 +41,16 @@ public class Track {
     double scaledProgress = (progress * (track.size() - 1)) + 0.5;
     Rail rail = track.get((int) scaledProgress);
 
-    return rail.getOffset(scaledProgress % 1d);
+    return rail.offset(scaledProgress % 1d);
   }
 
-  private static class Rail {
-    private final BlockVector position;
-    private final RailOffset offset;
-
-    public Rail(BlockVector position, RailOffset offset) {
+  private record Rail(BlockVector position, RailOffset offset) {
+    private Rail(BlockVector position, RailOffset offset) {
       this.position = BlockVectors.center(position);
       this.offset = offset;
     }
 
-    public Vector getOffset(double progress) {
+    public Vector offset(double progress) {
       return offset.getOffset(progress).add(position);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -26,7 +26,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.match.Match;
@@ -124,16 +124,16 @@ public class PickerMatchModule implements MatchModule, Listener {
 
   protected boolean settingEnabled(MatchPlayer player, boolean playerTriggered) {
     boolean hasPermission = player.getBukkit().hasPermission(Permissions.JOIN_CHOOSE);
-    switch (player.getSettings().getValue(SettingKey.PICKER)) {
-      case PICKER_OFF: // When off never show GUI
-        return false;
-      case PICKER_ON: // When on always show the GUI
-        return true;
-      case PICKER_MANUAL: // Only show the GUI when right clicked
-        return playerTriggered;
-      default: // Display after map cycle, but check perms when clicking button.
-        return !playerTriggered || hasPermission || hasClasses;
-    }
+    return switch (player.getSettings().getValue(SettingKey.PICKER)) {
+      case PICKER_OFF -> // When off never show GUI
+        false;
+      case PICKER_ON -> // When on always show the GUI
+        true;
+      case PICKER_MANUAL -> // Only show the GUI when right clicked
+        playerTriggered;
+      default -> // Display after map cycle, but check perms when clicking button.
+        !playerTriggered || hasPermission || hasClasses;
+    };
   }
 
   private boolean hasJoined(MatchPlayer joining) {
@@ -240,12 +240,9 @@ public class PickerMatchModule implements MatchModule, Listener {
         ChatColor.DARK_PURPLE + TextTranslations.translate("picker.tooltip", player.getBukkit())));
 
     // Color the leather helmet to match player team
-    if (player != null
-        && player.getParty() != null
-        && !(player.getParty() instanceof ObserverParty)) {
+    if (player.getParty() != null && !(player.getParty() instanceof ObserverParty)) {
       LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
       armorMeta.setColor(player.getParty().getFullColor());
-      meta = armorMeta;
     }
 
     stack.setItemMeta(meta);
@@ -557,7 +554,7 @@ public class PickerMatchModule implements MatchModule, Listener {
       }
     }
 
-    return slots.toArray(new ItemStack[slots.size()]);
+    return slots.toArray(new ItemStack[0]);
   }
 
   private ItemStack createClassButton(MatchPlayer viewer, PlayerClass cls) {
@@ -617,11 +614,6 @@ public class PickerMatchModule implements MatchModule, Listener {
     JoinResult result = jmm.queryJoin(player, JoinRequest.fromPlayer(player, team));
     if (result instanceof JoinResultOption) {
       switch ((JoinResultOption) result) {
-        default:
-          lore.add(ChatColor.GREEN
-              + TextTranslations.translate("picker.clickToJoin", player.getBukkit()));
-          break;
-
         case REJOINED:
           lore.add(ChatColor.GREEN
               + TextTranslations.translate("picker.clickToRejoin", player.getBukkit()));
@@ -635,6 +627,11 @@ public class PickerMatchModule implements MatchModule, Listener {
         case FULL:
           lore.add(ChatColor.DARK_RED
               + TextTranslations.translate("picker.capacity", player.getBukkit()));
+          break;
+
+        default:
+          lore.add(ChatColor.GREEN
+              + TextTranslations.translate("picker.clickToJoin", player.getBukkit()));
           break;
       }
     }

--- a/core/src/main/java/tc/oc/pgm/points/PointParser.java
+++ b/core/src/main/java/tc/oc/pgm/points/PointParser.java
@@ -46,15 +46,13 @@ public class PointParser {
 
     List<PointProvider> providers = new ArrayList<>();
     for (Attribute attr : XMLUtils.getAttributes(el, aliases)) {
-      providers.add(
-          new RegionPointProvider(
-              validate(regionParser.parseReference(attr), new Node(attr)), attributes));
+      providers.add(new RegionPointProvider(
+          validate(regionParser.parseReference(attr), new Node(attr)), attributes));
     }
     for (Element child : XMLUtils.getChildren(el, aliases)) {
-      providers.add(
-          new RegionPointProvider(
-              validate(regionParser.parseChild(child), new Node(child)),
-              parseAttributes(child, attributes)));
+      providers.add(new RegionPointProvider(
+          validate(regionParser.parseChild(child), new Node(child)),
+          parseAttributes(child, attributes)));
     }
     return providers;
   }
@@ -73,7 +71,7 @@ public class PointParser {
       throws InvalidXMLException {
     List<PointProvider> points = new ArrayList<>();
     parsePoint(points, el, attributes);
-    if (points.size() == 1) return points.get(0);
+    if (points.size() == 1) return points.getFirst();
     throw new InvalidXMLException(
         "Expected one location, either as direct value or as a single child region", el);
   }
@@ -126,7 +124,7 @@ public class PointParser {
       List<PointProvider> providers, Element el, PointProviderAttributes attributes)
       throws InvalidXMLException {
     Node node = new Node(el);
-    for (Region region : expandRegion(new ArrayList<Region>(), regionParser.parse(el))) {
+    for (Region region : expandRegion(new ArrayList<>(), regionParser.parse(el))) {
       providers.add(new RegionPointProvider(validate(region, node), attributes));
     }
   }

--- a/core/src/main/java/tc/oc/pgm/points/PointProviderAttributes.java
+++ b/core/src/main/java/tc/oc/pgm/points/PointProviderAttributes.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.points;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class PointProviderAttributes {
   private final @Nullable AngleProvider yawProvider;
@@ -9,7 +9,10 @@ public class PointProviderAttributes {
   private final boolean outdoors;
 
   public PointProviderAttributes(
-      AngleProvider yawProvider, AngleProvider pitchProvider, boolean safe, boolean outdoors) {
+      @Nullable AngleProvider yawProvider,
+      @Nullable AngleProvider pitchProvider,
+      boolean safe,
+      boolean outdoors) {
     this.yawProvider = yawProvider;
     this.pitchProvider = pitchProvider;
     this.safe = safe;

--- a/core/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
+++ b/core/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 
@@ -55,7 +55,7 @@ public class SpreadPointProvider extends AggregatePointProvider {
       }
     }
 
-    int index = (int) Math.floor(match.getRandom().nextInt(bestPoints.size()));
+    int index = (int) (double) match.getRandom().nextInt(bestPoints.size());
     return bestPoints.get(index);
   }
 

--- a/core/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
+++ b/core/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
@@ -55,7 +55,7 @@ public class SpreadPointProvider extends AggregatePointProvider {
       }
     }
 
-    int index = (int) (double) match.getRandom().nextInt(bestPoints.size());
+    int index = match.getRandom().nextInt(bestPoints.size());
     return bestPoints.get(index);
   }
 

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -29,7 +29,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.BlockIterator;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.filter.Filter;
@@ -144,8 +144,7 @@ public class ProjectileMatchModule implements MatchModule, Listener {
 
   @EventHandler
   public void onProjectileHurtEvent(EntityDamageByEntityEvent event) {
-    if (!(event.getEntity() instanceof LivingEntity)) return;
-    LivingEntity damagedEntity = (LivingEntity) event.getEntity();
+    if (!(event.getEntity() instanceof LivingEntity damagedEntity)) return;
 
     ProjectileDefinition projectileDefinition =
         ProjectileMatchModule.getProjectileDefinition(event.getDamager());
@@ -264,15 +263,11 @@ public class ProjectileMatchModule implements MatchModule, Listener {
   }
 
   private static boolean isValidProjectileAction(Action action, ClickAction clickAction) {
-    switch (clickAction) {
-      case RIGHT:
-        return action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK;
-      case LEFT:
-        return action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK;
-      case BOTH:
-        return action != Action.PHYSICAL;
-    }
-    return false;
+    return switch (clickAction) {
+      case RIGHT -> action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK;
+      case LEFT -> action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK;
+      case BOTH -> action != Action.PHYSICAL;
+    };
   }
 
   private void startCooldown(Player player, ProjectileDefinition definition) {

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
@@ -68,7 +68,7 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
             ? XMLUtils.parseBlockMaterialData(Node.fromAttr(projectileElement, "material"))
             : null;
         Float power = XMLUtils.parseNumber(
-            Node.fromChildOrAttr(projectileElement, "power"), Float.class, (Float) null);
+            Node.fromChildOrAttr(projectileElement, "power"), Float.class, null);
         List<PotionEffect> potionKit = kitParser.parsePotions(projectileElement);
         Filter destroyFilter =
             filterParser.parseFilterProperty(projectileElement, "destroy-filter");

--- a/core/src/main/java/tc/oc/pgm/regions/RFAContext.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RFAContext.java
@@ -46,7 +46,7 @@ public class RFAContext {
     /** Prepend the given RFA, giving it the highest priority */
     public void prepend(RegionFilterApplication rfa) {
       rfa.useRegionPriority = true; // Allows region priority to work on older maps
-      this.byPriority.add(0, rfa);
+      this.byPriority.addFirst(rfa);
     }
 
     @Override

--- a/core/src/main/java/tc/oc/pgm/regions/RegionFilterApplicationParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionFilterApplicationParser.java
@@ -71,10 +71,8 @@ public class RegionFilterApplicationParser {
   }
 
   public void parseLane(Element el) throws InvalidXMLException {
-    final Filter filter =
-        new DenyFilter(
-            new TeamFilter(
-                Teams.getTeamRef(new Node(XMLUtils.getRequiredAttribute(el, "team")), factory)));
+    final Filter filter = new DenyFilter(new TeamFilter(
+        Teams.getTeamRef(new Node(XMLUtils.getRequiredAttribute(el, "team")), factory)));
     final Region region = parseRegion(el);
     final Component message = translatable("match.laneExit");
 
@@ -150,18 +148,11 @@ public class RegionFilterApplicationParser {
           for (String name : Splitter.on(" ").split(node.getValue())) {
             filters.add(filterParser.parseReference(node, name));
           }
-          switch (filters.size()) {
-            case 0:
-              filter = null;
-              break;
-            case 1:
-              filter = filters.get(0);
-              break;
-            default:
-              filter =
-                  new FilterNode(
-                      filters, Collections.<Filter>emptyList(), Collections.<Filter>emptyList());
-          }
+          filter = switch (filters.size()) {
+            case 0 -> null;
+            case 1 -> filters.getFirst();
+            default -> new FilterNode(filters, Collections.emptyList(), Collections.emptyList());
+          };
         }
       }
 

--- a/core/src/main/java/tc/oc/pgm/regions/RegionMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionMatchModule.java
@@ -27,7 +27,7 @@ import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.filter.Filter.QueryResponse;
 import tc.oc.pgm.api.filter.query.BlockQuery;
@@ -417,23 +417,22 @@ public class RegionMatchModule implements MatchModule, Listener {
       return false;
     }
 
-    switch (rfa.filter.query(query)) {
-      case ALLOW:
-        if (query.getEvent() instanceof Cancellable) {
-          ((Cancellable) query.getEvent()).setCancelled(false);
+    return switch (rfa.filter.query(query)) {
+      case ALLOW -> {
+        if (query.getEvent() instanceof Cancellable cancellable) {
+          cancellable.setCancelled(false);
         }
-        return true;
-
-      case DENY:
-        if (query.getEvent() instanceof GeneralizedEvent) {
-          ((GeneralizedEvent) query.getEvent()).setCancelled(rfa.message);
-        } else if (query.getEvent() instanceof Cancellable) {
-          ((Cancellable) query.getEvent()).setCancelled(true);
+        yield true;
+      }
+      case DENY -> {
+        if (query.getEvent() instanceof GeneralizedEvent generalizedEvent) {
+          generalizedEvent.setCancelled(rfa.message);
+        } else if (query.getEvent() instanceof Cancellable cancellable) {
+          cancellable.setCancelled(true);
         }
-        return true;
-
-      default:
-        return false;
-    }
+        yield true;
+      }
+      default -> false;
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import org.bukkit.util.Vector;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.api.region.RegionDefinition;
@@ -49,7 +49,7 @@ public abstract class RegionParser implements XMLParser<Region, RegionDefinition
   }
 
   public List<Element> getRegionChildren(Element parent) {
-    List<Element> elements = new ArrayList<Element>();
+    List<Element> elements = new ArrayList<>();
     for (Element el : parent.getChildren()) {
       if (this.isRegion(el)) {
         elements.add(el);
@@ -223,14 +223,11 @@ public abstract class RegionParser implements XMLParser<Region, RegionDefinition
   @MethodParser("intersect")
   public Region parseIntersect(Element el) throws InvalidXMLException {
     Region[] regions = this.parseSubRegionsArray(el);
-    switch (regions.length) {
-      case 0:
-        throw new InvalidXMLException("Intersect must have at least one region.", el);
-      case 1:
-        return regions[0];
-      default:
-        return new Intersect(regions);
-    }
+    return switch (regions.length) {
+      case 0 -> throw new InvalidXMLException("Intersect must have at least one region.", el);
+      case 1 -> regions[0];
+      default -> new Intersect(regions);
+    };
   }
 
   @MethodParser("complement")
@@ -240,7 +237,7 @@ public abstract class RegionParser implements XMLParser<Region, RegionDefinition
       throw new InvalidXMLException("Complement requires at least 2 regions.", el);
     }
     return new Complement(
-        regions.get(0), regions.subList(1, regions.size()).toArray(new Region[0]));
+        regions.getFirst(), regions.subList(1, regions.size()).toArray(new Region[0]));
   }
 
   @MethodParser("negative")

--- a/core/src/main/java/tc/oc/pgm/renewable/Renewable.java
+++ b/core/src/main/java/tc/oc/pgm/renewable/Renewable.java
@@ -58,8 +58,8 @@ public class Renewable implements Listener, Tickable {
   // Cached queries of the renewable/shuffleable filters, invalidated every tick.
   // These are queries of the original blocks, not the current blocks.
   // This should cut down on repeated queries.
-  private Map<BlockVector, Filter.QueryResponse> renewableCache = new HashMap<>();
-  private Map<BlockVector, Filter.QueryResponse> shuffleableCache = new HashMap<>();
+  private final Map<BlockVector, Filter.QueryResponse> renewableCache = new HashMap<>();
+  private final Map<BlockVector, Filter.QueryResponse> shuffleableCache = new HashMap<>();
 
   public Renewable(RenewableDefinition definition, Match match, Logger parent) {
     this.definition = definition;

--- a/core/src/main/java/tc/oc/pgm/restart/RequestRestartEvent.java
+++ b/core/src/main/java/tc/oc/pgm/restart/RequestRestartEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.plugin.Plugin;
 
 public class RequestRestartEvent extends Event {
 
-  public class Deferral {
+  public static class Deferral {
     private final Plugin plugin;
 
     public Deferral(Plugin plugin) {

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -20,7 +20,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.Datastore;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
@@ -43,12 +43,12 @@ import tc.oc.pgm.util.TimeUtils;
  */
 public class MapPoolManager implements MapOrder {
 
-  private Logger logger;
+  private final Logger logger;
 
-  private File mapPoolsFile;
+  private final File mapPoolsFile;
   private FileConfiguration mapPoolFileConfig;
 
-  private Map<MapPool, MapActivity> mapPools = Maps.newHashMap();
+  private final Map<MapPool, MapActivity> mapPools = Maps.newHashMap();
   private MapPool activeMapPool;
   private MapOrder fallback; // Fallback map order in case no pool exists
 
@@ -111,18 +111,20 @@ public class MapPoolManager implements MapOrder {
           .filter(MapPool::isEnabled)
           .forEach(pool -> mapPools.put(pool, database.getMapActivity(pool.getName())));
 
-      activeMapPool =
-          mapPools.entrySet().stream()
-              .filter(e -> e.getValue().isActive())
-              .findFirst()
-              .map(Map.Entry::getKey)
-              .orElse(null);
+      activeMapPool = mapPools.entrySet().stream()
+          .filter(e -> e.getValue().isActive())
+          .findFirst()
+          .map(Map.Entry::getKey)
+          .orElse(null);
     }
 
     if (activeMapPool == null) {
       logger.log(Level.WARNING, "No active map pool was found, defaulting to first dynamic pool.");
-      activeMapPool =
-          mapPools.keySet().stream().sorted().filter(MapPool::isDynamic).findFirst().orElse(null);
+      activeMapPool = mapPools.keySet().stream()
+          .sorted()
+          .filter(MapPool::isDynamic)
+          .findFirst()
+          .orElse(null);
       if (activeMapPool == null) {
         logger.log(
             Level.SEVERE,
@@ -134,19 +136,17 @@ public class MapPoolManager implements MapOrder {
   }
 
   public void saveMapPools() {
-    mapPools.forEach(
-        (key, value) -> {
-          String nextMap = null;
-          if (key instanceof Rotation) {
-            nextMap = key.getNextMap().getName();
-          }
+    mapPools.forEach((key, value) -> {
+      String nextMap = null;
+      if (key instanceof Rotation) {
+        nextMap = key.getNextMap().getName();
+      }
 
-          boolean active =
-              getActiveMapPool() != null
-                  && getActiveMapPool().getName().equalsIgnoreCase(key.getName())
-                  && key.isDynamic();
-          value.update(nextMap, active);
-        });
+      boolean active = getActiveMapPool() != null
+          && getActiveMapPool().getName().equalsIgnoreCase(key.getName())
+          && key.isDynamic();
+      value.update(nextMap, active);
+    });
   }
 
   public MapPool getActiveMapPool() {
@@ -201,9 +201,8 @@ public class MapPoolManager implements MapOrder {
     }
 
     // Call a MapPoolAdjustEvent so plugins can listen when map pool has changed
-    match.callEvent(
-        new MapPoolAdjustEvent(
-            activeMapPool, mapPool, match, force, sender, poolTimeLimit, matchCountLimit));
+    match.callEvent(new MapPoolAdjustEvent(
+        activeMapPool, mapPool, match, force, sender, poolTimeLimit, matchCountLimit));
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/Rotation.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/Rotation.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.logging.Level;
 import org.bukkit.configuration.ConfigurationSection;
-import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.rotation.MapPoolManager;
@@ -21,7 +20,7 @@ public class Rotation extends MapPool {
       MapParser maps) {
     super(type, name, manager, section, maps);
 
-    @Nullable MapInfo nextMap = PGM.get().getMapLibrary().getMap(manager.getNextMapForPool(name));
+    MapInfo nextMap = PGM.get().getMapLibrary().getMap(manager.getNextMapForPool(name));
     if (nextMap != null) this.position = getMapPosition(nextMap);
     else {
       PGM.get()
@@ -81,7 +80,7 @@ public class Rotation extends MapPool {
                   + " from rotation with size "
                   + maps.size()
                   + " has been issued. Returning map in position 0 instead.");
-      return maps.get(0);
+      return maps.getFirst();
     }
 
     return maps.get(position);

--- a/core/src/main/java/tc/oc/pgm/scoreboard/SidebarRenderer.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/SidebarRenderer.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.Gamemode;
 import tc.oc.pgm.api.map.MapInfo;
@@ -173,7 +173,7 @@ class SidebarRenderer {
     sortedCompetitors.retainAll(context.competitorGoals.keySet());
     // Bump viewing party to the top of the list
     if (viewer instanceof Competitor && sortedCompetitors.remove(viewer)) {
-      sortedCompetitors.add(0, (Competitor) viewer);
+      sortedCompetitors.addFirst((Competitor) viewer);
     }
     return sortedCompetitors;
   }
@@ -253,8 +253,7 @@ class SidebarRenderer {
                 ? NamedTextColor.BLACK
                 : goal.renderSidebarStatusColor(competitor, viewingParty)));
 
-    if (goal instanceof ProximityGoal) {
-      final ProximityGoal<?> proximity = (ProximityGoal<?>) goal;
+    if (goal instanceof ProximityGoal<?> proximity) {
       if (proximity.shouldShowProximity(competitor, viewingParty)) {
         line.append(space());
         line.append(proximity.renderProximity(competitor, viewingParty));

--- a/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/ShopMenu.java
@@ -239,7 +239,7 @@ public class ShopMenu extends InventoryMenu {
 
     // Display free or single item price on the same line as cost
     if (price.size() == 1) {
-      cost.append(price.get(0));
+      cost.append(price.getFirst());
     }
 
     Component click =

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerMatchModule.java
@@ -7,7 +7,7 @@ import tc.oc.pgm.api.match.MatchScope;
 
 public class SpawnerMatchModule implements MatchModule {
 
-  private Match match;
+  private final Match match;
   private final List<SpawnerDefinition> definitions;
 
   public SpawnerMatchModule(Match match, List<SpawnerDefinition> definitions) {

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -25,7 +25,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.filter.Filter;
@@ -325,7 +325,7 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
     event.setSpawnLocation(match.getWorld().getSpawnLocation());
   }
 
-  @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = false)
+  @EventHandler(priority = EventPriority.NORMAL)
   public void teleportObservers(final EntityDamageEvent event) {
     // When an observer begins to take fall damage, teleport them to their spawn
     // Due to a bug causing infinite TP loop, only tp twice a second at most

--- a/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/start/StartCountdown.java
@@ -7,7 +7,7 @@ import java.time.Duration;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.teams.Team;
@@ -56,7 +56,6 @@ public class StartCountdown extends PreMatchCountdown {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   public void onTick(Duration remaining, Duration total) {
     super.onTick(remaining, total);
 

--- a/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamMatchModule.java
@@ -22,7 +22,7 @@ import net.kyori.adventure.util.Ticks;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.match.Match;
@@ -402,8 +402,7 @@ public class TeamMatchModule implements MatchModule, Listener, JoinHandler {
 
   @Override
   public boolean join(MatchPlayer joining, JoinRequest request, JoinResult result) {
-    if (result instanceof TeamJoinResult) {
-      TeamJoinResult teamResult = (TeamJoinResult) result;
+    if (result instanceof TeamJoinResult teamResult) {
       Team lastTeam = getLastTeam(joining.getId());
 
       switch (teamResult.getOption()) {

--- a/core/src/main/java/tc/oc/pgm/teams/TeamVictoryCondition.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamVictoryCondition.java
@@ -10,7 +10,7 @@ import tc.oc.pgm.result.ImmediateVictoryCondition;
 
 /** Immediate, unconditional victory for an explicit {@link Team}. */
 public class TeamVictoryCondition extends ImmediateVictoryCondition {
-  private TeamFactory teamDefinition;
+  private final TeamFactory teamDefinition;
 
   public TeamVictoryCondition(TeamFactory teamDefinition) {
     this.teamDefinition = assertNotNull(teamDefinition);

--- a/core/src/main/java/tc/oc/pgm/timelimit/OvertimeCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/timelimit/OvertimeCountdown.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.timelimit;
 
 import static net.kyori.adventure.text.Component.translatable;
+import static tc.oc.pgm.util.text.TemporalComponent.duration;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -9,10 +10,9 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
-import tc.oc.pgm.util.text.TemporalComponent;
 
 public class OvertimeCountdown extends TimeLimitCountdown {
 
@@ -46,8 +46,7 @@ public class OvertimeCountdown extends TimeLimitCountdown {
         .decoration(TextDecoration.BOLD, true);
   }
 
-  @Nullable
-  protected BossBar.Color barColor() {
+  protected BossBar.@Nullable Color barColor() {
     return BossBar.Color.YELLOW;
   }
 
@@ -77,8 +76,7 @@ public class OvertimeCountdown extends TimeLimitCountdown {
       match.sendMessage(translatable(
           "broadcast.overtime.limit",
           NamedTextColor.YELLOW,
-          TemporalComponent.briefNaturalApproximate(timeLimit.getMaxOvertime())
-              .color(NamedTextColor.AQUA)));
+          duration(timeLimit.getMaxOvertime()).color(NamedTextColor.AQUA)));
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTMatchModule.java
@@ -17,7 +17,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -98,8 +98,7 @@ public class TNTMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void setCustomProperties(ExplosionPrimeEvent event) {
-    if (event.getEntity() instanceof TNTPrimed) {
-      TNTPrimed tnt = (TNTPrimed) event.getEntity();
+    if (event.getEntity() instanceof TNTPrimed tnt) {
 
       if (this.properties.fuse != null) {
         tnt.setFuseTicks(this.getFuseTicks());

--- a/core/src/main/java/tc/oc/pgm/tracker/TrackerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/TrackerMatchModule.java
@@ -9,7 +9,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
@@ -38,12 +38,12 @@ import tc.oc.pgm.tracker.trackers.TNTTracker;
 
 public class TrackerMatchModule implements MatchModule {
 
-  private EntityTracker entityTracker;
-  private BlockTracker blockTracker;
-  private FallTracker fallTracker;
-  private FireTracker fireTracker;
-  private FallingBlockTracker fallingBlockTracker;
-  private CactiTracker cactiTracker;
+  private final EntityTracker entityTracker;
+  private final BlockTracker blockTracker;
+  private final FallTracker fallTracker;
+  private final FireTracker fireTracker;
+  private final FallingBlockTracker fallingBlockTracker;
+  private final CactiTracker cactiTracker;
 
   private final Set<DamageResolver> damageResolvers = new LinkedHashSet<>();
   private final Match match;

--- a/core/src/main/java/tc/oc/pgm/tracker/resolvers/ExplosionDamageResolver.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/resolvers/ExplosionDamageResolver.java
@@ -11,14 +11,11 @@ public class ExplosionDamageResolver implements DamageResolver {
   @Override
   public @Nullable ExplosionInfo resolveDamage(
       EntityDamageEvent.DamageCause damageType, Entity victim, @Nullable PhysicalInfo damager) {
-    switch (damageType) {
-      case ENTITY_EXPLOSION:
-      case BLOCK_EXPLOSION:
+    return switch (damageType) {
+      case ENTITY_EXPLOSION, BLOCK_EXPLOSION ->
         // Bukkit fires block explosion events with a null damager in rare situations
-        return damager == null ? null : new ExplosionInfo(damager);
-
-      default:
-        return null;
-    }
+        damager == null ? null : new ExplosionInfo(damager);
+      default -> null;
+    };
   }
 }

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/FallTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/FallTracker.java
@@ -12,7 +12,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.event.PlayerSpleefEvent;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
@@ -77,16 +77,13 @@ public class FallTracker implements Listener, DamageResolver {
 
       return fall;
     } else {
-      switch (damageType) {
-        case FALL:
-          return new GenericFallInfo(
-              FallInfo.To.GROUND, victim.getLocation(), victim.getFallDistance());
-        case VOID:
-          return new GenericFallInfo(
-              FallInfo.To.VOID, victim.getLocation(), victim.getFallDistance());
-      }
-
-      return null;
+      return switch (damageType) {
+        case FALL ->
+          new GenericFallInfo(FallInfo.To.GROUND, victim.getLocation(), victim.getFallDistance());
+        case VOID ->
+          new GenericFallInfo(FallInfo.To.VOID, victim.getLocation(), victim.getFallDistance());
+        default -> null;
+      };
     }
   }
 
@@ -230,7 +227,8 @@ public class FallTracker implements Listener, DamageResolver {
       Tick now = match.getTick();
 
       if (isClimbing != fall.isClimbing) {
-        if ((fall.isClimbing = isClimbing)) {
+        fall.isClimbing = isClimbing;
+        if (fall.isClimbing) {
           // Player moved onto a ladder, cancel the fall if they are still on it after
           // MAX_CLIMBING_TIME
           fall.climbingTick = now.tick;
@@ -241,7 +239,8 @@ public class FallTracker implements Listener, DamageResolver {
       }
 
       if (isSwimming != fall.isSwimming) {
-        if ((fall.isSwimming = isSwimming)) {
+        fall.isSwimming = isSwimming;
+        if (fall.isSwimming) {
           // Player moved into water, cancel the fall if they are still in it after
           // MAX_SWIMMING_TIME
           fall.swimmingTick = now.tick;
@@ -257,7 +256,8 @@ public class FallTracker implements Listener, DamageResolver {
       }
 
       if (isInLava != fall.isInLava) {
-        if (!(fall.isInLava = isInLava)) {
+        fall.isInLava = isInLava;
+        if (fall.isInLava) {
           fall.inLavaTick = now.tick;
         } else {
           fall.outLavaTick = now.tick;

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/OwnedMobTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/OwnedMobTracker.java
@@ -28,8 +28,7 @@ public class OwnedMobTracker extends AbstractTracker<MobInfo> {
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMobSpawn(PlayerSpawnEntityEvent event) {
     ParticipantState owner = match.getParticipantState(event.getPlayer());
-    if (event.getEntity() instanceof LivingEntity && owner != null) {
-      LivingEntity mob = (LivingEntity) event.getEntity();
+    if (event.getEntity() instanceof LivingEntity mob && owner != null) {
       entities().trackEntity(event.getEntity(), new MobInfo(mob, owner));
     }
   }
@@ -58,16 +57,14 @@ public class OwnedMobTracker extends AbstractTracker<MobInfo> {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onSlimeSplit(CreatureSpawnEvent event) {
-    switch (event.getSpawnReason()) {
-      case SLIME_SPLIT:
-        Slime parent = splitter.get();
-        if (parent != null) {
-          MobInfo info = resolveEntity(parent);
-          if (info != null) {
-            entities().trackEntity(event.getEntity(), info);
-          }
+    if (event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.SLIME_SPLIT) {
+      Slime parent = splitter.get();
+      if (parent != null) {
+        MobInfo info = resolveEntity(parent);
+        if (info != null) {
+          entities().trackEntity(event.getEntity(), info);
         }
-        break;
+      }
     }
   }
 

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/TNTTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/TNTTracker.java
@@ -36,9 +36,8 @@ public class TNTTracker extends AbstractTracker<TNTInfo> {
 
   @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void onPrime(ExplosionPrimeEvent event) {
-    if (event.getEntity() instanceof TNTPrimed) {
+    if (event.getEntity() instanceof TNTPrimed tnt) {
       // Some TNT was activated, try to figure out why
-      TNTPrimed tnt = (TNTPrimed) event.getEntity();
       TNTInfo info = null;
 
       if (event instanceof ExplosionPrimeByEntityEvent) {

--- a/core/src/main/java/tc/oc/pgm/util/MethodParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/MethodParser.java
@@ -5,5 +5,5 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MethodParser {
-  public String value();
+  String value();
 }

--- a/core/src/main/java/tc/oc/pgm/util/PrettyPaginatedComponentResults.java
+++ b/core/src/main/java/tc/oc/pgm/util/PrettyPaginatedComponentResults.java
@@ -74,7 +74,7 @@ public abstract class PrettyPaginatedComponentResults<T> {
    * @throws TextException no match exceptions
    */
   public void display(Audience audience, List<? extends T> data, int page) throws TextException {
-    if (data.size() == 0) {
+    if (data.isEmpty()) {
       audience.sendMessage(formatEmpty());
       return;
     }

--- a/core/src/main/java/tc/oc/pgm/util/XMLParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/XMLParser.java
@@ -1,7 +1,7 @@
 package tc.oc.pgm.util;
 
 import org.jdom2.Element;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.feature.FeatureDefinition;
 import tc.oc.pgm.api.feature.FeatureValidation;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -44,7 +44,7 @@ public interface XMLParser<F, FD extends FeatureDefinition> {
     } else if (parent.getChildren().size() > 1) {
       throw new InvalidXMLException("Expected only one child " + type() + ", not multiple", parent);
     }
-    return this.parse(parent.getChildren().get(0));
+    return this.parse(parent.getChildren().getFirst());
   }
 
   /**
@@ -91,10 +91,9 @@ public interface XMLParser<F, FD extends FeatureDefinition> {
   default F parseProperty(Node node, @Nullable F def, @Nullable FeatureValidation<FD> validation)
       throws InvalidXMLException {
     if (node == null) return def;
-    F feature =
-        node.isAttribute()
-            ? this.parseReference(node)
-            : this.parsePropertyElement(node.getElement());
+    F feature = node.isAttribute()
+        ? this.parseReference(node)
+        : this.parsePropertyElement(node.getElement());
 
     if (validation != null) validate(feature, validation, node);
     return feature;

--- a/core/src/main/java/tc/oc/pgm/util/compose/CompositionParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/compose/CompositionParser.java
@@ -29,39 +29,33 @@ public abstract class CompositionParser<T> {
       case 0:
         return new None<>();
       case 1:
-        return parseAtom(elements.get(0));
-      default:
-        {
-          List<Composition<T>> compositions = new ArrayList<>(elements.size());
-          for (Element element : elements) {
-            compositions.add(this.parseAtom(element));
-          }
-          return new All<>(compositions);
+        return parseAtom(elements.getFirst());
+      default: {
+        List<Composition<T>> compositions = new ArrayList<>(elements.size());
+        for (Element element : elements) {
+          compositions.add(this.parseAtom(element));
         }
+        return new All<>(compositions);
+      }
     }
   }
 
   public Composition<T> parseAtom(Element element) throws InvalidXMLException {
-    switch (element.getName()) {
-      case "none":
-        return new None<>();
-
-      case "maybe":
-        return new Maybe<>(
+    return switch (element.getName()) {
+      case "none" -> new None<>();
+      case "maybe" ->
+        new Maybe<>(
             this.factory.getFilters().parseFilterProperty(element, "filter"),
             parseElementList(element.getChildren()));
-      case "all":
-        return parseElementList(element.getChildren());
-
-      case "any":
-        return new Any<>(
+      case "all" -> parseElementList(element.getChildren());
+      case "any" ->
+        new Any<>(
             XMLUtils.parseBoundedNumericRange(
                 element.getAttribute("count"), Integer.class, Range.singleton(1)),
             XMLUtils.parseBoolean(element.getAttribute("unique"), true),
             this.parseOptions(element.getChildren()));
-      default:
-        return new Unit<>(this.parseUnit(element));
-    }
+      default -> new Unit<>(this.parseUnit(element));
+    };
   }
 
   private List<Any.Option<T>> parseOptions(List<Element> elements) throws InvalidXMLException {

--- a/core/src/main/java/tc/oc/pgm/util/player/PlayerData.java
+++ b/core/src/main/java/tc/oc/pgm/util/player/PlayerData.java
@@ -6,8 +6,8 @@ import java.util.Objects;
 import java.util.UUID;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.integration.Integration;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -19,14 +19,14 @@ class PlayerData {
 
   public final @Nullable String name;
   public final @Nullable String nick;
-  public final @NotNull TextColor teamColor;
+  public final @NonNull TextColor teamColor;
   public final boolean dead;
   public final boolean vanish;
   public final boolean online;
   public final boolean conceal; // If player is disguise, pretend they are offline?
-  public final @NotNull NameStyle style;
+  public final @NonNull NameStyle style;
 
-  public PlayerData(@NotNull Player player, @NotNull NameStyle style) {
+  public PlayerData(@NonNull Player player, @NonNull NameStyle style) {
     this.uuid = player.getUniqueId();
     this.name = player.getName();
     this.nick = Integration.getNick(player);
@@ -39,7 +39,7 @@ class PlayerData {
     this.style = style;
   }
 
-  public PlayerData(@NotNull MatchPlayer mp, @NotNull NameStyle style) {
+  public PlayerData(@NonNull MatchPlayer mp, @NonNull NameStyle style) {
     this.uuid = mp.getId();
 
     this.name = mp.getNameLegacy();
@@ -52,7 +52,7 @@ class PlayerData {
     this.style = style;
   }
 
-  public PlayerData(@NotNull MatchPlayerState mps, @NotNull NameStyle style) {
+  public PlayerData(@NonNull MatchPlayerState mps, @NonNull NameStyle style) {
     this.uuid = mps.getId();
 
     this.name = mps.getNameLegacy();
@@ -65,7 +65,7 @@ class PlayerData {
     this.style = style;
   }
 
-  public PlayerData(@Nullable Player player, @Nullable String username, @NotNull NameStyle style) {
+  public PlayerData(@Nullable Player player, @Nullable String username, @NonNull NameStyle style) {
     this.uuid = player != null ? player.getUniqueId() : null;
 
     this.name = player != null ? player.getName() : username;
@@ -83,9 +83,7 @@ class PlayerData {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof PlayerData)) return false;
-
-    PlayerData that = (PlayerData) o;
+    if (!(o instanceof PlayerData that)) return false;
 
     if (dead != that.dead) return false;
     if (vanish != that.vanish) return false;

--- a/core/src/main/java/tc/oc/pgm/util/player/PlayerRenderer.java
+++ b/core/src/main/java/tc/oc/pgm/util/player/PlayerRenderer.java
@@ -17,7 +17,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.util.named.NameDecorationProvider;
 import tc.oc.pgm.util.named.NameStyle;
@@ -34,12 +33,7 @@ public class PlayerRenderer {
   protected PlayerRenderer() {
     this.nameCache = CacheBuilder.newBuilder()
         .expireAfterAccess(15, TimeUnit.MINUTES)
-        .build(new CacheLoader<>() {
-          @Override
-          public Component load(@NonNull PlayerCacheKey key) {
-            return render(key);
-          }
-        });
+        .build(CacheLoader.from(this::render));
   }
 
   Component render(PlayerData data, PlayerRelationship relation) {

--- a/core/src/main/java/tc/oc/pgm/util/player/PlayerRenderer.java
+++ b/core/src/main/java/tc/oc/pgm/util/player/PlayerRenderer.java
@@ -17,7 +17,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.util.named.NameDecorationProvider;
 import tc.oc.pgm.util.named.NameStyle;
@@ -34,9 +34,9 @@ public class PlayerRenderer {
   protected PlayerRenderer() {
     this.nameCache = CacheBuilder.newBuilder()
         .expireAfterAccess(15, TimeUnit.MINUTES)
-        .build(new CacheLoader<PlayerCacheKey, Component>() {
+        .build(new CacheLoader<>() {
           @Override
-          public Component load(@NotNull PlayerCacheKey key) {
+          public Component load(@NonNull PlayerCacheKey key) {
             return render(key);
           }
         });

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -65,7 +65,7 @@ public class XMLFluentParser {
 
   public <T extends Enum<T>> PrimitiveBuilder.Generic<T> parseEnum(
       Class<T> type, Element el, String... prop) {
-    return new PrimitiveBuilder.Generic<T>(el, prop) {
+    return new PrimitiveBuilder.Generic<>(el, prop) {
       @Override
       protected T parse(String text) throws TextException {
         return TextParser.parseEnum(text, type);
@@ -160,7 +160,7 @@ public class XMLFluentParser {
   }
 
   public Builder.Generic<Component> component(Element el, String... prop) {
-    return new Builder.Generic<Component>(el, prop) {
+    return new Builder.Generic<>(el, prop) {
       @Override
       protected Component parse(Node node) throws InvalidXMLException {
         return XMLUtils.parseFormattedText(node);
@@ -169,7 +169,7 @@ public class XMLFluentParser {
   }
 
   public Builder.Generic<TextColor> textColor(Element el, String... prop) {
-    return new Builder.Generic<TextColor>(el, prop) {
+    return new Builder.Generic<>(el, prop) {
       @Override
       protected TextColor parse(Node node) throws InvalidXMLException {
         return TextFormatter.convert(XMLUtils.parseChatColor(node));
@@ -190,7 +190,7 @@ public class XMLFluentParser {
 
   public <T extends FeatureDefinition> ReferenceBuilder<T> reference(
       Class<T> clazz, Element el, String... prop) {
-    return new ReferenceBuilder<T>(features, clazz, el, prop);
+    return new ReferenceBuilder<>(features, clazz, el, prop);
   }
 
   public VariableBuilder<?> variable(Element el, String... prop) {

--- a/core/src/main/java/tc/oc/pgm/variables/VariablesMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariablesMatchModule.java
@@ -37,7 +37,7 @@ public class VariablesMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.LOWEST)
   public void onMatchLoad(MatchLoadEvent event) {
-    for (Variable var : context.getAll(Variable.class)) {
+    for (Variable<?> var : context.getAll(Variable.class)) {
       var.load(match);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
+++ b/core/src/main/java/tc/oc/pgm/wool/WoolModule.java
@@ -40,7 +40,7 @@ public class WoolModule implements MapModule<WoolMatchModule> {
   protected final Multimap<TeamFactory, MonumentWoolFactory> woolFactories;
 
   public WoolModule(Multimap<TeamFactory, MonumentWoolFactory> woolFactories) {
-    assert woolFactories.size() > 0;
+    assert !woolFactories.isEmpty();
     this.woolFactories = woolFactories;
   }
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/PgmBootstrap.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/PgmBootstrap.java
@@ -26,7 +26,7 @@ import org.bukkit.plugin.InvalidPluginException;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.PluginClassLoader;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.util.DataVersions;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -39,7 +39,7 @@ public class PgmBootstrap implements PluginBootstrap {
       Registries.DIMENSION_TYPE, ResourceLocation.fromNamespaceAndPath(NAMESPACE, PATH));
 
   @Override
-  public void bootstrap(@NotNull BootstrapContext context) {
+  public void bootstrap(@NonNull BootstrapContext context) {
     // Register the compatibility datapack
     context.getLifecycleManager().registerEventHandler(LifecycleEvents.DATAPACK_DISCOVERY, e -> {
       var registrar = e.registrar();
@@ -70,7 +70,7 @@ public class PgmBootstrap implements PluginBootstrap {
   }
 
   @Override
-  public JavaPlugin createPlugin(PluginProviderContext context) {
+  public @NonNull JavaPlugin createPlugin(PluginProviderContext context) {
     var ourClassLoader = (PaperPluginClassLoader) getClass().getClassLoader();
     var pluginMeta = (PaperPluginMeta) ourClassLoader.getConfiguration();
     var descriptor = new PluginDescriptionFile(

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernPlayerUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernPlayerUtils.java
@@ -27,8 +27,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.platform.modern.material.ModernBlockData;
 import tc.oc.pgm.platform.modern.packets.PacketManipulations;
@@ -93,7 +93,7 @@ public class ModernPlayerUtils implements PlayerUtils {
     if (updateMetadata(player, showInvisible, PacketManipulations.SHOW_INVISIBLE_KEY)) {
       // Refresh all seen entities' metadata
       var nmsPlayer = ((CraftPlayer) player).getHandle();
-      ServerLevel world = (ServerLevel) nmsPlayer.level();
+      ServerLevel world = nmsPlayer.level();
       var entityMap = world.getChunkSource().chunkMap.entityMap;
 
       for (var entity : world.players()) {
@@ -191,10 +191,10 @@ public class ModernPlayerUtils implements PlayerUtils {
     // A no-allocation implementation of a transform from BlockVectorSet to Map<Position, BlockData>
     player.sendMultiBlockChange(new AbstractMap<Location, BlockData>() {
       @Override
-      public @NotNull Set<Entry<Location, BlockData>> entrySet() {
+      public @NonNull Set<Entry<Location, BlockData>> entrySet() {
         return new AbstractSet<>() {
           @Override
-          public Iterator<Entry<Location, BlockData>> iterator() {
+          public @NonNull Iterator<Entry<Location, BlockData>> iterator() {
             return new Iterator<>() {
               private final LongIterator iterator = set.iterator();
               private final Location cachedLoc = player.getLocation();

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernAttributeUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernAttributeUtil.java
@@ -10,7 +10,7 @@ import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.EquipmentSlotGroup;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jdom2.Element;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.util.attribute.AttributeUtils;
 import tc.oc.pgm.util.inventory.Slot;
 import tc.oc.pgm.util.platform.Supports;
@@ -81,14 +81,16 @@ public class ModernAttributeUtil implements AttributeUtils {
       double amount, AttributeModifier.Operation operation, EquipmentSlotGroup group)
       implements SimpleAttributeModifier {
     @Override
-    public int compareTo(@NotNull SimpleAttributeModifier obj) {
-      if (!(obj instanceof SimpleModifier o)) return 0;
-      int res = operation.ordinal() - o.operation.ordinal();
+    public int compareTo(@NonNull SimpleAttributeModifier obj) {
+      if (!(obj
+          instanceof SimpleModifier(double a, AttributeModifier.Operation o, EquipmentSlotGroup g)))
+        return 0;
+      int res = operation.ordinal() - o.ordinal();
       if (res != 0) return res;
-      res = group.toString().compareTo(o.group.toString());
+      res = group.toString().compareTo(g.toString());
       if (res != 0) return res;
 
-      return Double.compare(amount, o.amount);
+      return Double.compare(amount, a);
     }
   }
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernEntityPackets.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernEntityPackets.java
@@ -134,8 +134,6 @@ public class ModernEntityPackets implements EntityPackets {
   @Override
   public Packet entityMetadataPacket(int entityId, Entity entity, boolean complete) {
     var data = ((CraftEntity) entity).getHandle().getEntityData().packAll();
-    return data == null
-        ? Packet.of()
-        : new ModernPacket<>(new ClientboundSetEntityDataPacket(entityId, data));
+    return new ModernPacket<>(new ClientboundSetEntityDataPacket(entityId, data));
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernEntityPackets.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernEntityPackets.java
@@ -132,8 +132,11 @@ public class ModernEntityPackets implements EntityPackets {
   }
 
   @Override
+  @SuppressWarnings("ConstantConditions")
   public Packet entityMetadataPacket(int entityId, Entity entity, boolean complete) {
     var data = ((CraftEntity) entity).getHandle().getEntityData().packAll();
-    return new ModernPacket<>(new ClientboundSetEntityDataPacket(entityId, data));
+    return data == null
+        ? Packet.of()
+        : new ModernPacket<>(new ClientboundSetEntityDataPacket(entityId, data));
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernTabPackets.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernTabPackets.java
@@ -33,7 +33,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.NameTagVisibility;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.platform.modern.util.Skins;
 import tc.oc.pgm.util.nms.EnumPlayerInfoAction;
 import tc.oc.pgm.util.nms.packets.Packet;
@@ -54,7 +54,6 @@ public class ModernTabPackets implements TabPackets {
   @Override
   public Packet spawnPlayerPacket(int entityId, UUID uuid, Location loc, Player player) {
     var data = ((CraftEntity) player).getHandle().getEntityData().packAll();
-    if (data == null) return Packet.of();
     return new ModernPacket<>(new ClientboundBundlePacket(List.of(
         new ClientboundAddEntityPacket(
             entityId,
@@ -135,7 +134,7 @@ public class ModernTabPackets implements TabPackets {
         String name,
         int ping,
         @Nullable Skin skin,
-        @Nullable net.kyori.adventure.text.Component displayName) {
+        net.kyori.adventure.text.Component displayName) {
       packet.profileIds().add(uuid);
     }
 
@@ -161,7 +160,7 @@ public class ModernTabPackets implements TabPackets {
         String name,
         int ping,
         @Nullable Skin skin,
-        @Nullable net.kyori.adventure.text.Component displayName) {
+        net.kyori.adventure.text.Component displayName) {
 
       GameProfile profile = new GameProfile(uuid, name, new MutablePropertyMap());
       if (skin != null) Skins.toProfile(profile, skin);

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernTabPackets.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernTabPackets.java
@@ -162,7 +162,7 @@ public class ModernTabPackets implements TabPackets {
         String name,
         int ping,
         @Nullable Skin skin,
-        net.kyori.adventure.text.Component displayName) {
+        net.kyori.adventure.text.@Nullable Component displayName) {
 
       GameProfile profile = new GameProfile(uuid, name, new MutablePropertyMap());
       if (skin != null) Skins.toProfile(profile, skin);

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernTabPackets.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/ModernTabPackets.java
@@ -52,8 +52,10 @@ public class ModernTabPackets implements TabPackets {
   }
 
   @Override
+  @SuppressWarnings("ConstantConditions")
   public Packet spawnPlayerPacket(int entityId, UUID uuid, Location loc, Player player) {
     var data = ((CraftEntity) player).getHandle().getEntityData().packAll();
+    if (data == null) return Packet.of();
     return new ModernPacket<>(new ClientboundBundlePacket(List.of(
         new ClientboundAddEntityPacket(
             entityId,
@@ -134,7 +136,7 @@ public class ModernTabPackets implements TabPackets {
         String name,
         int ping,
         @Nullable Skin skin,
-        net.kyori.adventure.text.Component displayName) {
+        net.kyori.adventure.text.@Nullable Component displayName) {
       packet.profileIds().add(uuid);
     }
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/PGMServerLevel.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/PGMServerLevel.java
@@ -20,7 +20,8 @@ import net.minecraft.world.level.storage.PrimaryLevelData;
 import org.bukkit.World;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.ChunkGenerator;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class PGMServerLevel extends ServerLevel {
   public PGMServerLevel(
@@ -58,7 +59,7 @@ public class PGMServerLevel extends ServerLevel {
   // Redirect all map operations to world-level storage
   @Nullable
   @Override
-  public MapItemSavedData getMapData(MapId mapId) {
+  public MapItemSavedData getMapData(@NonNull MapId mapId) {
     // Paper start - Call missing map initialize event and set id
     final DimensionDataStorage storage = getDataStorage();
 
@@ -85,7 +86,7 @@ public class PGMServerLevel extends ServerLevel {
   }
 
   @Override
-  public void setMapData(MapId mapId, MapItemSavedData data) {
+  public void setMapData(@NonNull MapId mapId, MapItemSavedData data) {
     // CraftBukkit start
     data.id = mapId;
     org.bukkit.event.server.MapInitializeEvent event =
@@ -96,7 +97,7 @@ public class PGMServerLevel extends ServerLevel {
   }
 
   @Override
-  public MapId getFreeMapId() {
+  public @NonNull MapId getFreeMapId() {
     return getDataStorage().computeIfAbsent(MapIndex.TYPE).getNextMapId();
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpAttributeUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpAttributeUtils.java
@@ -7,7 +7,7 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jdom2.Element;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.util.attribute.AttributeUtils;
 import tc.oc.pgm.util.platform.Supports;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -66,11 +66,11 @@ public class SpAttributeUtils implements AttributeUtils {
     }
 
     @Override
-    public int compareTo(@NotNull SimpleAttributeModifier obj) {
-      if (!(obj instanceof SimpleModifier o)) return 0;
-      int res = operation.ordinal() - o.operation.ordinal();
+    public int compareTo(@NonNull SimpleAttributeModifier obj) {
+      if (!(obj instanceof SimpleModifier(double a, AttributeModifier.Operation o))) return 0;
+      int res = operation.ordinal() - o.ordinal();
       if (res != 0) return res;
-      return Double.compare(amount, o.amount);
+      return Double.compare(amount, a);
     }
   }
 

--- a/server/src/main/java/tc/oc/pgm/server/PGMServer.java
+++ b/server/src/main/java/tc/oc/pgm/server/PGMServer.java
@@ -121,9 +121,7 @@ public class PGMServer extends DedicatedServer implements Runnable {
   }
 
   protected void setupConsole() {
-    final Thread console = new Thread(() -> {
-      new PaperConsole(PGMServer.this).start();
-    });
+    final Thread console = new Thread(() -> new PaperConsole(PGMServer.this).start());
     console.setDaemon(true);
     console.start();
   }

--- a/util/src/main/java/tc/oc/pgm/util/LegacyFormatUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/LegacyFormatUtils.java
@@ -8,8 +8,8 @@ import org.bukkit.ChatColor;
 /**
  * These utilities should no longer be used, instead use {@link tc.oc.pgm.util.text.TextFormatter}
  *
- * <p>TODO: Determine if any of these would be useful and move to {@link
- * tc.oc.pgm.util.text.TextFormatter}
+ * <p>TODO: Determine if any of these would be useful and move to
+ * {@link tc.oc.pgm.util.text.TextFormatter}
  */
 public final class LegacyFormatUtils {
 
@@ -26,56 +26,22 @@ public final class LegacyFormatUtils {
     } else if (Character.isDigit(c)) {
       return 5;
     } else if (Character.isLowerCase(c)) {
-      switch (c) {
-        case 'i':
-          return 1;
-
-        case 'l':
-          return 2;
-
-        case 't':
-          return 3;
-
-        case 'f':
-        case 'k':
-          return 4;
-
-        default:
-          return 5;
-      }
+      return switch (c) {
+        case 'i' -> 1;
+        case 'l' -> 2;
+        case 't' -> 3;
+        case 'f', 'k' -> 4;
+        default -> 5;
+      };
     } else {
-      switch (c) {
-        case '!':
-        case '.':
-        case ',':
-        case ';':
-        case ':':
-        case '|':
-          return 1;
-
-        case '\'':
-          return 2;
-
-        case '[':
-        case ']':
-        case ' ':
-          return 3;
-
-        case '*':
-        case '(':
-        case ')':
-        case '{':
-        case '}':
-        case '<':
-        case '>':
-          return 4;
-
-        case '@':
-          return 6;
-
-        default:
-          return 5;
-      }
+      return switch (c) {
+        case '!', '.', ',', ';', ':', '|' -> 1;
+        case '\'' -> 2;
+        case '[', ']', ' ' -> 3;
+        case '*', '(', ')', '{', '}', '<', '>' -> 4;
+        case '@' -> 6;
+        default -> 5;
+      };
     }
   }
 
@@ -224,15 +190,6 @@ public final class LegacyFormatUtils {
             this.format.italic = true;
             break;
 
-          default:
-            this.format.color = ChatColor.getByChar(c);
-            this.format.obfuscated = false;
-            this.format.bold = false;
-            this.format.strikethrough = false;
-            this.format.underline = false;
-            this.format.italic = false;
-            break;
-
           case 'r':
             this.format.obfuscated = false;
             this.format.bold = false;
@@ -240,6 +197,15 @@ public final class LegacyFormatUtils {
             this.format.underline = false;
             this.format.italic = false;
             this.format.color = null;
+            break;
+
+          default:
+            this.format.color = ChatColor.getByChar(c);
+            this.format.obfuscated = false;
+            this.format.bold = false;
+            this.format.strikethrough = false;
+            this.format.underline = false;
+            this.format.italic = false;
             break;
         }
 
@@ -389,7 +355,7 @@ public final class LegacyFormatUtils {
         + ChatColor.STRIKETHROUGH
         + Strings.repeat(" ", spaceCount)
         + text
-        + lineColor.toString()
+        + lineColor
         + ChatColor.STRIKETHROUGH
         + Strings.repeat(" ", spaceCount);
   }
@@ -429,7 +395,7 @@ public final class LegacyFormatUtils {
       if (format == null) {
         lines.add(text.substring(lineStart, parser.chars));
       } else {
-        lines.add(format.toString() + text.substring(lineStart, parser.chars));
+        lines.add(format + text.substring(lineStart, parser.chars));
       }
 
       lineStart = parser.chars;
@@ -451,7 +417,7 @@ public final class LegacyFormatUtils {
             / (dash.length() * 2);
     String dashes = dashCount >= 0 ? Strings.repeat(dash, dashCount) : "";
 
-    StringBuffer builder = new StringBuffer();
+    StringBuilder builder = new StringBuilder();
     if (dashCount > 0) {
       builder.append(dashPrefix).append(dashes).append(ChatColor.RESET);
     }
@@ -522,17 +488,10 @@ public final class LegacyFormatUtils {
   }
 
   public static boolean isFormat(ChatColor color) {
-    switch (color) {
-      case BOLD:
-      case ITALIC:
-      case UNDERLINE:
-      case STRIKETHROUGH:
-      case MAGIC:
-        return true;
-
-      default:
-        return false;
-    }
+    return switch (color) {
+      case BOLD, ITALIC, UNDERLINE, STRIKETHROUGH, MAGIC -> true;
+      default -> false;
+    };
   }
 
   /**

--- a/util/src/main/java/tc/oc/pgm/util/StreamUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/StreamUtils.java
@@ -12,15 +12,14 @@ import java.util.stream.StreamSupport;
 
 public class StreamUtils {
 
-  private static final Collector<Object, ?, ImmutableList<Object>> TO_IMMUTABLE_LIST =
-      Collector.of(
-          ImmutableList::builder,
-          ImmutableList.Builder::add,
-          (ImmutableList.Builder<Object> a, ImmutableList.Builder<Object> b) -> {
-            a.addAll(b.build());
-            return a;
-          },
-          ImmutableList.Builder::build);
+  private static final Collector<Object, ?, ImmutableList<Object>> TO_IMMUTABLE_LIST = Collector.of(
+      ImmutableList::builder,
+      ImmutableList.Builder::add,
+      (ImmutableList.Builder<Object> a, ImmutableList.Builder<Object> b) -> {
+        a.addAll(b.build());
+        return a;
+      },
+      ImmutableList.Builder::build);
 
   public static <T> Stream<T> of(Iterable<T> iterable) {
     return of(iterable.iterator());
@@ -38,7 +37,7 @@ public class StreamUtils {
 
   public static <T> Stream<T> toStream(Enumeration<T> e) {
     return StreamSupport.stream(
-        new Spliterators.AbstractSpliterator<T>(Long.MAX_VALUE, Spliterator.ORDERED) {
+        new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
           public boolean tryAdvance(Consumer<? super T> action) {
             if (e.hasMoreElements()) {
               action.accept(e.nextElement());

--- a/util/src/main/java/tc/oc/pgm/util/block/BlockFaces.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/BlockFaces.java
@@ -10,25 +10,24 @@ public interface BlockFaces {
     BlockFace.EAST, BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.UP, BlockFace.DOWN
   };
 
-  BlockFace[] CLOCKWISE =
-      new BlockFace[] {
-        BlockFace.SOUTH,
-        BlockFace.SOUTH_SOUTH_WEST,
-        BlockFace.SOUTH_WEST,
-        BlockFace.WEST_SOUTH_WEST,
-        BlockFace.WEST,
-        BlockFace.WEST_NORTH_WEST,
-        BlockFace.NORTH_WEST,
-        BlockFace.NORTH_NORTH_WEST,
-        BlockFace.NORTH,
-        BlockFace.NORTH_NORTH_EAST,
-        BlockFace.NORTH_EAST,
-        BlockFace.EAST_NORTH_EAST,
-        BlockFace.EAST,
-        BlockFace.EAST_SOUTH_EAST,
-        BlockFace.SOUTH_EAST,
-        BlockFace.SOUTH_SOUTH_EAST,
-      };
+  BlockFace[] CLOCKWISE = new BlockFace[] {
+    BlockFace.SOUTH,
+    BlockFace.SOUTH_SOUTH_WEST,
+    BlockFace.SOUTH_WEST,
+    BlockFace.WEST_SOUTH_WEST,
+    BlockFace.WEST,
+    BlockFace.WEST_NORTH_WEST,
+    BlockFace.NORTH_WEST,
+    BlockFace.NORTH_NORTH_WEST,
+    BlockFace.NORTH,
+    BlockFace.NORTH_NORTH_EAST,
+    BlockFace.NORTH_EAST,
+    BlockFace.EAST_NORTH_EAST,
+    BlockFace.EAST,
+    BlockFace.EAST_SOUTH_EAST,
+    BlockFace.SOUTH_EAST,
+    BlockFace.SOUTH_SOUTH_EAST,
+  };
 
   static BlockVector getRelative(BlockVector pos, BlockFace face) {
     return new BlockVector(
@@ -52,41 +51,23 @@ public interface BlockFaces {
   }
 
   static float faceToYaw(BlockFace face) {
-    switch (face) {
-      case SOUTH:
-        return 0f;
-      case SOUTH_SOUTH_WEST:
-        return 22.5f;
-      case SOUTH_WEST:
-        return 45f;
-      case WEST_SOUTH_WEST:
-        return 67.5f;
-      case WEST:
-        return 90f;
-      case WEST_NORTH_WEST:
-        return 112.5f;
-      case NORTH_WEST:
-        return 135f;
-      case NORTH_NORTH_WEST:
-        return 157.5f;
-      case NORTH:
-        return -180f;
-      case NORTH_NORTH_EAST:
-        return -157.5f;
-      case NORTH_EAST:
-        return -135f;
-      case EAST_NORTH_EAST:
-        return -112.5f;
-      case EAST:
-        return -90f;
-      case EAST_SOUTH_EAST:
-        return -67.5f;
-      case SOUTH_EAST:
-        return -45f;
-      case SOUTH_SOUTH_EAST:
-        return -22.5f;
-      default:
-        return 0f;
-    }
+    return switch (face) {
+      case SOUTH_SOUTH_WEST -> 22.5f;
+      case SOUTH_WEST -> 45f;
+      case WEST_SOUTH_WEST -> 67.5f;
+      case WEST -> 90f;
+      case WEST_NORTH_WEST -> 112.5f;
+      case NORTH_WEST -> 135f;
+      case NORTH_NORTH_WEST -> 157.5f;
+      case NORTH -> -180f;
+      case NORTH_NORTH_EAST -> -157.5f;
+      case NORTH_EAST -> -135f;
+      case EAST_NORTH_EAST -> -112.5f;
+      case EAST -> -90f;
+      case EAST_SOUTH_EAST -> -67.5f;
+      case SOUTH_EAST -> -45f;
+      case SOUTH_SOUTH_EAST -> -22.5f;
+      default -> 0f;
+    };
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/block/BlockVectorSet.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/BlockVectorSet.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.Random;
 import java.util.Set;
 import org.bukkit.util.BlockVector;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Optimized implementation of a set of block locations. Coordinates are encoded into a single long
@@ -50,7 +51,7 @@ public class BlockVectorSet implements Set<BlockVector> {
   }
 
   @Override
-  public Iterator<BlockVector> iterator() {
+  public @NonNull Iterator<BlockVector> iterator() {
     final var iter = this.set.iterator();
 
     return new Iterator<>() {
@@ -139,7 +140,7 @@ public class BlockVectorSet implements Set<BlockVector> {
   }
 
   @Override
-  public boolean retainAll(Collection<?> vectors) {
+  public boolean retainAll(@NonNull Collection<?> vectors) {
     return this.retainAll(BlockVectors.encodePosSet(vectors));
   }
 
@@ -148,7 +149,7 @@ public class BlockVectorSet implements Set<BlockVector> {
   }
 
   @Override
-  public boolean removeAll(Collection<?> vectors) {
+  public boolean removeAll(@NonNull Collection<?> vectors) {
     return this.removeAll(BlockVectors.encodePosSet(vectors));
   }
 
@@ -162,12 +163,12 @@ public class BlockVectorSet implements Set<BlockVector> {
   }
 
   @Override
-  public Object[] toArray() {
+  public Object @NonNull [] toArray() {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public <T> T[] toArray(T[] a) {
+  public <T> T @NonNull [] toArray(T @NonNull [] a) {
     throw new UnsupportedOperationException();
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/block/BlockVectors.java
+++ b/util/src/main/java/tc/oc/pgm/util/block/BlockVectors.java
@@ -15,7 +15,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.util.material.Materials;
 
 public interface BlockVectors {
@@ -114,7 +114,7 @@ public interface BlockVectors {
     loc.setZ(unpack(encoded, SHIFT + SHIFT));
   }
 
-  static final long ENCODED_NULL_POS = Long.MIN_VALUE;
+  long ENCODED_NULL_POS = Long.MIN_VALUE;
 
   static long encodePos(long x, long y, long z) {
     return (x & MASK) | ((y & MASK) << SHIFT) | ((z & MASK) << (SHIFT + SHIFT));

--- a/util/src/main/java/tc/oc/pgm/util/chunk/ChunkVector.java
+++ b/util/src/main/java/tc/oc/pgm/util/chunk/ChunkVector.java
@@ -84,8 +84,7 @@ public class ChunkVector {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ChunkVector)) return false;
-    ChunkVector other = (ChunkVector) o;
+    if (!(o instanceof ChunkVector other)) return false;
     return getChunkX() == other.getChunkX() && getChunkZ() == other.getChunkZ();
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/collection/ContextStore.java
+++ b/util/src/main/java/tc/oc/pgm/util/collection/ContextStore.java
@@ -8,12 +8,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 
 public class ContextStore<T> implements Iterable<Map.Entry<String, T>> {
   protected final Map<String, T> store = Maps.newTreeMap();
 
   @Override
-  public Iterator<Map.Entry<String, T>> iterator() {
+  public @NonNull Iterator<Map.Entry<String, T>> iterator() {
     return this.store.entrySet().iterator();
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/collection/DefaultMapAdapter.java
+++ b/util/src/main/java/tc/oc/pgm/util/collection/DefaultMapAdapter.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Adapt a Map to return a default value for missing keys. The default value can be constant or
@@ -63,7 +64,7 @@ public class DefaultMapAdapter<K, V> implements Map<K, V> {
 
   public V getOrDefault(K key) {
     V value = this.map.get(key);
-    return value != null ? value : this.defaultProvider.apply((K) key);
+    return value != null ? value : this.defaultProvider.apply(key);
   }
 
   public V getOrCreate(K key) {
@@ -90,7 +91,7 @@ public class DefaultMapAdapter<K, V> implements Map<K, V> {
   }
 
   @Override
-  public Set<Entry<K, V>> entrySet() {
+  public @NonNull Set<Entry<K, V>> entrySet() {
     return map.entrySet();
   }
 
@@ -110,7 +111,7 @@ public class DefaultMapAdapter<K, V> implements Map<K, V> {
   }
 
   @Override
-  public Set<K> keySet() {
+  public @NonNull Set<K> keySet() {
     return map.keySet();
   }
 
@@ -130,7 +131,7 @@ public class DefaultMapAdapter<K, V> implements Map<K, V> {
     return map.put(key, value);
   }
 
-  public void putAll(Map<? extends K, ? extends V> m) {
+  public void putAll(@NonNull Map<? extends K, ? extends V> m) {
     map.putAll(m);
   }
 
@@ -145,7 +146,7 @@ public class DefaultMapAdapter<K, V> implements Map<K, V> {
   }
 
   @Override
-  public Collection<V> values() {
+  public @NonNull Collection<V> values() {
     return map.values();
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/concurrent/TaskExecutorService.java
+++ b/util/src/main/java/tc/oc/pgm/util/concurrent/TaskExecutorService.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.util.TimeUtils;
 
 /** An executor service that is backed by a runnable executor. */
@@ -61,7 +61,7 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
   }
 
   @Override
-  public List<Runnable> shutdownNow() {
+  public @NonNull List<Runnable> shutdownNow() {
     if (!isShutdown()) shutdown();
     List<Runnable> pending = ImmutableList.copyOf(tasks);
 
@@ -83,7 +83,8 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
   }
 
   @Override
-  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+  public boolean awaitTermination(long timeout, @NonNull TimeUnit unit)
+      throws InterruptedException {
     if (terminated == null) return false;
 
     terminated.await(timeout, unit);
@@ -91,52 +92,54 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
   }
 
   @Override
-  public <T> CompletableFuture<T> submit(Callable<T> task) {
+  public <T> @NonNull CompletableFuture<T> submit(@NonNull Callable<T> task) {
     return new Task<>(task);
   }
 
   @Override
-  public <T> CompletableFuture<T> submit(Runnable task, T result) {
+  public <T> @NonNull CompletableFuture<T> submit(@NonNull Runnable task, T result) {
     return new Task<>(task, result);
   }
 
   @Override
-  public CompletableFuture<?> submit(Runnable task) {
+  public @NonNull CompletableFuture<?> submit(@NonNull Runnable task) {
     return new Task<>(task, null);
   }
 
   @Override
-  public ScheduledFuture<?> schedule(Runnable task, long delay, TimeUnit unit) {
+  public @NonNull ScheduledFuture<?> schedule(
+      @NonNull Runnable task, long delay, @NonNull TimeUnit unit) {
     return new Task<>(task, null, -1, delay, unit);
   }
 
   @Override
-  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+  public <V> @NonNull ScheduledFuture<V> schedule(
+      @NonNull Callable<V> callable, long delay, @NonNull TimeUnit unit) {
     return new Task<>(callable, -1, delay, unit);
   }
 
   @Override
-  public ScheduledFuture<?> scheduleAtFixedRate(
-      Runnable task, long initialDelay, long period, TimeUnit unit) {
+  public @NonNull ScheduledFuture<?> scheduleAtFixedRate(
+      @NonNull Runnable task, long initialDelay, long period, @NonNull TimeUnit unit) {
     return scheduleWithFixedDelay(
         task, initialDelay, period, unit); // FIXME: fixed rate != fixed delay
   }
 
   @Override
-  public ScheduledFuture<?> scheduleWithFixedDelay(
-      Runnable task, long initialDelay, long delay, TimeUnit unit) {
+  public @NonNull ScheduledFuture<?> scheduleWithFixedDelay(
+      @NonNull Runnable task, long initialDelay, long delay, @NonNull TimeUnit unit) {
     return new Task<>(task, null, delay, initialDelay, unit);
   }
 
   @Override
-  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+  public <T> @NonNull List<Future<T>> invokeAll(@NonNull Collection<? extends Callable<T>> tasks)
       throws InterruptedException {
     return invokeAll(tasks, 1, TimeUnit.DAYS);
   }
 
   @Override
-  public <T> List<Future<T>> invokeAll(
-      Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+  public <T> @NonNull List<Future<T>> invokeAll(
+      Collection<? extends Callable<T>> tasks, long timeout, @NonNull TimeUnit unit)
       throws InterruptedException {
     CompletableFuture<T>[] futures = new CompletableFuture[tasks.size()];
 
@@ -155,7 +158,7 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
   }
 
   @Override
-  public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+  public <T> @NonNull T invokeAny(@NonNull Collection<? extends Callable<T>> tasks)
       throws InterruptedException, ExecutionException {
     try {
       return invokeAny(tasks, 1, TimeUnit.DAYS);
@@ -165,7 +168,8 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
   }
 
   @Override
-  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+  public <T> T invokeAny(
+      Collection<? extends Callable<T>> tasks, long timeout, @NonNull TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
     CompletableFuture<T>[] futures = new CompletableFuture[tasks.size()];
 
@@ -178,7 +182,7 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
   }
 
   @Override
-  public void execute(Runnable task) {
+  public void execute(@NonNull Runnable task) {
     submit(task);
   }
 
@@ -249,12 +253,12 @@ public abstract class TaskExecutorService implements ScheduledExecutorService {
     }
 
     @Override
-    public long getDelay(@NotNull TimeUnit unit) {
+    public long getDelay(@NonNull TimeUnit unit) {
       return 0;
     }
 
     @Override
-    public int compareTo(@NotNull Delayed other) {
+    public int compareTo(@NonNull Delayed other) {
       if (!(other instanceof Task<?> ot)) return -1;
       return Integer.compare(taskId, ot.taskId);
     }

--- a/util/src/main/java/tc/oc/pgm/util/event/GeneralizedEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/GeneralizedEvent.java
@@ -132,13 +132,13 @@ public abstract class GeneralizedEvent extends PreemptiveEvent {
    * @param event The event to look for a {@link World} in
    */
   public static @Nullable World getWorldIfPresent(Event event) {
-    if (event instanceof WorldEvent) return ((WorldEvent) event).getWorld();
-    if (event instanceof PlayerEvent) return ((PlayerEvent) event).getPlayer().getWorld();
-    if (event instanceof EntityEvent) return ((EntityEvent) event).getEntity().getWorld();
-    if (event instanceof BlockEvent) return ((BlockEvent) event).getBlock().getWorld();
-    if (event instanceof VehicleEvent)
-      return ((VehicleEvent) event).getVehicle().getWorld();
-    if (event instanceof WeatherEvent) return ((WeatherEvent) event).getWorld();
+    if (event instanceof WorldEvent worldEvent) return worldEvent.getWorld();
+    if (event instanceof PlayerEvent playerEvent) return playerEvent.getPlayer().getWorld();
+    if (event instanceof EntityEvent entityEvent) return entityEvent.getEntity().getWorld();
+    if (event instanceof BlockEvent blockEvent) return blockEvent.getBlock().getWorld();
+    if (event instanceof VehicleEvent vehicleEvent)
+      return vehicleEvent.getVehicle().getWorld();
+    if (event instanceof WeatherEvent weatherEvent) return weatherEvent.getWorld();
 
     return null;
   }

--- a/util/src/main/java/tc/oc/pgm/util/event/GeneralizedEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/GeneralizedEvent.java
@@ -21,7 +21,7 @@ import org.bukkit.event.vehicle.VehicleEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.event.weather.WeatherEvent;
 import org.bukkit.event.world.WorldEvent;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /** An event that wraps another event. */
 public abstract class GeneralizedEvent extends PreemptiveEvent {
@@ -77,25 +77,49 @@ public abstract class GeneralizedEvent extends PreemptiveEvent {
   }
 
   public static @Nullable Entity getActorIfPresent(Event event) {
-    if (event == null) return null;
-
-    if (event instanceof EntityEvent) return ((EntityEvent) event).getEntity();
-    if (event instanceof PlayerEvent) return ((PlayerEvent) event).getPlayer();
-    if (event instanceof BlockEvent) {
-      if (event instanceof BlockPlaceEvent) return ((BlockPlaceEvent) event).getPlayer();
-      if (event instanceof BlockBreakEvent) return ((BlockBreakEvent) event).getPlayer();
-      if (event instanceof BlockDamageEvent) return ((BlockDamageEvent) event).getPlayer();
-      if (event instanceof FurnaceExtractEvent) return ((FurnaceExtractEvent) event).getPlayer();
-      if (event instanceof SignChangeEvent) return ((SignChangeEvent) event).getPlayer();
+    switch (event) {
+      case null -> {
+        return null;
+      }
+      case EntityEvent entityEvent -> {
+        return entityEvent.getEntity();
+      }
+      case PlayerEvent playerEvent -> {
+        return playerEvent.getPlayer();
+      }
+      case BlockEvent blockEvent -> {
+        switch (blockEvent) {
+          case BlockPlaceEvent blockPlaceEvent -> {
+            return blockPlaceEvent.getPlayer();
+          }
+          case BlockBreakEvent blockBreakEvent -> {
+            return blockBreakEvent.getPlayer();
+          }
+          case BlockDamageEvent blockDamageEvent -> {
+            return blockDamageEvent.getPlayer();
+          }
+          case FurnaceExtractEvent furnaceExtractEvent -> {
+            return furnaceExtractEvent.getPlayer();
+          }
+          case SignChangeEvent signChangeEvent -> {
+            return signChangeEvent.getPlayer();
+          }
+          default -> {}
+        }
+      }
+      default -> {}
     }
-    if (event instanceof VehicleEvent) {
-      if (event instanceof VehicleExitEvent) return ((VehicleExitEvent) event).getExited();
-      if (event instanceof VehicleDamageEvent) return ((VehicleDamageEvent) event).getAttacker();
-      if (event instanceof VehicleDestroyEvent) return ((VehicleDestroyEvent) event).getAttacker();
-      if (event instanceof VehicleEnterEvent) return ((VehicleEnterEvent) event).getEntered();
-      if (event instanceof VehicleEntityCollisionEvent)
-        return ((VehicleEntityCollisionEvent) event).getEntity();
-      return ((VehicleEvent) event).getVehicle();
+
+    if (event instanceof VehicleEvent vehicleEvent) {
+      return switch (vehicleEvent) {
+        case VehicleExitEvent vehicleExitEvent -> vehicleExitEvent.getExited();
+        case VehicleDamageEvent vehicleDamageEvent -> vehicleDamageEvent.getAttacker();
+        case VehicleDestroyEvent vehicleDestroyEvent -> vehicleDestroyEvent.getAttacker();
+        case VehicleEnterEvent vehicleEnterEvent -> vehicleEnterEvent.getEntered();
+        case VehicleEntityCollisionEvent vehicleEntityCollisionEvent ->
+          vehicleEntityCollisionEvent.getEntity();
+        default -> vehicleEvent.getVehicle();
+      };
     }
     if (event instanceof GeneralizedEvent) return ((GeneralizedEvent) event).getActor();
 
@@ -103,7 +127,7 @@ public abstract class GeneralizedEvent extends PreemptiveEvent {
   }
 
   /**
-   * Tries to extract a {@link World} from a event.
+   * Tries to extract a {@link World} from an event.
    *
    * @param event The event to look for a {@link World} in
    */
@@ -112,7 +136,8 @@ public abstract class GeneralizedEvent extends PreemptiveEvent {
     if (event instanceof PlayerEvent) return ((PlayerEvent) event).getPlayer().getWorld();
     if (event instanceof EntityEvent) return ((EntityEvent) event).getEntity().getWorld();
     if (event instanceof BlockEvent) return ((BlockEvent) event).getBlock().getWorld();
-    if (event instanceof VehicleEvent) return ((VehicleEvent) event).getVehicle().getWorld();
+    if (event instanceof VehicleEvent)
+      return ((VehicleEvent) event).getVehicle().getWorld();
     if (event instanceof WeatherEvent) return ((WeatherEvent) event).getWorld();
 
     return null;

--- a/util/src/main/java/tc/oc/pgm/util/event/GeneralizedEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/GeneralizedEvent.java
@@ -77,53 +77,33 @@ public abstract class GeneralizedEvent extends PreemptiveEvent {
   }
 
   public static @Nullable Entity getActorIfPresent(Event event) {
-    switch (event) {
-      case null -> {
-        return null;
-      }
-      case EntityEvent entityEvent -> {
-        return entityEvent.getEntity();
-      }
-      case PlayerEvent playerEvent -> {
-        return playerEvent.getPlayer();
-      }
-      case BlockEvent blockEvent -> {
+    if (event == null) return null;
+
+    return switch (event) {
+      case EntityEvent entityEvent -> entityEvent.getEntity();
+      case PlayerEvent playerEvent -> playerEvent.getPlayer();
+      case BlockEvent blockEvent ->
         switch (blockEvent) {
-          case BlockPlaceEvent blockPlaceEvent -> {
-            return blockPlaceEvent.getPlayer();
-          }
-          case BlockBreakEvent blockBreakEvent -> {
-            return blockBreakEvent.getPlayer();
-          }
-          case BlockDamageEvent blockDamageEvent -> {
-            return blockDamageEvent.getPlayer();
-          }
-          case FurnaceExtractEvent furnaceExtractEvent -> {
-            return furnaceExtractEvent.getPlayer();
-          }
-          case SignChangeEvent signChangeEvent -> {
-            return signChangeEvent.getPlayer();
-          }
-          default -> {}
-        }
-      }
-      default -> {}
-    }
-
-    if (event instanceof VehicleEvent vehicleEvent) {
-      return switch (vehicleEvent) {
-        case VehicleExitEvent vehicleExitEvent -> vehicleExitEvent.getExited();
-        case VehicleDamageEvent vehicleDamageEvent -> vehicleDamageEvent.getAttacker();
-        case VehicleDestroyEvent vehicleDestroyEvent -> vehicleDestroyEvent.getAttacker();
-        case VehicleEnterEvent vehicleEnterEvent -> vehicleEnterEvent.getEntered();
-        case VehicleEntityCollisionEvent vehicleEntityCollisionEvent ->
-          vehicleEntityCollisionEvent.getEntity();
-        default -> vehicleEvent.getVehicle();
-      };
-    }
-    if (event instanceof GeneralizedEvent) return ((GeneralizedEvent) event).getActor();
-
-    return null;
+          case BlockPlaceEvent blockPlaceEvent -> blockPlaceEvent.getPlayer();
+          case BlockBreakEvent blockBreakEvent -> blockBreakEvent.getPlayer();
+          case BlockDamageEvent blockDamageEvent -> blockDamageEvent.getPlayer();
+          case FurnaceExtractEvent furnaceExtractEvent -> furnaceExtractEvent.getPlayer();
+          case SignChangeEvent signChangeEvent -> signChangeEvent.getPlayer();
+          default -> null;
+        };
+      case VehicleEvent vehicleEvent ->
+        switch (vehicleEvent) {
+          case VehicleExitEvent vehicleExitEvent -> vehicleExitEvent.getExited();
+          case VehicleDamageEvent vehicleDamageEvent -> vehicleDamageEvent.getAttacker();
+          case VehicleDestroyEvent vehicleDestroyEvent -> vehicleDestroyEvent.getAttacker();
+          case VehicleEnterEvent vehicleEnterEvent -> vehicleEnterEvent.getEntered();
+          case VehicleEntityCollisionEvent vehicleEntityCollisionEvent ->
+            vehicleEntityCollisionEvent.getEntity();
+          default -> vehicleEvent.getVehicle();
+        };
+      case GeneralizedEvent generalizedEvent -> generalizedEvent.getActor();
+      default -> null;
+    };
   }
 
   /**
@@ -132,14 +112,14 @@ public abstract class GeneralizedEvent extends PreemptiveEvent {
    * @param event The event to look for a {@link World} in
    */
   public static @Nullable World getWorldIfPresent(Event event) {
-    if (event instanceof WorldEvent worldEvent) return worldEvent.getWorld();
-    if (event instanceof PlayerEvent playerEvent) return playerEvent.getPlayer().getWorld();
-    if (event instanceof EntityEvent entityEvent) return entityEvent.getEntity().getWorld();
-    if (event instanceof BlockEvent blockEvent) return blockEvent.getBlock().getWorld();
-    if (event instanceof VehicleEvent vehicleEvent)
-      return vehicleEvent.getVehicle().getWorld();
-    if (event instanceof WeatherEvent weatherEvent) return weatherEvent.getWorld();
-
-    return null;
+    return switch (event) {
+      case WorldEvent worldEvent -> worldEvent.getWorld();
+      case PlayerEvent playerEvent -> playerEvent.getPlayer().getWorld();
+      case EntityEvent entityEvent -> entityEvent.getEntity().getWorld();
+      case BlockEvent blockEvent -> blockEvent.getBlock().getWorld();
+      case VehicleEvent vehicleEvent -> vehicleEvent.getVehicle().getWorld();
+      case WeatherEvent weatherEvent -> weatherEvent.getWorld();
+      default -> null;
+    };
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -23,7 +23,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.platform.Platform;
@@ -123,17 +123,15 @@ public final class InventoryUtils {
       return stack;
     }
 
-    if (leftover == stack.getAmount()) {
-      return stack;
-    } else {
+    if (leftover != stack.getAmount()) {
       placed = stack.clone();
       placed.setAmount(amount);
       inv.setItem(slot, placed);
 
       stack = stack.clone();
       stack.setAmount(leftover);
-      return stack;
     }
+    return stack;
   }
 
   public static ItemStack placeStack(Inventory inv, Iterable<Integer> slots, ItemStack stack) {

--- a/util/src/main/java/tc/oc/pgm/util/skin/Skin.java
+++ b/util/src/main/java/tc/oc/pgm/util/skin/Skin.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.util.skin;
 
+import java.util.Objects;
+
 /** A self-contained skin */
 public class Skin {
   public static final Skin EMPTY = new Skin(null, null);
@@ -34,17 +36,13 @@ public class Skin {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof Skin)) {
+    if (!(o instanceof Skin skin)) {
       return false;
     }
-    Skin skin = (Skin) o;
-    if (data != null ? !data.equals(skin.data) : skin.data != null) {
+    if (!Objects.equals(data, skin.data)) {
       return false;
     }
-    if (signature != null ? !signature.equals(skin.signature) : skin.signature != null) {
-      return false;
-    }
-    return true;
+    return Objects.equals(signature, skin.signature);
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabManager.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabManager.java
@@ -95,8 +95,8 @@ public abstract class TabManager implements Listener {
     return this.playerEntries.get(player);
   }
 
-  public void removePlayerEntry(Player player) {
-    this.playerEntries.remove(player);
+  public TabEntry removePlayerEntry(Player player) {
+    return this.playerEntries.remove(player);
   }
 
   protected TabEntry getBlankEntry(int index) {

--- a/util/src/main/java/tc/oc/pgm/util/tablist/TabManager.java
+++ b/util/src/main/java/tc/oc/pgm/util/tablist/TabManager.java
@@ -14,7 +14,7 @@ import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.util.ClassLogger;
 import tc.oc.pgm.util.collection.DefaultMapAdapter;
 import tc.oc.pgm.util.event.player.PlayerSkinPartsChangeEvent;
@@ -48,7 +48,7 @@ public abstract class TabManager implements Listener {
 
   protected final DefaultMapAdapter<Player, TabEntry> playerEntries;
   final Map<Integer, TabEntry> blankEntries =
-      new DefaultMapAdapter<Integer, TabEntry>(key -> new BlankTabEntry(), true);
+      new DefaultMapAdapter<>(key -> new BlankTabEntry(), true);
 
   protected TabManagerDirtyTracker dirty;
 
@@ -95,8 +95,8 @@ public abstract class TabManager implements Listener {
     return this.playerEntries.get(player);
   }
 
-  public TabEntry removePlayerEntry(Player player) {
-    return this.playerEntries.remove(player);
+  public void removePlayerEntry(Player player) {
+    this.playerEntries.remove(player);
   }
 
   protected TabEntry getBlankEntry(int index) {

--- a/util/src/main/java/tc/oc/pgm/util/text/ComponentRenderer.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/ComponentRenderer.java
@@ -19,8 +19,8 @@ import net.kyori.adventure.translation.GlobalTranslator;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class ComponentRenderer extends TranslatableComponentRenderer<Pointered> {
 
@@ -35,8 +35,8 @@ public class ComponentRenderer extends TranslatableComponentRenderer<Pointered> 
   private ComponentRenderer() {}
 
   @Override
-  protected @NotNull Component renderVirtual(
-      @NotNull VirtualComponent vc, @NotNull Pointered pointer) {
+  protected @NonNull Component renderVirtual(
+      @NonNull VirtualComponent vc, @NonNull Pointered pointer) {
     var factory = contextFactory.get(vc.contextType());
     if (factory == null)
       throw new UnsupportedOperationException("Context type not supported: " + vc.contextType());
@@ -58,7 +58,7 @@ public class ComponentRenderer extends TranslatableComponentRenderer<Pointered> 
   }
 
   @Override
-  protected @Nullable MessageFormat translate(@NotNull String key, @NotNull Pointered context) {
+  protected @Nullable MessageFormat translate(@NonNull String key, @NonNull Pointered context) {
     return GlobalTranslator.translator().translate(key, TextTranslations.getLocale(context));
   }
 
@@ -68,8 +68,8 @@ public class ComponentRenderer extends TranslatableComponentRenderer<Pointered> 
    * See <a href="https://github.com/KyoriPowered/adventure/issues/1299">Adventure#1299</a>.
    */
   @Override
-  protected @NotNull Component renderTranslatable(
-      @NotNull TranslatableComponent component, final @NotNull Pointered context) {
+  protected @NonNull Component renderTranslatable(
+      @NonNull TranslatableComponent component, final @NonNull Pointered context) {
     final List<TranslationArgument> arguments = component.arguments();
 
     if (!arguments.isEmpty()) {
@@ -79,7 +79,7 @@ public class ComponentRenderer extends TranslatableComponentRenderer<Pointered> 
           translatedArguments.set(i, TranslationArgument.component(this.render(c, context)));
       }
 
-      component = component.toBuilder().arguments(translatedArguments).build();
+      component = component.arguments(translatedArguments);
     }
 
     return this.renderTranslatableInner(component, context);

--- a/util/src/main/java/tc/oc/pgm/util/text/TextException.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextException.java
@@ -14,8 +14,8 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.util.ComponentMessageThrowable;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /** An exception with a localized error message. */
 public class TextException extends RuntimeException
@@ -27,23 +27,22 @@ public class TextException extends RuntimeException
       @Nullable Throwable cause, @Nullable String suggestion, String key, Component... args) {
     super(key, cause);
     final boolean suggest = suggestion != null;
-    this.message =
-        translatable()
-            .key(key)
-            .args(args)
-            .color(NamedTextColor.RED)
-            .append(suggest ? space() : empty())
-            .append(suggest ? translatable("error.suggestionSuffix", text(suggestion)) : empty())
-            .build();
+    this.message = translatable()
+        .key(key)
+        .arguments(args)
+        .color(NamedTextColor.RED)
+        .append(suggest ? space() : empty())
+        .append(suggest ? translatable("error.suggestionSuffix", text(suggestion)) : empty())
+        .build();
   }
 
   @Override
-  public @NotNull Component componentMessage() {
+  public @NonNull Component componentMessage() {
     return this.message;
   }
 
   @Override
-  public @NotNull Component asComponent() {
+  public @NonNull Component asComponent() {
     return this.message;
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/text/TextParser.java
+++ b/util/src/main/java/tc/oc/pgm/util/text/TextParser.java
@@ -7,7 +7,6 @@ import static tc.oc.pgm.util.text.TextException.unknown;
 
 import com.google.common.collect.Range;
 import com.google.gson.JsonSyntaxException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
@@ -28,7 +27,7 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Chunk;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import tc.oc.pgm.util.Aliased;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.TimeUtils;
@@ -99,7 +98,7 @@ public final class TextParser {
   }
 
   public static <T extends Comparable<T>> void assertInRange(
-      @NotNull T val, @NotNull Range<T> range) {
+      @NonNull T val, @NonNull Range<T> range) {
     if (!range.contains(val)) throw outOfRange(val.toString(), range);
   }
 
@@ -555,9 +554,8 @@ public final class TextParser {
 
     // Driver uris will always start with "jdbc:"
     try {
-      return DriverManager.getConnection(
-          URLDecoder.decode("jdbc:" + uri.toString(), StandardCharsets.UTF_8.name()));
-    } catch (UnsupportedEncodingException | SQLException e) {
+      return DriverManager.getConnection(URLDecoder.decode("jdbc:" + uri, StandardCharsets.UTF_8));
+    } catch (SQLException e) {
       throw unknown(e); // TODO: wrap common database errors with more friendly messages
     }
   }

--- a/util/src/main/java/tc/oc/pgm/util/xml/InvalidXMLException.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/InvalidXMLException.java
@@ -5,7 +5,7 @@ import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.input.JDOMParseException;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class InvalidXMLException extends Exception {
 
@@ -137,10 +137,7 @@ public class InvalidXMLException extends Exception {
         return what + " @ " + where;
       }
       return what;
-    } else if (where != null) {
-      return where;
-    }
-    return null;
+    } else return where;
   }
 
   public @Nullable String getFullLocation() {

--- a/util/src/main/java/tc/oc/pgm/util/xml/Node.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/Node.java
@@ -109,15 +109,12 @@ public class Node {
   }
 
   private static int getStartLine(Object node) {
-    if (node instanceof InheritingElement) {
-      return ((InheritingElement) node).getStartLine();
-    } else if (node instanceof Located) {
-      return ((Located) node).getLine();
-    } else if (node instanceof Attribute) {
-      return getStartLine(((Attribute) node).getParent());
-    } else {
-      return 0;
-    }
+    return switch (node) {
+      case InheritingElement inheritingElement -> inheritingElement.getStartLine();
+      case Located located -> located.getLine();
+      case Attribute attribute -> getStartLine(attribute.getParent());
+      case null, default -> 0;
+    };
   }
 
   public int getEndLine() {
@@ -125,15 +122,12 @@ public class Node {
   }
 
   public static int getEndLine(Object node) {
-    if (node instanceof InheritingElement) {
-      return ((InheritingElement) node).getEndLine();
-    } else if (node instanceof Located) {
-      return ((Located) node).getLine();
-    } else if (node instanceof Attribute) {
-      return getEndLine(((Attribute) node).getParent());
-    } else {
-      return 0;
-    }
+    return switch (node) {
+      case InheritingElement inheritingElement -> inheritingElement.getEndLine();
+      case Located located -> located.getLine();
+      case Attribute attribute -> getEndLine(attribute.getParent());
+      case null, default -> 0;
+    };
   }
 
   public int getColumn() {


### PR DESCRIPTION
This PR selectively applies many IntelliJ suggestions that are less disruptive and/or less breaking:

1. Use switch expressions where possible
2. Use pattern variables where possible
3. Migrate some internal classes to records where possible, and use record patterns where applicable
4. Add many missing annotations
5. Cleanup a lot of logic oddities, and remove some unused variables in classes going back to ProjectAres
6. Migrate all modified classes to JSpecify following #1597 

Some future considerations:
1. FileUtils seems to be quite legacy and cites a source site that no longer exists, maybe worth using modern Java APIs for this
2. There are a lot of classes that we could migrate to being records, but many getters are used outside of PGM so perhaps maintaining those while deprecating is worth doing.