### PR TITLE
Implement multiple consumables

### DIFF
--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumableMatchModule.java
@@ -6,12 +6,10 @@ import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -30,53 +28,41 @@ public class ConsumableMatchModule implements MatchModule, Listener {
     this.consumables = consumables;
   }
 
-  private @Nullable ConsumableDefinition getConsumableDefinition(ItemStack item) {
-    if (item == null) return null;
-    return consumables.get(ItemTags.CONSUMABLE.get(item));
-  }
-
   @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
   private void onItemConsume(PlayerItemConsumeEvent event) {
-    ConsumableDefinition consumable = getConsumableDefinition(event.getItem());
-    if (consumable == null || consumable.getCause() != ConsumeCause.EAT) return;
-
-    runConsumable(event, consumable);
+    runConsumable(event, event.getItem(), ConsumeCause.EAT);
   }
 
   @EventHandler(priority = EventPriority.HIGH)
   private void onClick(PlayerInteractEvent event) {
-    // It's been cancelled
+    // It's been canceled
     if (event.useItemInHand() == Event.Result.DENY) return;
 
-    ConsumableDefinition consumable = getConsumableDefinition(event.getItem());
-    if (consumable == null) return;
-
-    var action = event.getAction();
-    if (!switch (consumable.getCause()) {
-      case LEFT_CLICK -> action == Action.LEFT_CLICK_BLOCK || action == Action.LEFT_CLICK_AIR;
-      case RIGHT_CLICK -> action == Action.RIGHT_CLICK_BLOCK || action == Action.RIGHT_CLICK_AIR;
-      case CLICK -> action == Action.LEFT_CLICK_BLOCK
-          || action == Action.LEFT_CLICK_AIR
-          || action == Action.RIGHT_CLICK_BLOCK
-          || action == Action.RIGHT_CLICK_AIR;
-      default -> false;
-    }) return;
-
-    runConsumable(event, consumable);
+    runConsumable(
+        event,
+        event.getItem(),
+        switch (event.getAction()) {
+          case LEFT_CLICK_BLOCK, LEFT_CLICK_AIR -> ConsumeCause.LEFT_CLICK;
+          case RIGHT_CLICK_BLOCK, RIGHT_CLICK_AIR -> ConsumeCause.RIGHT_CLICK;
+          default -> null;
+        });
   }
 
