### PR TITLE
Ensure item is not null when checking if locked

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
@@ -100,7 +100,7 @@ public class KitMatchModule implements MatchModule, Listener {
         Slot slot = Slot.Hotbar.forIndex(event.getHotbarButton());
         if (slot == null) return;
         ItemStack item = event.getWhoClicked().getInventory().getItem(slot.getIndex());
-        if (item != null && ItemTags.LOCKED.has(item)) break;
+        if (isLocked(item)) break;
 
       case PICKUP_ALL:
       case PICKUP_HALF:
@@ -112,7 +112,7 @@ public class KitMatchModule implements MatchModule, Listener {
       case DROP_ALL_SLOT:
       case COLLECT_TO_CURSOR:
       case NOTHING:
-        if (ItemTags.LOCKED.has(event.getCurrentItem())) break;
+        if (isLocked(event.getCurrentItem())) break;
       default:
         return;
     }


### PR DESCRIPTION
```
[04:13:40 ERROR]: Could not pass event InventoryClickEvent to PGM v0.16-SNAPSHOT (git-eb4733ea)                                                                      04:14:36 [1359/46273]
java.lang.NullPointerException: Cannot invoke "org.bukkit.inventory.ItemStack.hasItemMeta()" because "item" is null
        at PGM.jar//tc.oc.pgm.platform.modern.inventory.ModernItemTag.get(ModernItemTag.java:26) ~[?:?]
        at PGM.jar//tc.oc.pgm.util.inventory.tag.ItemTag.has(ItemTag.java:28) ~[?:?]
        at PGM.jar//tc.oc.pgm.kits.KitMatchModule.onInventoryClick(KitMatchModule.java:115) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3297) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:59) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:14) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.network.PacketProcessor$ListenerAndPacket.handle(PacketProcessor.java:99) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.network.PacketProcessor.executeSinglePacket(PacketProcessor.java:33) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1499) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.server.MinecraftServer.recordTaskExecutionTimeWhileWaiting(MinecraftServer.java:1225) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1341) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
[04:13:42 ERROR]: Could not pass event InventoryClickEvent to PGM v0.16-SNAPSHOT (git-eb4733ea)
java.lang.NullPointerException: Cannot invoke "org.bukkit.inventory.ItemStack.hasItemMeta()" because "item" is null
        at PGM.jar//tc.oc.pgm.platform.modern.inventory.ModernItemTag.get(ModernItemTag.java:26) ~[?:?]
        at PGM.jar//tc.oc.pgm.util.inventory.tag.ItemTag.has(ItemTag.java:28) ~[?:?]
        at PGM.jar//tc.oc.pgm.kits.KitMatchModule.onInventoryClick(KitMatchModule.java:115) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3297) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:59) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:14) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.network.PacketProcessor$ListenerAndPacket.handle(PacketProcessor.java:99) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.network.PacketProcessor.executeSinglePacket(PacketProcessor.java:33) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1499) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.server.MinecraftServer.recordTaskExecutionTimeWhileWaiting(MinecraftServer.java:1225) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1341) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388) ~[paper-1.21.11.jar:1.21.11-127-bd74bf6]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```