### PR TITLE
fix: stereo global sounds on 1.14+

### DIFF
--- a/util/src/main/java/tc/oc/pgm/util/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/Audience.java
@@ -21,7 +21,6 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.bukkit.Sounds;
-import tc.oc.pgm.util.bukkit.ViaUtils;
 import tc.oc.pgm.util.text.ComponentRenderer;
 
 /** Receiver of chat messages, sounds, titles, and other media. */
@@ -64,9 +63,7 @@ public interface Audience extends ForwardingAudience.Single {
     if (global) {
       if (player.isEmpty()) break omnipresent;
       // account for MC-146721 only on affected clients for affected sounds
-      var version = ViaUtils.getProtocolVersion(player.get());
-      if (Sounds.MODERN_GLOBAL_SOUNDS.contains(sound.name().value())
-          && version >= ViaUtils.VERSION_1_14) break omnipresent;
+      if (Sounds.MODERN_GLOBAL_SOUNDS.contains(sound.name().value())) break omnipresent;
       var location = player.get().getEyeLocation();
       var realVolume =
           soundDistance / (16f * (1f - Math.max(0f, Math.min(maxVolume, sound.volume()))));

--- a/util/src/main/java/tc/oc/pgm/util/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/Audience.java
@@ -21,6 +21,8 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.bukkit.Sounds;
+import tc.oc.pgm.util.bukkit.ViaUtils;
+import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.text.ComponentRenderer;
 
 /** Receiver of chat messages, sounds, titles, and other media. */
@@ -54,8 +56,28 @@ public interface Audience extends ForwardingAudience.Single {
    */
   @Override
   default void playSound(@NotNull Sound sound) {
+    this.playSound(sound, true);
+  }
+
+  default void playSound(@NotNull Sound sound, boolean global) {
     var player = pointers().get(Identity.UUID).map(Bukkit::getPlayer);
-    if (player.isPresent()) {
+    omnipresent:
+    if (global) {
+      if (player.isEmpty()) break omnipresent;
+      // account for MC-146721 only on affected clients for affected sounds
+      var version = ViaUtils.getProtocolVersion(player.get());
+      if (Sounds.MODERN_GLOBAL_SOUNDS.contains(sound.name().value())
+          && version >= ViaUtils.VERSION_1_14) {
+        // emitter volume and pitch is completely ignored for 1.15.2-1.16.5, MC-138832
+        // has been observed on 1.14.4, either due to some Via translation error or the bug reaches
+        // that far back, so keeping this one a looser bound
+        if (version <= ViaUtils.VERSION_1_16_5) break omnipresent;
+        // adventure on modern platforms can move the sound with the entity (in flawed ways, but
+        // it's better than nothing)
+        if (!Platform.isModern()) break omnipresent;
+        this.playSound(sound, Sound.Emitter.self());
+        return;
+      }
       var location = player.get().getEyeLocation();
       var realVolume =
           soundDistance / (16f * (1f - Math.max(0f, Math.min(maxVolume, sound.volume()))));

--- a/util/src/main/java/tc/oc/pgm/util/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/Audience.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.bukkit.Sounds;
 import tc.oc.pgm.util.bukkit.ViaUtils;
-import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.text.ComponentRenderer;
 
 /** Receiver of chat messages, sounds, titles, and other media. */
@@ -67,17 +66,7 @@ public interface Audience extends ForwardingAudience.Single {
       // account for MC-146721 only on affected clients for affected sounds
       var version = ViaUtils.getProtocolVersion(player.get());
       if (Sounds.MODERN_GLOBAL_SOUNDS.contains(sound.name().value())
-          && version >= ViaUtils.VERSION_1_14) {
-        // emitter volume and pitch is completely ignored for 1.15.2-1.16.5, MC-138832
-        // has been observed on 1.14.4, either due to some Via translation error or the bug reaches
-        // that far back, so keeping this one a looser bound
-        if (version <= ViaUtils.VERSION_1_16_5) break omnipresent;
-        // adventure on modern platforms can move the sound with the entity (in flawed ways, but
-        // it's better than nothing)
-        if (!Platform.isModern()) break omnipresent;
-        this.playSound(sound, Sound.Emitter.self());
-        return;
-      }
+          && version >= ViaUtils.VERSION_1_14) break omnipresent;
       var location = player.get().getEyeLocation();
       var realVolume =
           soundDistance / (16f * (1f - Math.max(0f, Math.min(maxVolume, sound.volume()))));

--- a/util/src/main/java/tc/oc/pgm/util/Audience.java
+++ b/util/src/main/java/tc/oc/pgm/util/Audience.java
@@ -54,16 +54,9 @@ public interface Audience extends ForwardingAudience.Single {
    */
   @Override
   default void playSound(@NotNull Sound sound) {
-    this.playSound(sound, true);
-  }
-
-  default void playSound(@NotNull Sound sound, boolean global) {
     var player = pointers().get(Identity.UUID).map(Bukkit::getPlayer);
-    omnipresent:
-    if (global) {
-      if (player.isEmpty()) break omnipresent;
-      // account for MC-146721 only on affected clients for affected sounds
-      if (Sounds.MODERN_GLOBAL_SOUNDS.contains(sound.name().value())) break omnipresent;
+    // account for MC-146721 only on affected clients for affected sounds
+    if (player.isPresent() && !Sounds.GLOBAL_SOUNDS.contains(sound.name().value())) {
       var location = player.get().getEyeLocation();
       var realVolume =
           soundDistance / (16f * (1f - Math.max(0f, Math.min(maxVolume, sound.volume()))));

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/Sounds.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/Sounds.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.util.bukkit;
 
 import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 
+import java.util.Set;
 import net.kyori.adventure.sound.Sound;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -57,6 +58,92 @@ public interface Sounds {
   Sound TIP = sound("ENDERMAN_IDLE", "ENTITY_ENDERMAN_AMBIENT", 1f, 1.2f);
   Sound TNT_FUSE = sound("FUSE", "ENTITY_TNT_PRIMED");
   Sound WARNING = sound("NOTE_BASS", "BLOCK_NOTE_BLOCK_BASS", 1f, 0.75f);
+
+  // these sounds on ≈1.14+ do not get quieter with distance, as per MC-146721.
+  // see: https://github.com/PGMDev/PGM/pull/1635#issuecomment-4035905537
+  Set<String> MODERN_GLOBAL_SOUNDS = Set.of(
+      "ambient.basalt_deltas.additions",
+      "ambient.basalt_deltas.loop",
+      "ambient.crimson_forest.additions",
+      "ambient.crimson_forest.loop",
+      "ambient.nether_wastes.additions",
+      "ambient.nether_wastes.loop",
+      "ambient.soul_sand_valley.additions",
+      "ambient.soul_sand_valley.loop",
+      "ambient.underwater.enter",
+      "ambient.underwater.exit",
+      "ambient.underwater.loop",
+      "ambient.underwater.loop.additions",
+      "ambient.underwater.loop.additions.rare",
+      "ambient.underwater.loop.additions.ultra_rare",
+      "ambient.warped_forest.additions",
+      "ambient.warped_forest.loop",
+      "block.bubble_column.upwards_inside",
+      "block.bubble_column.whirlpool_inside",
+      "block.dry_grass.ambient",
+      "block.end_portal.spawn",
+      "block.portal.travel",
+      "block.portal.trigger",
+      "entity.baby_nautilus.ambient_land",
+      "entity.baby_nautilus.death_land",
+      "entity.baby_nautilus.hurt_land",
+      "entity.elder_guardian.curse",
+      "entity.ender_dragon.death",
+      "entity.happy_ghast.riding",
+      "entity.minecart.inside",
+      "entity.minecart.inside.underwater",
+      "entity.nautilus.riding",
+      "entity.wither.spawn",
+      "item.elytra.flying",
+      "item.goat_horn.sound.3",
+      "music.creative",
+      "music.credits",
+      "music.dragon",
+      "music.end",
+      "music.game",
+      "music.menu",
+      "music.nether.basalt_deltas",
+      "music.nether.crimson_forest",
+      "music.nether.nether_wastes",
+      "music.nether.soul_sand_valley",
+      "music.overworld.badlands",
+      "music.overworld.bamboo_jungle",
+      "music.overworld.cherry_grove",
+      "music.overworld.deep_dark",
+      "music.overworld.desert",
+      "music.overworld.dripstone_caves",
+      "music.overworld.flower_forest",
+      "music.overworld.forest",
+      "music.overworld.frozen_peaks",
+      "music.overworld.grove",
+      "music.overworld.jagged_peaks",
+      "music.overworld.jungle",
+      "music.overworld.lush_caves",
+      "music.overworld.meadow",
+      "music.overworld.old_growth_taiga",
+      "music.overworld.snowy_slopes",
+      "music.overworld.sparse_jungle",
+      "music.overworld.stony_peaks",
+      "music.overworld.swamp",
+      "music.under_water",
+      "ui.button.click",
+      "ui.loom.select_pattern",
+      "ui.toast.challenge_complete",
+      "ui.toast.in",
+      "ui.toast.out",
+      // 1.8 representations of the previous sounds, here because sometimes the sound gets played in
+      // its "native" form on SP then ViaVersion converts it to a modern sound
+      "gui.button.press",
+      "minecart.inside",
+      "mob.enderdragon.end",
+      "mob.guardian.curse",
+      "mob.wither.spawn",
+      "music.game.creative",
+      "music.game.end",
+      "music.game.end.credits",
+      "music.game.end.dragon",
+      "portal.travel",
+      "portal.trigger");
 
   static Sound sound(String legacyConstant, String modernConstant) {
     return sound(legacyConstant, modernConstant, 1f, 1f);

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/Sounds.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/Sounds.java
@@ -61,7 +61,7 @@ public interface Sounds {
 
   // these sounds on ≈1.14+ do not get quieter with distance, as per MC-146721.
   // see: https://github.com/PGMDev/PGM/pull/1635#issuecomment-4035905537
-  Set<String> MODERN_GLOBAL_SOUNDS = Set.of(
+  Set<String> GLOBAL_SOUNDS = Set.of(
       "ambient.basalt_deltas.additions",
       "ambient.basalt_deltas.loop",
       "ambient.crimson_forest.additions",

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
@@ -12,6 +12,8 @@ public class ViaUtils {
   public static final int VERSION_1_7 = 5;
   public static final int VERSION_1_8 = 47;
   public static final int VERSION_1_13 = 393;
+  public static final int VERSION_1_14 = 477;
+  public static final int VERSION_1_16_5 = 754;
   public static final int VERSION_1_21_10 = 773;
 
   private static final boolean ENABLED = isViaLoaded();

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
@@ -13,7 +13,6 @@ public class ViaUtils {
   public static final int VERSION_1_8 = 47;
   public static final int VERSION_1_13 = 393;
   public static final int VERSION_1_14 = 477;
-  public static final int VERSION_1_16_5 = 754;
   public static final int VERSION_1_21_10 = 773;
 
   private static final boolean ENABLED = isViaLoaded();

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/ViaUtils.java
@@ -12,7 +12,6 @@ public class ViaUtils {
   public static final int VERSION_1_7 = 5;
   public static final int VERSION_1_8 = 47;
   public static final int VERSION_1_13 = 393;
-  public static final int VERSION_1_14 = 477;
   public static final int VERSION_1_21_10 = 773;
 
   private static final boolean ENABLED = isViaLoaded();


### PR DESCRIPTION
With the inclusion of https://github.com/PGMDev/PGM/pull/1635, which introduced "global sounds" (sounds with more desirable characteristics for what they were being used for) based on strategically playing loud sounds far away from the player comes a bug: [MC-146721](https://bugs.mojang.com/browse/MC/issues/MC-146721). This manifests in the form of things like quiet [portal sounds](https://github.com/PGMDev/PGM/pull/1635#issuecomment-4035905537) playing really loudly on modern game versions.

This pull request remedies the aforementioned issue. To do so, it takes a list of all stereo sounds from the game version `1.21.11` (which also has their `1.8` equivalents as keys) and if you are on `1.14`+, checks if a global sound playing is in that list. If those conditions are met, it will try to then play the sound as best as it can:
- If you are unaffected by [MC-138832](https://bugs.mojang.com/browse/MC/issues/MC-138832) i.e. outside of the range of `1.15.2`-`1.16.5`, it will fall back to playing the sound at your feet (the old way) since there is no better way to play the sound. I've gotten it to happen as low as `1.14.4`, though so I suspect there is some packet translation error in a Via plugin or the bug has reached that far back in versions, so if your game client is at or below `1.16.5` and is at or above `1.14`, it will fall back to the adventure old way.
- If the server is on a modern platform, [adventure-platform](https://github.com/PaperMC/adventure-platform) supports attaching the sound to the target player (there is no legacy compatibility). The downside to this approach though is that ears are interpolated on the client and update position every frame, while the sound emitter is at the uninterpolated position of the player, so moving can cause the sound to be heard more in one ear than the other.
- Otherwise, it will fall back to the most legacy way of playing the sound, which is to just play it at the player's feet (the old way).

A side effect of fixing it at the Audience is that the fix also comes for free to default PGM sounds. Nice!

## Validation
Performed by listening for expected behavior, and in development by using "printf debugging". Platforms have ViaVersion `5.7.2`, ViaBackwards `5.7.2`, and ViaRewind `4.0.15`. The sound tested was `portal.travel` (on 1.8.9) or `block.portal.travel` (on modern). Remember, the below table only applies to problematic stereo sounds!

|Server Version|Client Version|Notes|
|-|-|-|
|`1.21.10`|`1.21.11`|✅ Falls back to adventure emitters|
|`1.21.10`|`1.16.5`|✅ Falls back to adventure|
|`1.21.10`|`1.8.9`|✅ Uses the omnipresent method|
|||
|`1.8.9`|`1.21.11`|✅ Falls back to adventure emitters|
|`1.8.9`|`1.16.5`|✅ Falls back to adventure|
|`1.8.9`|`1.8.9`|✅ Uses the omnipresent method|
|||
|`1.21.10`|`1.14.4`|✅ Falls back to adventure (@arcadeboss' case tested specifically)|
|`1.8.9`|`1.14.4`|✅ Falls back to adventure|