-  public <T extends PlayerEvent & Cancellable> void runConsumable(
-      T event, ConsumableDefinition consumable) {
-    MatchPlayer matchPlayer = match.getPlayer(event.getPlayer());
-    if (!MatchPlayers.canInteract(matchPlayer)) return;
+  private <T extends PlayerEvent & Cancellable> void runConsumable(
+      T event, ItemStack item, ConsumeCause cause) {
+    if (item == null || cause == null) return;
+    MatchPlayer pl = match.getPlayer(event.getPlayer());
+    if (!MatchPlayers.canInteract(pl)) return;
+    var ids = ItemTags.CONSUMABLE.get(item);
+    if (ids == null) return;
 
-    if (consumable.getOverride()) {
-      event.setCancelled(true);
+    for (String id : ids) {
+      var consumable = consumables.get(id);
+      if (consumable == null || !consumable.getCause().triggersOn(cause)) continue;
+      if (consumable.getOverride()) event.setCancelled(true);
+      if (consumable.getConsume()) InventoryUtils.consumeItem(event, pl.getBukkit());
+      consumable.getAction().trigger(pl);
+      return;
     }
-    if (consumable.getConsume()) {
-      InventoryUtils.consumeItem(event);
-    }
-
-    consumable.getAction().trigger(matchPlayer);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/consumable/ConsumeCause.java
+++ b/core/src/main/java/tc/oc/pgm/consumable/ConsumeCause.java
@@ -4,5 +4,9 @@ public enum ConsumeCause {
   EAT,
   RIGHT_CLICK,
   LEFT_CLICK,
-  CLICK
+  CLICK;
+
+  public boolean triggersOn(ConsumeCause cause) {
+    return cause == this || (this == CLICK && (cause == RIGHT_CLICK || cause == LEFT_CLICK));
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -81,8 +80,8 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
       List<DestroyableFactory> destroyables = Lists.newArrayList();
       var parser = context.getParser();
 
-      for (Element el : XMLUtils.flattenElements(
-          doc.getRootElement(), Set.of("destroyables"), Set.of("destroyable"))) {
+      for (Element el :
+          XMLUtils.flattenElements(doc.getRootElement(), "destroyables", "destroyable")) {
         var owner = parser.node(n -> Teams.getTeam(n, context), el, "owner").required();
         String name = parser.string(el, "name").required();
 

--- a/core/src/main/java/tc/oc/pgm/kits/KitParser.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitParser.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.kits;
 
+import static tc.oc.pgm.consumable.ConsumeCause.*;
 import static tc.oc.pgm.util.inventory.InventoryUtils.INVENTORY_UTILS;
 import static tc.oc.pgm.util.material.ColorUtils.COLOR_UTILS;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
@@ -52,7 +53,9 @@ import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.consumable.ConsumableDefinition;
+import tc.oc.pgm.consumable.ConsumeCause;
 import tc.oc.pgm.doublejump.DoubleJumpKit;
+import tc.oc.pgm.features.XMLFeatureReference;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.itemmeta.ItemModifyModule;
 import tc.oc.pgm.kits.tag.Grenade;
@@ -63,6 +66,7 @@ import tc.oc.pgm.shield.ShieldKit;
 import tc.oc.pgm.shield.ShieldParameters;
 import tc.oc.pgm.teams.TeamFactory;
 import tc.oc.pgm.teams.Teams;
+import tc.oc.pgm.util.StreamUtils;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.bukkit.ComponentApplicator;
@@ -653,12 +657,21 @@ public abstract class KitParser {
 
     Node consumableNode = Node.fromAttr(el, "consumable");
     if (consumableNode != null) {
+      var features = factory.getFeatures();
+      var references = StreamUtils.of(Splitter.on(';').split(consumableNode.getValue()))
+          .map(id -> features.createReference(consumableNode, id, ConsumableDefinition.class))
+          .toList();
+
+      features.validate(references.getFirst(), (first, node) -> {
+        Set<ConsumeCause> causes = EnumSet.noneOf(ConsumeCause.class);
+        for (var ref : references) {
+          var c = ref.get().getCause();
+          if (c == CLICK ? !(causes.add(RIGHT_CLICK) | causes.add(LEFT_CLICK)) : !causes.add(c))
+            throw new InvalidXMLException("Overlapping consumable causes", node);
+        }
+      });
       ItemTags.CONSUMABLE.set(
-          itemStack,
-          factory
-              .getFeatures()
-              .createReference(consumableNode, ConsumableDefinition.class)
-              .getId());
+          itemStack, references.stream().map(XMLFeatureReference::getId).toList());
     }
   }
 
@@ -683,9 +696,7 @@ public abstract class KitParser {
         int level = 1;
         List<String> parts = Lists.newArrayList(Splitter.on(":").limit(2).split(enchantmentText));
         Enchantment enchant = XMLUtils.parseEnchantment(attr, parts.get(0));
-        if (parts.size() > 1) {
-          level = XMLUtils.parseNumber(attr, parts.get(1), Integer.class);
-        }
+        if (parts.size() > 1) {}
         enchantments.put(enchant, level);
       }
     }

--- a/core/src/main/java/tc/oc/pgm/kits/tag/ItemTags.java
+++ b/core/src/main/java/tc/oc/pgm/kits/tag/ItemTags.java
@@ -1,12 +1,13 @@
 package tc.oc.pgm.kits.tag;
 
+import java.util.List;
 import tc.oc.pgm.util.inventory.tag.ItemTag;
 
 public class ItemTags {
 
   public static final ItemTag<Boolean> PREVENT_SHARING = ItemTag.newBoolean("prevent-sharing");
   public static final ItemTag<String> PROJECTILE = ItemTag.newString("projectile");
-  public static final ItemTag<String> CONSUMABLE = ItemTag.newString("consumable");
+  public static final ItemTag<List<String>> CONSUMABLE = ItemTag.newStringList("consumable");
   public static final ItemTag<String> ORIGINAL_NAME = ItemTag.newString("original-name");
   public static final ItemTag<Boolean> INFINITE = ItemTag.newBoolean("infinite");
   public static final ItemTag<Boolean> LOCKED = ItemTag.newBoolean("locked");

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernItemTagFactory.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/inventory/ModernItemTagFactory.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.platform.modern.inventory;
 
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
+import java.util.List;
 import org.bukkit.persistence.PersistentDataType;
 import tc.oc.pgm.util.inventory.tag.ItemTag;
 import tc.oc.pgm.util.platform.Supports;
@@ -12,6 +13,11 @@ public class ModernItemTagFactory implements ItemTag.Factory {
   @Override
   public ItemTag<String> newString(String key) {
     return new ModernItemTag<>(key, PersistentDataType.STRING);
+  }
+
+  @Override
+  public ItemTag<List<String>> newStringList(String key) {
+    return new ModernItemTag<>(key, PersistentDataType.LIST.strings());
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpItemTag.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpItemTag.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.platform.sportpaper.inventory;
 
+import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.function.Function;
 import net.minecraft.server.v1_8_R3.NBTBase;
 import net.minecraft.server.v1_8_R3.NBTTagByte;
@@ -8,6 +10,7 @@ import net.minecraft.server.v1_8_R3.NBTTagDouble;
 import net.minecraft.server.v1_8_R3.NBTTagFloat;
 import net.minecraft.server.v1_8_R3.NBTTagInt;
 import net.minecraft.server.v1_8_R3.NBTTagIntArray;
+import net.minecraft.server.v1_8_R3.NBTTagList;
 import net.minecraft.server.v1_8_R3.NBTTagLong;
 import net.minecraft.server.v1_8_R3.NBTTagShort;
 import net.minecraft.server.v1_8_R3.NBTTagString;
@@ -82,5 +85,13 @@ public class SpItemTag<T, N extends NBTBase> implements ItemTag<T> {
         new Codec<>(b -> new NBTTagByte((byte) (b ? 1 : 0)), byteTag -> byteTag.f() != 0);
     public static Codec<int[], NBTTagIntArray> INT_ARRAY =
         new Codec<>(NBTTagIntArray::new, NBTTagIntArray::c);
+    public static Codec<List<String>, NBTTagList> STRING_LIST = new Codec<>(
+        (List<String> strings) -> {
+          var nbt = new NBTTagList();
+          nbt.list = Lists.transform(strings, NBTTagString::new);
+          return nbt;
+        },
+        nbt -> Lists.transform(
+            nbt.list, b -> b instanceof NBTTagString str ? str.a_() : b.toString()));
   }
 }

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpItemTagFactory.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/inventory/SpItemTagFactory.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.platform.sportpaper.inventory;
 
+import java.util.List;
 import tc.oc.pgm.util.inventory.tag.ItemTag;
 import tc.oc.pgm.util.platform.Supports;
 
@@ -8,6 +9,11 @@ public class SpItemTagFactory implements ItemTag.Factory {
   @Override
   public ItemTag<String> newString(String key) {
     return new SpItemTag<>(key, SpItemTag.Codec.STRING);
+  }
+
+  @Override
+  public ItemTag<List<String>> newStringList(String key) {
+    return new SpItemTag<>(key, SpItemTag.Codec.STRING_LIST);
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/inventory/tag/ItemTag.java
+++ b/util/src/main/java/tc/oc/pgm/util/inventory/tag/ItemTag.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.util.inventory.tag;
 
+import java.util.List;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.util.platform.Platform;
@@ -54,6 +55,16 @@ public interface ItemTag<T> {
   }
 
   /**
+   * Creates a string list item tag.
+   *
+   * @param key A key.
+   * @return An item tag.
+   */
+  static ItemTag<List<String>> newStringList(String key) {
+    return FACTORY.newStringList(key);
+  }
+
+  /**
    * Creates a boolean item tag.
    *
    * @param key A key.
@@ -65,6 +76,8 @@ public interface ItemTag<T> {
 
   interface Factory {
     ItemTag<String> newString(String key);
+
+    ItemTag<List<String>> newStringList(String key);
 
     ItemTag<Boolean> newBoolean(String key);
   }


### PR DESCRIPTION
Allows items to specify multiple consumables, so long as their consume causes do not overlap.

```xml
<kits>
  <kit id="spawn">
    <item material="diamond" consumable="consumable-a;consumable-b"/>
  </kit>
</kits>
<consumables>
  <consumable id="consumable-a" on="right click" action="action-a"/>
  <consumable id="consumable-b" on="left click" action="action-b"/>
</consumables>
```

Opening as draft as it hasn't been tested