### PR TITLE
Fix some issues with team names

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -417,7 +417,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
 
       if (message != null) {
         getLogger().log(Level.INFO, ChatColor.stripColor(message));
-        Bukkit.broadcast(message, Permissions.DEBUG);
+        Bukkit.broadcast(ChatColor.RED + message, Permissions.DEBUG);
       }
 
       if (message == null || message.contains("Unhandled")) {

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -418,10 +418,15 @@ public class ActionParser {
         parser.parseBool(el, "events").orFalse());
   }
 
+  private static final Pattern TEAM_NAME =
+      Pattern.compile(".*[a-z]{3}.*", Pattern.CASE_INSENSITIVE);
+
   @MethodParser("team-alias")
   public <T extends Filterable<?>> Action<?> parseTeamAliasAction(Element el, Class<T> scope)
       throws InvalidXMLException {
-    String alias = parser.string(el, "alias").required();
+    String alias = parser.string(el, "alias").validate(TEAM_NAME).required().trim();
+    if ("obs".equalsIgnoreCase(alias))
+      throw new InvalidXMLException("'obs' is a reserved team alias", el);
     var action = new TeamAliasAction(alias);
     var teamBuilder = parser.reference(TeamFactory.class, el, "team");
     var team = scope == Party.class ? teamBuilder.orNull() : teamBuilder.required();

--- a/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TeamAliasAction.java
@@ -1,6 +1,10 @@
 package tc.oc.pgm.action.actions;
 
+import java.util.logging.Level;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.teams.TeamMatchModule;
 
 public class TeamAliasAction extends AbstractAction<Party> {
   protected final String alias;
@@ -12,6 +16,18 @@ public class TeamAliasAction extends AbstractAction<Party> {
 
   @Override
   public void trigger(Party party) {
+    // No-op for non-team parties, we don't want people renaming obs
+    if (!(party instanceof Team)) return;
+    var existingTeam = party.getMatch().needModule(TeamMatchModule.class).getTeam(alias);
+    if (existingTeam != null && existingTeam != party) {
+      PGM.get()
+          .getGameLogger()
+          .log(
+              Level.WARNING,
+              "Team alias '%s' cannot be applied to '%s' as it's already in use"
+                  .formatted(alias, party.getName()));
+      return;
+    }
     party.setName(this.alias);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/teams/TeamModule.java
+++ b/core/src/main/java/tc/oc/pgm/teams/TeamModule.java
@@ -44,11 +44,8 @@ public class TeamModule implements MapModule<TeamMatchModule> {
     final int size = teams.size();
     return TAGS.computeIfAbsent(
         size,
-        s ->
-            ImmutableList.of(
-                new MapTag(
-                    size + "team" + (size == 1 ? "" : "s"),
-                    size + " Team" + (size == 1 ? "" : "s"))));
+        s -> ImmutableList.of(new MapTag(
+            size + "team" + (size == 1 ? "" : "s"), size + " Team" + (size == 1 ? "" : "s"))));
   }
 
   @Override
@@ -109,17 +106,16 @@ public class TeamModule implements MapModule<TeamMatchModule> {
     String id = el.getAttributeValue("id");
 
     String name = el.getTextNormalize();
-    if ("".equals(name)) {
-      throw new InvalidXMLException("Team name cannot be blank", el);
+    if (name.isBlank() || "obs".equalsIgnoreCase(name)) {
+      throw new InvalidXMLException("Team name cannot be blank or 'obs'", el);
     }
 
     boolean plural = XMLUtils.parseBoolean(el.getAttribute("plural"), false);
 
     ChatColor color = XMLUtils.parseChatColor(Node.fromAttr(el, "color"), ChatColor.WHITE);
     DyeColor dyeColor = XMLUtils.parseDyeColor(el.getAttribute("dye-color"), null);
-    NameTagVisibility nameTagVisibility =
-        XMLUtils.parseNameTagVisibility(
-            Node.fromAttr(el, "show-name-tags"), NameTagVisibility.ALWAYS);
+    NameTagVisibility nameTagVisibility = XMLUtils.parseNameTagVisibility(
+        Node.fromAttr(el, "show-name-tags"), NameTagVisibility.ALWAYS);
 
     int minPlayers = XMLUtils.parseNumber(Node.fromAttr(el, "min"), Integer.class, 0);
     int maxPlayers = XMLUtils.parseNumber(Node.fromRequiredAttr(el, "max"), Integer.class);
@@ -131,17 +127,8 @@ public class TeamModule implements MapModule<TeamMatchModule> {
       throw new InvalidXMLException("Max overfill can not be less then max players.", el);
     }
 
-    TeamFactory teamFactory =
-        new TeamFactory(
-            id,
-            name,
-            plural,
-            color,
-            dyeColor,
-            minPlayers,
-            maxPlayers,
-            maxOverfill,
-            nameTagVisibility);
+    TeamFactory teamFactory = new TeamFactory(
+        id, name, plural, color, dyeColor, minPlayers, maxPlayers, maxOverfill, nameTagVisibility);
     factory.getFeatures().addFeature(el, teamFactory);
 
     return teamFactory;

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/StringBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/StringBuilder.java
@@ -1,8 +1,10 @@
 package tc.oc.pgm.util.xml.parsers;
 
+import java.util.regex.Pattern;
 import org.bukkit.ChatColor;
 import org.jdom2.Element;
 import tc.oc.pgm.util.text.TextException;
+import tc.oc.pgm.util.xml.InvalidXMLException;
 
 public class StringBuilder extends PrimitiveBuilder<String, StringBuilder> {
   private boolean colored;
@@ -20,6 +22,14 @@ public class StringBuilder extends PrimitiveBuilder<String, StringBuilder> {
   protected String parse(String text) throws TextException {
     if (colored) text = ChatColor.translateAlternateColorCodes('`', text);
     return text;
+  }
+
+  public StringBuilder validate(Pattern pattern) {
+    var predicate = pattern.asMatchPredicate();
+    return this.validate((s, node) -> {
+      if (!predicate.test(s))
+        throw new InvalidXMLException("Expected string to match " + pattern, el);
+    });
   }
 
   @Override


### PR DESCRIPTION
- Turns `obs` into a reserved name, teams cannot be named `obs` anymore
- `team-alias` names now:
  - Must have at least 3 consecutive a-z characters, so names with fully non-ascii characters, or empty names aren't allowed
  - Their starting/preceding whitespace will be trimmed
  - Cannot use `obs` as their name
  - Two teams cannot be renamed into the same alias. If they try, a warn will show for ops and the rename will not take place.

While this is technically a breaking change to teams and team aliases, i expect no maps to be affected by the team change, and the alias is a very recent feature which was already on thin ice when introduced.