### PR TITLE
Implement custom item components

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -526,6 +526,9 @@ public abstract class KitParser {
 
     parseCustomNBT(el, itemStack);
 
+    var components = Node.fromAttr(el, "components");
+    if (components != null) INVENTORY_UTILS.applyComponents(itemStack, components);
+
     return itemStack;
   }
 

--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -192,7 +192,7 @@ public class BlockTransformListener implements Listener {
         handleDoor(event, (Door) newData);
       }
     }
-    logger.finest("Generated event " + event);
+    logger.finest(() -> "Generated event " + event);
     currentEvents.put(event.getCause(), event);
   }
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernInventoryUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernInventoryUtil.java
@@ -2,10 +2,18 @@ package tc.oc.pgm.platform.modern.inventory;
 
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.item.ItemParser;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.Item;
 import org.bukkit.Material;
+import org.bukkit.craftbukkit.CraftRegistry;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
@@ -21,6 +29,8 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import tc.oc.pgm.util.inventory.InventoryUtils;
 import tc.oc.pgm.util.platform.Supports;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
 
 @Supports(value = PAPER, minVersion = "1.21.1")
 public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatform {
@@ -92,5 +102,23 @@ public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatfor
   @Override
   public boolean isViewable(Inventory inventory) {
     return inventory.getType().isCreatable();
+  }
+
+  private static final Registry<Item> ITEMS =
+      CraftRegistry.getMinecraftRegistry().lookupOrThrow(Registries.ITEM);
+  private static final ItemParser ITEM_PARSER =
+      new ItemParser(Commands.createValidationContext(CraftRegistry.getMinecraftRegistry()));
+
+  public void applyComponents(ItemStack itemStack, Node components) throws InvalidXMLException {
+    var nmsStack = CraftItemStack.unwrap(itemStack);
+    try {
+      var key = ITEMS.getKey(nmsStack.getItem());
+      if (key == null) throw new IllegalStateException("Invalid item stack: " + nmsStack);
+
+      var str = new StringReader(key.toShortString() + "[" + components.getValueNormalize() + "]");
+      nmsStack.applyComponents(ITEM_PARSER.parse(str).components());
+    } catch (CommandSyntaxException ex) {
+      throw new InvalidXMLException("Failed to parse components", components, ex);
+    }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -27,6 +27,8 @@ import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.platform.Platform;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
 
 public final class InventoryUtils {
   public static final InventoryUtilsPlatform INVENTORY_UTILS =
@@ -195,5 +197,9 @@ public final class InventoryUtils {
     Set<Material> getCanPlaceOn(ItemMeta itemMeta);
 
     boolean isViewable(Inventory inventory);
+
+    default void applyComponents(ItemStack itemStack, Node components) throws InvalidXMLException {
+      // Default no-op for legacy
+    }
   }
 }


### PR DESCRIPTION
Did someone say they wanted to use any item components in modern? wait no more!

```xml
    <kit id="spawn-kit">
        <item slot="2" material="diamond pickaxe" components="equippable={slot:head}"/>
    </kit>
```
The new `components` xml attribute takes in a vanilla component definition and applies it to the item.
The syntax is the same as vanilla's /give item components, eg: for `/give @p diamond_pickaxe[equippable={slot:head}]`, you would just pass pgm the `equippable={slot:head}`.

In the future we expect that commonly used components can get a pgm xml-native way to be described (think of how you just set `unbreakable="true"` and not `components="unbreakable={}`), but components themselves will remain being supported as a generic way for all the components that don't have a specific way parser in pgm.
