### PR TITLE
feat: omni-directional/present consistently volumed sounds

### DIFF
--- a/core/src/main/java/tc/oc/pgm/doublejump/DoubleJumpMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/doublejump/DoubleJumpMatchModule.java
@@ -107,7 +107,7 @@ public class DoubleJumpMatchModule implements MatchModule, Listener, Tickable {
       impulse.setY(0.75 + Math.abs(impulse.getY()) * 0.5);
       impulse.multiply(jumper.kit.power / 3f);
       player.setVelocity(impulse);
-      Sounds.play(player, Sounds.DOUBLE_JUMP);
+      Sounds.play(player, Sounds.DOUBLE_JUMP, player.getLocation());
     }
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/Audience.java
@@ -45,6 +45,13 @@ public interface Audience extends ForwardingAudience.Single {
   float soundDistance = 4096f;
   float maxVolume = 0.9999f;
 
+  /**
+   * Plays a sound "globally", without a particular location.
+   *
+   * <p>For non-global sounds, use {@link Audience#playSound(Sound, Location)}.
+   *
+   * @param sound a sound
+   */
   @Override
   default void playSound(@NotNull Sound sound) {
     var player = pointers().get(Identity.UUID).map(Bukkit::getPlayer);

--- a/util/src/main/java/tc/oc/pgm/util/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/Audience.java
@@ -9,11 +9,13 @@ import java.util.function.Predicate;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import net.kyori.adventure.audience.ForwardingAudience;
+import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +41,27 @@ public interface Audience extends ForwardingAudience.Single {
   BukkitAudiences PROVIDER = BukkitAudiences.builder(BukkitUtils.getPlugin())
       .componentRenderer(ComponentRenderer.RENDERER)
       .build();
+
+  float soundDistance = 4096f;
+  float maxVolume = 0.9999f;
+
+  @Override
+  default void playSound(@NotNull Sound sound) {
+    var player = pointers().get(Identity.UUID).map(Bukkit::getPlayer);
+    if (player.isPresent()) {
+      var location = player.get().getEyeLocation();
+      var realVolume =
+          soundDistance / (16f * (1f - Math.max(0f, Math.min(maxVolume, sound.volume()))));
+      this.playSound(
+          Sound.sound(sound).volume(realVolume).build(),
+          location.getX(),
+          location.getY() + soundDistance,
+          location.getZ());
+      return;
+    }
+
+    Single.super.playSound(sound);
+  }
 
   static Audience console() {
     return PROVIDER::console;

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/Sounds.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/Sounds.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.util.bukkit;
 import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 
 import net.kyori.adventure.sound.Sound;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.platform.Platform;
@@ -72,5 +73,9 @@ public interface Sounds {
 
   static void play(Player player, Sound sound) {
     Audience.get(player).playSound(sound);
+  }
+
+  static void play(Player player, Sound sound, Location location) {
+    Audience.get(player).playSound(sound, location);
   }
 }


### PR DESCRIPTION
## TL;DR

Problems:
- When playing audience sounds without a location, moving players perceive sounds as coming from a certain location.
  - Because sounds come from a single location, ostensibly "UI" sounds can player louder in one ear than the other. Example: the error bass sound played from an invalid command such as `/start abc`
  - Consequently, sounds meant to be heard at a certain (lower) volume when a player is moving can quickly fade out as they are moving away from the sound source, which is an undesireable behavior as well for "UI" sounds played without a location
- The sound's location, because of https://github.com/PaperMC/adventure-platform/issues/240, is played from the feet of the player making the actual volume of the sound $\approx 10\\%$ quieter than it should be

Solution:
- Play the sound really loud thousands of blocks far into the sky
- Since the sound is in the sky, it doesn't sound like it's coming from any direction
  - Moving your head in the yaw direction doesn't make the sound more/less prominent
  - The aforementioned UI sounds don't come from one ear more than the other
- Since the sound's output volume is linear to its volume, you can control the output volume by simply adjusting the volume of the faraway sound via a formula
  - Since the sound is very far, moving a bunch doesn't make the sound quieter
- Since we can eliminate the adventure sound playing at feet issue, overall accuracy is increased

## Method

The way most (that are relevant to this PR) Minecraft sounds work is through a packet. There are version differences such as new versions having extra features to attach sounds to entities, but in 1.8.9 the sound packet has:

|Field|Notes|
|-|-|
|Sound||
|x, y, z|Fixed point int, up to 1/8th of a block in resolution|
|Volume|Dictates range, and $\in [0, \infty)$|
|Pitch|$\in [1.5, 2]$|

The volume field is interesting because it does determine the output volume and also range. Precisely, the volume of the source is clamped between values of $[0, 1]$ volume, but the actual range is $16 \times \text{max}(v, 1)$ where $v \in [0, \infty)$.

> [!NOTE]
> You can play with the output volume and the volume in this graph: https://www.desmos.com/calculator/6wdl8d0qi8.
> The x-axis is distance from the sound, and the y-axis is the experienced volume. You can play with the volume variable/slider to achieve different results.

There's also linear attenuation, with the attenuation radius (the point at which the sound is silent) being the aforementioned range. This means that if we can position the sound while paying careful attention to its range, we can force the player to experience sound at a certain volume.

Exploiting this property, using really high volume and really faraway sounds, we can control the volume while making its range huge. With a huge range, a moving player would have to move pretty far to experience a change in volume, which is a desirable property for UI sounds specifically.

With all of that in mind, if we wanted to play a sound at some desired volume, $d$, we would use this formula:

$$ \frac{k}{16(1-d)} $$

Where $k$ is the distance we place the sound **from the player's eyes** (the listener is at the eye location of the player).

Note that since we are playing the sound at some distance away from the player (and to avoid division by 0), we have to restrict $d \in [0, 1)$. Intuitively, this makes sense since the maximum output volume you can hear a sound is by having your ears directly at its origin. Since we're far away from this origin it only makes sense we can't truly play 1 volume.

In practice, this means restricting $d$ to some value which in this PR is $0.9999$, resulting in a minuscule volume error of $6.25 \times 10^{-6}$.

This all comes together in the code submitted in this pull request, where it will take sounds played without an explicit location as to mean "sound that can be played everywhere" and as such plays the sound $k = 4096$ blocks above the player's eye height at the volume computed by the formula.

## Verification

Demonstrating that this produced volumes consistent with vanilla sounds played at the player's ears at certain volumes was done by instrumenting a Minecraft 1.8.9 client. Output volume was computed by simulating the linear attenuation calculation that the audio driver does and logging the results.

<img width="1800" height="900" alt="absolute_error_plot" src="https://github.com/user-attachments/assets/4704a0fd-d4f8-472f-9ae5-533ec8463346" />


The player was positioned strategically at $\langle 0, 400 - 1.62, 0 \rangle$ so the ears would be right up to the sound, as to account for the 1/8ths of a block resolution. 100 sounds with volumes ranging from 0 to 1 were then played using my method, stock adventure, and a directly constructed packet were played then logged using the modification.

Interestingly, we can observe a large amount of error in the expected volume from the adventure method (which is the one currently used in PGM). This can be attributed to https://github.com/PaperMC/adventure-platform/issues/240.

The maximum amount of error in volume for my method is $1.20878 \times 10^{−4}$, which is far more desirable than adventure's error of $0.10125$. Very nice!

## Compatibility

While I didn't test every Minecraft version, versions significant to PGM were tested. For the latest version, I also made sure to test some highly popular sound physics mods too.

| Game Version | Notes |
|-|---|
|1.7.10|✅ Works as expected (by ear)|
|1.8.9|✅ Demonstrated by code analysis and thorough testing to have a max error of $\approx 1.2 \times 10^{-4}$ volume|
|1.16.4|✅ Works as expected (by ear)|
|1.21.11 (vanilla)|✅ Works as expected (by ear)|
|1.21.11 with [Sound Physics Perfected](https://modrinth.com/mod/sound-physics-perfected)|⚠️ Sounds fine, barely noticeable discrepancies (as to be expected with sound physics on, anyway)|
|1.21.11 with [Sound Physics Remastered](https://modrinth.com/mod/sound-physics-remastered)|⚠️ Sounds okay, muffled variations from vanilla nearing the bottom of the spectrum $\approx 0.4$ volume|

---
Shoutout to @Pablete1234 for pushing me to understand this as deeply as possible, and for providing technical advice.