### PR TITLE
refactor(tnt): use fluent parsing and modern Java features

### DIFF
--- a/core/src/main/java/tc/oc/pgm/listeners/AntiGriefListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/AntiGriefListener.java
@@ -68,7 +68,7 @@ public class AntiGriefListener implements Listener {
     if (!(entity instanceof TNTPrimed)) return;
 
     TNTMatchModule tntmm = mm.getMatch(player.getWorld()).getModule(TNTMatchModule.class);
-    if (tntmm != null && !tntmm.getProperties().friendlyDefuse) return;
+    if (tntmm != null && !tntmm.getProperties().friendlyDefuse()) return;
 
     MatchPlayer clicker = this.mm.getPlayer(player);
     if (clicker == null || !clicker.canInteract()) return;

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTMatchModule.java
@@ -17,6 +17,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.event.BlockTransformEvent;
 import tc.oc.pgm.api.match.Match;
@@ -29,6 +30,7 @@ import tc.oc.pgm.util.event.entity.ExplosionPrimeByEntityEvent;
 import tc.oc.pgm.util.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.util.inventory.InventoryUtils;
 
+@NullMarked
 @ListenerScope(MatchScope.RUNNING)
 public class TNTMatchModule implements MatchModule, Listener {
 
@@ -45,8 +47,8 @@ public class TNTMatchModule implements MatchModule, Listener {
   }
 
   public int getFuseTicks() {
-    assert this.properties.fuse != null;
-    return (int) TimeUtils.toTicks(this.properties.fuse);
+    assert this.properties.fuse() != null;
+    return (int) TimeUtils.toTicks(this.properties.fuse());
   }
 
   private boolean callPrimeEvent(TNTPrimed tnt, @Nullable Entity primer) {
@@ -67,25 +69,25 @@ public class TNTMatchModule implements MatchModule, Listener {
 
   @EventHandler(ignoreCancelled = true)
   public void yieldSet(EntityExplodeEvent event) {
-    if (this.properties.yield != null && event.getEntity() instanceof TNTPrimed) {
-      event.setYield(this.properties.yield);
+    if (this.properties.yield() != null && event.getEntity() instanceof TNTPrimed) {
+      event.setYield(this.properties.yield());
     }
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void handleInstantActivation(BlockPlaceEvent event) {
-    if (this.properties.instantIgnite && event.getBlock().getType() == Material.TNT) {
+    if (this.properties.instantIgnite() && event.getBlock().getType() == Material.TNT) {
       World world = event.getBlock().getWorld();
       TNTPrimed tnt = world.spawn(
           event.getBlock().getLocation().clone().add(new Location(world, 0.5, 0.5, 0.5)),
           TNTPrimed.class);
 
-      if (this.properties.fuse != null) {
+      if (this.properties.fuse() != null) {
         tnt.setFuseTicks(this.getFuseTicks());
       }
 
-      if (this.properties.power != null) {
-        tnt.setYield(this.properties.power); // Note: not related to EntityExplodeEvent.yield
+      if (this.properties.power() != null) {
+        tnt.setYield(this.properties.power()); // Note: not related to EntityExplodeEvent.yield
       }
 
       if (callPrimeEvent(tnt, event.getPlayer())) {
@@ -99,13 +101,12 @@ public class TNTMatchModule implements MatchModule, Listener {
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void setCustomProperties(ExplosionPrimeEvent event) {
     if (event.getEntity() instanceof TNTPrimed tnt) {
-
-      if (this.properties.fuse != null) {
+      if (this.properties.fuse() != null) {
         tnt.setFuseTicks(this.getFuseTicks());
       }
 
-      if (this.properties.power != null) {
-        tnt.setYield(this.properties.power); // Note: not related to EntityExplodeEvent.yield
+      if (this.properties.power() != null) {
+        tnt.setYield(this.properties.power()); // Note: not related to EntityExplodeEvent.yield
       }
     }
   }
@@ -116,15 +117,15 @@ public class TNTMatchModule implements MatchModule, Listener {
   public void dispenserNukes(BlockTransformEvent event) {
     BlockState oldState = event.getOldState();
     if (oldState instanceof Dispenser dispenser
-        && this.properties.dispenserNukeLimit > 0
-        && this.properties.dispenserNukeMultiplier > 0
+        && this.properties.dispenserNukeLimit() > 0
+        && this.properties.dispenserNukeMultiplier() > 0
         && event.getCause() instanceof EntityExplodeEvent explodeEvent
         && MISC_UTILS.isDestructiveExplosion(explodeEvent)) {
-      int tntLimit =
-          Math.round(this.properties.dispenserNukeLimit / this.properties.dispenserNukeMultiplier);
+      int tntLimit = Math.round(
+          this.properties.dispenserNukeLimit() / this.properties.dispenserNukeMultiplier());
       int tntCount = 0;
 
-      ItemStack[] inv = dispenser.getInventory().getContents();
+      @Nullable ItemStack[] inv = dispenser.getInventory().getContents();
       for (int slot = 0; slot < inv.length; slot++) {
         ItemStack stack = inv[slot];
         if (stack != null && stack.getType() == Material.TNT) {
@@ -137,15 +138,13 @@ public class TNTMatchModule implements MatchModule, Listener {
         }
       }
 
-      tntCount = (int) Math.ceil(tntCount * this.properties.dispenserNukeMultiplier);
+      tntCount = (int) Math.ceil(tntCount * this.properties.dispenserNukeMultiplier());
 
       for (int i = 0; i < tntCount; i++) {
         TNTPrimed tnt = match.getWorld().spawn(dispenser.getLocation(), TNTPrimed.class);
 
-        tnt.setFuseTicks(10
-            + match
-                .getRandom()
-                .nextInt(10)); // between 0.5 and 1.0 seconds, same as vanilla TNT chaining
+        // between 0.5 and 1.0 seconds, same as vanilla TNT chaining
+        tnt.setFuseTicks(10 + match.getRandom().nextInt(10));
 
         Random random = match.getRandom();
         Vector velocity = new Vector(

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTModule.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTModule.java
@@ -69,22 +69,20 @@ public class TNTModule implements MapModule<TNTMatchModule> {
       for (Element tntElement : doc.getRootElement().getChildren("tnt")) {
         exists = true;
         instantIgnite =
-            parser.parseBool(tntElement, "instantignite").child().optional(instantIgnite);
-        blockDamage = parser.parseBool(tntElement, "blockdamage").child().optional(blockDamage);
-        yield = parser.parseFloat(tntElement, "yield").child().optional(yield);
-        power = parser.parseFloat(tntElement, "power").child().optional(power);
+            parser.parseBool(tntElement, "instant-ignite", "instantignite").optional(instantIgnite);
+        blockDamage =
+            parser.parseBool(tntElement, "block-damage", "blockdamage").optional(blockDamage);
+        yield = parser.parseFloat(tntElement, "yield").optional(yield);
+        power = parser.parseFloat(tntElement, "power").optional(power);
         dispenserNukeLimit =
-            parser.parseInt(tntElement, "dispenser-tnt-limit").child().optional(dispenserNukeLimit);
+            parser.parseInt(tntElement, "dispenser-tnt-limit").optional(dispenserNukeLimit);
         dispenserNukeMultiplier = parser
             .parseFloat(tntElement, "dispenser-tnt-multiplier")
-            .child()
             .optional(dispenserNukeMultiplier);
-        licensing = parser.parseBool(tntElement, "licensing").child().optional(licensing);
-        friendlyDefuse =
-            parser.parseBool(tntElement, "friendly-defuse").child().optional(friendlyDefuse);
+        licensing = parser.parseBool(tntElement, "licensing").optional(licensing);
+        friendlyDefuse = parser.parseBool(tntElement, "friendly-defuse").optional(friendlyDefuse);
         fuse = parser
             .duration(tntElement, "fuse")
-            .child()
             .validate((duration, node) -> {
               if (TimeUtils.isLongerThan(duration, Duration.ofSeconds(4))) {
                 // TNT disappears on the client after 4 seconds, no way to extend it

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTModule.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTModule.java
@@ -1,13 +1,14 @@
 package tc.oc.pgm.tnt;
 
-import com.google.common.collect.ImmutableList;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
@@ -21,11 +22,10 @@ import tc.oc.pgm.regions.RegionFilterApplication;
 import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.util.TimeUtils;
 import tc.oc.pgm.util.xml.InvalidXMLException;
-import tc.oc.pgm.util.xml.XMLUtils;
 
+@NullMarked
 public class TNTModule implements MapModule<TNTMatchModule> {
-  private static final Collection<MapTag> TAGS =
-      ImmutableList.of(new MapTag("autotnt", "Instant TNT"));
+  private static final Collection<MapTag> TAGS = List.of(new MapTag("autotnt", "Instant TNT"));
   public static final int DEFAULT_DISPENSER_NUKE_LIMIT = 16;
   public static final float DEFAULT_DISPENSER_NUKE_MULTIPLIER = 0.25f;
 
@@ -37,7 +37,7 @@ public class TNTModule implements MapModule<TNTMatchModule> {
 
   @Override
   public Collection<MapTag> getTags() {
-    return properties.instantIgnite ? TAGS : Collections.emptyList();
+    return properties.instantIgnite() ? TAGS : List.of();
   }
 
   @Override
@@ -48,12 +48,13 @@ public class TNTModule implements MapModule<TNTMatchModule> {
   public static class Factory implements MapModuleFactory<TNTModule> {
     @Override
     public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
-      return ImmutableList.of(RegionModule.class);
+      return List.of(RegionModule.class);
     }
 
     @Override
-    public TNTModule parse(MapFactory factory, Logger logger, Document doc)
+    public @Nullable TNTModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
+      var parser = factory.getParser();
       Float yield = null;
       Float power = null;
       boolean instantIgnite = false;
@@ -68,68 +69,56 @@ public class TNTModule implements MapModule<TNTMatchModule> {
       for (Element tntElement : doc.getRootElement().getChildren("tnt")) {
         exists = true;
         instantIgnite =
-            XMLUtils.parseBoolean(
-                XMLUtils.getUniqueChild(tntElement, "instantignite"), instantIgnite);
-        blockDamage =
-            XMLUtils.parseBoolean(XMLUtils.getUniqueChild(tntElement, "blockdamage"), blockDamage);
-        yield =
-            XMLUtils.parseNumber(XMLUtils.getUniqueChild(tntElement, "yield"), Float.class, yield);
-        power =
-            XMLUtils.parseNumber(XMLUtils.getUniqueChild(tntElement, "power"), Float.class, power);
+            parser.parseBool(tntElement, "instantignite").child().optional(instantIgnite);
+        blockDamage = parser.parseBool(tntElement, "blockdamage").child().optional(blockDamage);
+        yield = parser.parseFloat(tntElement, "yield").child().optional(yield);
+        power = parser.parseFloat(tntElement, "power").child().optional(power);
         dispenserNukeLimit =
-            XMLUtils.parseNumber(
-                XMLUtils.getUniqueChild(tntElement, "dispenser-tnt-limit"),
-                Integer.class,
-                dispenserNukeLimit);
-        dispenserNukeMultiplier =
-            XMLUtils.parseNumber(
-                XMLUtils.getUniqueChild(tntElement, "dispenser-tnt-multiplier"),
-                Float.class,
-                dispenserNukeMultiplier);
-        licensing =
-            XMLUtils.parseBoolean(XMLUtils.getUniqueChild(tntElement, "licensing"), licensing);
+            parser.parseInt(tntElement, "dispenser-tnt-limit").child().optional(dispenserNukeLimit);
+        dispenserNukeMultiplier = parser
+            .parseFloat(tntElement, "dispenser-tnt-multiplier")
+            .child()
+            .optional(dispenserNukeMultiplier);
+        licensing = parser.parseBool(tntElement, "licensing").child().optional(licensing);
         friendlyDefuse =
-            XMLUtils.parseBoolean(
-                XMLUtils.getUniqueChild(tntElement, "friendly-defuse"), friendlyDefuse);
-
-        Element fuseElement = XMLUtils.getUniqueChild(tntElement, "fuse");
-        if (fuseElement != null) {
-          fuse = XMLUtils.parseDuration(fuseElement, fuse);
-
-          if (TimeUtils.isLongerThan(fuse, Duration.ofSeconds(4))) {
-            // TNT disappears on the client after 4 seconds, no way to extend it
-            // If this is ever really needed, we could spawn new entities on the client every 4
-            // seconds
-            throw new InvalidXMLException("TNT fuse cannot be longer than 4 seconds", fuseElement);
-          }
-        }
+            parser.parseBool(tntElement, "friendly-defuse").child().optional(friendlyDefuse);
+        fuse = parser
+            .duration(tntElement, "fuse")
+            .child()
+            .validate((duration, node) -> {
+              if (TimeUtils.isLongerThan(duration, Duration.ofSeconds(4))) {
+                // TNT disappears on the client after 4 seconds, no way to extend it
+                // If this is ever really needed, we could spawn new entities on the client every 4
+                // seconds
+                throw new InvalidXMLException("TNT fuse cannot be longer than 4 seconds", node);
+              }
+            })
+            .optional(fuse);
       }
 
       if (!blockDamage) {
         factory
             .needModule(RegionModule.class)
             .getRFAContextBuilder()
-            .prepend(
-                new RegionFilterApplication(
-                    RFAScope.BLOCK_BREAK,
-                    EverywhereRegion.INSTANCE,
-                    new DenyFilter(new CauseFilter(CauseFilter.Cause.EXPLOSION)),
-                    (Component) null,
-                    false));
+            .prepend(new RegionFilterApplication(
+                RFAScope.BLOCK_BREAK,
+                EverywhereRegion.INSTANCE,
+                new DenyFilter(new CauseFilter(CauseFilter.Cause.EXPLOSION)),
+                (Component) null,
+                false));
       }
 
       return exists
-          ? new TNTModule(
-              new TNTProperties(
-                  yield,
-                  power,
-                  instantIgnite,
-                  blockDamage,
-                  fuse,
-                  dispenserNukeLimit,
-                  dispenserNukeMultiplier,
-                  licensing,
-                  friendlyDefuse))
+          ? new TNTModule(new TNTProperties(
+              yield,
+              power,
+              instantIgnite,
+              blockDamage,
+              fuse,
+              dispenserNukeLimit,
+              dispenserNukeMultiplier,
+              licensing,
+              friendlyDefuse))
           : null;
     }
   }

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTProperties.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTProperties.java
@@ -1,8 +1,8 @@
 package tc.oc.pgm.tnt;
 
 import java.time.Duration;
-import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public record TNTProperties(

--- a/core/src/main/java/tc/oc/pgm/tnt/TNTProperties.java
+++ b/core/src/main/java/tc/oc/pgm/tnt/TNTProperties.java
@@ -1,37 +1,17 @@
 package tc.oc.pgm.tnt;
 
 import java.time.Duration;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
 
-public class TNTProperties {
-  public final @Nullable Float yield;
-  public final @Nullable Float power;
-  public final boolean instantIgnite;
-  public final boolean blockDamage;
-  public final @Nullable Duration fuse;
-  public final int dispenserNukeLimit;
-  public final float dispenserNukeMultiplier;
-  public final boolean licensing;
-  public final boolean friendlyDefuse;
-
-  public TNTProperties(
-      @Nullable Float yield,
-      @Nullable Float power,
-      boolean instantIgnite,
-      boolean blockDamage,
-      @Nullable Duration fuse,
-      int dispenserNukeLimit,
-      float dispenserNukeMultiplier,
-      boolean licensing,
-      boolean friendlyDefuse) {
-    this.yield = yield;
-    this.power = power;
-    this.instantIgnite = instantIgnite;
-    this.blockDamage = blockDamage;
-    this.fuse = fuse;
-    this.dispenserNukeLimit = dispenserNukeLimit;
-    this.dispenserNukeMultiplier = dispenserNukeMultiplier;
-    this.licensing = licensing;
-    this.friendlyDefuse = friendlyDefuse;
-  }
-}
+@NullMarked
+public record TNTProperties(
+    @Nullable Float yield,
+    @Nullable Float power,
+    boolean instantIgnite,
+    boolean blockDamage,
+    @Nullable Duration fuse,
+    int dispenserNukeLimit,
+    float dispenserNukeMultiplier,
+    boolean licensing,
+    boolean friendlyDefuse) {}

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -94,6 +94,10 @@ public class XMLFluentParser {
     return number(Double.class, el, prop);
   }
 
+  public NumberBuilder<Float> parseFloat(Element el, String... prop) {
+    return number(Float.class, el, prop);
+  }
+
   public <T extends Number> NumberBuilder<T> number(Class<T> cls, Element el, String... prop) {
     return new NumberBuilder<>(cls, el, prop);
   }


### PR DESCRIPTION
- TNT module is now parsed using the fluent parser
- TNT module settings are now properties -- they can be set using attributes now
- `instantignite` and `blockdamage` have been renamed to `instant-ignite` and `block-damage` (the old names are still supported)
- TNTProperties are now a record
- Added nullability annotations to the `tc.oc.pgm.tnt` package (mostly dealt with `@NullMarked` that marks everything as implicitly not-null)
- Minor cosmetic code changes (using standard library immutable lists instead of Guava, and some comment moving to make the code flow better)