### PR TITLE
Add payload, control points & scorebox waypoints

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
@@ -121,7 +121,7 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
       if (stage instanceof Revertable) {
         ((Revertable) stage).revert();
       } else {
-        throw new IllegalStateException("Unable to revert a loaded match");
+        throw new IllegalStateException("Unable to revert a loaded match", err);
       }
     }
 

--- a/core/src/main/java/tc/oc/pgm/payload/Payload.java
+++ b/core/src/main/java/tc/oc/pgm/payload/Payload.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.payload;
 import static tc.oc.pgm.util.bukkit.Effects.EFFECTS;
 
 import java.time.Duration;
+import java.util.UUID;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
@@ -38,6 +39,7 @@ public class Payload extends ControlPoint {
 
   private Competitor dominantTeam;
   private Vector position;
+  private boolean shouldDisplay = true;
 
   public Payload(Match match, PayloadDefinition definition) {
     super(match, definition);
@@ -61,6 +63,15 @@ public class Payload extends ControlPoint {
     minecart.setSlowWhenEmpty(true);
     minecart.setMetadata(METADATA_KEY, new FixedMetadataValue(PGM.get(), true));
     return minecart;
+  }
+
+  public UUID getMinecartUuid() {
+    return this.minecart.getUniqueId();
+  }
+
+  public boolean shouldDisplay(boolean update) {
+    if (update) shouldDisplay = definition.getDisplayFilter().query(match).isAllowed();
+    return this.shouldDisplay;
   }
 
   @Override
@@ -89,12 +100,12 @@ public class Payload extends ControlPoint {
     tickMinecart();
   }
 
-  private Competitor getDisplayTeam() {
+  public Competitor getDisplayTeam() {
     return dominantTeam != null ? dominantTeam : controllingTeam != null ? controllingTeam : null;
   }
 
   private void tickParticles(long tick) {
-    if (!definition.getDisplayFilter().query(match).isAllowed()) return;
+    if (!shouldDisplay(true)) return;
     Competitor display = getDisplayTeam();
     Color color = display != null ? display.getFullColor() : Color.WHITE;
 

--- a/core/src/main/java/tc/oc/pgm/score/ScoreBox.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreBox.java
@@ -6,11 +6,16 @@ import com.google.common.collect.Maps;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
 public class ScoreBox {
@@ -33,6 +38,18 @@ public class ScoreBox {
 
   public Filter getFilter() {
     return this.definition.filter();
+  }
+
+  public Optional<Competitor> getOwner(Match match) {
+    return match.moduleOptional(TeamMatchModule.class).map(tmm -> {
+      Team owner = null;
+      for (Team team : tmm.getTeams()) {
+        if (getFilter().query(team).isAllowed()) continue;
+        if (owner != null) return null; // Multiple owners, can't be.
+        owner = team;
+      }
+      return owner;
+    });
   }
 
   public Map<MaterialMatcher, Double> getRedeemables() {

--- a/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
@@ -96,6 +96,10 @@ public class ScoreMatchModule implements MatchModule, Listener {
     return this.config.scoreLimit();
   }
 
+  public Set<ScoreBox> getScoreBoxes() {
+    return this.scoreBoxes;
+  }
+
   public ScoreDefinition getDefinition() {
     return this.config;
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/WaypointMatchModule.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/WaypointMatchModule.java
@@ -1,10 +1,8 @@
 package tc.oc.pgm.platform.modern.modules;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import net.minecraft.server.waypoints.ServerWaypointManager;
-import net.minecraft.world.waypoints.WaypointTransmitter;
+import org.bukkit.Color;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -14,6 +12,7 @@ import org.bukkit.event.Listener;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.match.Tickable;
 import tc.oc.pgm.api.match.event.MatchLoadEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.ListenerScope;
@@ -22,60 +21,71 @@ import tc.oc.pgm.flag.event.FlagStateChangeEvent;
 import tc.oc.pgm.flag.state.Carried;
 import tc.oc.pgm.goals.Goal;
 import tc.oc.pgm.goals.GoalMatchModule;
+import tc.oc.pgm.platform.modern.modules.waypoints.PGMWaypointTransmitter;
 import tc.oc.pgm.platform.modern.modules.waypoints.Waypoints;
+import tc.oc.pgm.score.ScoreBox;
+import tc.oc.pgm.score.ScoreMatchModule;
 
 @ListenerScope(MatchScope.LOADED)
 public class WaypointMatchModule implements MatchModule, Listener {
 
   private final Match match;
-  private final Map<Goal<?>, WaypointTransmitter> trackedWaypoints;
   private final ServerWaypointManager waypointManager;
 
   public WaypointMatchModule(Match match) {
     this.match = match;
-    this.trackedWaypoints = new HashMap<>();
     this.waypointManager = ((CraftWorld) match.getWorld()).getHandle().getWaypointManager();
   }
 
-  private void track(Goal<?> goal, WaypointTransmitter transmitter) {
+  private void track(PGMWaypointTransmitter transmitter) {
     if (transmitter == null) return;
 
     waypointManager.trackWaypoint(transmitter);
-    trackedWaypoints.put(goal, transmitter);
-  }
-
-  private void update(Goal<?> goal) {
-    var waypoint = trackedWaypoints.get(goal);
-    if (waypoint != null) waypointManager.updateWaypoint(waypoint);
+    if (transmitter instanceof Tickable t) {
+      // Initial update before match start
+      t.tick(match, match.getTick());
+      match.addTickable(t, MatchScope.RUNNING);
+    }
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void afterLoad(MatchLoadEvent event) {
     match.moduleOptional(GoalMatchModule.class).ifPresent(gmm -> {
       for (Goal<?> goal : gmm.getGoals()) {
-        track(goal, Waypoints.from(goal));
+        track(Waypoints.from(goal));
+      }
+    });
+    match.moduleOptional(ScoreMatchModule.class).ifPresent(smm -> {
+      for (ScoreBox scoreBox : smm.getScoreBoxes()) {
+        scoreBox
+            .getOwner(match)
+            .ifPresent(owner -> track(Waypoints.immutable(
+                Waypoints.toBlockPos(match, scoreBox.getRegion()),
+                owner.getFullColor().asRGB())));
       }
     });
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerJoin(PlayerJoinMatchEvent event) {
-    setPlayerWaypoint(event.getPlayer(), false, 0);
+    setPlayerWaypoint(event.getPlayer(), null);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onFlagPickup(FlagStateChangeEvent event) {
-    if (event.getOldState() instanceof Carried c) setPlayerWaypoint(c.getCarrier(), false, 0);
+    if (event.getOldState() instanceof Carried c) setPlayerWaypoint(c.getCarrier(), null);
     if (event.getNewState() instanceof Carried c)
-      setPlayerWaypoint(c.getCarrier(), true, event.getFlag().getColor().asRGB());
-    update(event.getFlag());
+      setPlayerWaypoint(c.getCarrier(), event.getFlag().getColor());
   }
 
-  private void setPlayerWaypoint(MatchPlayer player, boolean enabled, int color) {
+  private void setPlayerWaypoint(MatchPlayer player, Color color) {
     var attr = player.getAttribute(Attribute.WAYPOINT_TRANSMIT_RANGE);
     if (attr == null) return;
-    if (enabled) {
-      ((CraftPlayer) player.getBukkit()).getHandle().waypointIcon().color = Optional.of(color);
+    if (color != null) {
+      var nmsPlayer = ((CraftPlayer) player.getBukkit()).getHandle();
+      // Ensures they're newly registered so the color updates
+      waypointManager.untrackWaypoint(nmsPlayer);
+      nmsPlayer.waypointIcon().color = Optional.of(color.asRGB());
       attr.setBaseValue(256);
     } else {
       attr.setBaseValue(0);

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/AbstractWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/AbstractWaypointTransmitter.java
@@ -4,10 +4,15 @@ import java.util.Optional;
 import java.util.UUID;
 import net.minecraft.server.level.ServerPlayer;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 abstract class AbstractWaypointTransmitter implements PGMWaypointTransmitter {
-  private final UUID uuid = UUID.randomUUID();
+  private final UUID uuid;
   protected final Icon waypointIcon = new Icon();
+
+  protected AbstractWaypointTransmitter(@Nullable UUID uuid) {
+    this.uuid = uuid != null ? uuid : UUID.randomUUID();
+  }
 
   @Override
   public boolean isTransmittingWaypoint() {

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/ControlPointWaypoint.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/ControlPointWaypoint.java
@@ -1,0 +1,34 @@
+package tc.oc.pgm.platform.modern.modules.waypoints;
+
+import java.util.Optional;
+import org.bukkit.Color;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.Tickable;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.api.time.Tick;
+import tc.oc.pgm.controlpoint.ControlPoint;
+
+public class ControlPointWaypoint extends GoalWaypoint<ControlPoint> implements Tickable {
+
+  private Competitor lastCompetitor;
+
+  public ControlPointWaypoint(ControlPoint goal) {
+    super(goal, Color.WHITE.asRGB());
+    setPosition(goal.getCenterPoint());
+  }
+
+  @Override
+  public void tick(Match match, Tick tick) {
+    var comp = goal.getControllingTeam();
+    if (this.lastCompetitor != comp) {
+      this.lastCompetitor = comp;
+      var color = comp != null ? comp.getFullColor() : Color.WHITE;
+      waypointIcon().color = Optional.of(color.asRGB());
+    }
+  }
+
+  @Override
+  public boolean isTransmittingWaypoint() {
+    return !goal.isCompleted() || !goal.getDefinition().isPermanent();
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/FlagWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/FlagWaypointTransmitter.java
@@ -1,24 +1,25 @@
 package tc.oc.pgm.platform.modern.modules.waypoints;
 
-import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerPlayer;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.Tickable;
+import tc.oc.pgm.api.time.Tick;
 import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.flag.state.Carried;
 
-public class FlagWaypointTransmitter extends GoalWaypoint<Flag> {
+public class FlagWaypointTransmitter extends GoalWaypoint<Flag> implements Tickable {
 
   FlagWaypointTransmitter(Flag flag) {
     super(flag, flag.getDyeColor().getColor().asRGB());
   }
 
   @Override
-  public boolean isTransmittingWaypoint() {
-    // Carried flags will use the player was waypoint instead, so that movement is smooth
-    return super.isTransmittingWaypoint() && !goal.isCurrent(Carried.class);
+  public void tick(Match match, Tick tick) {
+    setPosition(goal.getLocation().orElse(null));
   }
 
   @Override
-  public BlockPos position(ServerPlayer receiver) {
-    return goal.getLocation().map(l -> Waypoints.toBlockPos(l.toVector())).orElse(null);
+  public boolean isTransmittingWaypoint() {
+    // Carried flags will use the player was waypoint instead, so that movement is smooth
+    return super.isTransmittingWaypoint() && !goal.isCurrent(Carried.class);
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/GoalWaypoint.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/GoalWaypoint.java
@@ -1,16 +1,32 @@
 package tc.oc.pgm.platform.modern.modules.waypoints;
 
 import java.util.Optional;
+import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.goals.Goal;
 
-public abstract class GoalWaypoint<T extends Goal<?>> extends AbstractWaypointTransmitter {
+public class GoalWaypoint<T extends Goal<?>> extends AbstractWaypointTransmitter {
   protected final T goal;
+  protected BlockPos position;
 
-  GoalWaypoint(T goal, int color) {
+  protected GoalWaypoint(T goal, int color) {
+    this(goal, color, null);
+  }
+
+  protected GoalWaypoint(T goal, int color, @Nullable UUID uuid) {
+    super(uuid);
     this.goal = goal;
     this.waypointIcon.color = Optional.of(color);
+  }
+
+  public static <T extends Goal<?>> GoalWaypoint<T> simple(T goal, BlockPos pos, int color) {
+    var waypoint = new GoalWaypoint<>(goal, color);
+    waypoint.position = pos;
+    return waypoint;
   }
 
   @Override
@@ -18,17 +34,23 @@ public abstract class GoalWaypoint<T extends Goal<?>> extends AbstractWaypointTr
     return !goal.isCompleted();
   }
 
-  static class Immovable<T extends Goal<?>> extends GoalWaypoint<T> {
-    private final BlockPos pos;
+  @Override
+  public @Nullable BlockPos position(ServerPlayer player) {
+    return position;
+  }
 
-    public Immovable(T goal, BlockPos pos, int color) {
-      super(goal, color);
-      this.pos = pos;
-    }
+  protected void setPosition(@Nullable Location loc) {
+    setPosition(loc == null ? null : loc.toVector());
+  }
 
-    @Override
-    public BlockPos position(ServerPlayer player) {
-      return pos;
-    }
+  protected void setPosition(@Nullable Vector pos) {
+    this.position = pos == null
+        ? null
+        : this.position == null
+                || position.getX() != pos.getBlockX()
+                || position.getY() != pos.getBlockY()
+                || position.getZ() != pos.getBlockZ()
+            ? Waypoints.toBlockPos(pos)
+            : this.position;
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/ImmutableWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/ImmutableWaypointTransmitter.java
@@ -8,6 +8,7 @@ public class ImmutableWaypointTransmitter extends AbstractWaypointTransmitter {
   private final BlockPos blockPos;
 
   public ImmutableWaypointTransmitter(BlockPos pos, Integer color) {
+    super(null);
     this.blockPos = pos;
     this.waypointIcon.color = Optional.ofNullable(color);
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/PGMBlockConnection.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/PGMBlockConnection.java
@@ -36,10 +36,16 @@ class PGMBlockConnection implements WaypointTransmitter.Connection {
   }
 
   public void update() {
+    // It appears the client will not update the icon/color unless waypoint is removed and re-added
+    // Luckily this is pretty trivial for us to do instead of an update
     var icon = transmitter.waypointIcon();
-    if (iconChanged(icon) || newPosition.distManhattan(this.lastPosition) > 0) {
+    if (iconChanged(icon)) {
       this.lastPosition = this.newPosition;
-      this.lastIcon.color = transmitter.waypointIcon().color;
+      this.lastIcon.copyFrom(icon);
+      disconnect();
+      connect();
+    } else if (this.newPosition.distManhattan(this.lastPosition) > 0) {
+      this.lastPosition = this.newPosition;
 
       this.receiver.connection.send(ClientboundTrackedWaypointPacket.updateWaypointPosition(
           transmitter.uuid(), lastIcon, lastPosition));

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/PayloadWaypoint.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/PayloadWaypoint.java
@@ -1,0 +1,39 @@
+package tc.oc.pgm.platform.modern.modules.waypoints;
+
+import java.util.Optional;
+import org.bukkit.Color;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.Tickable;
+import tc.oc.pgm.api.party.Competitor;
+import tc.oc.pgm.api.time.Tick;
+import tc.oc.pgm.payload.Payload;
+
+public class PayloadWaypoint extends GoalWaypoint<Payload> implements Tickable {
+
+  private Competitor lastCompetitor;
+
+  public PayloadWaypoint(Payload goal) {
+    super(goal, Color.WHITE.asRGB(), goal.getMinecartUuid());
+    // Force a first reload
+    goal.shouldDisplay(true);
+  }
+
+  @Override
+  public void tick(Match match, Tick tick) {
+    setPosition(goal.getCenterPoint());
+
+    var comp = goal.getDisplayTeam();
+    if (this.lastCompetitor != comp) {
+      this.lastCompetitor = comp;
+      var color = comp != null ? comp.getFullColor() : Color.WHITE;
+      waypointIcon().color = Optional.of(color.asRGB());
+    }
+  }
+
+  @Override
+  public boolean isTransmittingWaypoint() {
+    return super.isTransmittingWaypoint()
+        && (!goal.isCompleted() || !goal.getDefinition().isPermanent())
+        && goal.shouldDisplay(false);
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/Waypoints.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/Waypoints.java
@@ -1,44 +1,51 @@
 package tc.oc.pgm.platform.modern.modules.waypoints;
 
 import io.papermc.paper.math.Position;
-import net.kyori.adventure.text.format.TextColor;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.waypoints.WaypointTransmitter;
 import org.bukkit.Color;
+import org.bukkit.Location;
 import org.bukkit.util.Vector;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.controlpoint.ControlPoint;
 import tc.oc.pgm.core.Core;
 import tc.oc.pgm.destroyable.Destroyable;
 import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.goals.Goal;
 import tc.oc.pgm.goals.ShowOption;
+import tc.oc.pgm.payload.Payload;
+import tc.oc.pgm.regions.EmptyRegion;
 import tc.oc.pgm.wool.MonumentWool;
 
 @SuppressWarnings("UnstableApiUsage")
 public interface Waypoints {
 
-  static WaypointTransmitter immutable(Vector loc, Color color) {
+  static PGMWaypointTransmitter immutable(Vector loc, Color color) {
     return new ImmutableWaypointTransmitter(
         new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()), color.asRGB());
   }
 
-  static WaypointTransmitter immutable(Position loc, TextColor color) {
-    return new ImmutableWaypointTransmitter(toBlockPos(loc), color.value());
+  static PGMWaypointTransmitter immutable(BlockPos pos, int color) {
+    if (pos == null) return null;
+    return new ImmutableWaypointTransmitter(pos, color);
   }
 
-  static WaypointTransmitter from(Goal<?> goal) {
+  static PGMWaypointTransmitter from(Goal<?> goal) {
     if (!goal.hasShowOption(ShowOption.SHOW_WAYPOINT)) return null;
     return switch (goal) {
       case MonumentWool w -> new WoolWaypointTransmitter(w);
       case Flag f -> new FlagWaypointTransmitter(f);
+      case Payload p -> new PayloadWaypoint(p);
+      case ControlPoint c -> new ControlPointWaypoint(c);
       case Core c ->
-        new GoalWaypoint.Immovable<>(
+        GoalWaypoint.simple(
             c,
-            toBlockPos(c.getLavaRegion().getBounds().getCenterPoint()),
+            toBlockPos(c.getMatch(), c.getLavaRegion(), c.getDefinition().getRegion()),
             c.getOwner().getFullColor().asRGB());
       case Destroyable d ->
-        new GoalWaypoint.Immovable<>(
+        GoalWaypoint.simple(
             d,
-            toBlockPos(d.getBlockRegion().getBounds().getCenterPoint()),
+            toBlockPos(d.getMatch(), d.getBlockRegion(), d.getDefinition().getRegion()),
             d.getOwner().getFullColor().asRGB());
       default -> null;
     };
@@ -47,6 +54,28 @@ public interface Waypoints {
   static BlockPos toBlockPos(Vector loc) {
     if (loc == null) return null;
     return new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+  }
+
+  static BlockPos toBlockPos(Location loc) {
+    if (loc == null) return null;
+    return new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+  }
+
+  static <T extends Goal<?>> BlockPos toBlockPos(Match match, Region region) {
+    return toBlockPos(match, region, EmptyRegion.INSTANCE);
+  }
+
+  static <T extends Goal<?>> BlockPos toBlockPos(Match match, Region region, Region containing) {
+    var staticReg = region.getStatic(match);
+    var bounds = staticReg.getBounds();
+    var center = bounds.getCenterPoint();
+    var size = bounds.getSize();
+    // Region must either be small enough, or contain its own center
+    // If not, we assume some union of far-apart things, and showing the center makes no sense
+    boolean isSmall = size.getX() < 15 && size.getY() < 30 && size.getZ() < 15;
+    if (isSmall || staticReg.contains(center) || containing.getStatic(match).contains(center))
+      return toBlockPos(center);
+    return null;
   }
 
   private static BlockPos toBlockPos(Position loc) {

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/WoolWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoints/WoolWaypointTransmitter.java
@@ -2,30 +2,29 @@ package tc.oc.pgm.platform.modern.modules.waypoints;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
-import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.wool.MonumentWool;
 
 public class WoolWaypointTransmitter extends GoalWaypoint<MonumentWool> {
-  private final @Nullable BlockPos woolLocation;
   private final BlockPos monumentLocation;
 
   WoolWaypointTransmitter(MonumentWool wool) {
     super(wool, wool.getColor().asRGB());
 
     var def = wool.getDefinition();
-    this.woolLocation = Waypoints.toBlockPos(def.getLocation());
-    this.monumentLocation =
-        Waypoints.toBlockPos(def.getPlacementRegion().getBounds().getCenterPoint());
+    var loc = def.getLocation();
+    var len = loc.lengthSquared();
+    setPosition(len == 0 || Double.isInfinite(len) ? null : loc);
+    this.monumentLocation = Waypoints.toBlockPos(wool.getMatch(), def.getPlacementRegion());
   }
 
   @Override
   public boolean shouldSee(ServerPlayer player) {
-    return isTransmittingWaypoint() && (woolLocation != null || hasWool(player));
+    return isTransmittingWaypoint() && (position != null || hasWool(player));
   }
 
   @Override
   public BlockPos position(ServerPlayer receiver) {
-    return woolLocation == null || hasWool(receiver) ? monumentLocation : woolLocation;
+    return position == null || hasWool(receiver) ? monumentLocation : position;
   }
 
   private boolean hasWool(ServerPlayer player) {


### PR DESCRIPTION
Makes it so payloads (which are not display-hidden), control points, and scoreboxes show as waypoints too.
After this i believe all relevant objectives to have been tackled.

Notes:
 - Payloads will show the color of the pushing team, much like the wool in the payload, the beam color, and other particles
   - Payloads currently not displaying (ie display-filter isn't passing), won't show up either
 - Control points will show the color of the controlling team, similar to how the owner region changes the color around the point after a team takes capture.
   - Permanent control points (ie: hills) which can only be captured once, stop showing after they become captured
 - Scoreboxes will try to determine their owner by passing all teams in the match thru the filter
   - If one and only one team is not allowed, that team is determined to be the owner and the scorebox will render of that teams' color like it did for cores/monuments
   - If no teams or multiple teams do not pass the filter, the scorebox won't get a waypoint.