### PR TITLE
Move global xml after constants

### DIFF
--- a/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
+++ b/core/src/main/java/tc/oc/pgm/map/MapFilePreprocessor.java
@@ -19,7 +19,7 @@ import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.Text;
 import org.jdom2.input.SAXBuilder;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.map.MapSource;
 import tc.oc.pgm.api.map.exception.MapMissingException;
 import tc.oc.pgm.api.map.includes.MapInclude;
@@ -44,6 +44,7 @@ public class MapFilePreprocessor {
   private final MapSource source;
   private final String variant;
   private final List<MapInclude> includes;
+  private @Nullable MapInclude global; // Once included becomes null
 
   private final Map<String, String> constants;
   private final Set<String> variantIds;
@@ -60,6 +61,7 @@ public class MapFilePreprocessor {
     this.includes = new ArrayList<>();
     this.constants = new HashMap<>();
     this.variantIds = new HashSet<>();
+    this.global = includeProcessor.getGlobalInclude();
   }
 
   public Document getDocument()
@@ -75,16 +77,11 @@ public class MapFilePreprocessor {
       variantIds.add(XMLUtils.parseRequiredId(variant));
     }
 
-    document.runWithoutVisitation(() -> {
-      MapInclude global = includeProcessor.getGlobalInclude();
-      if (global != null) {
-        document.getRootElement().addContent(0, global.getContent());
-        includes.add(global);
-      }
+    document.runWithoutVisitation(() -> preprocessChildren(document.getRootElement(), true));
+    source.setIncludes(includes);
 
-      preprocessChildren(document.getRootElement());
-      source.setIncludes(includes);
-    });
+    if (global != null)
+      throw new InvalidXMLException("Did not find a place to inject global xml! :(", document);
 
     // If no constants are set, assume we can skip the step
     if (!constants.isEmpty()) {
@@ -106,26 +103,36 @@ public class MapFilePreprocessor {
     return constants;
   }
 
-  private void preprocessChildren(Element parent) throws InvalidXMLException {
+  private void preprocessChildren(Element parent, boolean isRoot) throws InvalidXMLException {
     for (int i = 0; i < parent.getContentSize(); i++) {
       Content content = parent.getContent(i);
       if (!(content instanceof Element child)) continue;
 
+      boolean processChildren = true;
       List<Content> replacement =
           switch (child.getName()) {
             case "include" -> processIncludeElement(child);
             case "if" -> processConditional(child, true);
             case "unless" -> processConditional(child, false);
             case "constant" -> processConstant(child);
-            default -> null;
+            case "constants" -> null;
+            default -> {
+              if (isRoot && global != null) {
+                parent.addContent(i, global.getContent());
+                includes.add(global);
+                global = null;
+                i--; // Go back and process newly injected global
+                processChildren = false;
+              }
+              yield null;
+            }
           };
-
       if (replacement != null) {
         parent.removeContent(i);
         parent.addContent(i, replacement);
         i--; // Process replacement content
-      } else {
-        preprocessChildren(child);
+      } else if (processChildren) {
+        preprocessChildren(child, false);
       }
     }
   }

--- a/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/DocumentWrapper.java
@@ -11,7 +11,9 @@ import org.jdom2.Namespace;
 
 public class DocumentWrapper extends Document {
 
-  private static final Set<String> IGNORED =
+  private static final Set<String> IGNORED_ATTRIBUTES =
+      Set.of("min-server-version", "max-server-version");
+  private static final Set<String> IGNORED_ELEMENTS =
       Set.of("constants", "edition", "name", "tutorial", "variant");
 
   private boolean visitingAllowed = true;
@@ -51,19 +53,21 @@ public class DocumentWrapper extends Document {
   }
 
   private void checkVisited(Element el, Consumer<Node> unvisited) {
-    for (Attribute attribute : el.getAttributes()) {
-      if (attribute.getNamespace() == Namespace.NO_NAMESPACE
-          && !((VisitableAttribute) attribute).wasVisited())
-        unvisited.accept(Node.fromNullable(attribute));
-    }
-
     boolean canIgnore = el == getRootElement();
+
+    for (Attribute a : el.getAttributes()) {
+      if (!(a instanceof VisitableAttribute visitable)) continue;
+      if (a.getNamespace() != Namespace.NO_NAMESPACE) continue;
+      if (canIgnore && IGNORED_ATTRIBUTES.contains(a.getName())) continue;
+
+      if (!visitable.wasVisited()) unvisited.accept(Node.fromNullable(a));
+    }
 
     for (int i = 0; i < el.getContentSize(); i++) {
       Content c = el.getContent(i);
       if (!(c instanceof InheritingElement child)) continue;
       if (child.getNamespace() != Namespace.NO_NAMESPACE) continue;
-      if (canIgnore && IGNORED.contains(child.getName())) continue;
+      if (canIgnore && IGNORED_ELEMENTS.contains(child.getName())) continue;
 
       if (!child.wasVisited()) unvisited.accept(Node.fromNullable(child));
       else checkVisited(child, unvisited);


### PR DESCRIPTION
Fixes #1602 

Global XML will now be included right before the first non-preprocessed child element of the document's root.
Effectively speaking this means you can have `if`, `unless`, `include`, `constants` and `constant` at the top of the xml to modify behavior of the global xml, and then global will be appended (still towards the top of the xml) right before the first relevant element, usually by convention, `<name>`.

eg:
```xml
<map>
  <constant id="legacy-pvp">false</constant>
  <!-- global will be placed here -->
  <name>My modern map</name>
  <!-- ... -->
</map>
```
Before, global would insert before constant, now it will insert before name.

Things that also work:
```xml
<map>
  <if variant="modern">
    <constant id="legacy-pvp">false</constant>
  </if>
  <!-- global will be placed here -->
  <name>My modern map</name>
  <!-- ... -->
</map>
```

Things that "don't" work (the global would end up above where you'd want it):
```xml
<map>
  <if variant="modern">
    <!-- global will be placed here -->
    <maxbuildheight>32</maxbuildheight>
    <constant id="legacy-pvp">false</constant>
  </if>
  <name>My modern map</name>
  <!-- ... -->
</map>
```