### PR TITLE
Soft-limit score and initial value

### DIFF
--- a/core/src/main/java/tc/oc/pgm/score/ScoreDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreDefinition.java
@@ -11,7 +11,9 @@ import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.util.named.NameStyle;
 
 public record ScoreDefinition(
+    int initial,
     int scoreLimit,
+    boolean enforceLimit,
     int deathScore,
     int killScore,
     int mercyLimit,

--- a/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreMatchModule.java
@@ -57,7 +57,9 @@ public class ScoreMatchModule implements MatchModule, Listener {
     this.match = match;
     this.config = config;
     this.scoreBoxes = scoreBoxes;
-    this.match.getCompetitors().forEach(competitor -> this.scores.put(competitor, 0.0));
+    this.match
+        .getCompetitors()
+        .forEach(competitor -> this.scores.put(competitor, (double) config.initial()));
 
     if (this.config.mercyLimit() > 0) {
       this.mercyRule =
@@ -76,6 +78,10 @@ public class ScoreMatchModule implements MatchModule, Listener {
 
   public boolean hasScoreLimit() {
     return this.config.scoreLimit() > 0 || hasMercyRule();
+  }
+
+  public boolean enforcesScoreLimit() {
+    return this.config.enforceLimit() && hasScoreLimit();
   }
 
   public boolean hasMercyRule() {

--- a/core/src/main/java/tc/oc/pgm/score/ScoreModule.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreModule.java
@@ -95,7 +95,9 @@ public class ScoreModule implements MapModule<ScoreMatchModule> {
       }
 
       RegionParser regionParser = factory.getRegions();
+      int initial = 0;
       int scoreLimit = -1;
+      Boolean enforceLimit = null;
       int deathScore = 0;
       int killScore = 0;
       int mercyLimit = -1;
@@ -105,7 +107,9 @@ public class ScoreModule implements MapModule<ScoreMatchModule> {
       ImmutableSet.Builder<ScoreBoxDefinition> scoreBoxes = ImmutableSet.builder();
 
       for (Element el : scoreElements) {
+        initial = parser.parseInt(el, "initial").optional(initial);
         scoreLimit = parser.parseInt(el, "limit").optional(-1);
+        enforceLimit = parser.parseBool(el, "enforce-limit").optional(enforceLimit);
 
         // For backwards compatibility, default kill/death points to 1 if proto is old and <king/>
         // tag is not present
@@ -143,9 +147,19 @@ public class ScoreModule implements MapModule<ScoreMatchModule> {
           scoreBoxes.add(new ScoreBoxDefinition(region, points, filter, redeemables, silent));
         }
       }
+      // by default, if limit is set and initial >= to it, do not enforce it
+      if (enforceLimit == null) enforceLimit = !(scoreLimit > 0 && initial >= scoreLimit);
 
       var config = new ScoreDefinition(
-          scoreLimit, deathScore, killScore, mercyLimit, mercyLimitMin, display, sbFilter);
+          initial,
+          scoreLimit,
+          enforceLimit,
+          deathScore,
+          killScore,
+          mercyLimit,
+          mercyLimitMin,
+          display,
+          sbFilter);
       return new ScoreModule(config, scoreBoxes.build());
     }
 

--- a/core/src/main/java/tc/oc/pgm/score/ScoreVictoryCondition.java
+++ b/core/src/main/java/tc/oc/pgm/score/ScoreVictoryCondition.java
@@ -22,7 +22,7 @@ public class ScoreVictoryCondition implements VictoryCondition {
   @Override
   public boolean isCompleted(Match match) {
     ScoreMatchModule smm = match.needModule(ScoreMatchModule.class);
-    if (!smm.hasScoreLimit()) return false;
+    if (!smm.enforcesScoreLimit()) return false;
 
     double limit = smm.getScoreLimit();
     for (Competitor competitor : match.getCompetitors()) {


### PR DESCRIPTION
adds `initial` & `enforce-limit`  properties to the score module, so you can do things like:
```xml
<score>
  <initial>10</initial>
  <limit>10</limit>
  <enforce-limit>false</limit>
</score>
<score initial="10" limit="10" />
```
`initial` - defines the initial score of the teams, until now this was effectively 0, and that continues to be the defaultt
`enforce-limit` - defines if PGM should end the match as soon as a team is above the limit. defaults to true, but pgm will automatically default it to false if both `limit` and `initial` are set, and `limit <= initial`.

In practice i believe enforce-limit may not need to be tweaked by maps, but it remains an option just in case a map wants to explicitly just disable limit ending the match for any reason:
```xml
<score limit="10" enforce-limit="false" />
```

What this PR aims to address is in particular this:
<img width="216" height="111" alt="image" src="https://github.com/user-attachments/assets/65c15192-e091-484a-98b5-52f18648e76d" />
Where limit is set to 11 so that pgm doesn't end it, and an action has to be ran to set the scores to 10 on load.
After the pgm change:
<img width="198" height="110" alt="image" src="https://github.com/user-attachments/assets/9391c425-1625-469f-a9b8-820770703395" />
