### PR TITLE
Fix item & block damage issues in modern

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernItemData.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernItemData.java
@@ -10,14 +10,21 @@ import tc.oc.pgm.util.material.matcher.SingularMaterialMatcher;
 
 public class ModernItemData implements ItemMaterialData {
   private final Material material;
+  private final short damage;
 
   public ModernItemData(Material material) {
+    this(material, (short) 0);
+  }
+
+  public ModernItemData(Material material, short damage) {
     this.material = material;
+    this.damage = damage == 0 || material.getMaxDurability() == 0 ? 0 : damage;
   }
 
   @Override
   public ItemStack toItemStack(int amount) {
-    return new ItemStack(material, amount);
+    //noinspection deprecation
+    return new ItemStack(material, amount, damage);
   }
 
   @Override

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
@@ -66,7 +66,11 @@ class ModernMaterialParser {
   }
 
   public static Material[] flatten(Material material) {
-    if (!material.isLegacy()) return new Material[] {material};
+    if (!material.isLegacy()) {
+      var legacyMat = UNSAFE.toLegacy(material);
+      if (legacyMat.isAir()) return new Material[] {material};
+      material = legacyMat;
+    }
     var md = new org.bukkit.material.MaterialData(material, (byte) 0);
     var main = UNSAFE.fromLegacy(md);
     md.setData((byte) 1);
@@ -161,7 +165,7 @@ class ModernMaterialParser {
       public ItemMaterialData visit(Material material, short data) {
         return switch (material = upgrade(material, data)) {
           case POTION, SPLASH_POTION -> new PotionMaterialData(data);
-          default -> new ModernItemData(material);
+          default -> new ModernItemData(material, data);
         };
       }
     };

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
@@ -161,29 +161,32 @@ public class ModernMaterialUtils implements MaterialUtils {
 
     @Override
     public MaterialMatcher.Builder visit(Material material) {
-      return addAll(ModernMaterialParser.flatten(material));
+      return add(material, true);
     }
 
     @Override
     public MaterialMatcher.Builder visit(Material material, short data) {
       BlockData bd = Bukkit.getUnsafe().fromLegacy(material, (byte) data);
-      if (MATERIAL_UTILS.hasBlockStates(bd.getMaterial())) {
-        return add(new BlockStateMaterialMatcher(bd));
-      } else {
-        return add(bd.getMaterial());
-      }
+      // Just a plain block with no states now, add material directly,
+      if (!MATERIAL_UTILS.hasBlockStates(material)) return add(bd.getMaterial());
+
+      // This has block states, there's two options:
+      // a) 'data' is now bundled in the material itself (eg: stained-glass panes)
+      // b) 'data' defines a specific block state (eg: rails or water)
+      // A bit of a hack, but test by creating different data and check if materials match
+      var other = Bukkit.getUnsafe().fromLegacy(material, (byte) (data == 0 ? 1 : data - 1));
+      if (other.getMaterial() == bd.getMaterial()) add(new BlockStateMaterialMatcher(bd));
+      return add(bd.getMaterial());
     }
 
     @Override
     public MaterialMatcher.Builder add(Material material, boolean flatten) {
-      // TODO: PLATFORM 1.20 - flatten non-legacy itemstack into list of modern
-      return add(material);
+      return flatten ? addAll(ModernMaterialParser.flatten(material)) : add(material);
     }
 
     @Override
     public MaterialMatcher.Builder add(ItemStack item, boolean flatten) {
-      // TODO: PLATFORM 1.20 - flatten non-legacy itemstack into list of modern
-      return add(item.getType());
+      return add(item.getType(), flatten);
     }
 
     @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
@@ -184,9 +184,9 @@ public class SpMaterialUtils implements MaterialUtils {
 
     @Override
     public MaterialMatcher.Builder add(ItemStack item, boolean flatten) {
-      if (flatten) add(item.getType());
-      else add(new ExactMaterialMatcher(item.getType(), item.getData().getData()));
-      return this;
+      return flatten
+          ? visit(item.getType())
+          : visit(item.getType(), item.getData().getData());
     }
 
     @Override


### PR DESCRIPTION
Fixes mainly two bugs on modern:
 - `damage` attribute on items would only affect material (eg: wool color) but wouldn't create damaged tools
 - `stained glass pane:8` in a block filter was interpreted as exactly the default blockstate for light gray stained glass pane.
   - The `8` metadata has already been applied by changing the material, and should no longer dictate state matching.
   - In other cases (eg: `rail:8`, `water:1`) that metadata does determine a specific blockstate, and so still does exact matching.