### PR TITLE
Match `flag-captured` to respawning flags where `wasCaptured` is true

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/matcher/match/FlagStateFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/matcher/match/FlagStateFilter.java
@@ -11,6 +11,7 @@ import tc.oc.pgm.flag.Flag;
 import tc.oc.pgm.flag.FlagDefinition;
 import tc.oc.pgm.flag.event.FlagStateChangeEvent;
 import tc.oc.pgm.flag.post.PostDefinition;
+import tc.oc.pgm.flag.state.Captured;
 import tc.oc.pgm.flag.state.State;
 
 public class FlagStateFilter extends TypedFilter.Impl<MatchQuery> {
@@ -44,6 +45,8 @@ public class FlagStateFilter extends TypedFilter.Impl<MatchQuery> {
     // FIXME: This may occur at load time. We need a better fix for this.
     if (flag == null) return false;
 
-    return flag.isCurrent(this.state) && (this.post == null || flag.isAtPost(this.post.get()));
+    return (flag.isCurrent(this.state)
+            || (this.state == Captured.class && flag.isRespawningAfterCapture()))
+        && (this.post == null || flag.isAtPost(this.post.get()));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -43,6 +43,7 @@ import tc.oc.pgm.flag.state.BaseState;
 import tc.oc.pgm.flag.state.Captured;
 import tc.oc.pgm.flag.state.Completed;
 import tc.oc.pgm.flag.state.Dropped;
+import tc.oc.pgm.flag.state.Respawning;
 import tc.oc.pgm.flag.state.Returned;
 import tc.oc.pgm.flag.state.Spawned;
 import tc.oc.pgm.flag.state.State;
@@ -443,6 +444,10 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
 
   public boolean isCaptured() {
     return isCompleted() || isCurrent(Captured.class);
+  }
+
+  public boolean isRespawningAfterCapture() {
+    return this.state instanceof Respawning respawning && respawning.wasCaptured();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/flag/state/Respawning.java
+++ b/core/src/main/java/tc/oc/pgm/flag/state/Respawning.java
@@ -46,6 +46,10 @@ public class Respawning extends Spawned implements Returning {
     this.wasDelayed = wasDelayed;
   }
 
+  public boolean wasCaptured() {
+    return this.wasCaptured;
+  }
+
   @Override
   protected Duration getDuration() {
     return respawnTime;


### PR DESCRIPTION
While `flag-captured` and all other flag filters have tended to refer to the explicit state of a flag, it is helpful to be able to filter a flag by whether or not it has been captured, even if its actual state is `Respawning`. 

Alternatively, we could implement a `flag-respawning` filter with a `captured="true"` option.