### PR TITLE
Fix modern not overwriting base effects

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernInventoryUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernInventoryUtil.java
@@ -116,6 +116,11 @@ public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatfor
     return List.of();
   }
 
+  @Override
+  public ComponentApplicator.Builder applicatorBuilder(boolean merge) {
+    return new ModernComponentApplicatorBuilder(merge);
+  }
+
   private static final Registry<Item> ITEMS =
       CraftRegistry.getMinecraftRegistry().lookupOrThrow(Registries.ITEM);
   private static final ItemParser ITEM_PARSER =
@@ -133,6 +138,27 @@ public class ModernInventoryUtil implements InventoryUtils.InventoryUtilsPlatfor
       return is -> CraftItemStack.unwrap(is).applyComponents(patch);
     } catch (CommandSyntaxException ex) {
       throw new InvalidXMLException("Failed to parse components", components, ex);
+    }
+  }
+
+  private static class ModernComponentApplicatorBuilder extends ComponentApplicatorBuilderImpl {
+    public ModernComponentApplicatorBuilder(boolean merge) {
+      super(merge);
+    }
+
+    @Override
+    public void addPotions(List<PotionEffect> potions) {
+      if (potions.isEmpty() || merge) {
+        super.addPotions(potions);
+        return;
+      }
+      register(PotionMeta.class, meta -> {
+        var color = meta.computeEffectiveColor();
+        meta.clearCustomEffects();
+        meta.setBasePotionType(null); // Modern needs to clear the base effect
+        potions.forEach(e -> meta.addCustomEffect(e, false));
+        meta.setColor(color);
+      });
     }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/InventoryUtils.java
@@ -238,7 +238,7 @@ public final class InventoryUtils {
     }
 
     class ComponentApplicatorBuilderImpl implements ComponentApplicator.Builder {
-      private final boolean merge;
+      protected final boolean merge;
       private final List<BiConsumer<ItemStack, ItemMeta>> modifiers = new ArrayList<>();
       private ComponentApplicator other = ComponentApplicator.EMPTY;
 
@@ -246,17 +246,17 @@ public final class InventoryUtils {
         this.merge = merge;
       }
 
-      private void register(Consumer<ItemMeta> metaModifier) {
+      protected void register(Consumer<ItemMeta> metaModifier) {
         modifiers.add((is, meta) -> metaModifier.accept(meta));
       }
 
-      private <T extends ItemMeta> void register(Class<T> type, Consumer<T> metaModifier) {
+      protected <T extends ItemMeta> void register(Class<T> type, Consumer<T> metaModifier) {
         modifiers.add((is, meta) -> {
           if (type.isInstance(meta)) metaModifier.accept(type.cast(meta));
         });
       }
 
-      private <T extends ItemMeta> void register(
+      protected <T extends ItemMeta> void register(
           Class<T> type, BiConsumer<ItemStack, T> metaModifier) {
         modifiers.add((is, meta) -> {
           if (type.isInstance(meta)) metaModifier.accept(is, type.cast(meta));


### PR DESCRIPTION
As the example in the documentation says:
```xml
<!-- Strength potion color -->
<item material="potion" damage="9">
    <effect amplifier="3" duration="100">absorption</effect>
    <effect amplifier="1" duration="30">fast_digging</effect>
    <effect amplifier="2" duration="30">speed</effect>
    <!-- Strength potion effect is not applied at all -->
</item>
```
This is a strength pot, but should give no strength, as the pgm effects override whatever was default.
In legacy, just calling `clearCustomEffects` was enough to get rid of base effect (base effect was just the 1st in the list of custom effects) but in modern its a separate thing, that needs to be cleared separately.