### PR TITLE
Add support for Spawning LivingEntities to xml spawners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dependency-reduced-pom.xml
 # Gradle generated files
 build/
 .gradle
+**/bin
 
 # Mac OSX generated files
 .DS_Store

--- a/core/src/main/java/tc/oc/pgm/entity/MobProperties.java
+++ b/core/src/main/java/tc/oc/pgm/entity/MobProperties.java
@@ -1,0 +1,154 @@
+package tc.oc.pgm.entity;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.bukkit.DyeColor;
+import org.bukkit.entity.Ageable;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Bat;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Damageable;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Guardian;
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.IronGolem;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Ocelot;
+import org.bukkit.entity.Pig;
+import org.bukkit.entity.PigZombie;
+import org.bukkit.entity.Rabbit;
+import org.bukkit.entity.Sheep;
+import org.bukkit.entity.Slime;
+import org.bukkit.entity.Tameable;
+import org.bukkit.entity.Wolf;
+import org.bukkit.entity.Zombie;
+import org.bukkit.material.Colorable;
+import org.jdom2.Element;
+import org.jetbrains.annotations.Nullable;
+import tc.oc.pgm.entity.MobProperty.Parser;
+import tc.oc.pgm.util.platform.Platform;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLUtils;
+
+public abstract class MobProperties {
+  protected static final Parser<Boolean> BOOL = XMLUtils::parseBoolean;
+  protected static final Parser<Integer> INT = n -> XMLUtils.parseNumber(n, Integer.class);
+  protected static final Parser<Double> DOUBLE = n -> XMLUtils.parseNumber(n, Double.class);
+  protected static final Parser<Float> FLOAT = n -> XMLUtils.parseNumber(n, Float.class);
+  protected static final Parser<String> STRING = Node::getValue;
+
+  protected static <T extends Enum<T>> Parser<T> enumOf(Class<T> type) {
+    return n -> XMLUtils.parseEnum(n, type);
+  }
+
+  public static final MobProperties MOB_PROPERTIES = Platform.get(MobProperties.class);
+
+  private final List<MobProperty<?, ?>> properties = new ArrayList<>();
+
+  protected MobProperties() {
+    register(Entity.class, "custom-name", STRING, Entity::setCustomName);
+    register(Entity.class, "custom-name-visible", BOOL, Entity::setCustomNameVisible);
+    register(Entity.class, "fire-ticks", INT, Entity::setFireTicks);
+
+    register(LivingEntity.class, "can-pickup-items", BOOL, LivingEntity::setCanPickupItems);
+    register(LivingEntity.class, "remove-when-far-away", BOOL, LivingEntity::setRemoveWhenFarAway);
+    register(LivingEntity.class, "arrows-stuck", INT, LivingEntity::setArrowsStuck);
+    register(LivingEntity.class, "maximum-air", INT, LivingEntity::setMaximumAir);
+    register(LivingEntity.class, "remaining-air", INT, LivingEntity::setRemainingAir);
+    register(
+        LivingEntity.class, "maximum-no-damage-ticks", INT, LivingEntity::setMaximumNoDamageTicks);
+    register(LivingEntity.class, "no-damage-ticks", INT, LivingEntity::setNoDamageTicks);
+
+    register(Damageable.class, "max-health", DOUBLE, Damageable::setMaxHealth);
+    register(Damageable.class, "health", DOUBLE, Damageable::setHealth);
+
+    register(Ageable.class, "baby", BOOL, (a, baby) -> {
+      if (baby) a.setBaby();
+      else a.setAdult();
+    });
+    register(Ageable.class, "age", INT, Ageable::setAge);
+    register(Ageable.class, "age-lock", BOOL, Ageable::setAgeLock);
+
+    register(Tameable.class, "tamed", BOOL, Tameable::setTamed);
+    register(Colorable.class, "color", enumOf(DyeColor.class), Colorable::setColor);
+
+    register(Slime.class, "size", INT, Slime::setSize);
+    register(Sheep.class, "sheared", BOOL, Sheep::setSheared);
+    register(Pig.class, "saddle", BOOL, Pig::setSaddle);
+
+    register(Horse.class, "color", enumOf(Horse.Color.class), Horse::setColor);
+    register(Horse.class, "style", enumOf(Horse.Style.class), Horse::setStyle);
+    register(Horse.class, "carrying-chest", BOOL, Horse::setCarryingChest);
+    register(Horse.class, "max-domestication", INT, Horse::setMaxDomestication);
+    register(Horse.class, "domestication", INT, Horse::setDomestication);
+    register(Horse.class, "jump-strength", DOUBLE, Horse::setJumpStrength);
+
+    register(Wolf.class, "angry", BOOL, Wolf::setAngry);
+    register(Wolf.class, "sitting", BOOL, Wolf::setSitting);
+    register(Wolf.class, "collar-color", enumOf(DyeColor.class), Wolf::setCollarColor);
+
+    register(Ocelot.class, "cat-type", enumOf(Ocelot.Type.class), Ocelot::setCatType);
+
+    register(Zombie.class, "baby", BOOL, Zombie::setBaby);
+    register(Zombie.class, "villager", BOOL, Zombie::setVillager);
+    register(PigZombie.class, "anger", INT, PigZombie::setAnger);
+    register(PigZombie.class, "angry", BOOL, PigZombie::setAngry);
+
+    register(IronGolem.class, "player-created", BOOL, IronGolem::setPlayerCreated);
+    register(Rabbit.class, "rabbit-type", enumOf(Rabbit.Type.class), Rabbit::setRabbitType);
+    register(Bat.class, "awake", BOOL, Bat::setAwake);
+    register(Guardian.class, "elder", BOOL, Guardian::setElder);
+    register(Creeper.class, "powered", BOOL, Creeper::setPowered);
+
+    register(ArmorStand.class, "base-plate", BOOL, ArmorStand::setBasePlate);
+    register(ArmorStand.class, "visible", BOOL, ArmorStand::setVisible);
+    register(ArmorStand.class, "arms", BOOL, ArmorStand::setArms);
+    register(ArmorStand.class, "small", BOOL, ArmorStand::setSmall);
+    register(ArmorStand.class, "marker", BOOL, ArmorStand::setMarker);
+    register(ArmorStand.class, "can-move", BOOL, ArmorStand::setCanMove);
+  }
+
+  protected final <E, V> void register(
+      Class<E> ownerType, String xmlName, Parser<V> parser, BiConsumer<E, V> setter) {
+    properties.add(new MobProperty<>(ownerType, xmlName, parser, setter));
+  }
+
+  public final @Nullable MobProperty<?, ?> find(Class<? extends Entity> type, String xmlName) {
+    for (var property : properties) {
+      if (property.ownerType().isAssignableFrom(type) && property.xmlName().equals(xmlName)) {
+        return property;
+      }
+    }
+    return null;
+  }
+
+  public final List<Consumer<Entity>> parseAttributes(
+      Class<? extends Entity> type, Element el, String... excluded) throws InvalidXMLException {
+    var skip = Set.of(excluded);
+    Set<String> matched = new HashSet<>();
+    List<Consumer<Entity>> applied = new ArrayList<>();
+    // Walk the registry in order, to maintain dependency order, ie maxHealth before health
+    for (var property : properties) {
+      var name = property.xmlName();
+      if (matched.contains(name) || !property.ownerType().isAssignableFrom(type)) continue;
+      var attr = el.getAttribute(name);
+      if (attr == null) continue;
+      applied.add(property.parseValue(new Node(attr)));
+      matched.add(name);
+    }
+    for (var attr : el.getAttributes()) {
+      if (!skip.contains(attr.getName()) && !matched.contains(attr.getName())) {
+        throw new InvalidXMLException(
+            "Attribute '" + attr.getName() + "' is not a valid property for "
+                + type.getSimpleName(),
+            el);
+      }
+    }
+    return applied;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/entity/MobProperty.java
+++ b/core/src/main/java/tc/oc/pgm/entity/MobProperty.java
@@ -1,0 +1,22 @@
+package tc.oc.pgm.entity;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.bukkit.entity.Entity;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+
+public record MobProperty<E, V>(
+    Class<E> ownerType, String xmlName, Parser<V> parser, BiConsumer<E, V> setter) {
+
+  @SuppressWarnings("unchecked")
+  public Consumer<Entity> parseValue(Node node) throws InvalidXMLException {
+    V value = parser.parse(node);
+    return entity -> setter.accept((E) entity, value);
+  }
+
+  @FunctionalInterface
+  public interface Parser<V> {
+    V parse(Node node) throws InvalidXMLException;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/entity/SpawnableEntity.java
+++ b/core/src/main/java/tc/oc/pgm/entity/SpawnableEntity.java
@@ -1,0 +1,43 @@
+package tc.oc.pgm.entity;
+
+import java.util.List;
+import java.util.function.Consumer;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.jdom2.Element;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLUtils;
+
+public record SpawnableEntity(
+    Class<? extends LivingEntity> entityType, List<Consumer<Entity>> properties) {
+
+  public Entity spawn(Location location) {
+    Entity entity = location.getWorld().spawn(location, entityType);
+    for (var property : properties) {
+      property.accept(entity);
+    }
+    return entity;
+  }
+
+  public static SpawnableEntity parse(Element el) throws InvalidXMLException {
+    var type = parseType(Node.fromRequiredAttr(el, "type"));
+    return new SpawnableEntity(
+        type, MobProperties.MOB_PROPERTIES.parseAttributes(type, el, "type"));
+  }
+
+  private static Class<? extends LivingEntity> parseType(Node typeNode) throws InvalidXMLException {
+    Class<? extends Entity> raw = XMLUtils.parseEntityType(typeNode);
+    if (!LivingEntity.class.isAssignableFrom(raw)) {
+      throw new InvalidXMLException(
+          "Mob type must be a living entity, got " + raw.getSimpleName(), typeNode);
+    }
+    if (Player.class.isAssignableFrom(raw)) {
+      throw new InvalidXMLException(
+          "Mob type " + raw.getSimpleName() + " cannot be spawned", typeNode);
+    }
+    return raw.asSubclass(LivingEntity.class);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -5,9 +5,13 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import org.bukkit.Material;
+import org.bukkit.entity.EnderDragon;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Wither;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.jdom2.Attribute;
@@ -19,6 +23,7 @@ import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.entity.SpawnableEntity;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.filters.parse.FilterParser;
@@ -26,6 +31,7 @@ import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.spawner.objects.SpawnableItem;
+import tc.oc.pgm.spawner.objects.SpawnableMob;
 import tc.oc.pgm.spawner.objects.SpawnablePotion;
 import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.xml.InheritingElement;
@@ -35,6 +41,8 @@ import tc.oc.pgm.util.xml.XMLUtils;
 public class SpawnerModule implements MapModule<SpawnerMatchModule> {
 
   private static final int SPLASH_BIT = 0x4000;
+  private static final Set<Class<? extends LivingEntity>> EXCLUDED_MOB_TYPES =
+      Set.of(Wither.class, EnderDragon.class);
 
   private final List<SpawnerDefinition> spawnerDefinitions = new ArrayList<>();
 
@@ -110,6 +118,10 @@ public class SpawnerModule implements MapModule<SpawnerMatchModule> {
           objects.add(new SpawnablePotion(potion, id));
         }
 
+        for (Element mobEl : XMLUtils.getChildren(spawnerEl, "mob")) {
+          objects.add(parseMob(mobEl, id));
+        }
+
         SpawnerDefinition spawnerDefinition = new SpawnerDefinition(
             id,
             objects,
@@ -125,6 +137,17 @@ public class SpawnerModule implements MapModule<SpawnerMatchModule> {
       }
 
       return spawnerModule.spawnerDefinitions.isEmpty() ? null : spawnerModule;
+    }
+
+    private static SpawnableMob parseMob(Element mobEl, String spawnerId)
+        throws InvalidXMLException {
+      var entity = SpawnableEntity.parse(mobEl);
+      if (EXCLUDED_MOB_TYPES.stream().anyMatch(c -> c.isAssignableFrom(entity.entityType()))) {
+        throw new InvalidXMLException(
+            "Spawner mob type " + entity.entityType().getSimpleName() + " cannot be spawned",
+            mobEl);
+      }
+      return new SpawnableMob(entity, spawnerId);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnableMob.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/objects/SpawnableMob.java
@@ -1,0 +1,32 @@
+package tc.oc.pgm.spawner.objects;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.metadata.FixedMetadataValue;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.entity.SpawnableEntity;
+import tc.oc.pgm.spawner.Spawnable;
+import tc.oc.pgm.spawner.Spawner;
+
+public class SpawnableMob implements Spawnable {
+
+  private final SpawnableEntity entity;
+  private final String spawnerId;
+
+  public SpawnableMob(SpawnableEntity entity, String spawnerId) {
+    this.entity = entity;
+    this.spawnerId = spawnerId;
+  }
+
+  @Override
+  public void spawn(Location location, Match match) {
+    Entity spawned = entity.spawn(location);
+    spawned.setMetadata(Spawner.METADATA_KEY, new FixedMetadataValue(PGM.get(), spawnerId));
+  }
+
+  @Override
+  public int getSpawnCount() {
+    return 1;
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/entity/ModernMobProperties.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/entity/ModernMobProperties.java
@@ -1,0 +1,96 @@
+package tc.oc.pgm.platform.modern.entity;
+
+import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
+
+import org.bukkit.DyeColor;
+import org.bukkit.entity.Bee;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Endermite;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Fox;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Ocelot;
+import org.bukkit.entity.Panda;
+import org.bukkit.entity.Phantom;
+import org.bukkit.entity.Snowman;
+import org.bukkit.entity.Witch;
+import org.bukkit.entity.Wither;
+import org.bukkit.entity.Zombie;
+import tc.oc.pgm.entity.MobProperties;
+import tc.oc.pgm.util.platform.Supports;
+
+@Supports(PAPER)
+public class ModernMobProperties extends MobProperties {
+
+  public ModernMobProperties() {
+    register(Entity.class, "silent", BOOL, Entity::setSilent);
+    register(Entity.class, "glowing", BOOL, Entity::setGlowing);
+    register(Entity.class, "invulnerable", BOOL, Entity::setInvulnerable);
+    register(Entity.class, "invisible", BOOL, Entity::setInvisible);
+    register(Entity.class, "persistent", BOOL, Entity::setPersistent);
+    register(Entity.class, "gravity", BOOL, Entity::setGravity);
+    register(Entity.class, "no-physics", BOOL, Entity::setNoPhysics);
+    register(Entity.class, "freeze-ticks", INT, Entity::setFreezeTicks);
+    register(Entity.class, "portal-cooldown", INT, Entity::setPortalCooldown);
+
+    register(LivingEntity.class, "ai", BOOL, LivingEntity::setAI);
+    register(LivingEntity.class, "collidable", BOOL, LivingEntity::setCollidable);
+    register(LivingEntity.class, "gliding", BOOL, LivingEntity::setGliding);
+    register(LivingEntity.class, "swimming", BOOL, LivingEntity::setSwimming);
+    register(LivingEntity.class, "no-action-ticks", INT, LivingEntity::setNoActionTicks);
+
+    register(Mob.class, "aware", BOOL, Mob::setAware);
+    register(Mob.class, "aggressive", BOOL, Mob::setAggressive);
+    register(Mob.class, "left-handed", BOOL, Mob::setLeftHanded);
+
+    register(Zombie.class, "can-break-doors", BOOL, Zombie::setCanBreakDoors);
+    register(Zombie.class, "arms-raised", BOOL, Zombie::setArmsRaised);
+    register(Zombie.class, "should-burn-in-day", BOOL, Zombie::setShouldBurnInDay);
+    register(Zombie.class, "conversion-time", INT, Zombie::setConversionTime);
+
+    register(Creeper.class, "max-fuse-ticks", INT, Creeper::setMaxFuseTicks);
+    register(Creeper.class, "fuse-ticks", INT, Creeper::setFuseTicks);
+    register(Creeper.class, "explosion-radius", INT, Creeper::setExplosionRadius);
+    register(Creeper.class, "ignited", BOOL, Creeper::setIgnited);
+
+    register(Phantom.class, "size", INT, Phantom::setSize);
+    register(Phantom.class, "should-burn-in-day", BOOL, Phantom::setShouldBurnInDay);
+
+    register(Ocelot.class, "trusting", BOOL, Ocelot::setTrusting);
+
+    register(Cat.class, "collar-color", enumOf(DyeColor.class), Cat::setCollarColor);
+    register(Cat.class, "lying-down", BOOL, Cat::setLyingDown);
+    register(Cat.class, "head-up", BOOL, Cat::setHeadUp);
+
+    register(Fox.class, "fox-type", enumOf(Fox.Type.class), Fox::setFoxType);
+    register(Fox.class, "crouching", BOOL, Fox::setCrouching);
+    register(Fox.class, "sleeping", BOOL, Fox::setSleeping);
+    register(Fox.class, "interested", BOOL, Fox::setInterested);
+    register(Fox.class, "leaping", BOOL, Fox::setLeaping);
+    register(Fox.class, "defending", BOOL, Fox::setDefending);
+    register(Fox.class, "faceplanted", BOOL, Fox::setFaceplanted);
+
+    register(Panda.class, "main-gene", enumOf(Panda.Gene.class), Panda::setMainGene);
+    register(Panda.class, "hidden-gene", enumOf(Panda.Gene.class), Panda::setHiddenGene);
+    register(Panda.class, "rolling", BOOL, Panda::setRolling);
+    register(Panda.class, "sneezing", BOOL, Panda::setSneezing);
+    register(Panda.class, "eating", BOOL, Panda::setEating);
+
+    register(Bee.class, "has-nectar", BOOL, Bee::setHasNectar);
+    register(Bee.class, "has-stung", BOOL, Bee::setHasStung);
+    register(Bee.class, "anger", INT, Bee::setAnger);
+    register(Bee.class, "cannot-enter-hive-ticks", INT, Bee::setCannotEnterHiveTicks);
+    register(Bee.class, "time-since-sting", INT, Bee::setTimeSinceSting);
+
+    register(Snowman.class, "derp", BOOL, Snowman::setDerp);
+
+    register(Endermite.class, "lifetime-ticks", INT, Endermite::setLifetimeTicks);
+
+    register(Witch.class, "potion-use-time-left", INT, Witch::setPotionUseTimeLeft);
+
+    register(Wither.class, "invulnerable-ticks", INT, Wither::setInvulnerableTicks);
+    register(Wither.class, "can-travel-through-portals", BOOL, Wither::setCanTravelThroughPortals);
+  }
+}

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/entity/SpMobProperties.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/entity/SpMobProperties.java
@@ -1,0 +1,23 @@
+package tc.oc.pgm.platform.sportpaper.entity;
+
+import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
+
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.Skeleton;
+import tc.oc.pgm.entity.MobProperties;
+import tc.oc.pgm.util.platform.Supports;
+
+@Supports(SPORTPAPER)
+public class SpMobProperties extends MobProperties {
+
+  public SpMobProperties() {
+    register(ArmorStand.class, "gravity", BOOL, ArmorStand::setGravity);
+    register(Horse.class, "variant", enumOf(Horse.Variant.class), Horse::setVariant);
+    register(
+        Skeleton.class,
+        "skeleton-type",
+        enumOf(Skeleton.SkeletonType.class),
+        Skeleton::setSkeletonType);
+  }
+}


### PR DESCRIPTION
Add support for spawning LivingEntities via xml spawners.

So you can do something like so:
```xml
<spawners>
    <spawner spawn-region="south-mob-point" player-region="south-mob" delay="4s">
        <mob type="Zombie" custom-name="Boss" custom-name-visible="true" baby="true"
             health="40" max-health="40" fire-ticks="600" can-pickup-items="false"/>
    </spawner>
</spawners>
```
Or for say modern:
```xml
<spawners>
    <spawner spawn-region="north-mob-point" player-region="north-mob" delay="4s">
        <mob type="Bee" silent="true" glowing="true" invulnerable="true" ai="true" anger="100" has-nectar="true" cannot-enter-hive-ticks="600"/>
    </spawner>
</spawners>
```

With this you should be able to spawn essentially any living entity with xml spawners. 

As for xml parameters, I made it so that you can use essentially any setter in the bukkit api for a living entity with a single parameter that is either a primitive type or an enum.

I've specifically excluded being able to spawn the classes: Player, Wither, and Ender Dragon
