### PR TITLE
feat: allow disabling command blocks via config

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -127,6 +127,9 @@ public final class PGMConfig implements Config {
   // experiments.*
   private final Map<String, Object> experiments;
 
+  // modern.*
+  private final boolean commandBlocksEnabled;
+
   PGMConfig(FileConfiguration config, File dataFolder) throws TextException {
     handleLegacyConfig(config, dataFolder);
 
@@ -241,6 +244,8 @@ public final class PGMConfig implements Config {
 
     final ConfigurationSection experiments = config.getConfigurationSection("experiments");
     this.experiments = experiments == null ? ImmutableMap.of() : experiments.getValues(false);
+
+    commandBlocksEnabled = parseBoolean(config.getString("modern.allow-command-blocks", "false"));
   }
 
   private Path getPath(Path base, String dir) {
@@ -697,6 +702,11 @@ public final class PGMConfig implements Config {
   @Override
   public Map<String, Object> getExperiments() {
     return experiments;
+  }
+
+  @Override
+  public boolean allowCommandBlocks() {
+    return commandBlocksEnabled;
   }
 
   private static class Group implements Config.Group {

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -493,4 +493,11 @@ public interface Config {
     Object exp = getExperiments().getOrDefault(key, def);
     return exp instanceof Boolean ? (Boolean) exp : exp.toString().equals("true");
   }
+
+  /**
+   * Gets whether command blocks are enabled. Effective only on modern servers.
+   *
+   * @return Whether command blocks are enabled in PGM-loaded worlds or not.
+   */
+  boolean allowCommandBlocks();
 }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -236,7 +236,7 @@ modern:
   # In an ABSOLUTE MAJORITY of cases you will NEVER NEED TO have to enable this setting. If you do need to do so, please
   # let us know why at https://github.com/PGMDev/PGM/issues.
   #
-  # Command blocks run with operator permissions and can be used to perform potentially malicious actions on the server.
+  # Command blocks run with elevated permissions and can be used to perform potentially malicious actions on the server.
   #
   # ENABLE IF AND ONLY IF YOU TRUST ALL LOADED MAPS ON THE SERVER, and are aware of the risks involved.
   allow-command-blocks: false

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -227,3 +227,16 @@ vanish: true
 experiments:
   # Enable payload preview. This is not fully finished and xml syntax is likely to change at a later time.
   payload: false
+
+# Settings effective only on modern servers.
+modern:
+  # Whether to permit command blocks to run commands. Behaves similar to the "enable-command-block" server property
+  # that has been removed in favor of game rules in 1.21.9.
+  #
+  # In an ABSOLUTE MAJORITY of cases you will NEVER NEED TO have to enable this setting. If you do need to do so, please
+  # let us know why at https://github.com/PGMDev/PGM/issues.
+  #
+  # Command blocks run with operator permissions and can be used to perform potentially malicious actions on the server.
+  #
+  # ENABLE IF AND ONLY IF YOU TRUST ALL LOADED MAPS ON THE SERVER, and are aware of the risks involved.
+  allow-command-blocks: false

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/PGMServerLevel.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/util/PGMServerLevel.java
@@ -22,6 +22,7 @@ import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.ChunkGenerator;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.PGM;
 
 public class PGMServerLevel extends ServerLevel {
   public PGMServerLevel(
@@ -99,5 +100,12 @@ public class PGMServerLevel extends ServerLevel {
   @Override
   public @NonNull MapId getFreeMapId() {
     return getDataStorage().computeIfAbsent(MapIndex.TYPE).getNextMapId();
+  }
+
+  // Allow command blocks to be disabled via config
+  @Override
+  public boolean isCommandBlockEnabled() {
+    if (!PGM.get().getConfiguration().allowCommandBlocks()) return false;
+    return super.isCommandBlockEnabled();
   }
 }


### PR DESCRIPTION
Allows disabling command blocks in PGM-loaded worlds using PGM's config, re-introducing the `enable-command-block` server property removed with moving the enablement status into game rules in 1.21.9 – unfortunately, as PGM loads arbitrary untrusted worlds, this is a potential security concern.

If disabled:
- Command blocks will be disabled (obviously)
- They cannot be re-enabled back (setting the `commandBlocksEnabled`/`minecraft:command_blocks_work` game rule through XML/operator commands will work, but won't have any effect)

If enabled:
- Command blocks are not blocked by PGM, but may be blocked by game rules