### PR TITLE
Platform-specific listeners for block physics and BlockTransformListener

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -48,7 +48,6 @@ import tc.oc.pgm.db.SQLDatastore;
 import tc.oc.pgm.db.SqlUsernameResolver;
 import tc.oc.pgm.integrations.SimpleVanishIntegration;
 import tc.oc.pgm.listeners.AntiGriefListener;
-import tc.oc.pgm.listeners.BlockTransformListener;
 import tc.oc.pgm.listeners.FormattingListener;
 import tc.oc.pgm.listeners.InitialMatchLoader;
 import tc.oc.pgm.listeners.JoinLeaveAnnouncer;
@@ -216,7 +215,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     final File[] worldDirs = getServer().getWorldContainer().listFiles();
     if (worldDirs != null) {
       for (File dir : worldDirs) {
-        if (dir.isDirectory() && dir.getName().startsWith("match")) {
+        if (dir.isDirectory() && Match.isMatchWorld(dir.getName())) {
           FileUtils.delete(dir);
         }
       }
@@ -413,7 +412,6 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     registerEvents(new PlayerMoveListener());
     registerEvents(new ItemTransferListener());
     registerEvents(new TNTMinecartPlacementListener());
-    new BlockTransformListener(this).registerEvents();
     registerEvents(matchManager);
     inventoryManager.init();
     registerEvents(afkTracker);

--- a/core/src/main/java/tc/oc/pgm/api/map/WorldInfo.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/WorldInfo.java
@@ -29,4 +29,11 @@ public interface WorldInfo {
    * @return The world environment type.
    */
   World.Environment getEnvironment();
+
+  /**
+   * Get whether block physics are allowed pre-match
+   *
+   * @return true if block physics are allowed pre-match, false otherwise
+   */
+  boolean initialPhysics();
 }

--- a/core/src/main/java/tc/oc/pgm/api/match/Match.java
+++ b/core/src/main/java/tc/oc/pgm/api/match/Match.java
@@ -455,4 +455,19 @@ public interface Match
   default Match getMatch() {
     return this;
   }
+
+  String WORLD_PREFIX = "match-";
+
+  static boolean isMatchWorld(@Nullable String name) {
+    if (name == null || name.length() <= WORLD_PREFIX.length() || !name.startsWith(WORLD_PREFIX))
+      return false;
+    for (int i = WORLD_PREFIX.length(); i < name.length(); i++) {
+      if (!Character.isDigit(name.charAt(i))) return false;
+    }
+    return true;
+  }
+
+  static boolean isMatchWorld(@Nullable World world) {
+    return world != null && isMatchWorld(world.getName());
+  }
 }

--- a/core/src/main/java/tc/oc/pgm/listeners/BlockPhysicsListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockPhysicsListener.java
@@ -1,0 +1,33 @@
+package tc.oc.pgm.listeners;
+
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockFromToEvent;
+import org.bukkit.event.block.BlockPhysicsEvent;
+import org.jspecify.annotations.NullMarked;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.match.Match;
+
+@NullMarked
+public class BlockPhysicsListener implements Listener {
+
+  protected boolean allowPhysics(World world) {
+    Match match = PGM.get().getMatchManager().getMatch(world);
+    if (match == null) return !Match.isMatchWorld(world);
+    if (match.isFinished()) return false;
+    if (match.isRunning()) return true;
+    return match.getMap().getWorld().initialPhysics();
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST)
+  public void onBlockPhysics(BlockPhysicsEvent event) {
+    if (!allowPhysics(event.getBlock().getWorld())) event.setCancelled(true);
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST)
+  public void onBlockFromTo(BlockFromToEvent event) {
+    if (!allowPhysics(event.getBlock().getWorld())) event.setCancelled(true);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
+++ b/core/src/main/java/tc/oc/pgm/listeners/BlockTransformListener.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.bukkit.Material;
@@ -28,6 +29,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
 import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockFadeEvent;
 import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.block.BlockFromToEvent;
@@ -39,6 +41,7 @@ import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockSpreadEvent;
+import org.bukkit.event.block.LeavesDecayEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
@@ -49,6 +52,7 @@ import org.bukkit.material.Door;
 import org.bukkit.plugin.EventExecutor;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.event.BlockTransformEvent;
@@ -69,13 +73,14 @@ import tc.oc.pgm.util.event.entity.ExplosionPrimeByEntityEvent;
 import tc.oc.pgm.util.event.entity.ExplosionPrimeEvent;
 import tc.oc.pgm.util.material.Materials;
 
+@NullMarked
 public class BlockTransformListener implements Listener {
   private static final BlockFace[] NEIGHBORS = {
     BlockFace.WEST, BlockFace.EAST, BlockFace.DOWN, BlockFace.UP, BlockFace.NORTH, BlockFace.SOUTH
   };
 
   @Retention(RetentionPolicy.RUNTIME)
-  @interface EventWrapper {}
+  public @interface EventWrapper {}
 
   protected final Logger logger;
   protected final Plugin plugin;
@@ -99,12 +104,6 @@ public class BlockTransformListener implements Listener {
 
           for (final EventPriority priority : EventPriority.values()) {
             EventExecutor executor = (listener, event) -> {
-              // if (event instanceof Physical
-              //    && PGM.get().getMatchManager().getMatch(((Physical) event).getWorld())
-              // ==
-              // null)
-              //  return;
-
               if (!Events.isCancelled(event)) {
                 // At the first priority level, call the event handler method.
                 // If it decides to generate a BlockTransformEvent, it will be stored in
@@ -148,12 +147,7 @@ public class BlockTransformListener implements Listener {
   private void finishCauseEvent(Event causeEvent) {
     List<BlockTransformEvent> wrapperEvents = currentEvents.removeAll(causeEvent);
 
-    // A few of the event handlers need to do some post-processing after the wrapper event returns.
-    if (causeEvent instanceof EntityExplodeEvent) {
-      finishEntityExplode((EntityExplodeEvent) causeEvent, wrapperEvents);
-    } else if (causeEvent instanceof BlockPistonEvent) {
-      finishPistonMove((BlockPistonEvent) causeEvent, wrapperEvents);
-    }
+    finishCauseEvent(causeEvent, wrapperEvents);
 
     for (BlockTransformEvent bte : wrapperEvents) {
       processCancelMessage(bte);
@@ -162,6 +156,21 @@ public class BlockTransformListener implements Listener {
     for (BlockTransformEvent bte : wrapperEvents) {
       processBlockDrops(bte);
     }
+  }
+
+  // A few of the event handlers need to do some post-processing after the wrapper events return.
+  protected void finishCauseEvent(Event causeEvent, List<BlockTransformEvent> wrapperEvents) {
+    if (causeEvent instanceof EntityExplodeEvent entityExplodeEvent)
+      removeCancelled(entityExplodeEvent.blockList(), wrapperEvents, Function.identity());
+
+    if (causeEvent instanceof BlockExplodeEvent blockExplodeEvent)
+      removeCancelled(blockExplodeEvent.blockList(), wrapperEvents, Function.identity());
+
+    if (causeEvent instanceof StructureGrowEvent structureGrowEvent)
+      removeCancelled(structureGrowEvent.getBlocks(), wrapperEvents, BlockState::getBlock);
+
+    if (causeEvent instanceof BlockPistonEvent blockPistonEvent)
+      finishPistonMove(blockPistonEvent, wrapperEvents);
   }
 
   private void handleDoor(BlockTransformEvent event, Door door) {
@@ -181,7 +190,7 @@ public class BlockTransformListener implements Listener {
     callEvent(toCall, true);
   }
 
-  private void callEvent(final BlockTransformEvent event, boolean checked) {
+  protected void callEvent(final BlockTransformEvent event, boolean checked) {
     if (!checked) {
       org.bukkit.material.MaterialData oldData = event.getOldState().getData();
       org.bukkit.material.MaterialData newData = event.getNewState().getData();
@@ -196,18 +205,18 @@ public class BlockTransformListener implements Listener {
     currentEvents.put(event.getCause(), event);
   }
 
-  private void callEvent(final BlockTransformEvent event) {
+  protected void callEvent(final BlockTransformEvent event) {
     callEvent(event, false);
   }
 
-  private BlockTransformEvent callEvent(
+  protected BlockTransformEvent callEvent(
       Event cause, BlockState oldState, BlockState newState, @Nullable Player player) {
     MatchPlayer matchPlayer = PGM.get().getMatchManager().getPlayer(player);
     return callEvent(
         cause, oldState, newState, matchPlayer == null ? null : matchPlayer.getState());
   }
 
-  private BlockTransformEvent callEvent(
+  protected BlockTransformEvent callEvent(
       Event cause, BlockState oldState, BlockState newState, @Nullable MatchPlayerState player) {
     BlockTransformEvent event;
     if (player == null) {
@@ -253,8 +262,10 @@ public class BlockTransformListener implements Listener {
   @EventWrapper
   public void onStructureGrow(final StructureGrowEvent event) {
     for (BlockState block : event.getBlocks()) {
-      this.callEvent(
-          new BlockTransformEvent(event, block.getLocation().getBlock().getState(), block));
+      BlockTransformEvent transform =
+          new BlockTransformEvent(event, block.getLocation().getBlock().getState(), block);
+      transform.setPropagate(false);
+      callEvent(transform);
     }
   }
 
@@ -390,12 +401,23 @@ public class BlockTransformListener implements Listener {
     }
   }
 
-  private void finishEntityExplode(
-      EntityExplodeEvent causeEvent, Collection<BlockTransformEvent> wrapperEvents) {
-    // Remove blocks from the explosion if their wrapper event was cancelled
+  @EventWrapper
+  public void onBlockExplode(final BlockExplodeEvent event) {
+    for (Block block : event.blockList()) {
+      // Don't cancel the explosion when individual blocks are cancelled
+      BlockTransformEvent transform =
+          new BlockTransformEvent(event, block.getState(), BlockStates.toAir(block));
+      transform.setPropagate(false);
+      callEvent(transform);
+    }
+  }
+
+  protected <T> void removeCancelled(
+      List<T> elements, Collection<BlockTransformEvent> wrapperEvents, Function<T, Block> toBlock) {
     for (BlockTransformEvent wrapper : wrapperEvents) {
       if (wrapper.isCancelled()) {
-        causeEvent.blockList().remove(wrapper.getOldState().getBlock());
+        Block block = wrapper.getOldState().getBlock();
+        elements.removeIf(element -> toBlock.apply(element).equals(block));
       }
     }
   }
@@ -425,6 +447,12 @@ public class BlockTransformListener implements Listener {
   public void onBlockFade(final BlockFadeEvent event) {
     BlockState state = event.getBlock().getState();
     this.callEvent(new BlockTransformEvent(event, state, BlockStates.toAir(state)));
+  }
+
+  @EventWrapper
+  public void onLeavesDecay(final LeavesDecayEvent event) {
+    this.callEvent(new BlockTransformEvent(
+        event, event.getBlock().getState(), BlockStates.toAir(event.getBlock())));
   }
 
   // -----------------------
@@ -551,7 +579,7 @@ public class BlockTransformListener implements Listener {
         event, event.getBlock().getState(), BlockStates.toAir(event.getBlock().getState())));
   }
 
-  private static Material getTrampledType(Material newType) {
+  private static @Nullable Material getTrampledType(Material newType) {
     if (newType == Materials.SOIL) return Material.DIRT;
     return null;
   }
@@ -572,12 +600,13 @@ public class BlockTransformListener implements Listener {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public void processBlockDrops(BlockTransformEvent event) {
     // If the event has been altered with custom block drops/replacement,
     // call on the BlockDropsMatchModule to handle this. We do this here
     // because doBlockDrops will cancel the event, and we don't want any
     // other listeners to think the event is cancelled when it isn't.
-    if (event != null && !event.isCancelled() && event.getDrops() != null) {
+    if (!event.isCancelled() && event.getDrops() != null) {
       Match match = PGM.get().getMatchManager().getMatch(event.getWorld());
       if (match != null) {
         BlockDropsMatchModule bdmm = match.getModule(BlockDropsMatchModule.class);

--- a/core/src/main/java/tc/oc/pgm/map/WorldInfoImpl.java
+++ b/core/src/main/java/tc/oc/pgm/map/WorldInfoImpl.java
@@ -16,9 +16,10 @@ public class WorldInfoImpl implements WorldInfo {
   private final long seed; // 0 means random every time
   private final boolean terrain;
   private final World.Environment environment;
+  private final boolean initialPhysics;
 
   public WorldInfoImpl() {
-    this(0L, false, World.Environment.NORMAL);
+    this(0L, false, World.Environment.NORMAL, false);
   }
 
   public WorldInfoImpl(Element element) throws InvalidXMLException {
@@ -28,13 +29,16 @@ public class WorldInfoImpl implements WorldInfo {
         XMLUtils.parseEnum(
             Node.fromLastChildOrAttr(element, "environment"),
             World.Environment.class,
-            World.Environment.NORMAL));
+            World.Environment.NORMAL),
+        XMLUtils.parseBoolean(element.getAttribute("pre-match-physics"), false));
   }
 
-  private WorldInfoImpl(long seed, boolean terrain, World.Environment environment) {
+  private WorldInfoImpl(
+      long seed, boolean terrain, World.Environment environment, boolean initialPhysics) {
     this.seed = seed;
     this.terrain = terrain;
     this.environment = environment;
+    this.initialPhysics = initialPhysics;
   }
 
   @Override
@@ -50,6 +54,11 @@ public class WorldInfoImpl implements WorldInfo {
   @Override
   public World.Environment getEnvironment() {
     return environment;
+  }
+
+  @Override
+  public boolean initialPhysics() {
+    return initialPhysics;
   }
 
   private static long parseSeed(@Nullable String value) {

--- a/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchFactoryImpl.java
@@ -225,7 +225,7 @@ public class MatchFactoryImpl implements MatchFactory, Callable<Match> {
       if (dir == null) {
         dir = new File(
             PGM.get().getServer().getWorldContainer().getAbsoluteFile(),
-            "match-" + counter.getAndIncrement());
+            Match.WORLD_PREFIX + counter.getAndIncrement());
       }
       return dir;
     }

--- a/core/src/main/java/tc/oc/pgm/match/MatchManagerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchManagerImpl.java
@@ -101,14 +101,13 @@ public class MatchManagerImpl implements MatchManager, Listener {
   }
 
   private void onNonMatchUnload(World world) {
-    final String name = world.getName();
-    if (name.startsWith("match")) return;
+    if (Match.isMatchWorld(world)) return;
 
     NMS_HACKS.resetDimension(world);
     NMS_HACKS.cleanupWorld(world);
 
-    if (PGM.get().getServer().unloadWorld(name, false)) {
-      logger.info("Unloaded non-match " + name);
+    if (PGM.get().getServer().unloadWorld(world, false)) {
+      logger.info("Unloaded non-match " + world.getName());
     }
   }
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
@@ -8,6 +8,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.spigotmc.SpigotConfig;
 import tc.oc.pgm.platform.modern.listeners.DispenserListener;
+import tc.oc.pgm.platform.modern.listeners.ModernBlockPhysicsListener;
+import tc.oc.pgm.platform.modern.listeners.ModernBlockTransformListener;
 import tc.oc.pgm.platform.modern.listeners.ModernListener;
 import tc.oc.pgm.platform.modern.listeners.PlayerTracker;
 import tc.oc.pgm.platform.modern.listeners.RecipeUnlocker;
@@ -36,8 +38,11 @@ public class ModernPlatform implements Platform.Manifest {
             tracker = new PlayerTracker(),
             new RecipeUnlocker(),
             new SpawnEggUseListener(),
-            new TntListener())
+            new TntListener(),
+            new ModernBlockPhysicsListener())
         .forEach(l -> Bukkit.getServer().getPluginManager().registerEvents(l, plugin));
+
+    new ModernBlockTransformListener(plugin).registerEvents();
 
     packetManipulations = new PacketManipulations(tracker);
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernBlockPhysicsListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernBlockPhysicsListener.java
@@ -1,0 +1,89 @@
+package tc.oc.pgm.platform.modern.listeners;
+
+import com.destroystokyo.paper.event.block.BlockDestroyEvent;
+import com.destroystokyo.paper.event.server.ServerTickEndEvent;
+import java.util.HashSet;
+import java.util.Set;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.state.BlockState;
+import org.bukkit.Chunk;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.block.data.CraftBlockData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.FluidLevelChangeEvent;
+import org.bukkit.event.world.ChunkLoadEvent;
+import org.jspecify.annotations.NullMarked;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.listeners.BlockPhysicsListener;
+
+@NullMarked
+public class ModernBlockPhysicsListener extends BlockPhysicsListener {
+  private final Set<Chunk> loadingChunks = new HashSet<>();
+
+  @EventHandler(priority = EventPriority.LOWEST)
+  public void onFluidLevelChange(FluidLevelChangeEvent event) {
+    if (!allowPhysics(event.getBlock().getWorld())) event.setCancelled(true);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onChunkLoad(ChunkLoadEvent event) {
+    if (Match.isMatchWorld(event.getWorld())) {
+      loadingChunks.add(event.getChunk());
+    }
+  }
+
+  @EventHandler
+  public void onTickEnd(ServerTickEndEvent event) {
+    loadingChunks.removeIf(chunk -> chunk.getLoadLevel() != Chunk.LoadLevel.BORDER);
+  }
+
+  @EventHandler(priority = EventPriority.LOWEST)
+  public void onBlockDestroy(BlockDestroyEvent event) {
+    Block block = event.getBlock();
+    boolean loading = !loadingChunks.isEmpty() && loadingChunks.contains(block.getChunk());
+
+    if (!loading && allowPhysics(block.getWorld())) return;
+
+    event.setCancelled(true);
+    updateShapeWithoutDestroying(block);
+  }
+
+  /**
+   * Paper calls BlockDestroyEvent for indirect block breakage. We want to suppress this as that can
+   * include "block physics", but legacy maps have certain blocks in unsupported states that do
+   * break when upgraded. This includes, notably, redstone lines to indicate void regions.
+   * Cancelling BlockDestroyEvent maintains them, but block connections are not maintained in the
+   * world upgrade. This method is called after cancelling the event to ensure block connections are
+   * updated without the block actually breaking. We do the same for chunks that are not fully
+   * loaded.
+   */
+  private void updateShapeWithoutDestroying(Block block) {
+    ServerLevel level = ((CraftWorld) block.getWorld()).getHandle();
+    BlockPos pos = new BlockPos(block.getX(), block.getY(), block.getZ());
+    BlockState state = level.getBlockState(pos);
+    BlockState updated = state;
+
+    for (Direction direction : Direction.values()) {
+      BlockPos neighborPos = pos.relative(direction);
+      BlockState candidate = updated.updateShape(
+          level,
+          level,
+          pos,
+          direction,
+          neighborPos,
+          level.getBlockState(neighborPos),
+          level.getRandom());
+      if (!candidate.isAir()) {
+        updated = candidate;
+      }
+    }
+
+    if (updated != state) {
+      block.setBlockData(CraftBlockData.createData(updated), false);
+    }
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernBlockTransformListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernBlockTransformListener.java
@@ -1,0 +1,185 @@
+package tc.oc.pgm.platform.modern.listeners;
+
+import java.util.List;
+import org.bukkit.Material;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Waterlogged;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.BlockFertilizeEvent;
+import org.bukkit.event.block.CauldronLevelChangeEvent;
+import org.bukkit.event.block.FluidLevelChangeEvent;
+import org.bukkit.event.block.MoistureChangeEvent;
+import org.bukkit.event.block.SpongeAbsorbEvent;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.bukkit.event.world.StructureGrowEvent;
+import org.bukkit.plugin.Plugin;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.event.BlockTransformEvent;
+import tc.oc.pgm.listeners.BlockTransformListener;
+import tc.oc.pgm.platform.modern.material.ModernBlockData;
+import tc.oc.pgm.tracker.Trackers;
+import tc.oc.pgm.util.block.BlockStates;
+import tc.oc.pgm.util.material.MaterialMatcher;
+
+@NullMarked
+public class ModernBlockTransformListener extends BlockTransformListener {
+
+  public ModernBlockTransformListener(Plugin plugin) {
+    super(plugin);
+  }
+
+  private static final MaterialMatcher CAULDRON =
+      MaterialMatcher.of(m -> m.name().endsWith("CAULDRON"));
+
+  @Override
+  protected void finishCauseEvent(Event causeEvent, List<BlockTransformEvent> wrapperEvents) {
+    super.finishCauseEvent(causeEvent, wrapperEvents);
+
+    if (causeEvent instanceof BlockExplodeEvent blockExplodeEvent) {
+      BlockState explodedBlockState = blockExplodeEvent.getExplodedBlockState();
+      for (BlockTransformEvent wrapper : wrapperEvents) {
+        if (wrapper.isCancelled() && wrapper.getOldState() == explodedBlockState) {
+          explodedBlockState.update(true, false);
+          break;
+        }
+      }
+    }
+
+    if (causeEvent instanceof SpongeAbsorbEvent sponge)
+      removeCancelled(sponge.getBlocks(), wrapperEvents, BlockState::getBlock);
+
+    if (causeEvent instanceof BlockFertilizeEvent fertilize)
+      removeCancelled(fertilize.getBlocks(), wrapperEvents, BlockState::getBlock);
+  }
+
+  @Override
+  @EventWrapper
+  public void onPlayerBucketEmpty(final PlayerBucketEmptyEvent event) {
+    // Cauldrons are handled by onCauldronLevelChange
+    if (CAULDRON.matches(event.getBlock().getType())) return;
+
+    Material contents =
+        switch (event.getBucket()) {
+          case LAVA_BUCKET -> Material.LAVA;
+          case POWDER_SNOW_BUCKET -> Material.POWDER_SNOW;
+          default -> Material.WATER;
+        };
+
+    BlockState oldBlock = event.getBlock().getState();
+    BlockState waterloggedBlock =
+        contents == Material.WATER ? waterloggedState(oldBlock, true) : null;
+    BlockState newBlock = waterloggedBlock != null
+        ? waterloggedBlock
+        : BlockStates.cloneWithMaterial(event.getBlock(), contents);
+    callEvent(event, oldBlock, newBlock, event.getPlayer());
+  }
+
+  private @Nullable BlockState waterloggedState(BlockState state, boolean waterlogged) {
+    BlockData data = state.getBlockData();
+    if (!(data instanceof Waterlogged oldData)) {
+      return null;
+    }
+    if (oldData.isWaterlogged() == waterlogged) {
+      return null;
+    }
+
+    BlockState newState = state.getBlock().getState();
+    Waterlogged newData = (Waterlogged) oldData.clone();
+    newData.setWaterlogged(waterlogged);
+    newState.setBlockData(newData);
+    return newState;
+  }
+
+  @Override
+  @EventWrapper
+  public void onStructureGrow(final StructureGrowEvent event) {
+    // Bonemeal is handled by onBlockFertilize
+    if (!event.isFromBonemeal()) {
+      super.onStructureGrow(event);
+    }
+  }
+
+  @Override
+  @EventWrapper
+  public void onPlayerBucketFill(final PlayerBucketFillEvent event) {
+    if (CAULDRON.matches(event.getBlock().getType())) return;
+
+    BlockState state = event.getBlock().getState();
+    BlockState newState = waterloggedState(state, false);
+    if (newState != null) {
+      callEvent(event, state, newState, event.getPlayer());
+      return;
+    }
+
+    // Don't count milking cows as a block transform
+    boolean bucketFillSource =
+        switch (state.getType()) {
+          case WATER, LAVA, POWDER_SNOW -> true;
+          default -> false;
+        };
+    if (!bucketFillSource) return;
+
+    callEvent(event, state, BlockStates.toAir(state), event.getPlayer());
+  }
+
+  @Override
+  @EventWrapper
+  public void onBlockExplode(final BlockExplodeEvent event) {
+    BlockState oldState = event.getExplodedBlockState();
+    BlockTransformEvent transform =
+        new BlockTransformEvent(event, oldState, BlockStates.toAir(oldState));
+    transform.setPropagate(false);
+    callEvent(transform);
+
+    super.onBlockExplode(event);
+  }
+
+  @EventWrapper
+  public void onFluidLevelChange(final FluidLevelChangeEvent event) {
+    BlockState newState = event.getBlock().getState();
+    new ModernBlockData(event.getNewData()).applyTo(newState);
+    callEvent(new BlockTransformEvent(event, event.getBlock().getState(), newState));
+  }
+
+  @EventWrapper
+  public void onCauldronLevelChange(final CauldronLevelChangeEvent event) {
+    if (event.getEntity() instanceof Player player) {
+      callEvent(event, event.getBlock().getState(), event.getNewState(), player);
+    } else {
+      var entity = event.getEntity();
+      callEvent(
+          event,
+          event.getBlock().getState(),
+          event.getNewState(),
+          entity == null ? null : Trackers.getOwner(entity));
+    }
+  }
+
+  @EventWrapper
+  public void onSpongeAbsorb(final SpongeAbsorbEvent event) {
+    for (BlockState newState : event.getBlocks()) {
+      BlockTransformEvent transform =
+          new BlockTransformEvent(event, newState.getBlock().getState(), newState);
+      transform.setPropagate(false);
+      callEvent(transform);
+    }
+  }
+
+  @EventWrapper
+  public void onMoistureChange(final MoistureChangeEvent event) {
+    callEvent(new BlockTransformEvent(event, event.getBlock().getState(), event.getNewState()));
+  }
+
+  @EventWrapper
+  public void onBlockFertilize(final BlockFertilizeEvent event) {
+    for (BlockState newState : event.getBlocks()) {
+      callEvent(event, newState.getBlock().getState(), newState, event.getPlayer())
+          .setPropagate(false);
+    }
+  }
+}

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SportPaperPlatform.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/SportPaperPlatform.java
@@ -3,8 +3,11 @@ package tc.oc.pgm.platform.sportpaper;
 import static tc.oc.pgm.util.platform.Supports.Priority.HIGHEST;
 import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
 
+import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
+import tc.oc.pgm.listeners.BlockPhysicsListener;
+import tc.oc.pgm.listeners.BlockTransformListener;
 import tc.oc.pgm.platform.sportpaper.material.ModernMaterialNames;
 import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.platform.Supports;
@@ -19,6 +22,9 @@ public class SportPaperPlatform implements Platform.Manifest {
 
   @Override
   public void onEnable(Plugin plugin) {
-    Bukkit.getServer().getPluginManager().registerEvents(new SportPaperListener(), plugin);
+    List.of(new SportPaperListener(), new BlockPhysicsListener())
+        .forEach(l -> Bukkit.getPluginManager().registerEvents(l, plugin));
+
+    new BlockTransformListener(plugin).registerEvents();
   }
 }


### PR DESCRIPTION
Permits for platform-specific `BlockTransformListener` extends where events that are unique to specific platforms can be also be listened on. Additionally adds listeners for  `BlockExplodeEvent` and `LeavesDecayEvent` for both modern and SportPaper.

Also implements `pre-match-physics` from ProjectAres with a default of false as was the case in ProjectAres, fixing things like water flowing in undesirable scenarios in legacy maps on the modern platform (covered by `BlockFromToEvent`). Additionally we cancel `BlockDestroyEvent` on modern when pre-match physics is disabled to avoid legacy maps with unsupported blocks like redstone wire from breaking, but we update to block to maintain its correct block connections.