### PR TITLE
Get filterable handle from `getWhoClicked` in InventoryInteractEvent

### DIFF
--- a/core/src/main/java/tc/oc/pgm/util/MethodHandleUtils.java
+++ b/core/src/main/java/tc/oc/pgm/util/MethodHandleUtils.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -27,7 +28,8 @@ public final class MethodHandleUtils {
       new HandleFinder(Match.class, "getMatch"),
       new HandleFinder(Player.class, "getPlayer", "getActor"),
       new HandleFinder(LivingEntity.class, "getEntity", "getActor"),
-      new HandleFinder(Entity.class, "getEntity", "getActor"));
+      new HandleFinder(Entity.class, "getEntity", "getActor"),
+      new HandleFinder(HumanEntity.class, "getWhoClicked"));
 
   public static MethodHandle getHandle(Class<? extends Event> event) throws NoSuchMethodException {
     MethodHandle handle = CACHED_HANDLES.computeIfAbsent(event, MethodHandleUtils::findHandle);


### PR DESCRIPTION
Fixes the following error:

```
[04:15:53 ERROR]: [PGM.MatchImpl] [MatchImpl] No getter for Filterable or Player found in class org.bukkit.event.inventory.InventoryClickEvent
java.lang.NoSuchMethodException: No method to extract a Filterable or Player found on class org.bukkit.event.inventory.InventoryClickEvent
        at PGM.jar//tc.oc.pgm.util.MethodHandleUtils.getHandle(MethodHandleUtils.java:36) ~[?:?]
        at PGM.jar//tc.oc.pgm.filters.FilterMatchModule.registerListenersFor(FilterMatchModule.java:415) ~[?:?]
        at PGM.jar//tc.oc.pgm.filters.FilterMatchModule.lambda$onMatchLoad$0(FilterMatchModule.java:129) ~[?:?]
        at com.google.common.collect.Maps$KeySet.lambda$forEach$0(Maps.java:3939) ~[guava-33.5.0-jre.jar:?]
        at java.base/java.util.Map.forEach(Map.java:733) ~[?:?]
        at com.google.common.collect.Maps$KeySet.forEach(Maps.java:3939) ~[guava-33.5.0-jre.jar:?]
        at PGM.jar//tc.oc.pgm.filters.FilterMatchModule.onMatchLoad(FilterMatchModule.java:122) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at PGM.jar//tc.oc.pgm.match.MatchImpl$EventExecutor.execute(MatchImpl.java:348) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at PGM.jar//tc.oc.pgm.match.MatchImpl.callEvent(MatchImpl.java:258) ~[?:?]
        at PGM.jar//tc.oc.pgm.match.MatchImpl.load(MatchImpl.java:878) ~[?:?]
        at PGM.jar//tc.oc.pgm.match.MatchFactoryImpl$InitMatchStage.advanceSync(MatchFactoryImpl.java:311) ~[?:?]
        at org.bukkit.craftbukkit.scheduler.CraftFuture.run(CraftFuture.java:88) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1756) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1611) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:427) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1667) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1335) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388) ~[paper-1.21.11.jar:1.21.11-126-3f5728e]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```