### PR TITLE
Fix destroyable modes parsing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableModule.java
@@ -97,12 +97,13 @@ public class DestroyableModule implements MapModule<DestroyableMatchModule> {
             .parse(Node.fromRequiredAttr(el, "materials", "material"))
             .build();
 
-        var modeSet = parser.node(n -> parseModeSet(context, n), el, "modes").orNull();
-        var modeChanges = parser.parseBool(el, "mode-changes").orNull();
-        if (modeChanges != null) {
-          if (modeSet != null)
+        var modeSet =
+            parser.node(n -> parseModeSet(context, n), el, "modes").optional(ImmutableSet.of());
+        var modeChanges = parser.parseBool(el, "mode-changes").orFalse();
+        if (modeChanges) {
+          if (!modeSet.isEmpty())
             throw new InvalidXMLException("Cannot combine modes and mode-changes", el);
-          modeSet = modeChanges ? null : ImmutableSet.of();
+          modeSet = null;
         }
 
         boolean showProgress = parser.parseBool(el, "show-progress").orFalse();


### PR DESCRIPTION
The following XML excerpt is from the map Lunar Crescent; following f493b7352a60a9b7531d1b15ddf1cb87a352e492 the following happens:

- We default `modeSet` and `modeChanges` to null if they are not defined; it's defined as true for the two spawn drop monuments but `null` for the actual monuments players are meant to destroy.
- Because `modeSet` is `null` unless defined, and `modeChanges` is `null` for the two monuments that matter, they actually have the monument mode applied to them since passing a `null` `modeSet` applies all modes.

```xml
<destroyables>
    <destroyables owner="magenta" show-progress="true">
        <destroyable name="Right Monument" materials="packed ice" completion="100%" region="magenta-right-mon"/>
        <destroyable name="Left Monument" materials="packed ice" completion="100%" region="magenta-left-mon"/>
    </destroyables>
    <destroyables owner="orange" show-progress="true">
        <destroyable name="Right Monument" materials="packed ice" completion="100%" region="orange-right-mon"/>
        <destroyable name="Left Monument" materials="packed ice" completion="100%" region="orange-left-mon"/>
    </destroyables>
    <destroyables name="Spawn Drops" show="false" materials="stained clay">
        <destroyable owner="magenta" mode-changes="true">
            <region>
                <cuboid min="71,102,-169" max="76,103,-164"/>
            </region>
        </destroyable>
        <destroyable owner="orange" mode-changes="true">
            <region>
                <cuboid min="-61,102,-35" max="-56,103,-30"/>
            </region>
        </destroyable>
    </destroyables>
</destroyables>
<modes>
    <mode after="15s" material="air" name="Players are released!"/>
</modes>
```

This PR restores the previous default of empty and `null` for `modeSet` and `modeChanges` respectively, and changes `modeSet` to null if `modeChanges` is true, while continuing to throw if both are defined erroneously.