### PR TITLE
Use AsyncPlayerSpawnLocationEvent for SpawnMatchModule on modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -26,7 +26,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jspecify.annotations.Nullable;
-import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
@@ -55,6 +54,7 @@ import tc.oc.pgm.spawns.states.State;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.event.player.PlayerAttackEntityEvent;
+import tc.oc.pgm.util.event.player.PlayerSpawnLocationEvent;
 
 @SuppressWarnings("UnstableApiUsage")
 @ListenerScope(MatchScope.LOADED)
@@ -64,6 +64,7 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
 
   private final Match match;
   private final SpawnModule module;
+  private final Location worldSpawn;
   private final Map<MatchPlayer, State> states = new HashMap<>();
   private final ListMultimap<MatchPlayer, State> transitions = ArrayListMultimap.create();
 
@@ -79,6 +80,7 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
   public SpawnMatchModule(Match match, SpawnModule module) {
     this.match = match;
     this.module = module;
+    this.worldSpawn = match.getWorld().getSpawnLocation().clone();
   }
 
   public Match getMatch() {
@@ -322,7 +324,8 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onInitialSpawn(final PlayerSpawnLocationEvent event) {
     // Ensure the player spawns in the match world
-    event.setSpawnLocation(match.getWorld().getSpawnLocation());
+    // This event is async on modern Paper, so we set a clone of the location
+    event.setSpawnLocation(worldSpawn);
   }
 
   @EventHandler(priority = EventPriority.NORMAL)

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
@@ -32,6 +32,7 @@ import tc.oc.pgm.util.event.player.PlayerAttackEntityEvent;
 import tc.oc.pgm.util.event.player.PlayerLocaleChangeEvent;
 import tc.oc.pgm.util.event.player.PlayerOnGroundEvent;
 import tc.oc.pgm.util.event.player.PlayerSkinPartsChangeEvent;
+import tc.oc.pgm.util.event.player.PlayerSpawnLocationEvent;
 
 /**
  * TODO: fix unsupported events: <br>
@@ -122,5 +123,12 @@ public class ModernListener implements Listener {
       conn.restartClientLoadTimerAfterRespawn();
       conn.handleAcceptPlayerLoad(PLAYER_LOADED_PACKET);
     });
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onInitialSpawn(io.papermc.paper.event.player.AsyncPlayerSpawnLocationEvent event) {
+    var pgmEvent = new PlayerSpawnLocationEvent(event.getSpawnLocation());
+    handleCall(pgmEvent, event);
+    event.setSpawnLocation(pgmEvent.getSpawnLocation());
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SportPaperListener.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SportPaperListener.java
@@ -5,6 +5,7 @@ import static tc.oc.pgm.util.event.EventUtil.handleCall;
 import com.google.gson.JsonObject;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInitialSpawnEvent;
 import org.bukkit.plugin.Plugin;
 import tc.oc.pgm.util.event.ExtraPingDataRequestEvent;
 import tc.oc.pgm.util.event.block.BlockDispenseEntityEvent;
@@ -20,6 +21,7 @@ import tc.oc.pgm.util.event.player.PlayerLocaleChangeEvent;
 import tc.oc.pgm.util.event.player.PlayerOnGroundEvent;
 import tc.oc.pgm.util.event.player.PlayerSkinPartsChangeEvent;
 import tc.oc.pgm.util.event.player.PlayerSpawnEntityEvent;
+import tc.oc.pgm.util.event.player.PlayerSpawnLocationEvent;
 
 public class SportPaperListener implements Listener {
   @EventHandler(ignoreCancelled = true)
@@ -121,5 +123,12 @@ public class SportPaperListener implements Listener {
           }
         },
         event);
+  }
+
+  @EventHandler
+  public void onInitialSpawn(PlayerInitialSpawnEvent event) {
+    var pgmEvent = new PlayerSpawnLocationEvent(event.getSpawnLocation());
+    handleCall(pgmEvent, event);
+    event.setSpawnLocation(pgmEvent.getSpawnLocation());
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/event/player/PlayerSpawnLocationEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/player/PlayerSpawnLocationEvent.java
@@ -1,0 +1,37 @@
+package tc.oc.pgm.util.event.player;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jspecify.annotations.NullMarked;
+import tc.oc.pgm.util.platform.Platform;
+
+@NullMarked
+public class PlayerSpawnLocationEvent extends Event {
+
+  private static final HandlerList HANDLER_LIST = new HandlerList();
+
+  private Location spawnLocation;
+
+  public PlayerSpawnLocationEvent(final Location spawnLocation) {
+    super(Platform.isModern());
+    this.spawnLocation = spawnLocation.clone();
+  }
+
+  public Location getSpawnLocation() {
+    return this.spawnLocation.clone();
+  }
+
+  public void setSpawnLocation(final Location location) {
+    this.spawnLocation = location.clone();
+  }
+
+  @Override
+  public HandlerList getHandlers() {
+    return HANDLER_LIST;
+  }
+
+  public static HandlerList getHandlerList() {
+    return HANDLER_LIST;
+  }
+}


### PR DESCRIPTION
Adds a shim of `AsyncPlayerSpawnLocationEvent` to handle Paper's `AsyncPlayerSpawnLocationEvent` on modern and `PlayerSpawnLocationEvent` on legacy. This avoids early creation of the player object on modern by use of the deprecated `PlayerSpawnLocationEvent`.

Prior to Spigot support, PGM used to use `PlayerInitialSpawnEvent` for SportPaper; perhaps we should use this again given that we have limited our supported platforms to SportPaper and modern Paper?