### PR TITLE
--hideDefaults flag for /variables

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
@@ -45,6 +45,7 @@ import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.text.TextFormatter;
 import tc.oc.pgm.variables.Variable;
 import tc.oc.pgm.variables.VariablesMatchModule;
+import tc.oc.pgm.variables.types.PlayerVariable;
 
 public class MapDevCommand {
 
@@ -61,10 +62,12 @@ public class MapDevCommand {
       @Argument("target") @Default(CURRENT) MatchPlayer target,
       @Argument("page") @Default("1") int page,
       @Flag(value = "query", aliases = "q") String query,
+      @Flag(value = "hideDefaults", aliases = "d") boolean hideDefaults,
       @Flag(value = "all", aliases = "a") boolean all) {
 
     List<Map.Entry<String, Variable<?>>> variables = vmm.getVariables()
         .filter(e -> query == null || e.getKey().contains(query))
+        .filter(e -> !(hideDefaults && e.getValue() instanceof PlayerVariable))
         .sorted(Map.Entry.comparingByKey())
         .collect(Collectors.toList());
 

--- a/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/MapDevCommand.java
@@ -66,8 +66,8 @@ public class MapDevCommand {
       @Flag(value = "all", aliases = "a") boolean all) {
 
     List<Map.Entry<String, Variable<?>>> variables = vmm.getVariables()
-        .filter(e -> query == null || e.getKey().contains(query))
         .filter(e -> !(hideDefaults && e.getValue() instanceof PlayerVariable))
+        .filter(e -> query == null || e.getKey().contains(query))
         .sorted(Map.Entry.comparingByKey())
         .collect(Collectors.toList());
 


### PR DESCRIPTION
This PR adds a ``-d (--hideDefaults)`` flag for ``/variables``. The -d flag hides all default player. variables. 

player. variables take up 3 pages when doing /variables.

On connect 4 when using ``/variables`` 
<img width="934" height="657" alt="image" src="https://github.com/user-attachments/assets/44d71f74-170c-42a1-b566-92a6e08628c2" />

Now when using ``/variables -ad``
<img width="586" height="497" alt="image" src="https://github.com/user-attachments/assets/fc4a78dc-6b17-4e4a-a720-0158fb6f408b" />