### PR TITLE
Support material matchers in item matchers

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/feature/FeatureValidation.java
+++ b/core/src/main/java/tc/oc/pgm/api/feature/FeatureValidation.java
@@ -2,7 +2,8 @@ package tc.oc.pgm.api.feature;
 
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.Validator;
 
-public interface FeatureValidation<T extends FeatureDefinition> {
+public interface FeatureValidation<T extends FeatureDefinition> extends Validator<T> {
   void validate(T definition, Node node) throws InvalidXMLException;
 }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
@@ -132,7 +132,7 @@ public class LegacyFilterParser extends FilterParser {
   @MethodParser("block")
   public Filter parseBlock(Element el) throws InvalidXMLException {
     MaterialMatcher pattern = MaterialMatcher.parse(el);
-    var mat = pattern.getRepresentativeMaterial();
+    var mat = pattern.getSample();
     if (mat == null || !mat.isBlock()) {
       throw new InvalidXMLException("Material is not a block", el);
     }

--- a/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/LegacyFilterParser.java
@@ -132,7 +132,8 @@ public class LegacyFilterParser extends FilterParser {
   @MethodParser("block")
   public Filter parseBlock(Element el) throws InvalidXMLException {
     MaterialMatcher pattern = MaterialMatcher.parse(el);
-    if (!pattern.getMaterials().iterator().next().isBlock()) {
+    var mat = pattern.getRepresentativeMaterial();
+    if (mat == null || !mat.isBlock()) {
       throw new InvalidXMLException("Material is not a block", el);
     }
     return new MaterialFilter(pattern);

--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyModule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyModule.java
@@ -52,13 +52,15 @@ public class ItemModifyModule implements MapModule<ItemModifyMatchModule> {
 
       List<ItemRule> rules = new ArrayList<>();
       for (Element el : XMLUtils.flattenElements(doc.getRootElement(), "item-mods", "rule")) {
-        var items = parser.node(XMLUtils::parseMaterialMatcher, el, "match")
+        var items = parser
+            .node(XMLUtils::parseMaterialMatcher, el, "match")
             .child()
             .validate(MaterialMatcher.NOT_EMPTY)
             .required();
 
         var elModify = XMLUtils.getRequiredUniqueChild(el, "modify");
-        var applicator = factory.getKits().parseItemMeta(items.getRepresentativeMaterial(), elModify, true);
+        var applicator =
+            factory.getKits().parseItemMeta(items.getRepresentativeMaterial(), elModify, true);
 
         ItemRule rule = new ItemRule(items, applicator);
         rules.add(rule);

--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyModule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyModule.java
@@ -59,8 +59,7 @@ public class ItemModifyModule implements MapModule<ItemModifyMatchModule> {
             .required();
 
         var elModify = XMLUtils.getRequiredUniqueChild(el, "modify");
-        var applicator =
-            factory.getKits().parseItemMeta(items.getRepresentativeMaterial(), elModify, true);
+        var applicator = factory.getKits().parseItemMeta(items.getSample(), elModify, true);
 
         ItemRule rule = new ItemRule(items, applicator);
         rules.add(rule);

--- a/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyModule.java
+++ b/core/src/main/java/tc/oc/pgm/itemmeta/ItemModifyModule.java
@@ -13,6 +13,7 @@ import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.util.inventory.tag.ItemTag;
+import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
@@ -51,12 +52,13 @@ public class ItemModifyModule implements MapModule<ItemModifyMatchModule> {
 
       List<ItemRule> rules = new ArrayList<>();
       for (Element el : XMLUtils.flattenElements(doc.getRootElement(), "item-mods", "rule")) {
-        var items =
-            parser.node(XMLUtils::parseMaterialMatcher, el, "match").child().required();
-        var material = items.getMaterials().iterator().next();
+        var items = parser.node(XMLUtils::parseMaterialMatcher, el, "match")
+            .child()
+            .validate(MaterialMatcher.NOT_EMPTY)
+            .required();
 
         var elModify = XMLUtils.getRequiredUniqueChild(el, "modify");
-        var applicator = factory.getKits().parseItemMeta(material, elModify, true);
+        var applicator = factory.getKits().parseItemMeta(items.getRepresentativeMaterial(), elModify, true);
 
         ItemRule rule = new ItemRule(items, applicator);
         rules.add(rule);

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -482,9 +482,7 @@ public abstract class KitParser {
         .child()
         .validate(MaterialMatcher.NOT_EMPTY)
         .orNull();
-    var stack = matcher != null
-        ? parseItem(itemEl, matcher.getRepresentativeMaterial())
-        : parseItem(itemEl, false);
+    var stack = matcher != null ? parseItem(itemEl, matcher.getSample()) : parseItem(itemEl, false);
 
     if (stack == null)
       throw new InvalidXMLException("Child " + childName + " element expected", parent);

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -477,25 +477,31 @@ public abstract class KitParser {
   public ItemMatcher parseItemMatcher(Element parent, String childName) throws InvalidXMLException {
     var itemEl = parent.getChild(childName);
 
-    var matcher = parser.node(XMLUtils::parseMaterialMatcher, itemEl, "match")
-        .child().validate(MaterialMatcher.NOT_EMPTY).orNull();
-    var stack = matcher != null ?
-        parseItem(itemEl, matcher.getRepresentativeMaterial()) : parseItem(itemEl, false);
+    var matcher = parser
+        .node(XMLUtils::parseMaterialMatcher, itemEl, "match")
+        .child()
+        .validate(MaterialMatcher.NOT_EMPTY)
+        .orNull();
+    var stack = matcher != null
+        ? parseItem(itemEl, matcher.getRepresentativeMaterial())
+        : parseItem(itemEl, false);
 
     if (stack == null)
       throw new InvalidXMLException("Child " + childName + " element expected", parent);
 
-    Range<Integer> amount = parser.intRange(parent, "amount")
+    Range<Integer> amount = parser
+        .intRange(parent, "amount")
         .validate((r, n) -> {
           if (stack.getAmount() != 1)
-                throw new InvalidXMLException("Cannot combine amount range with an item amount", n);
+            throw new InvalidXMLException("Cannot combine amount range with an item amount", n);
         })
         .optional(() -> Range.atLeast(stack.getAmount()));
 
     boolean ignoreDurability = parser.parseBool(parent, "ignore-durability").orTrue();
     boolean ignoreMetadata = parser.parseBool(parent, "ignore-metadata").orFalse();
     boolean ignoreName = parser.parseBool(parent, "ignore-name").optional(ignoreMetadata);
-    boolean ignoreEnchantments = parser.parseBool(parent, "ignore-enchantments").optional(ignoreMetadata);
+    boolean ignoreEnchantments =
+        parser.parseBool(parent, "ignore-enchantments").optional(ignoreMetadata);
 
     return new ItemMatcher(
         matcher, stack, amount, ignoreDurability, ignoreMetadata, ignoreName, ignoreEnchantments);
@@ -518,8 +524,7 @@ public abstract class KitParser {
 
   public ItemStack parseItem(Element el, Material type) throws InvalidXMLException {
     return parseItem(
-        el,
-        MaterialData.item(type, parser.number(Short.class, el, "damage").optional((short) 0)));
+        el, MaterialData.item(type, parser.number(Short.class, el, "damage").optional((short) 0)));
   }
 
   public ItemStack parseItem(Element el, ItemMaterialData material) throws InvalidXMLException {

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -72,10 +72,12 @@ import tc.oc.pgm.util.inventory.Slot;
 import tc.oc.pgm.util.inventory.SlotGroup;
 import tc.oc.pgm.util.material.ItemMaterialData;
 import tc.oc.pgm.util.material.MaterialData;
+import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.material.Materials;
 import tc.oc.pgm.util.xml.InheritingElement;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLFluentParser;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public abstract class KitParser {
@@ -83,10 +85,12 @@ public abstract class KitParser {
       Set.of("item", "book", "head", "firework", "banner");
 
   protected final MapFactory factory;
+  protected final XMLFluentParser parser;
   protected final Set<Kit> kits = new HashSet<>();
 
   public KitParser(MapFactory factory) {
     this.factory = factory;
+    this.parser = factory.getParser();
   }
 
   public Set<Kit> getKits() {
@@ -471,48 +475,51 @@ public abstract class KitParser {
   }
 
   public ItemMatcher parseItemMatcher(Element parent, String childName) throws InvalidXMLException {
-    ItemStack stack = parseItem(parent.getChild(childName), false);
+    var itemEl = parent.getChild(childName);
+
+    var matcher = parser.node(XMLUtils::parseMaterialMatcher, itemEl, "match")
+        .child().validate(MaterialMatcher.NOT_EMPTY).orNull();
+    var stack = matcher != null ?
+        parseItem(itemEl, matcher.getRepresentativeMaterial()) : parseItem(itemEl, false);
+
     if (stack == null)
       throw new InvalidXMLException("Child " + childName + " element expected", parent);
 
-    Range<Integer> amount =
-        XMLUtils.parseNumericRange(Node.fromAttr(parent, "amount"), Integer.class, null);
-    if (amount == null) amount = Range.atLeast(stack.getAmount());
-    else if (stack.getAmount() != 1)
-      throw new InvalidXMLException("Cannot combine amount range with an item amount", parent);
+    Range<Integer> amount = parser.intRange(parent, "amount")
+        .validate((r, n) -> {
+          if (stack.getAmount() != 1)
+                throw new InvalidXMLException("Cannot combine amount range with an item amount", n);
+        })
+        .optional(() -> Range.atLeast(stack.getAmount()));
 
-    boolean ignoreDurability =
-        XMLUtils.parseBoolean(Node.fromAttr(parent, "ignore-durability"), true);
-    boolean ignoreMetadata = XMLUtils.parseBoolean(Node.fromAttr(parent, "ignore-metadata"), false);
-    boolean ignoreName =
-        XMLUtils.parseBoolean(Node.fromAttr(parent, "ignore-name"), ignoreMetadata);
-    boolean ignoreEnchantments =
-        XMLUtils.parseBoolean(Node.fromAttr(parent, "ignore-enchantments"), ignoreMetadata);
+    boolean ignoreDurability = parser.parseBool(parent, "ignore-durability").orTrue();
+    boolean ignoreMetadata = parser.parseBool(parent, "ignore-metadata").orFalse();
+    boolean ignoreName = parser.parseBool(parent, "ignore-name").optional(ignoreMetadata);
+    boolean ignoreEnchantments = parser.parseBool(parent, "ignore-enchantments").optional(ignoreMetadata);
 
     return new ItemMatcher(
-        stack, amount, ignoreDurability, ignoreMetadata, ignoreName, ignoreEnchantments);
+        matcher, stack, amount, ignoreDurability, ignoreMetadata, ignoreName, ignoreEnchantments);
   }
 
   public ItemStack parseItem(Element el, boolean allowAir) throws InvalidXMLException {
     if (el == null) return null;
 
-    org.jdom2.Attribute attrMaterial = el.getAttribute("material");
-    String name = attrMaterial != null ? attrMaterial.getValue() : el.getValue();
-    short dmg = XMLUtils.parseNumber(el.getAttribute("damage"), Short.class, (short) 0);
-    var md = XMLUtils.parseItemMaterialData(new Node(el), name, dmg);
+    short dmg = parser.number(Short.class, el, "damage").optional((short) 0);
+    var materialData = parser
+        .node(n -> XMLUtils.parseItemMaterialData(n, n.getValue(), dmg), el, "material")
+        .validate((md, node) -> {
+          if (md == null || (!allowAir && md.getItemType() == Material.AIR))
+            throw new InvalidXMLException("Invalid material type '" + node.getValue() + "'", node);
+        })
+        .orSelf();
 
-    if (md == null || (md.getItemType() == Material.AIR && !allowAir)) {
-      throw new InvalidXMLException("Invalid material type '" + name + "'", el);
-    }
-
-    return parseItem(el, md);
+    return parseItem(el, materialData);
   }
 
   public ItemStack parseItem(Element el, Material type) throws InvalidXMLException {
     return parseItem(
         el,
-        MaterialData.item(
-            type, XMLUtils.parseNumber(el.getAttribute("damage"), Short.class, (short) 0)));
+        MaterialData.item(type, parser.number(Short.class, el, "damage").optional((short) 0)));
   }
 
   public ItemStack parseItem(Element el, ItemMaterialData material) throws InvalidXMLException {
@@ -538,7 +545,6 @@ public abstract class KitParser {
 
   public ComponentApplicator parseItemMeta(Material type, Element el, boolean merge)
       throws InvalidXMLException {
-    var parser = factory.getParser();
     var builder = INVENTORY_UTILS.applicatorBuilder(merge);
     var meta = Bukkit.getItemFactory().getItemMeta(type);
 
@@ -815,7 +821,6 @@ public abstract class KitParser {
   public ActionKit parseActionKit(Element parent) throws InvalidXMLException {
     if (parent.getChildren("action").isEmpty()) return null;
 
-    var parser = factory.getParser();
     ImmutableList.Builder<Action<? super MatchPlayer>> builder = ImmutableList.builder();
     for (Element action : parent.getChildren("action")) {
       builder.add(parser.action(MatchPlayer.class, action).required());

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/Builder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/Builder.java
@@ -10,6 +10,7 @@ import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.util.function.ThrowingSupplier;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.Validator;
 
 public abstract class Builder<T, B extends Builder<T, B>> {
   protected final @Nullable Element el;
@@ -102,10 +103,6 @@ public abstract class Builder<T, B extends Builder<T, B>> {
   protected abstract T parse(Node node) throws InvalidXMLException;
 
   protected abstract B getThis();
-
-  public interface Validator<T> {
-    void validate(T t, Node node) throws InvalidXMLException;
-  }
 
   public abstract static class Generic<T> extends Builder<T, Generic<T>> {
     public Generic(@Nullable Element el, String... prop) {

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/BlockStateMaterialMatcher.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/BlockStateMaterialMatcher.java
@@ -16,11 +16,6 @@ public class BlockStateMaterialMatcher implements MaterialMatcher.Singular {
   }
 
   @Override
-  public Set<Material> getMaterials() {
-    return Set.of(data.getMaterial());
-  }
-
-  @Override
   public Material getMaterial() {
     return data.getMaterial();
   }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/ExactMaterialMatcher.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/ExactMaterialMatcher.java
@@ -18,11 +18,6 @@ public class ExactMaterialMatcher implements MaterialMatcher.Singular {
   }
 
   @Override
-  public Set<Material> getMaterials() {
-    return Set.of(material);
-  }
-
-  @Override
   public Material getMaterial() {
     return material;
   }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/ItemMatcher.java
@@ -3,10 +3,12 @@ package tc.oc.pgm.util.inventory;
 import com.google.common.collect.Range;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.material.Materials;
 
 public class ItemMatcher {
 
+  private final MaterialMatcher matcher;
   private final ItemStack base;
   private final Range<Integer> amount;
 
@@ -16,15 +18,16 @@ public class ItemMatcher {
   private final boolean ignoreEnchantments;
 
   public ItemMatcher(
+      MaterialMatcher matcher,
       ItemStack base,
       Range<Integer> amount,
       boolean ignoreDurability,
       boolean ignoreMetadata,
       boolean ignoreName,
       boolean ignoreEnchantments) {
+    this.matcher = matcher;
 
     this.ignoreDurability = ignoreDurability;
-
     this.ignoreMetadata = ignoreMetadata;
     this.ignoreName = ignoreName;
     this.ignoreEnchantments = ignoreEnchantments;
@@ -69,8 +72,10 @@ public class ItemMatcher {
   }
 
   public boolean matches(ItemStack query) {
-    return amount.contains(query.getAmount())
-        && Materials.itemsSimilarMaterial(base, query, ignoreDurability)
+    return query != null
+        && amount.contains(query.getAmount())
+        && (matcher != null ? matcher.matches(query) : Materials.itemsSimilarMaterial(base, query))
+        && Materials.itemsSimilarDurability(base, query, ignoreDurability)
         && Materials.itemsSimilarMeta(base, stripMeta(query));
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
@@ -16,7 +16,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
 import org.jdom2.Element;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.util.material.matcher.CompoundMaterialMatcher;
 import tc.oc.pgm.util.material.matcher.MultipleMaterialMatcher;
 import tc.oc.pgm.util.material.matcher.SingularMaterialMatcher;
@@ -27,8 +27,7 @@ import tc.oc.pgm.util.xml.Validator;
 /** A predicate on world */
 public interface MaterialMatcher {
   Validator<MaterialMatcher> NOT_EMPTY = (mm, node) -> {
-    if (mm.getRepresentativeMaterial() == null)
-      throw new InvalidXMLException("No material specified", node);
+    if (mm.getSample() == null) throw new InvalidXMLException("No material specified", node);
   };
 
   boolean matches(Material material);
@@ -51,8 +50,9 @@ public interface MaterialMatcher {
    */
   Set<Material> getMaterials();
 
-  /** Get a material that is representative of the matcher, usually the first material. */
-  Material getRepresentativeMaterial();
+  /** Get a sample material for the matcher, usually the first material. */
+  @Nullable
+  Material getSample();
 
   Set<BlockMaterialData> getPossibleBlocks();
 
@@ -93,7 +93,7 @@ public interface MaterialMatcher {
     }
 
     @Override
-    default Material getRepresentativeMaterial() {
+    default Material getSample() {
       return getMaterial();
     }
   }

--- a/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
@@ -51,9 +51,7 @@ public interface MaterialMatcher {
    */
   Set<Material> getMaterials();
 
-  /**
-   * Get a material that is representative of the matcher, usually the first material.
-   */
+  /** Get a material that is representative of the matcher, usually the first material. */
   Material getRepresentativeMaterial();
 
   Set<BlockMaterialData> getPossibleBlocks();

--- a/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/MaterialMatcher.java
@@ -22,9 +22,14 @@ import tc.oc.pgm.util.material.matcher.MultipleMaterialMatcher;
 import tc.oc.pgm.util.material.matcher.SingularMaterialMatcher;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.Validator;
 
 /** A predicate on world */
 public interface MaterialMatcher {
+  Validator<MaterialMatcher> NOT_EMPTY = (mm, node) -> {
+    if (mm.getRepresentativeMaterial() == null)
+      throw new InvalidXMLException("No material specified", node);
+  };
 
   boolean matches(Material material);
 
@@ -45,6 +50,11 @@ public interface MaterialMatcher {
    * is very broad.
    */
   Set<Material> getMaterials();
+
+  /**
+   * Get a material that is representative of the matcher, usually the first material.
+   */
+  Material getRepresentativeMaterial();
 
   Set<BlockMaterialData> getPossibleBlocks();
 
@@ -78,6 +88,16 @@ public interface MaterialMatcher {
 
   interface Singular extends MaterialMatcher {
     Material getMaterial();
+
+    @Override
+    default Set<Material> getMaterials() {
+      return Set.of(getMaterial());
+    }
+
+    @Override
+    default Material getRepresentativeMaterial() {
+      return getMaterial();
+    }
   }
 
   interface Builder {

--- a/util/src/main/java/tc/oc/pgm/util/material/Materials.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/Materials.java
@@ -116,14 +116,17 @@ public interface Materials {
   }
 
   static boolean itemsSimilar(ItemStack first, ItemStack second, boolean skipDur) {
-    return itemsSimilarMaterial(first, second, skipDur) && itemsSimilarMeta(first, second);
+    return itemsSimilarMaterial(first, second)
+        && itemsSimilarDurability(first, second, skipDur)
+        && itemsSimilarMeta(first, second);
   }
 
-  static boolean itemsSimilarMaterial(ItemStack first, ItemStack second, boolean skipDur) {
-    return first != null
-        && second != null
-        && first.getType().equals(second.getType())
-        && (skipDur || first.getDurability() == second.getDurability());
+  static boolean itemsSimilarDurability(ItemStack first, ItemStack second, boolean skipDur) {
+    return (skipDur || first.getDurability() == second.getDurability());
+  }
+
+  static boolean itemsSimilarMaterial(ItemStack first, ItemStack second) {
+    return first != null && second != null && first.getType().equals(second.getType());
   }
 
   static boolean itemsSimilarMeta(ItemStack first, ItemStack second) {

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/AllMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/AllMaterialMatcher.java
@@ -36,6 +36,11 @@ public class AllMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
+  public Material getRepresentativeMaterial() {
+    return Material.STONE;
+  }
+
+  @Override
   public Set<BlockMaterialData> getPossibleBlocks() {
     throw new UnsupportedOperationException("Cannot iterate material data for all materials");
   }

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/AllMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/AllMaterialMatcher.java
@@ -36,7 +36,7 @@ public class AllMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
-  public Material getRepresentativeMaterial() {
+  public Material getSample() {
     return Material.STONE;
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/BlockMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/BlockMaterialMatcher.java
@@ -39,7 +39,7 @@ public class BlockMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
-  public Material getRepresentativeMaterial() {
+  public Material getSample() {
     return Material.STONE;
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/BlockMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/BlockMaterialMatcher.java
@@ -39,6 +39,11 @@ public class BlockMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
+  public Material getRepresentativeMaterial() {
+    return Material.STONE;
+  }
+
+  @Override
   public Set<BlockMaterialData> getPossibleBlocks() {
     throw new UnsupportedOperationException("Cannot iterate material data for all blocks");
   }

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/CompoundMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/CompoundMaterialMatcher.java
@@ -59,9 +59,9 @@ public class CompoundMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
-  public Material getRepresentativeMaterial() {
+  public Material getSample() {
     for (MaterialMatcher child : children) {
-      var mat = child.getRepresentativeMaterial();
+      var mat = child.getSample();
       if (mat != null) return mat;
     }
     return null;

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/CompoundMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/CompoundMaterialMatcher.java
@@ -59,6 +59,15 @@ public class CompoundMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
+  public Material getRepresentativeMaterial() {
+    for (MaterialMatcher child : children) {
+      var mat = child.getRepresentativeMaterial();
+      if (mat != null) return mat;
+    }
+    return null;
+  }
+
+  @Override
   public Set<BlockMaterialData> getPossibleBlocks() {
     Set<BlockMaterialData> result = new HashSet<>(children.size());
     for (MaterialMatcher child : children) result.addAll(child.getPossibleBlocks());

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/MultipleMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/MultipleMaterialMatcher.java
@@ -40,6 +40,11 @@ public class MultipleMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
+  public Material getRepresentativeMaterial() {
+    return materials.iterator().next();
+  }
+
+  @Override
   public Set<BlockMaterialData> getPossibleBlocks() {
     Set<BlockMaterialData> possibleBlocks = new HashSet<>(materials.size());
     for (Material material : materials) {

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/MultipleMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/MultipleMaterialMatcher.java
@@ -40,7 +40,7 @@ public class MultipleMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
-  public Material getRepresentativeMaterial() {
+  public Material getSample() {
     return materials.iterator().next();
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/NoMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/NoMaterialMatcher.java
@@ -34,7 +34,7 @@ public class NoMaterialMatcher implements MaterialMatcher {
   }
 
   @Override
-  public Material getRepresentativeMaterial() {
+  public Material getSample() {
     return null;
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/NoMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/NoMaterialMatcher.java
@@ -1,6 +1,5 @@
 package tc.oc.pgm.util.material.matcher;
 
-import java.util.Collections;
 import java.util.Set;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -31,7 +30,12 @@ public class NoMaterialMatcher implements MaterialMatcher {
 
   @Override
   public Set<Material> getMaterials() {
-    return Collections.emptySet();
+    return Set.of();
+  }
+
+  @Override
+  public Material getRepresentativeMaterial() {
+    return null;
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/material/matcher/SingularMaterialMatcher.java
+++ b/util/src/main/java/tc/oc/pgm/util/material/matcher/SingularMaterialMatcher.java
@@ -32,11 +32,6 @@ public class SingularMaterialMatcher implements MaterialMatcher.Singular {
   }
 
   @Override
-  public Set<Material> getMaterials() {
-    return Set.of(material);
-  }
-
-  @Override
   public Material getMaterial() {
     return material;
   }

--- a/util/src/main/java/tc/oc/pgm/util/xml/Validator.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/Validator.java
@@ -1,0 +1,5 @@
+package tc.oc.pgm.util.xml;
+
+public interface Validator<T> {
+  void validate(T t, Node node) throws InvalidXMLException;
+}


### PR DESCRIPTION
Currently item matchers are locked to matching a single material type, with this, they are allowed to match any arbitrary amount of types, via a material matcher:
```xml
<wearing id="wearing-protection">
  <item enchantment="protection:1">
    <match>
      <all-items/>
    </match>
  </item>
</wearing>

<holding id="holding-block">
  <item amount="5" name="Block!">
    <match>
      <material>stone</material>
      <material>dirt</material>
    </match>
  </item>
</holding>
```

The main change is that the `item` no longer gets a `material="stone"` attribute, and instead gets a `<match>` child which parses as a material matcher, similar to how itemmods' `match`, items' `can-place-on` work.


