### PR TITLE
Add hover event for top 10 player stats in StatsMatchModule.getMessage()

### DIFF
--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -79,6 +78,7 @@ import tc.oc.pgm.stats.menu.items.VerboseStatsMenuItem;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.tracker.TrackerMatchModule;
 import tc.oc.pgm.tracker.info.ProjectileInfo;
+import tc.oc.pgm.util.collection.RankedSet;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextFormatter;
 import tc.oc.pgm.util.usernames.UsernameResolvers;
@@ -106,6 +106,7 @@ public class StatsMatchModule implements MatchModule, Listener {
   private List<MenuItem> teams;
 
   private static final int TOP_HOVER_LIMIT = 10;
+  private static final int MAX_PLAYERS = 15;
 
   public StatsMatchModule(Match match, List<StatType.OfFormula> formulaStats) {
     this.match = match;
@@ -499,38 +500,43 @@ public class StatsMatchModule implements MatchModule, Listener {
   }
 
   private Component buildTopHover(AggStat<?> agg) {
-    var top = allPlayerStats.entrySet().stream()
-        .map(e -> {
-          Number val = getStatValue(agg.type, match.getPlayer(e.getKey()), e.getValue());
-          return val != null && val.doubleValue() > 0
-              ? Map.entry(e.getKey(), val.doubleValue())
-              : null;
-        })
-        .filter(Objects::nonNull)
-        .sorted(Map.Entry.<UUID, Double>comparingByValue().reversed())
-        .toList();
+    RankedSet<Map.Entry<UUID, Double>> ranked =
+        new RankedSet<>(Comparator.<Map.Entry<UUID, Double>, Double>comparing(Map.Entry::getValue)
+            .reversed());
 
-    if (top.size() <= 1) return null;
+    for (Map.Entry<UUID, PlayerStats> e : allPlayerStats.entrySet()) {
+      Number val = getStatValue(agg.type, match.getPlayer(e.getKey()), e.getValue());
+      if (val != null && val.doubleValue() > 0)
+        ranked.add(Map.entry(e.getKey(), val.doubleValue()));
+    }
 
-    var lines = new ArrayList<Component>();
-    for (int i = 0; i < top.size() && lines.size() < TOP_HOVER_LIMIT; ) {
-      double value = top.get(i).getValue();
-      int j = i;
-      while (j < top.size() && Double.compare(top.get(j).getValue(), value) == 0) {
-        j++;
+    if (ranked.size() <= 1) return null;
+
+    List<Component> lines = new ArrayList<>();
+    int playersShown = 0;
+    int rank = 1;
+
+    for (Set<Map.Entry<UUID, Double>> rankSet : ranked.ranksView()) {
+      if (lines.size() >= TOP_HOVER_LIMIT || playersShown >= MAX_PLAYERS) break;
+
+      List<Map.Entry<UUID, Double>> entries = new ArrayList<>(rankSet);
+      int rankSize = entries.size();
+
+      if (rankSize <= 3) {
+        List<Component> names =
+            entries.stream().map(e -> getPlayerComponent(e.getKey())).toList();
+        lines.add(rankLine(
+            rank, agg, list(names, NamedTextColor.GRAY), entries.getFirst().getValue()));
+        playersShown += rankSize;
+      } else {
+        for (Map.Entry<UUID, Double> entry : entries) {
+          if (lines.size() >= TOP_HOVER_LIMIT || playersShown >= MAX_PLAYERS) break;
+          lines.add(rankLine(rank, agg, getPlayerComponent(entry.getKey()), entry.getValue()));
+          playersShown++;
+        }
       }
 
-      var tiedPlayers = top.subList(i, j).stream()
-          .map(entry -> getPlayerComponent(entry.getKey()))
-          .toList();
-
-      lines.add(text((lines.size() + 1) + ". ")
-          .color(NamedTextColor.WHITE)
-          .append(list(tiedPlayers, NamedTextColor.GRAY))
-          .append(text(" - ").color(NamedTextColor.GRAY))
-          .append(agg.type.makeNumber(value)));
-
-      i = j;
+      rank += rankSize;
     }
 
     return Component.join(
@@ -539,5 +545,13 @@ public class StatsMatchModule implements MatchModule, Listener {
                 Stream.of(translatable("match.stats.top", agg.type.component(empty()))),
                 lines.stream())
             .toList());
+  }
+
+  private Component rankLine(int rank, AggStat<?> agg, Component who, double value) {
+    return text(rank + ". ")
+        .color(NamedTextColor.WHITE)
+        .append(who)
+        .append(text(" - ").color(NamedTextColor.GRAY))
+        .append(agg.type.makeNumber(value));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -23,7 +23,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -365,7 +367,7 @@ public class StatsMatchModule implements MatchModule, Listener {
         var number = agg.type.makeNumber(value);
         return !best ? number : text("   ").append(translatable("match.stats.you.short", number));
       }));
-    return agg.type.component(who);
+    return agg.type.component(who).hoverEvent(buildTop10Hover(agg));
   }
 
   private Component credit(Set<UUID> players) {
@@ -491,5 +493,45 @@ public class StatsMatchModule implements MatchModule, Listener {
       case StatType.OfFormula formulaStats ->
         player != null ? formulaStats.formula().apply(player) : null;
     };
+  }
+
+  private Component buildTop10Hover(AggStat<?> agg) {
+    Map<Double, List<UUID>> byValue = new java.util.TreeMap<>(Comparator.reverseOrder());
+    Component header = text("Top ").append(agg.type.component(empty()));
+
+    allPlayerStats.forEach((uuid, playerStats) -> {
+      MatchPlayer player = match.getPlayer(uuid);
+      Number val = getStatValue(agg.type, player, playerStats);
+      if (val == null) return;
+      double d = val.doubleValue();
+      if (d <= 0) return;
+      byValue.computeIfAbsent(d, k -> new ArrayList<>()).add(uuid);
+    });
+
+    List<Component> lines = new ArrayList<>();
+    lines.add(header);
+    int rank = 1;
+    for (Map.Entry<Double, List<UUID>> entry : byValue.entrySet()) {
+      if (rank > 10) break;
+      double val = entry.getKey();
+      List<UUID> tied = entry.getValue();
+
+      List<Component> names =
+          tied.stream().map(this::getPlayerComponent).collect(Collectors.toList());
+      Component namesPart = TextFormatter.list(names, NamedTextColor.WHITE);
+
+      Component line = text(rank + ". ")
+          .color(NamedTextColor.WHITE)
+          .append(namesPart)
+          .append(text(" - ").color(NamedTextColor.GRAY))
+          .append(agg.type.makeNumber(val));
+
+      lines.add(line);
+      rank += tied.size();
+    }
+
+    if (lines.isEmpty()) return empty();
+
+    return Component.join(JoinConfiguration.newlines(), lines);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -20,10 +20,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -103,6 +104,8 @@ public class StatsMatchModule implements MatchModule, Listener {
   private final int verboseItemSlot = PGM.get().getConfiguration().getVerboseItemSlot();
 
   private List<MenuItem> teams;
+
+  private static final int TOP_HOVER_LIMIT = 10;
 
   public StatsMatchModule(Match match, List<StatType.OfFormula> formulaStats) {
     this.match = match;
@@ -367,7 +370,7 @@ public class StatsMatchModule implements MatchModule, Listener {
         var number = agg.type.makeNumber(value);
         return !best ? number : text("   ").append(translatable("match.stats.you.short", number));
       }));
-    return agg.type.component(who).hoverEvent(buildTop10Hover(agg));
+    return agg.type.component(who).hoverEvent(buildTopHover(agg));
   }
 
   private Component credit(Set<UUID> players) {
@@ -495,43 +498,46 @@ public class StatsMatchModule implements MatchModule, Listener {
     };
   }
 
-  private Component buildTop10Hover(AggStat<?> agg) {
-    Map<Double, List<UUID>> byValue = new java.util.TreeMap<>(Comparator.reverseOrder());
-    Component header = text("Top ").append(agg.type.component(empty()));
+  private Component buildTopHover(AggStat<?> agg) {
+    var top = allPlayerStats.entrySet().stream()
+        .map(e -> {
+          Number val = getStatValue(agg.type, match.getPlayer(e.getKey()), e.getValue());
+          return val != null && val.doubleValue() > 0
+              ? Map.entry(e.getKey(), val.doubleValue())
+              : null;
+        })
+        .filter(Objects::nonNull)
+        .sorted(Map.Entry.<UUID, Double>comparingByValue().reversed())
+        .toList();
 
-    allPlayerStats.forEach((uuid, playerStats) -> {
-      MatchPlayer player = match.getPlayer(uuid);
-      Number val = getStatValue(agg.type, player, playerStats);
-      if (val == null) return;
-      double d = val.doubleValue();
-      if (d <= 0) return;
-      byValue.computeIfAbsent(d, k -> new ArrayList<>()).add(uuid);
-    });
+    if (top.size() <= 1) return null;
 
-    List<Component> lines = new ArrayList<>();
-    lines.add(header);
-    int rank = 1;
-    for (Map.Entry<Double, List<UUID>> entry : byValue.entrySet()) {
-      if (rank > 10) break;
-      double val = entry.getKey();
-      List<UUID> tied = entry.getValue();
+    var lines = new ArrayList<Component>();
+    for (int i = 0; i < top.size() && lines.size() < TOP_HOVER_LIMIT; ) {
+      double value = top.get(i).getValue();
+      int j = i;
+      while (j < top.size() && Double.compare(top.get(j).getValue(), value) == 0) {
+        j++;
+      }
 
-      List<Component> names =
-          tied.stream().map(this::getPlayerComponent).collect(Collectors.toList());
-      Component namesPart = TextFormatter.list(names, NamedTextColor.WHITE);
+      var tiedPlayers = top.subList(i, j).stream()
+          .map(entry -> getPlayerComponent(entry.getKey()))
+          .toList();
 
-      Component line = text(rank + ". ")
+      lines.add(text((lines.size() + 1) + ". ")
           .color(NamedTextColor.WHITE)
-          .append(namesPart)
+          .append(list(tiedPlayers, NamedTextColor.GRAY))
           .append(text(" - ").color(NamedTextColor.GRAY))
-          .append(agg.type.makeNumber(val));
+          .append(agg.type.makeNumber(value)));
 
-      lines.add(line);
-      rank += tied.size();
+      i = j;
     }
 
-    if (lines.isEmpty()) return empty();
-
-    return Component.join(JoinConfiguration.newlines(), lines);
+    return Component.join(
+        JoinConfiguration.newlines(),
+        Stream.concat(
+                Stream.of(translatable("match.stats.top", agg.type.component(empty()))),
+                lines.stream())
+            .toList());
   }
 }

--- a/util/src/main/i18n/templates/match.properties
+++ b/util/src/main/i18n/templates/match.properties
@@ -62,6 +62,9 @@ match.stats.type.longest_bow_shot.blocks = {0} blocks
 match.stats.type.damage = Damage: {0}
 match.stats.type.generic = {0}: {1}
 
+# {0} = a match stat type (e.g. "Kills:", "Deahts:", "Assists:", etc.)
+match.stats.top = Top {0}
+
 # Used for anywhere from 4 to 10 players
 match.stats.severalPlayers = Several Players
 

--- a/util/src/main/java/tc/oc/pgm/util/collection/RankedSet.java
+++ b/util/src/main/java/tc/oc/pgm/util/collection/RankedSet.java
@@ -104,6 +104,11 @@ public class RankedSet<E> extends ForwardingSet<E> {
     return list.iterator();
   }
 
+  public List<Set<E>> ranksView() {
+    freshenRanking();
+    return Collections.unmodifiableList(ranks);
+  }
+
   /** Iterate in arbitrary order */
   public Iterator<E> unorderedIterator() {
     return super.iterator();


### PR DESCRIPTION
I updated getMessage to add a hover tooltip that shows the Top 10 players for that stat, skips entries with value 0, and displays tied entries on the same line using TextFormatter.list.

The objective is to make it easier for people to see top <stat> without the use of a website or going into the stats menu for each team and comparing them manually.