### PR TITLE
fix(kits): correct item modifier application order for armor kits

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
+++ b/core/src/main/java/tc/oc/pgm/kits/ArmorKit.java
@@ -47,8 +47,8 @@ public class ArmorKit extends AbstractKit {
     this.armor.forEach((slot, item) -> {
       var wearing = slot.getItem(player);
       if (force || wearing == null) {
-        slot.setItem(player, wearing = item.stack.clone());
-        ItemModifier.apply(wearing, player);
+        ItemModifier.apply(wearing = item.stack.clone(), player);
+        slot.setItem(player, wearing);
       }
     });
   }


### PR DESCRIPTION
Commit 2651562b965f17c90d3face2052db58baffde1dd introduced a regression with armor kits making item modifiers such as `team-color` not to be applied. This patch corrects the application order, fixing the issue.