### PR TITLE
Add upgrade strategy for items & blocks

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
@@ -1,10 +1,12 @@
 package tc.oc.pgm.platform.modern.material;
 
+import com.google.common.collect.HashMultimap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.UnsafeValues;
@@ -23,10 +25,39 @@ class ModernMaterialParser {
 
   private static final UnsafeValues UNSAFE = Bukkit.getUnsafe();
   private static final Int2ObjectMap<Material> BY_ID = new Int2ObjectOpenHashMap<>(400);
+  private static final int[] UPGRADE_COUNT = new int[256];
 
   static {
+    HashMultimap<Material, BlockState> reachableStates = HashMultimap.create(256, 1);
     for (Material value : CraftLegacy.values()) {
       BY_ID.put(value.getId(), value);
+
+      // Legacy blocks 0..255, some legacy items may also respond true to isBlock
+      if (value.getId() >= 256) continue;
+
+      for (byte i = 0; i < 16; i++) {
+        var state = CraftLegacy.fromLegacyData(value, i);
+        if (!state.isAir()) reachableStates.put(state.getBukkitMaterial(), state);
+      }
+    }
+
+    for (Material value : CraftLegacy.values()) {
+      if (value.getId() >= 256) break;
+
+      // Compute for each material:data if we should match as material, blockstate, or a mix.
+      int result = 0;
+      for (byte i = 0; i < 16; i++) {
+        var state = CraftLegacy.fromLegacyData(value, i);
+        if (state.isAir()) continue;
+
+        var reachable = reachableStates.get(state.getBukkitMaterial()).size();
+        if (reachable == 1) continue; // no need to write USE_MATERIAL(0)
+        var modern = state.getBlock().getStateDefinition().getPossibleStates().size();
+        if (modern == 1) continue; // no need to write USE_MATERIAL(0)
+
+        result |= (reachable == modern ? UpgradeStrat.BLOCK_STATE : UpgradeStrat.GOOD_LUCK).to(i);
+      }
+      UPGRADE_COUNT[value.getId()] = result;
     }
   }
 
@@ -86,6 +117,29 @@ class ModernMaterialParser {
     }
     materials.remove(Material.AIR);
     return materials.toArray(Material[]::new);
+  }
+
+  enum UpgradeStrat {
+    MATERIAL,
+    BLOCK_STATE,
+    GOOD_LUCK;
+
+    private static final UpgradeStrat[] VALUES = UpgradeStrat.values();
+
+    int to(byte data) {
+      return ordinal() << (data << 1);
+    }
+
+    static UpgradeStrat of(int value, byte data) {
+      return VALUES[(value >> (data << 1)) & 0b11];
+    }
+  }
+
+  public static UpgradeStrat getUpgradeStrategy(Material legacy, byte data) {
+    if (!legacy.isLegacy()) return UpgradeStrat.MATERIAL;
+    var id = legacy.getId();
+    if (id < 0 || id >= 256) return UpgradeStrat.MATERIAL;
+    return UpgradeStrat.of(UPGRADE_COUNT[id], data);
   }
 
   private static Material parseLegacyMaterial(String text, Node node) throws InvalidXMLException {

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
@@ -6,14 +6,15 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.ChunkSnapshot;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Bisected;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Door;
+import org.bukkit.craftbukkit.legacy.CraftLegacy;
 import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 import org.bukkit.entity.GlowItemFrame;
 import org.bukkit.entity.Hanging;
@@ -24,6 +25,7 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BlockVector;
 import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.util.chunk.ChunkVector;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.ItemMaterialData;
@@ -140,12 +142,6 @@ public class ModernMaterialUtils implements MaterialUtils {
   }
 
   @Override
-  public boolean hasBlockStates(Material material) {
-    var block = CraftMagicNumbers.getBlock(material);
-    return !block.getStateDefinition().getPossibleStates().isEmpty();
-  }
-
-  @Override
   public MaterialMatcher.Builder matcherBuilder() {
     return new MaterialMatcherBuilderImpl();
   }
@@ -158,6 +154,7 @@ public class ModernMaterialUtils implements MaterialUtils {
 
   private static class MaterialMatcherBuilderImpl extends MaterialMatcher.BuilderImpl
       implements ModernMaterialParser.Adapter<MaterialMatcher.Builder> {
+    private Node currentNode = null;
 
     @Override
     public MaterialMatcher.Builder visit(Material material) {
@@ -166,22 +163,50 @@ public class ModernMaterialUtils implements MaterialUtils {
 
     @Override
     public MaterialMatcher.Builder visit(Material material, short data) {
-      BlockData bd = Bukkit.getUnsafe().fromLegacy(material, (byte) data);
-      // Just a plain block with no states now, add material directly,
-      if (!MATERIAL_UTILS.hasBlockStates(material)) return add(bd.getMaterial());
+      // Filter out air so any air=invalid later on, and any modern material
+      if (material.isAir() || !material.isLegacy()) return add(CraftLegacy.fromLegacy(material));
 
-      // This has block states, there's two options:
-      // a) 'data' is now bundled in the material itself (eg: stained-glass panes)
-      // b) 'data' defines a specific block state (eg: rails or water)
-      // A bit of a hack, but test by creating different data and check if materials match
-      var other = Bukkit.getUnsafe().fromLegacy(material, (byte) (data == 0 ? 1 : data - 1));
-      if (other.getMaterial() == bd.getMaterial()) add(new BlockStateMaterialMatcher(bd));
-      return add(bd.getMaterial());
+      var item = CraftLegacy.fromLegacyData(material, data);
+      var itemMaterial = CraftMagicNumbers.getMaterial(item);
+
+      // Treat as item, upgrade the material to its modern post-flattening version and we're done
+      if (!itemMaterial.isAir() && material.getId() > 255) return add(itemMaterial);
+
+      var block = CraftLegacy.fromLegacyData(material, (byte) data);
+      var blockMaterial = block.getBukkitMaterial();
+
+      if (itemMaterial.isAir() && blockMaterial.isAir()) {
+        var ex = new InvalidXMLException(
+            "Material doesn't exist (did it ever?)'" + material + ":" + data + "'", currentNode);
+        PGM.get().getGameLogger().log(Level.WARNING, null, ex);
+        return this;
+      }
+
+      return switch (ModernMaterialParser.getUpgradeStrategy(material, (byte) data)) {
+        // Exists as single-state in modern, eg: wool:0 -> white_wool
+        // Or a single legacy state can translate into it, eg:
+        // stained_glass_pane:8 -> light_gray_stained_glass_pane[*]
+        // wall:0 -> cobblestone_wall[*]
+        case MATERIAL -> add(blockMaterial);
+        // There is a 1:1 mapping between upgraded states and modern states eg:
+        // log:0 -> oak_log[axis=y],
+        // log:4 -> oak_log[axis=x],
+        // log:8 -> oak_log[axis=z]
+        case BLOCK_STATE -> add(new BlockStateMaterialMatcher(block.createCraftBlockData()));
+        // Legacy translates into LESS states than are available in modern, eg:
+        // step:0 -> smooth_stone_slab[type=bottom,waterlogged=false],
+        // step:8 -> smooth_stone_slab[type=top,waterlogged=false]
+        // TODO: step:0 could use a new matcher for smooth_stone_slab[type=bottom,waterlogged=*]
+        // Basically any water-loggable block goes thru here
+        case GOOD_LUCK -> add(blockMaterial);
+      };
     }
 
     @Override
     public MaterialMatcher.Builder add(Material material, boolean flatten) {
-      return flatten ? addAll(ModernMaterialParser.flatten(material)) : add(material);
+      return flatten
+          ? addAll(ModernMaterialParser.flatten(material))
+          : add(CraftLegacy.fromLegacy(material));
     }
 
     @Override
@@ -191,7 +216,12 @@ public class ModernMaterialUtils implements MaterialUtils {
 
     @Override
     protected void parseSingle(String text, @Nullable Node node) throws InvalidXMLException {
-      ModernMaterialParser.parse(text, node, materialsOnly, this);
+      try {
+        currentNode = node;
+        ModernMaterialParser.parse(text, node, materialsOnly, this);
+      } finally {
+        currentNode = null;
+      }
     }
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
@@ -148,12 +148,6 @@ public class SpMaterialUtils implements MaterialUtils {
   }
 
   @Override
-  public boolean hasBlockStates(Material material) {
-    Block block = CraftMagicNumbers.getBlock(material);
-    return !block.P().a().isEmpty();
-  }
-
-  @Override
   public MaterialMatcher.Builder matcherBuilder() {
     return new MaterialMatcherBuilderImpl();
   }

--- a/util/src/main/java/tc/oc/pgm/util/material/MaterialUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/MaterialUtils.java
@@ -55,8 +55,6 @@ public interface MaterialUtils {
 
   Set<BlockMaterialData> getPossibleBlocks(Material material);
 
-  boolean hasBlockStates(Material material);
-
   MaterialMatcher.Builder matcherBuilder();
 
   boolean isUpperHalfOfDoor(Block block);


### PR DESCRIPTION
It's not perfect, but its the closest to perfect I could do for now.

There's still some things that won't exactly behave the same in modern and legacy, mainly stairs and slabs.
Eg: in modern `stone_slab:0` would match only bottom half smooth stone slabs, in modern it will match any smooth stone slab (the alternative would be it only matching non-waterlogged bottom-block smooth stone slabs, which is probably not wanted behavior, and gets worse with other things in this category).