### PR TITLE
Improve reliability of server list pings on modern servers

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/PacketManipulations.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/PacketManipulations.java
@@ -142,6 +142,7 @@ public class PacketManipulations implements PacketSender {
   }
 
   private void handleServerPing(PacketEvent event) {
+    if (event.isCancelled()) return;
     JsonObject pingExtra = new JsonObject();
     new ExtraPingDataRequestEvent() {
       @Override

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/PacketManipulations.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/PacketManipulations.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.protocol.status.ClientboundStatusResponsePacket;
 import net.minecraft.network.protocol.status.ServerStatus;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.SynchedEntityData;
@@ -152,9 +153,9 @@ public class PacketManipulations implements PacketSender {
 
     if (!pingExtra.isEmpty()) {
       // Encode the response manually, otherwise the extra data will get lost
-      var serverPing = (ServerStatus) event.getPacket().getServerPings().read(0).getHandle();
+      var nmsPacket = (ClientboundStatusResponsePacket) event.getPacket().getHandle();
       var jsonData = ServerStatus.CODEC
-          .encodeStart(JsonOps.INSTANCE, serverPing)
+          .encodeStart(JsonOps.INSTANCE, nmsPacket.status())
           .getOrThrow()
           .getAsJsonObject();
 


### PR DESCRIPTION
This PR tries to improve the reliability of the custom server list ping data injector on modern servers.
- When the underlying packet is cancelled by lower priority handlers, PGM won't process the packet to avoid unexpected responses
- Server status serialization now uses the underlying NMS packet instead of going through ProtocolLib's wrappers. This has the benefit of reducing structure copies, and it should prevent the following exception from happening on rare occasions:
```
[00:46:53 ERROR]: [PGM] Unhandled exception occurred in onPacketSending(PacketEvent) for PGM
java.lang.IllegalStateException: Unable to construct new instance using public net.minecraft.network.protocol.status.ServerStatus$Players(int,int,java.util.List)
        at ProtocolLib.jar/com.comphenix.protocol.reflect.accessors.DefaultConstrutorAccessor.invoke(DefaultConstrutorAccessor.java:21) ~[ProtocolLib.jar:?]
        at ProtocolLib.jar/com.comphenix.protocol.wrappers.AutoWrapper.unwrap(AutoWrapper.java:126) ~[ProtocolLib.jar:?]
        at ProtocolLib.jar/com.comphenix.protocol.wrappers.ping.ServerPingRecord.getHandle(ServerPingRecord.java:366) ~[ProtocolLib.jar:?]
        at ProtocolLib.jar/com.comphenix.protocol.wrappers.WrappedServerPing.getHandle(WrappedServerPing.java:319) ~[ProtocolLib.jar:?]
        at PGM.jar/tc.oc.pgm.platform.modern.packets.PacketManipulations.handleServerPing(PacketManipulations.java:155) ~[PGM.jar:?]
        at PGM.jar/tc.oc.pgm.platform.modern.util.Packets$1.onPacketSending(Packets.java:26) ~[PGM.jar:?]
        at ProtocolLib.jar/com.comphenix.protocol.injector.collection.OutboundPacketListenerSet.invokeListener(OutboundPacketListenerSet.java:74) ~[ProtocolLib.jar:?]
        (rest of stacktrace snipped)
Caused by: java.lang.NullPointerException: null array reference
        at java.base/java.lang.invoke.MethodHandleImpl.checkSpreadArgument(MethodHandleImpl.java:585) ~[?:?]
        at ProtocolLib.jar/com.comphenix.protocol.reflect.accessors.DefaultConstrutorAccessor.invoke(DefaultConstrutorAccessor.java:19) ~[ProtocolLib.jar:?]
        ... 101 more
```
(Although personally, I believe this to be a possible [race condition problem](https://github.com/dmulloy2/ProtocolLib/blob/f606cc954d4809de3e04b73aef8b295559dc4d90/src/main/java/com/comphenix/protocol/wrappers/AutoWrapper.java#L123-L126) in ProtocolLib rather than the problem of PGM.)