### PR TITLE
fix: don't turn dropped items that are hooked into fish on modern servers

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -242,7 +242,8 @@ public class PGMListener implements Listener {
 
   @EventHandler
   public void nerfFishing(PlayerFishEvent event) {
-    if (event.getCaught() instanceof Item caught) {
+    if (event.getState() == PlayerFishEvent.State.CAUGHT_FISH
+        && event.getCaught() instanceof Item caught) {
       if (caught.getItemStack().getType() != Materials.RAW_FISH) {
         caught.setItemStack(new ItemStack(Materials.RAW_FISH));
       }


### PR DESCRIPTION
On modern servers, you can hook dropped items with a fishing rod. Those get turned into fish if reeled in. Probably not a thing it should do.