### PR TITLE
Ignore armour in `carrying` and fix-up item matching

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/player/CarryingItemFilter.java
@@ -40,7 +40,9 @@ public class CarryingItemFilter extends ParticipantItemFilter {
 
   @Override
   protected Stream<ItemStack> getItems(MatchPlayer player) {
-    Stream<ItemStack> inventory = Slot.Player.player().map(s -> s.getItem(player));
+    Stream<ItemStack> inventory = Stream.concat(
+            Slot.Storage.storage(), Slot.OffHand.offHand().stream())
+        .map(s -> s.getItem(player));
 
     // Potentially add the crafting grid if that's the currently open inventory
     InventoryView invView = player.getBukkit().getOpenInventory();

--- a/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
@@ -42,15 +42,24 @@ public class ItemMatcher {
       // Strip all meta, then re-add if needed
       newItem.setItemMeta(null);
 
-      // Restore name or enchants
-      if (!ignoreName) newItem.getItemMeta().setDisplayName(item.getItemMeta().getDisplayName());
+      // Restore name
+      if (!ignoreName) {
+        ItemMeta meta = newItem.getItemMeta();
+        meta.setDisplayName(item.getItemMeta().getDisplayName());
+        newItem.setItemMeta(meta);
+      }
+
+      // Restore enchants
       if (!ignoreEnchantments) newItem.addUnsafeEnchantments(item.getEnchantments());
     } else {
       // Strip only specific parts
       ItemMeta meta = item.getItemMeta();
 
       if (ignoreName) meta.setDisplayName(null);
-      if (ignoreEnchantments) item.getEnchantments().keySet().forEach(item::removeEnchantment);
+      if (ignoreEnchantments)
+        newItem.getEnchantments().keySet().forEach(newItem::removeEnchantment);
+
+      newItem.setItemMeta(meta);
     }
 
     return newItem;


### PR DESCRIPTION
1. Ignore armour in `carrying`: While PGM didn't promise this before, it's how it behaved in legacy by default and I think moving away from such an expectation would warrant a proto bump.
2. Fix-up ItemMatcher
3. ~~Ignore `custom-meta-applied` when checking if items are similar Apply item mods in KitParser; this makes comparisons in `Materials.itemsSimilar` accurate when comparing against kit-given items.~~