### PR TITLE
Prevent flag capturing after match end

### DIFF
--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -364,6 +364,7 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
   }
 
   public void pickupFlag(MatchPlayer carrier, Location location) {
+    if (carrier == null || !carrier.canInteract() || carrier.getBukkit().isDead()) return;
     this.state.pickupFlag(carrier, location);
   }
 

--- a/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Carried.java
@@ -372,6 +372,9 @@ public class Carried extends Spawned implements Missing {
   }
 
   protected void checkCapture(Location to) {
+    // Prevents on match end, a player dropping the flag, allowing another flag to be captured.
+    if (!flag.getMatch().isRunning()) return;
+
     if (to == null) to = this.carrier.getBukkit().getLocation();
 
     this.deniedByFlag = null;
@@ -379,19 +382,16 @@ public class Carried extends Spawned implements Missing {
       this.deniedByNet = null;
     }
 
+    boolean useSticky = this.deniedByNet != null;
     for (NetDefinition net : this.flag.getNets()) {
       if (net.getRegion().contains(to)) {
-        if (tryCapture(net)) {
-          return;
-        } else {
-          this.deniedByNet = net;
-        }
+        if (tryCapture(net)) return;
+        this.deniedByNet = net;
+        useSticky = false;
       }
     }
 
-    if (this.deniedByNet != null) {
-      tryCapture(this.deniedByNet);
-    }
+    if (useSticky) tryCapture(this.deniedByNet);
   }
 
   protected boolean tryCapture(NetDefinition net) {


### PR DESCRIPTION
Should fix a scenario like this:

https://github.com/user-attachments/assets/119fa7f4-9e82-4ab6-9221-ecccfe89cae5

Both teams have the flag, and have passed thru a sticky net or are standing in the net, one of them is bound to be transitoned to observing first, which would cause the other flag to capture, even tho match is already over.

The match outcome is not changed by this, but it's still a weird effect.