### PR TITLE
Fix inventory access bugs in modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/actions/EnchantItemAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/EnchantItemAction.java
@@ -6,6 +6,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.util.inventory.ItemMatcher;
+import tc.oc.pgm.util.inventory.Slot;
 import tc.oc.pgm.util.math.Formula;
 
 public class EnchantItemAction extends AbstractAction<MatchPlayer> {
@@ -27,23 +28,16 @@ public class EnchantItemAction extends AbstractAction<MatchPlayer> {
 
     int level = Math.max(0, (int) this.level.applyAsDouble(player));
 
-    for (ItemStack current : inv.getArmorContents()) {
-      if (current != null && matcher.matches(current)) enchant(current, level);
-    }
-    for (int i = 0; i < inv.getSize(); i++) {
-      ItemStack current = inv.getItem(i);
-      if (current != null && matcher.matches(current)) {
-        enchant(current, level);
-        // Makes item sync with client instantly
-        inv.setItem(i, current);
-      }
-    }
+    Slot.Player.forEach(inv, (slot, stack) -> {
+      if (matcher.matches(stack)) slot.setItem(inv, enchant(stack, level));
+    });
   }
 
-  private void enchant(ItemStack current, int level) {
+  private ItemStack enchant(ItemStack current, int level) {
     if (current.getEnchantmentLevel(enchant) != level) {
       if (level == 0) current.removeEnchantment(enchant);
       else current.addUnsafeEnchantment(enchant, level);
     }
+    return current;
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/ReplaceItemAction.java
@@ -5,6 +5,7 @@ import org.bukkit.inventory.PlayerInventory;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.tag.ItemModifier;
 import tc.oc.pgm.util.inventory.ItemMatcher;
+import tc.oc.pgm.util.inventory.Slot;
 
 public class ReplaceItemAction extends AbstractAction<MatchPlayer> {
 
@@ -25,20 +26,9 @@ public class ReplaceItemAction extends AbstractAction<MatchPlayer> {
   @Override
   public void trigger(MatchPlayer player) {
     PlayerInventory inv = player.getInventory();
-
-    ItemStack[] armor = inv.getArmorContents();
-    for (int i = 0; i < armor.length; i++) {
-      ItemStack current = armor[i];
-      if (current == null || !matcher.matches(current)) continue;
-      armor[i] = replaceItem(current, player);
-    }
-    inv.setArmorContents(armor);
-
-    for (int i = 0; i < inv.getSize(); i++) {
-      ItemStack current = inv.getItem(i);
-      if (current == null || !matcher.matches(current)) continue;
-      inv.setItem(i, replaceItem(current, player));
-    }
+    Slot.Player.forEach(inv, (slot, stack) -> {
+      if (matcher.matches(stack)) slot.setItem(inv, replaceItem(stack, player));
+    });
   }
 
   private ItemStack replaceItem(ItemStack current, MatchPlayer player) {

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
@@ -18,6 +18,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.inventory.ItemMatcher;
+import tc.oc.pgm.util.inventory.Slot;
 
 public class CarryingItemFilter extends ParticipantItemFilter {
   public CarryingItemFilter(ItemMatcher matcher) {
@@ -39,9 +40,7 @@ public class CarryingItemFilter extends ParticipantItemFilter {
 
   @Override
   protected Stream<ItemStack> getItems(MatchPlayer player) {
-    Stream<ItemStack> inventory = Stream.concat(
-        Arrays.stream(player.getBukkit().getInventory().getContents()),
-        Stream.of(player.getBukkit().getItemOnCursor()));
+    Stream<ItemStack> inventory = Slot.Player.player().map(s -> s.getItem(player));
 
     // Potentially add the crafting grid if that's the currently open inventory
     InventoryView invView = player.getBukkit().getOpenInventory();

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/HoldingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/HoldingItemFilter.java
@@ -15,6 +15,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.inventory.ItemMatcher;
+import tc.oc.pgm.util.inventory.Slot;
 
 public class HoldingItemFilter extends ParticipantItemFilter {
   public HoldingItemFilter(ItemMatcher matcher) {
@@ -36,6 +37,6 @@ public class HoldingItemFilter extends ParticipantItemFilter {
 
   @Override
   protected Stream<ItemStack> getItems(MatchPlayer player) {
-    return Stream.of(player.getBukkit().getItemInHand());
+    return Slot.Equipment.hands().map(s -> s.getItem(player));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/WearingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/WearingItemFilter.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.filters.matcher.player;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Stream;
 import org.bukkit.event.Event;
@@ -13,6 +12,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.ApplyKitEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.inventory.ItemMatcher;
+import tc.oc.pgm.util.inventory.Slot;
 
 public class WearingItemFilter extends ParticipantItemFilter {
   public WearingItemFilter(ItemMatcher matcher) {
@@ -31,6 +31,6 @@ public class WearingItemFilter extends ParticipantItemFilter {
 
   @Override
   protected Stream<ItemStack> getItems(MatchPlayer player) {
-    return Arrays.stream(player.getBukkit().getInventory().getArmorContents());
+    return Slot.Armor.armor().map(s -> s.getItem(player));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
@@ -1,12 +1,14 @@
 package tc.oc.pgm.kits;
 
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.kits.tag.ItemModifier;
 import tc.oc.pgm.util.inventory.ArmorType;
+import tc.oc.pgm.util.inventory.Slot;
 
 public class ArmorKit extends AbstractKit {
   public static class ArmorItem {
@@ -19,14 +21,21 @@ public class ArmorKit extends AbstractKit {
     }
   }
 
-  private final Map<ArmorType, ArmorItem> armor;
+  private final Map<Slot.Armor, ArmorItem> armor;
 
-  public ArmorKit(Map<ArmorType, ArmorItem> armor) {
+  public ArmorKit(Map<Slot.Armor, ArmorItem> armor) {
     this.armor = armor;
   }
 
+  @Deprecated(forRemoval = true)
   public Map<ArmorType, ArmorItem> getArmor() {
-    return armor;
+    var remapped = new HashMap<ArmorType, ArmorItem>();
+    armor.forEach((slot, armorItem) -> remapped.put(slot.getArmorType(), armorItem));
+    return remapped;
+  }
+
+  public Collection<ArmorItem> getArmorItems() {
+    return armor.values();
   }
 
   /**
@@ -35,14 +44,12 @@ public class ArmorKit extends AbstractKit {
    */
   @Override
   public void applyPostEvent(MatchPlayer player, boolean force, List<ItemStack> displacedItems) {
-    ItemStack[] wearing = player.getBukkit().getInventory().getArmorContents();
-    for (Map.Entry<ArmorType, ArmorItem> entry : this.armor.entrySet()) {
-      int slot = entry.getKey().ordinal();
-      if (force || wearing[slot] == null || wearing[slot].getType() == Material.AIR) {
-        wearing[slot] = entry.getValue().stack.clone();
-        ItemModifier.apply(wearing[slot], player);
+    this.armor.forEach((slot, item) -> {
+      var wearing = slot.getItem(player);
+      if (force || wearing == null) {
+        slot.setItem(player, wearing = item.stack.clone());
+        ItemModifier.apply(wearing, player);
       }
-    }
-    player.getBukkit().getInventory().setArmorContents(wearing);
+    });
   }
 }

--- a/core/src/main/java/tc/oc/pgm/kits/ItemKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ItemKit.java
@@ -80,7 +80,7 @@ public class ItemKit implements KitDefinition {
 
     if (force) {
       for (Entry<Slot, ItemStack> kitEntry : event.getSlotItems().entrySet()) {
-        kitEntry.getKey().putItem(holder, kitEntry.getValue().clone());
+        kitEntry.getKey().setItem(holder, kitEntry.getValue().clone());
       }
     } else {
       // Tools in the player's inv are repaired using matching tools in the kit with less damage
@@ -144,7 +144,7 @@ public class ItemKit implements KitDefinition {
 
         Slot kitSlot = kitEntry.getKey();
         if (InventoryUtils.isNothing(kitSlot.getItem(holder))) {
-          kitSlot.putItem(holder, kitStack);
+          kitSlot.setItem(holder, kitStack);
         } else {
           displacedItems.add(kitStack);
         }

--- a/core/src/main/java/tc/oc/pgm/kits/KitModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitModule.java
@@ -121,8 +121,8 @@ public class KitModule implements MapModule<KitMatchModule> {
       }
 
       if (imm != null) {
-        if (kit instanceof ArmorKit) {
-          for (ArmorKit.ArmorItem armor : ((ArmorKit) kit).getArmor().values()) {
+        if (kit instanceof ArmorKit ak) {
+          for (ArmorKit.ArmorItem armor : ak.getArmorItems()) {
             imm.applyRules(armor.stack);
           }
         }

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -64,7 +64,6 @@ import tc.oc.pgm.shield.ShieldParameters;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.teams.Teams;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
-import tc.oc.pgm.util.inventory.ArmorType;
 import tc.oc.pgm.util.inventory.InventoryUtils;
 import tc.oc.pgm.util.inventory.ItemMatcher;
 import tc.oc.pgm.util.inventory.Slot;
@@ -233,14 +232,11 @@ public abstract class KitParser {
   }
 
   public ArmorKit parseArmorKit(Element el) throws InvalidXMLException {
-    Map<ArmorType, ArmorKit.ArmorItem> armor = new HashMap<>();
+    Map<Slot.Armor, ArmorKit.ArmorItem> armor = new HashMap<>();
 
-    for (ArmorType armorType : ArmorType.values()) {
-      ArmorKit.ArmorItem armorItem =
-          this.parseArmorItem(el.getChild(armorType.name().toLowerCase()));
-      if (armorItem != null) {
-        armor.put(armorType, armorItem);
-      }
+    for (Slot.Armor armorSlot : Slot.Armor.armor().toList()) {
+      var armorItem = parseArmorItem(el.getChild(armorSlot.getArmorType().name().toLowerCase()));
+      if (armorItem != null) armor.put(armorSlot, armorItem);
     }
 
     if (!armor.isEmpty()) {

--- a/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/PGMListener.java
@@ -12,7 +12,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.entity.EnderPearl;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
@@ -53,6 +52,7 @@ import tc.oc.pgm.gamerules.GameRulesMatchModule;
 import tc.oc.pgm.modules.WorldTimeModule;
 import tc.oc.pgm.util.bukkit.WorldBorders;
 import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
+import tc.oc.pgm.util.inventory.Slot;
 import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.skin.Skin;
 import tc.oc.pgm.util.text.TextTranslations;
@@ -257,15 +257,7 @@ public class PGMListener implements Listener {
 
     var world = quitter.getBukkit().getWorld();
     var location = quitter.getBukkit().getLocation();
-    for (ItemStack item : quitter.getInventory().getContents()) {
-      if (item == null || item.getType() == Material.AIR) continue;
-      world.dropItemNaturally(location, item);
-    }
-
-    for (ItemStack armor : quitter.getInventory().getArmorContents()) {
-      if (armor == null || armor.getType() == Material.AIR) continue;
-      world.dropItemNaturally(location, armor);
-    }
+    Slot.Player.forEach(quitter.getInventory(), (s, is) -> world.dropItemNaturally(location, is));
   }
 
   @EventHandler

--- a/core/src/main/java/tc/oc/pgm/loot/LootableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/loot/LootableMatchModule.java
@@ -264,7 +264,7 @@ public class LootableMatchModule implements MatchModule, Listener {
     }
 
     private void putItem(ItemStack item) {
-      this.slot.putItem(inventory, item);
+      this.slot.setItem(inventory, item);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modules/ItemKeepMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ItemKeepMatchModule.java
@@ -17,7 +17,8 @@ import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
-import tc.oc.pgm.util.inventory.ArmorType;
+import tc.oc.pgm.spawns.events.ParticipantSpawnEvent;
+import tc.oc.pgm.util.inventory.Slot;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
 @ListenerScope(MatchScope.RUNNING)
@@ -26,8 +27,7 @@ public class ItemKeepMatchModule implements MatchModule, Listener {
   private final Match match;
   private final MaterialMatcher itemsToKeep;
   private final MaterialMatcher armorToKeep;
-  private final Map<MatchPlayer, Map<Integer, ItemStack>> keptInv = Maps.newHashMap();
-  private final Map<MatchPlayer, Map<ArmorType, ItemStack>> keptArmor = Maps.newHashMap();
+  private final Map<MatchPlayer, Map<Slot.Player, ItemStack>> keptInv = Maps.newHashMap();
 
   public ItemKeepMatchModule(
       Match match, MaterialMatcher itemsToKeep, MaterialMatcher armorToKeep) {
@@ -36,12 +36,8 @@ public class ItemKeepMatchModule implements MatchModule, Listener {
     this.armorToKeep = armorToKeep;
   }
 
-  private boolean canKeepItem(ItemStack stack) {
-    return itemsToKeep.matches(stack);
-  }
-
-  private boolean canKeepArmor(ItemStack stack) {
-    return itemsToKeep.matches(stack) || armorToKeep.matches(stack);
+  private boolean canKeepItem(Slot.Player slot, ItemStack stack) {
+    return itemsToKeep.matches(stack) || (slot instanceof Slot.Armor && armorToKeep.matches(stack));
   }
 
   /**
@@ -55,81 +51,52 @@ public class ItemKeepMatchModule implements MatchModule, Listener {
       return;
     }
 
-    ItemStack[] carrying = event.getEntity().getInventory().getContents();
-    Map<Integer, ItemStack> keptItems = new HashMap<>();
-    for (int slot = 0; slot < carrying.length; slot++) {
-      ItemStack stack = carrying[slot];
-      if (stack != null && this.canKeepItem(stack)) {
+    var inv = event.getEntity().getInventory();
+    Map<Slot.Player, ItemStack> keptItems = new HashMap<>();
+    Slot.Player.forEach(inv, (slot, stack) -> {
+      if (this.canKeepItem(slot, stack)) {
         event.getDrops().remove(stack);
         keptItems.put(slot, stack);
       }
-    }
+    });
+    if (!keptItems.isEmpty()) this.keptInv.put(player, keptItems);
+  }
 
-    if (!keptItems.isEmpty()) {
-      this.keptInv.put(player, keptItems);
-    }
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void restoreKeptInventory(ParticipantSpawnEvent event) {
+    var player = event.getPlayer();
+    var kept = this.keptInv.remove(player);
+    if (kept == null) return;
+    List<ItemStack> displaced = new ArrayList<>();
+    PlayerInventory inv = player.getBukkit().getInventory();
 
-    ItemStack[] wearing = event.getEntity().getInventory().getArmorContents();
-    Map<ArmorType, ItemStack> keptArmor = new HashMap<>();
-    for (int slot = 0; slot < wearing.length; slot++) {
-      ItemStack stack = wearing[slot];
-      if (stack != null) {
-        if (this.canKeepArmor(stack)) {
-          event.getDrops().remove(stack);
-          keptArmor.put(ArmorType.byArmorSlot(slot), stack);
+    for (var entry : kept.entrySet()) {
+      var slot = entry.getKey();
+      var keptStack = entry.getValue();
+      var invStack = slot.getItem(inv);
+
+      if (invStack == null || slot instanceof Slot.Armor) {
+        slot.setItem(inv, keptStack);
+      } else {
+        if (invStack.isSimilar(keptStack)) {
+          int n =
+              Math.min(keptStack.getAmount(), invStack.getMaxStackSize() - invStack.getAmount());
+          invStack.setAmount(invStack.getAmount() + n);
+          keptStack.setAmount(keptStack.getAmount() - n);
+        }
+        if (keptStack.getAmount() > 0) {
+          displaced.add(keptStack);
         }
       }
     }
 
-    if (!keptArmor.isEmpty()) {
-      this.keptArmor.put(player, keptArmor);
-    }
-  }
-
-  public void restoreKeptInventory(MatchPlayer player) {
-    Map<Integer, ItemStack> kept = this.keptInv.remove(player);
-    if (kept != null) {
-      List<ItemStack> displaced = new ArrayList<>();
-      PlayerInventory inv = player.getBukkit().getInventory();
-
-      for (Map.Entry<Integer, ItemStack> entry : kept.entrySet()) {
-        int slot = entry.getKey();
-        ItemStack keptStack = entry.getValue();
-        ItemStack invStack = inv.getItem(slot);
-
-        if (invStack == null) {
-          inv.setItem(slot, keptStack);
-        } else {
-          if (invStack.isSimilar(keptStack)) {
-            int n =
-                Math.min(keptStack.getAmount(), invStack.getMaxStackSize() - invStack.getAmount());
-            invStack.setAmount(invStack.getAmount() + n);
-            keptStack.setAmount(keptStack.getAmount() - n);
-          }
-          if (keptStack.getAmount() > 0) {
-            displaced.add(keptStack);
-          }
-        }
-      }
-
-      for (ItemStack stack : displaced) {
-        inv.addItem(stack);
-      }
-    }
-  }
-
-  public void restoreKeptArmor(MatchPlayer player) {
-    Map<ArmorType, ItemStack> kept = this.keptArmor.remove(player);
-    if (kept != null) {
-      for (Map.Entry<ArmorType, ItemStack> entry : kept.entrySet()) {
-        entry.getKey().setItem(player.getBukkit().getInventory(), entry.getValue());
-      }
+    for (ItemStack stack : displaced) {
+      inv.addItem(stack);
     }
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void partyChange(PlayerPartyChangeEvent event) {
     this.keptInv.remove(event.getPlayer());
-    this.keptArmor.remove(event.getPlayer());
   }
 }

--- a/core/src/main/java/tc/oc/pgm/modules/ToolRepairMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ToolRepairMatchModule.java
@@ -3,19 +3,17 @@ package tc.oc.pgm.modules;
 import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 import static tc.oc.pgm.util.nms.Packets.PLAYERS;
 
-import com.google.common.collect.Iterables;
-import java.util.Arrays;
 import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.util.inventory.Slot;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
 @ListenerScope(MatchScope.RUNNING)
@@ -47,15 +45,9 @@ public class ToolRepairMatchModule implements MatchModule, Listener {
   public void processRepair(PlayerPickupItemEvent event) {
     ItemStack pickup = event.getItem().getItemStack();
 
-    if (this.toRepair.matches(pickup.getType())) {
-      PlayerInventory inv = event.getPlayer().getInventory();
-      for (ItemStack invStack : Iterables.concat(
-          Arrays.asList(inv.getContents()), Arrays.asList(inv.getArmorContents()))) {
-        if (this.canRepair(pickup, invStack)) {
-          this.doRepair(event, invStack);
-          return;
-        }
-      }
-    }
+    if (!this.toRepair.matches(pickup.getType())) return;
+    Slot.Player.forEach(event.getPlayer().getInventory(), (slot, stack) -> {
+      if (this.canRepair(pickup, stack)) this.doRepair(event, stack);
+    });
   }
 }

--- a/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
@@ -20,7 +20,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.api.PGM;
@@ -39,6 +38,7 @@ import tc.oc.pgm.util.bukkit.Sounds;
 import tc.oc.pgm.util.collection.DefaultMapAdapter;
 import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
+import tc.oc.pgm.util.inventory.Slot;
 import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextFormatter;
@@ -180,40 +180,22 @@ public class ScoreMatchModule implements MatchModule, Listener {
     }
   }
 
-  private double redeemItems(ScoreBox box, ItemStack stack) {
-    if (stack == null) return 0;
-    double points = 0;
-    for (Entry<MaterialMatcher, Double> entry : box.getRedeemables().entrySet()) {
-      if (entry.getKey().matches(stack)) {
-        points += entry.getValue() * stack.getAmount();
-        stack.setAmount(0);
+  private double redeemItems(ScoreBox box, PlayerInventory inv, Slot.Player slot) {
+    var stack = slot.getItem(inv);
+    if (stack != null) {
+      for (Entry<MaterialMatcher, Double> entry : box.getRedeemables().entrySet()) {
+        if (!entry.getKey().matches(stack)) continue;
+        slot.setItem(inv, null);
+        return entry.getValue() * stack.getAmount();
       }
     }
-    return points;
-  }
-
-  private double redeemItems(ScoreBox box, ItemStack[] stacks) {
-    double total = 0;
-    for (int i = 0; i < stacks.length; i++) {
-      double points = redeemItems(box, stacks[i]);
-      if (points != 0) stacks[i] = null;
-      total += points;
-    }
-    return total;
+    return 0;
   }
 
   private double redeemItems(ScoreBox box, PlayerInventory inventory) {
-    ItemStack[] notArmor = inventory.getContents();
-    ItemStack[] armor = inventory.getArmorContents();
-
-    double points = redeemItems(box, notArmor) + redeemItems(box, armor);
-
-    if (points != 0) {
-      inventory.setContents(notArmor);
-      inventory.setArmorContents(armor);
-    }
-
-    return points;
+    return Slot.Player.player()
+        .mapToDouble(slot -> redeemItems(box, inventory, slot))
+        .sum();
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/states/Alive.java
@@ -15,7 +15,6 @@ import tc.oc.pgm.classes.ClassMatchModule;
 import tc.oc.pgm.events.PlayerChangePartyEvent;
 import tc.oc.pgm.killreward.KillRewardMatchModule;
 import tc.oc.pgm.kits.Kit;
-import tc.oc.pgm.modules.ItemKeepMatchModule;
 import tc.oc.pgm.spawns.Spawn;
 import tc.oc.pgm.spawns.events.ParticipantDespawnEvent;
 import tc.oc.pgm.spawns.events.ParticipantKitApplyEvent;
@@ -54,15 +53,6 @@ public class Alive extends Participating {
 
     // Teleport the player
     player.getBukkit().teleport(spawnEvent.getLocation());
-
-    // Return kept items
-    // TODO: Module should do this itself, maybe from ParticipantSpawnEvent
-    ItemKeepMatchModule ikmm = player.getMatch().getModule(ItemKeepMatchModule.class);
-    if (ikmm != null) {
-      ikmm.restoreKeptArmor(player);
-      ikmm.restoreKeptInventory(player);
-    }
-
     player.setVisible(true);
     player.resetVisibility();
     player.setGameMode(GameMode.SURVIVAL);

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/CombatLogTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/CombatLogTracker.java
@@ -7,10 +7,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -31,6 +31,7 @@ import tc.oc.pgm.events.PlayerParticipationStopEvent;
 import tc.oc.pgm.join.JoinRequest;
 import tc.oc.pgm.tracker.TrackerMatchModule;
 import tc.oc.pgm.util.bukkit.PotionEffects;
+import tc.oc.pgm.util.inventory.Slot;
 import tc.oc.pgm.util.material.Materials;
 
 /**
@@ -161,13 +162,8 @@ public class CombatLogTracker implements Listener {
 
     // Simulate the player's death. The tracker will assume the death was caused by the
     // last damage event, which was either a real one or the fake one we generated above.
-    ArrayList<ItemStack> drops = new ArrayList<>();
-    for (ItemStack stack : player.getInventory().getContents()) {
-      if (stack != null && stack.getType() != Material.AIR) drops.add(stack);
-    }
-    for (ItemStack stack : player.getInventory().getArmorContents()) {
-      if (stack != null && stack.getType() != Material.AIR) drops.add(stack);
-    }
+    List<ItemStack> drops = new ArrayList<>();
+    Slot.Player.forEach(player.getInventory(), (slot, stack) -> drops.add(stack));
 
     try {
       currentDeathEvent = MISC_UTILS.createDeathEvent(

--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
@@ -125,9 +125,8 @@ public class MonumentWool extends TouchableGoal<MonumentWoolFactory>
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onArmorKitApplication(ApplyKitEvent event) {
-    if (event.getKit() instanceof ArmorKit) {
-      for (ArmorKit.ArmorItem armorPiece :
-          ((ArmorKit) event.getKit()).getArmor().values()) {
+    if (event.getKit() instanceof ArmorKit ak) {
+      for (ArmorKit.ArmorItem armorPiece : ak.getArmorItems()) {
         handleWoolAcquisition(event.getPlayer().getBukkit(), armorPiece.stack);
       }
     }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/Slot.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/Slot.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 import org.bukkit.Material;
 import org.bukkit.inventory.EquipmentSlot;
@@ -181,8 +182,8 @@ public abstract class Slot {
     return Optional.ofNullable(getItem(holder));
   }
 
-  public void putItem(InventoryHolder holder, ItemStack stack) {
-    putItem(getInventory(holder), stack);
+  public void setItem(InventoryHolder holder, ItemStack stack) {
+    setItem(getInventory(holder), stack);
   }
 
   /**
@@ -206,7 +207,7 @@ public abstract class Slot {
   }
 
   /** Put the given stack in this slot of the given holder's inventory. */
-  public void putItem(Inventory inv, ItemStack stack) {
+  public void setItem(Inventory inv, ItemStack stack) {
     inv.setItem(getIndex(), airToNull(stack));
   }
 
@@ -217,6 +218,8 @@ public abstract class Slot {
 
   protected org.bukkit.entity.Player asPlayer(InventoryHolder holder) {
     if (holder instanceof org.bukkit.entity.Player player) return player;
+    if (holder.getInventory() instanceof PlayerInventory pi
+        && pi.getHolder() instanceof org.bukkit.entity.Player player) return player;
     throw new IllegalArgumentException("Slot " + this + " is player-only inventory slot");
   }
 
@@ -248,6 +251,13 @@ public abstract class Slot {
           Stream.concat(Storage.storage(), Equipment.equipment()), Stream.of(Cursor.cursor()));
     }
 
+    public static void forEach(PlayerInventory inv, BiConsumer<Player, ItemStack> consumer) {
+      player().forEach(s -> {
+        var item = s.getItem(inv);
+        if (item != null) consumer.accept(s, s.getItem(inv));
+      });
+    }
+
     Player(String key, int index) {
       super(Player.class, key, index);
     }
@@ -257,18 +267,18 @@ public abstract class Slot {
     }
 
     @Override
-    public @Nullable ItemStack getItem(Inventory generic) {
-      var inv = asPlayerInventory(generic);
-      return isEquipment() ? airToNull(inv.getItem(toEquipmentSlot())) : super.getItem(inv);
+    public @Nullable ItemStack getItem(Inventory inv) {
+      return isEquipment()
+          ? airToNull(asPlayerInventory(inv).getItem(toEquipmentSlot()))
+          : super.getItem(inv);
     }
 
     @Override
-    public void putItem(Inventory generic, ItemStack stack) {
-      var inv = asPlayerInventory(generic);
+    public void setItem(Inventory inv, ItemStack stack) {
       if (isEquipment()) {
-        inv.setItem(toEquipmentSlot(), stack);
+        asPlayerInventory(inv).setItem(toEquipmentSlot(), stack);
       } else {
-        super.putItem(inv, stack);
+        super.setItem(inv, stack);
       }
     }
   }
@@ -338,7 +348,12 @@ public abstract class Slot {
     }
 
     public static Stream<? extends Equipment> equipment() {
-      return Stream.concat(Stream.of(OffHand.offHand()), Armor.armor());
+      return Stream.concat(OffHand.offHand().stream(), Armor.armor());
+    }
+
+    public static Stream<Slot> hands() {
+      Slot main = MainHand.mainHand();
+      return OffHand.offHand().map(o -> Stream.of(main, o)).orElseGet(() -> Stream.of(main));
     }
 
     private final EquipmentSlot equipmentSlot;
@@ -392,15 +407,12 @@ public abstract class Slot {
 
   public static class OffHand extends Equipment {
     static void init() {
-      if (Platform.isLegacy()) return;
-      offHand = new OffHand();
+      offHand = Platform.isLegacy() ? Optional.empty() : Optional.of(new OffHand());
     }
 
-    private static OffHand offHand;
+    private static Optional<OffHand> offHand;
 
-    public static OffHand offHand() {
-      if (Platform.isLegacy())
-        throw new UnsupportedOperationException("OffHand is not supported on legacy platform");
+    public static Optional<OffHand> offHand() {
       return offHand;
     }
 
@@ -410,14 +422,15 @@ public abstract class Slot {
   }
 
   public static class Armor extends Equipment {
+    private static Map<ArmorType, Armor> byArmorType;
+
     static void init() {
+      byArmorType = new EnumMap<>(ArmorType.class);
       new Armor("armor.feet", EquipmentSlot.FEET, ArmorType.BOOTS);
       new Armor("armor.legs", EquipmentSlot.LEGS, ArmorType.LEGGINGS);
       new Armor("armor.chest", EquipmentSlot.CHEST, ArmorType.CHESTPLATE);
       new Armor("armor.head", EquipmentSlot.HEAD, ArmorType.HELMET);
     }
-
-    private static final Map<ArmorType, Armor> byArmorType = new EnumMap<>(ArmorType.class);
 
     public static Stream<? extends Armor> armor() {
       return byArmorType.values().stream();
@@ -483,18 +496,18 @@ public abstract class Slot {
     }
 
     @Override
-    public void putItem(InventoryHolder holder, @Nullable ItemStack stack) {
+    public void setItem(InventoryHolder holder, @Nullable ItemStack stack) {
       asPlayer(holder).setItemOnCursor(stack);
     }
 
     @Override
     public @Nullable ItemStack getItem(Inventory inv) {
-      return getItem(asPlayerInventory(inv).getHolder());
+      return getItem(inv.getHolder());
     }
 
     @Override
-    public void putItem(Inventory inv, ItemStack stack) {
-      putItem(asPlayerInventory(inv).getHolder(), stack);
+    public void setItem(Inventory inv, ItemStack stack) {
+      setItem(inv.getHolder(), stack);
     }
   }
 }


### PR DESCRIPTION
In legacy, calling `PlayerInventory#getContents` does not include armor, so in many places PGM was doing code for both `PlayerInventory#getContents` AND `PlayerInventory#getArmorContents`, leading to modern effectively running twice over armor contents. One of the most trivially to observe was simply doing `/obs`, which would drop armor pieces twice on modern (as long as they aren't on itemremove).

The PR streamlines most inventory accesses (at least all of the ones that ever touched `getArmorContents`) to use the pgm `Slot` api, which is flexible and properly includes all slots, both in modern and legacy, including offhand and the item in the cursor too. This should make PGM more robust moving forward, given that it also fixed some behaviors on legacy that were probably not intended (eg: disconnecting while having an item in your cursor would delete that item, not drop it, and scoring with a redeemable on your cursor would allow you to keep it instead of being removed).