### PR TITLE
Implement Trims module

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -235,7 +235,7 @@ public abstract class KitParser {
     Map<Slot.Armor, ArmorKit.ArmorItem> armor = new HashMap<>();
 
     for (Slot.Armor armorSlot : Slot.Armor.armor().toList()) {
-      var armorItem = parseArmorItem(el.getChild(armorSlot.getArmorType().name().toLowerCase()));
+      var armorItem = parseArmorItem(el.getChild(armorSlot.armorTypeName()));
       if (armorItem != null) armor.put(armorSlot, armorItem);
     }
 

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.util.xml;
 
 import com.google.common.collect.Range;
 import java.time.Duration;
+import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.Material;
@@ -82,6 +83,15 @@ public class XMLFluentParser {
       @Override
       protected Duration parse(String text) throws TextException {
         return TextParser.parseDuration(text);
+      }
+    };
+  }
+
+  public <T> PrimitiveBuilder.Generic<T> parse(Function<String, T> fn, Element el, String... prop) {
+    return new PrimitiveBuilder.Generic<>(el, prop) {
+      @Override
+      protected T parse(String text) throws TextException {
+        return fn.apply(text);
       }
     };
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernModuleRegistrar.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernModuleRegistrar.java
@@ -3,12 +3,16 @@ package tc.oc.pgm.platform.modern.modules;
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
 import tc.oc.pgm.api.Modules;
+import tc.oc.pgm.platform.modern.modules.trim.TrimMatchModule;
+import tc.oc.pgm.platform.modern.modules.trim.TrimModule;
+import tc.oc.pgm.platform.modern.modules.waypoint.WaypointMatchModule;
 import tc.oc.pgm.util.platform.Supports;
 
 @Supports(PAPER)
 public class ModernModuleRegistrar implements Modules.ModuleRegistrar {
   @Override
   public void registerModules(Modules modules) {
+    modules.register(TrimModule.class, TrimMatchModule.class, new TrimModule.Factory());
     modules.register(WaypointMatchModule.class, WaypointMatchModule::new);
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/trim/TrimMatchModule.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/trim/TrimMatchModule.java
@@ -1,0 +1,71 @@
+package tc.oc.pgm.platform.modern.modules.trim;
+
+import io.papermc.paper.event.entity.EntityEquipmentChangedEvent;
+import java.util.HashMap;
+import java.util.Map;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ArmorMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.trim.ArmorTrim;
+import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.util.MatchPlayers;
+
+@NullMarked
+@ListenerScope(MatchScope.RUNNING)
+public class TrimMatchModule implements MatchModule, Listener {
+  private final Match match;
+  private final TrimProperties properties;
+
+  private final Map<TextColor, TrimMaterial> colors = new HashMap<>();
+
+  public TrimMatchModule(Match match, TrimProperties properties) {
+    this.match = match;
+    this.properties = properties;
+  }
+
+  private @Nullable TrimMaterial getColor(MatchPlayer mp) {
+    var cmp = mp.getCompetitor();
+    if (cmp == null) return null;
+    return colors.computeIfAbsent(cmp.getTextColor(), Trims::getNearestMaterial);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onArmorChange(EntityEquipmentChangedEvent event) {
+    TrimMaterial mat = null;
+    PlayerInventory inv = null;
+    for (var entry : event.getEquipmentChanges().entrySet()) {
+      if (!entry.getKey().isArmor()) continue;
+      var item = entry.getValue().newItem();
+      // Ignore non-armor or leather armor
+      if (!(item.getItemMeta() instanceof ArmorMeta meta)
+          || item.getItemMeta() instanceof LeatherArmorMeta) continue;
+
+      if (mat == null) {
+        var mp = match.getPlayer(event.getEntity());
+        if (!MatchPlayers.canInteract(mp)) return;
+        mat = getColor(mp);
+        inv = mp.getInventory();
+      }
+      var pattern = properties.patterns().get(entry.getKey());
+      if (pattern == null || mat == null) continue;
+
+      var toApply = new ArmorTrim(mat, pattern);
+      if (meta.hasTrim() && toApply.equals(meta.getTrim())) continue;
+
+      meta.setTrim(toApply);
+      item.setItemMeta(meta);
+      inv.setItem(entry.getKey(), item);
+    }
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/trim/TrimModule.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/trim/TrimModule.java
@@ -1,0 +1,78 @@
+package tc.oc.pgm.platform.modern.modules.trim;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.meta.trim.TrimPattern;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.map.MapModule;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.map.factory.MapModuleFactory;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.regions.RegionModule;
+import tc.oc.pgm.util.inventory.Slot;
+import tc.oc.pgm.util.text.TextException;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+
+@NullMarked
+public class TrimModule implements MapModule<TrimMatchModule> {
+  private final TrimProperties properties;
+
+  public TrimModule(TrimProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public TrimMatchModule createMatchModule(Match match) {
+    return new TrimMatchModule(match, this.properties);
+  }
+
+  public static class Factory implements MapModuleFactory<TrimModule> {
+    @Override
+    public Collection<Class<? extends MapModule<?>>> getSoftDependencies() {
+      return List.of(RegionModule.class);
+    }
+
+    @Override
+    public @Nullable TrimModule parse(MapFactory factory, Logger logger, Document doc)
+        throws InvalidXMLException {
+      var parser = factory.getParser();
+      boolean enabled = true;
+      Map<EquipmentSlot, TrimPattern> patterns = new HashMap<>();
+      patterns.put(EquipmentSlot.HEAD, TrimPattern.HOST);
+      patterns.put(EquipmentSlot.CHEST, TrimPattern.RAISER);
+      patterns.put(EquipmentSlot.LEGS, TrimPattern.DUNE);
+      patterns.put(EquipmentSlot.FEET, TrimPattern.DUNE);
+
+      for (Element el : doc.getRootElement().getChildren("trims")) {
+        enabled = parser.parseBool(el, "enabled").optional(enabled);
+
+        for (Slot.Armor slot : Slot.Armor.armor().toList()) {
+          var curr = patterns.get(slot.toEquipmentSlot());
+          var trim = parser.parse(this::parseTrim, el, slot.armorTypeName()).optional(curr);
+          if (curr == trim) continue;
+
+          if (trim == null) patterns.remove(slot.toEquipmentSlot());
+          else patterns.put(slot.toEquipmentSlot(), trim);
+        }
+      }
+
+      return enabled && !patterns.isEmpty()
+          ? new TrimModule(new TrimProperties(Map.copyOf(patterns)))
+          : null;
+    }
+
+    private @Nullable TrimPattern parseTrim(String key) {
+      if ("none".equalsIgnoreCase(key)) return null;
+      var trim = Trims.getPatternByKey(key);
+      if (trim == null) throw TextException.invalidFormat(key, TrimPattern.class);
+      return trim;
+    }
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/trim/TrimProperties.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/trim/TrimProperties.java
@@ -1,0 +1,9 @@
+package tc.oc.pgm.platform.modern.modules.trim;
+
+import java.util.Map;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.meta.trim.TrimPattern;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public record TrimProperties(Map<EquipmentSlot, TrimPattern> patterns) {}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/trim/Trims.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/trim/Trims.java
@@ -1,0 +1,89 @@
+package tc.oc.pgm.platform.modern.modules.trim;
+
+import static net.kyori.adventure.text.format.TextColor.color;
+
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.util.HSVLike;
+import org.bukkit.inventory.meta.trim.TrimMaterial;
+import org.bukkit.inventory.meta.trim.TrimPattern;
+import tc.oc.pgm.util.StringUtils;
+
+public class Trims {
+  private static final Map<String, TrimPattern> PATTERNS_BY_KEY = new HashMap<>();
+  private static final List<MaterialColor> TRIM_COLORS = new MaterialsBuilder().build();
+
+  static {
+    var patterns = RegistryAccess.registryAccess().getRegistry(RegistryKey.TRIM_PATTERN);
+    patterns.keyStream().forEach(key -> {
+      var pattern = patterns.getOrThrow(key);
+      PATTERNS_BY_KEY.put(StringUtils.simplify(key.asMinimalString()), pattern);
+      PATTERNS_BY_KEY.put(StringUtils.simplify(key.asString()), pattern);
+    });
+  }
+
+  public static TrimPattern getPatternByKey(String key) {
+    return PATTERNS_BY_KEY.get(StringUtils.simplify(key.toLowerCase(Locale.ROOT)));
+  }
+
+  public static TrimMaterial getNearestMaterial(TextColor color) {
+    var toMatch = color.asHSV();
+    float bestDist = Float.MAX_VALUE;
+    MaterialColor best = TRIM_COLORS.getFirst();
+
+    for (MaterialColor potential : TRIM_COLORS) {
+      float distance = distance(toMatch, potential);
+      if (distance < bestDist) {
+        best = potential;
+        bestDist = distance;
+      }
+    }
+    return best.material();
+  }
+
+  /*
+   * Color distance formula in the HSV space, weighted so hue is the most important & saturation is partly ignored
+   * This is
+   */
+  private static float distance(final HSVLike self, final HSVLike other) {
+    float hd =
+        5.0f * Math.min(Math.abs(self.h() - other.h()), 1.0F - Math.abs(self.h() - other.h()));
+    float sd = 0.5f * (self.s() - other.s());
+    float vd = (self.v() - other.v());
+    return hd * hd + sd * sd + vd * vd;
+  }
+
+  private record MaterialColor(TrimMaterial material, float h, float s, float v)
+      implements HSVLike {}
+
+  private static class MaterialsBuilder {
+    private final List<MaterialColor> materialColors = new ArrayList<>();
+
+    List<MaterialColor> build() {
+      // Palette from https://minecraft.wiki/w/Smithing#Material (2nd color)
+      register(TrimMaterial.AMETHYST, color(0x9A5CC6));
+      register(TrimMaterial.COPPER, color(0xB4684D));
+      register(TrimMaterial.DIAMOND, color(0x6EECD2));
+      register(TrimMaterial.EMERALD, color(0x0EC754));
+      register(TrimMaterial.GOLD, color(0xECD93F));
+      register(TrimMaterial.IRON, color(0xBFC9C8));
+      register(TrimMaterial.LAPIS, color(0x1C4D9C));
+      register(TrimMaterial.QUARTZ, color(0xF6EADF));
+      register(TrimMaterial.NETHERITE, color(0x443A3B));
+      register(TrimMaterial.REDSTONE, color(0xBD2008));
+      register(TrimMaterial.RESIN, color(0xF69F3B));
+      return List.copyOf(this.materialColors);
+    }
+
+    private void register(TrimMaterial material, TextColor color) {
+      var hsv = color.asHSV();
+      this.materialColors.add(new MaterialColor(material, hsv.h(), hsv.s(), hsv.v()));
+    }
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/WaypointMatchModule.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/WaypointMatchModule.java
@@ -1,7 +1,8 @@
-package tc.oc.pgm.platform.modern.modules;
+package tc.oc.pgm.platform.modern.modules.waypoint;
 
 import java.util.Optional;
 import net.minecraft.server.waypoints.ServerWaypointManager;
+import net.minecraft.world.waypoints.WaypointTransmitter;
 import org.bukkit.Color;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.craftbukkit.CraftWorld;
@@ -21,8 +22,7 @@ import tc.oc.pgm.flag.event.FlagStateChangeEvent;
 import tc.oc.pgm.flag.state.Carried;
 import tc.oc.pgm.goals.Goal;
 import tc.oc.pgm.goals.GoalMatchModule;
-import tc.oc.pgm.platform.modern.modules.waypoints.PGMWaypointTransmitter;
-import tc.oc.pgm.platform.modern.modules.waypoints.Waypoints;
+import tc.oc.pgm.platform.modern.modules.waypoint.types.Waypoints;
 import tc.oc.pgm.score.ScoreBox;
 import tc.oc.pgm.score.ScoreMatchModule;
 
@@ -37,7 +37,7 @@ public class WaypointMatchModule implements MatchModule, Listener {
     this.waypointManager = ((CraftWorld) match.getWorld()).getHandle().getWaypointManager();
   }
 
-  private void track(PGMWaypointTransmitter transmitter) {
+  private void track(WaypointTransmitter transmitter) {
     if (transmitter == null) return;
 
     waypointManager.trackWaypoint(transmitter);

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/AbstractWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/AbstractWaypointTransmitter.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import java.util.Optional;
 import java.util.UUID;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/ControlPointWaypoint.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/ControlPointWaypoint.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import java.util.Optional;
 import org.bukkit.Color;
@@ -6,23 +6,20 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.Tickable;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.time.Tick;
-import tc.oc.pgm.payload.Payload;
+import tc.oc.pgm.controlpoint.ControlPoint;
 
-public class PayloadWaypoint extends GoalWaypoint<Payload> implements Tickable {
+class ControlPointWaypoint extends GoalWaypoint<ControlPoint> implements Tickable {
 
   private Competitor lastCompetitor;
 
-  public PayloadWaypoint(Payload goal) {
-    super(goal, Color.WHITE.asRGB(), goal.getMinecartUuid());
-    // Force a first reload
-    goal.shouldDisplay(true);
+  ControlPointWaypoint(ControlPoint goal) {
+    super(goal, Color.WHITE.asRGB());
+    setPosition(goal.getCenterPoint());
   }
 
   @Override
   public void tick(Match match, Tick tick) {
-    setPosition(goal.getCenterPoint());
-
-    var comp = goal.getDisplayTeam();
+    var comp = goal.getControllingTeam();
     if (this.lastCompetitor != comp) {
       this.lastCompetitor = comp;
       var color = comp != null ? comp.getFullColor() : Color.WHITE;
@@ -32,8 +29,6 @@ public class PayloadWaypoint extends GoalWaypoint<Payload> implements Tickable {
 
   @Override
   public boolean isTransmittingWaypoint() {
-    return super.isTransmittingWaypoint()
-        && (!goal.isCompleted() || !goal.getDefinition().isPermanent())
-        && goal.shouldDisplay(false);
+    return !goal.isCompleted() || !goal.getDefinition().isPermanent();
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/FlagWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/FlagWaypointTransmitter.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.Tickable;
@@ -6,7 +6,7 @@ import tc.oc.pgm.api.time.Tick;
 import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.flag.state.Carried;
 
-public class FlagWaypointTransmitter extends GoalWaypoint<Flag> implements Tickable {
+class FlagWaypointTransmitter extends GoalWaypoint<Flag> implements Tickable {
 
   FlagWaypointTransmitter(Flag flag) {
     super(flag, flag.getDyeColor().getColor().asRGB());

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/GoalWaypoint.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/GoalWaypoint.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -9,7 +9,7 @@ import org.bukkit.util.Vector;
 import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.goals.Goal;
 
-public class GoalWaypoint<T extends Goal<?>> extends AbstractWaypointTransmitter {
+class GoalWaypoint<T extends Goal<?>> extends AbstractWaypointTransmitter {
   protected final T goal;
   protected BlockPos position;
 
@@ -23,7 +23,7 @@ public class GoalWaypoint<T extends Goal<?>> extends AbstractWaypointTransmitter
     this.waypointIcon.color = Optional.of(color);
   }
 
-  public static <T extends Goal<?>> GoalWaypoint<T> simple(T goal, BlockPos pos, int color) {
+  static <T extends Goal<?>> GoalWaypoint<T> simple(T goal, BlockPos pos, int color) {
     var waypoint = new GoalWaypoint<>(goal, color);
     waypoint.position = pos;
     return waypoint;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/ImmutableWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/ImmutableWaypointTransmitter.java
@@ -1,13 +1,13 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import java.util.Optional;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 
-public class ImmutableWaypointTransmitter extends AbstractWaypointTransmitter {
+class ImmutableWaypointTransmitter extends AbstractWaypointTransmitter {
   private final BlockPos blockPos;
 
-  public ImmutableWaypointTransmitter(BlockPos pos, Integer color) {
+  ImmutableWaypointTransmitter(BlockPos pos, Integer color) {
     super(null);
     this.blockPos = pos;
     this.waypointIcon.color = Optional.ofNullable(color);

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/PGMBlockConnection.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/PGMBlockConnection.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.ClientboundTrackedWaypointPacket;

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/PGMWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/PGMWaypointTransmitter.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
@@ -6,7 +6,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.waypoints.WaypointTransmitter;
 import org.jetbrains.annotations.Nullable;
 
-public interface PGMWaypointTransmitter extends WaypointTransmitter {
+interface PGMWaypointTransmitter extends WaypointTransmitter {
   UUID uuid();
 
   @Nullable

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/PayloadWaypoint.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/PayloadWaypoint.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import java.util.Optional;
 import org.bukkit.Color;
@@ -6,20 +6,23 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.Tickable;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.time.Tick;
-import tc.oc.pgm.controlpoint.ControlPoint;
+import tc.oc.pgm.payload.Payload;
 
-public class ControlPointWaypoint extends GoalWaypoint<ControlPoint> implements Tickable {
+class PayloadWaypoint extends GoalWaypoint<Payload> implements Tickable {
 
   private Competitor lastCompetitor;
 
-  public ControlPointWaypoint(ControlPoint goal) {
-    super(goal, Color.WHITE.asRGB());
-    setPosition(goal.getCenterPoint());
+  PayloadWaypoint(Payload goal) {
+    super(goal, Color.WHITE.asRGB(), goal.getMinecartUuid());
+    // Force a first reload
+    goal.shouldDisplay(true);
   }
 
   @Override
   public void tick(Match match, Tick tick) {
-    var comp = goal.getControllingTeam();
+    setPosition(goal.getCenterPoint());
+
+    var comp = goal.getDisplayTeam();
     if (this.lastCompetitor != comp) {
       this.lastCompetitor = comp;
       var color = comp != null ? comp.getFullColor() : Color.WHITE;
@@ -29,6 +32,8 @@ public class ControlPointWaypoint extends GoalWaypoint<ControlPoint> implements 
 
   @Override
   public boolean isTransmittingWaypoint() {
-    return !goal.isCompleted() || !goal.getDefinition().isPermanent();
+    return super.isTransmittingWaypoint()
+        && (!goal.isCompleted() || !goal.getDefinition().isPermanent())
+        && goal.shouldDisplay(false);
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/Waypoints.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/Waypoints.java
@@ -1,9 +1,8 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
-import io.papermc.paper.math.Position;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.waypoints.WaypointTransmitter;
 import org.bukkit.Color;
-import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
@@ -17,20 +16,19 @@ import tc.oc.pgm.payload.Payload;
 import tc.oc.pgm.regions.EmptyRegion;
 import tc.oc.pgm.wool.MonumentWool;
 
-@SuppressWarnings("UnstableApiUsage")
 public interface Waypoints {
 
-  static PGMWaypointTransmitter immutable(Vector loc, Color color) {
+  static WaypointTransmitter immutable(Vector loc, Color color) {
     return new ImmutableWaypointTransmitter(
         new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()), color.asRGB());
   }
 
-  static PGMWaypointTransmitter immutable(BlockPos pos, int color) {
+  static WaypointTransmitter immutable(BlockPos pos, int color) {
     if (pos == null) return null;
     return new ImmutableWaypointTransmitter(pos, color);
   }
 
-  static PGMWaypointTransmitter from(Goal<?> goal) {
+  static WaypointTransmitter from(Goal<?> goal) {
     if (!goal.hasShowOption(ShowOption.SHOW_WAYPOINT)) return null;
     return switch (goal) {
       case MonumentWool w -> new WoolWaypointTransmitter(w);
@@ -56,11 +54,6 @@ public interface Waypoints {
     return new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
   }
 
-  static BlockPos toBlockPos(Location loc) {
-    if (loc == null) return null;
-    return new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
-  }
-
   static <T extends Goal<?>> BlockPos toBlockPos(Match match, Region region) {
     return toBlockPos(match, region, EmptyRegion.INSTANCE);
   }
@@ -76,9 +69,5 @@ public interface Waypoints {
     if (isSmall || staticReg.contains(center) || containing.getStatic(match).contains(center))
       return toBlockPos(center);
     return null;
-  }
-
-  private static BlockPos toBlockPos(Position loc) {
-    return new BlockPos(loc.blockX(), loc.blockY(), loc.blockZ());
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/WoolWaypointTransmitter.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/waypoint/types/WoolWaypointTransmitter.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.platform.modern.modules.waypoints;
+package tc.oc.pgm.platform.modern.modules.waypoint.types;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;

--- a/util/src/main/java/tc/oc/pgm/util/inventory/Slot.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/Slot.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Table;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -446,6 +447,10 @@ public abstract class Slot {
 
     public ArmorType getArmorType() {
       return armorType;
+    }
+
+    public String armorTypeName() {
+      return armorType.name().toLowerCase(Locale.ROOT);
     }
 
     public static Armor forType(ArmorType armorType) {


### PR DESCRIPTION
Trims! the new way to show color on armor that can apply when it's not leather!

PGM, on modern, will by default automatically put trims on players' armor derived from the players' team, and maps can control/update what/if trims get applied.

To disable/disable or modify trimming behavior, any of these syntaxes work for defining overrides to the defaults:
```xml
<trims enabled="false"/>
<trims helmet="shaper" chestplate="shaper" leggings="none" boots="none" />
<trims>
  <helmet>shaper</helmet>
  <chestplate>shaper</chestplate>
  <leggings>shaper</leggings>
  <boots>shaper</boots>
</trims>
```


Note, the material color mappings are automatically derived, the results for existing colors are:
```
dark_red : REDSTONE
green : EMERALD
dark_green : EMERALD
black : NETHERITE
yellow : GOLD
dark_blue : LAPIS
dark_purple : AMETHYST
gold : RESIN
red : REDSTONE
aqua : DIAMOND
gray : COPPER
light_purple : AMETHYST
blue : LAPIS
white : QUARTZ
dark_aqua : DIAMOND
dark_gray : NETHERITE
```