### PR TITLE
Implement variable duration configs

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -156,10 +156,9 @@ public final class PGMConfig implements Config {
 
     this.mapSourceFactories = new ArrayList<>();
 
-    for (var repo : config.getList("map.repositories")) {
-      if (repo instanceof String uri)
-        registerRemoteMapSource(mapSourceFactories, Map.of("uri", uri));
-      else if (repo instanceof Map<?, ?> map) registerRemoteMapSource(mapSourceFactories, map);
+    for (var repo : config.getList("map.repositories", List.of())) {
+      if (repo instanceof String uri) mapSourceFactories.add(parseGit(Map.of("uri", uri)));
+      else if (repo instanceof Map<?, ?> map) mapSourceFactories.add(parseGit(map));
     }
 
     for (String folder : new TreeSet<>(config.getStringList("map.folders"))) {
@@ -258,8 +257,7 @@ public final class PGMConfig implements Config {
   public static final Map<?, ?> DEFAULT_REMOTE_REPO =
       ImmutableMap.of("uri", "https://github.com/PGMDev/Maps", "path", "default-maps");
 
-  public static void registerRemoteMapSource(
-      List<MapSourceFactory> mapSources, Map<?, ?> repository) {
+  public static GitMapSourceFactory parseGit(Map<?, ?> repository) {
     final URI uri = parseUri(String.valueOf(repository.get("uri")));
 
     String branch = String.valueOf(repository.get("branch"));
@@ -286,7 +284,7 @@ public final class PGMConfig implements Config {
           .stream().map(Object::toString).map(Paths::get).collect(Collectors.toList());
     }
 
-    mapSources.add(new GitMapSourceFactory(base, children, uri, branch));
+    return new GitMapSourceFactory(base, children, uri, branch);
   }
 
   // TODO: Can be removed after 1.0 release

--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -41,7 +40,9 @@ import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.Config;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.Permissions;
+import tc.oc.pgm.api.VariableDuration;
 import tc.oc.pgm.api.map.factory.MapSourceFactory;
+import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.map.source.GitMapSourceFactory;
 import tc.oc.pgm.map.source.PathMapSourceFactory;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
@@ -67,9 +68,10 @@ public final class PGMConfig implements Config {
   private final boolean enforceDevPhase;
 
   // countdown.*
-  private final Duration startTime;
+  private final VariableDuration startTime;
   private final Duration huddleTime;
-  private final Duration cycleTime;
+  private final VariableDuration cycleTime;
+  private final VariableDuration preloadTime;
   private final Duration restartTime;
 
   // restart.*
@@ -105,7 +107,7 @@ public final class PGMConfig implements Config {
   private final boolean showFireworks;
   private final boolean participantsSeeObservers;
   private final boolean verboseStats;
-  private final Duration statsShowAfter;
+  private final VariableDuration statsShowAfter;
   private final boolean statsShowBest;
   private final boolean statsShowOwn;
   private final int verboseItemSlot;
@@ -152,20 +154,15 @@ public final class PGMConfig implements Config {
     final String motd = config.getString("motd");
     this.motd = motd == null || motd.isEmpty() ? null : parseComponentLegacy(motd);
 
-    this.mapSourceFactories = new LinkedList<>();
+    this.mapSourceFactories = new ArrayList<>();
 
-    final TreeSet<String> folders = new TreeSet<>(config.getStringList("map.folders"));
-    final List<Map<?, ?>> repositories = new LinkedList<>(config.getMapList("map.repositories"));
-
-    for (String uri : config.getStringList("map.repositories")) {
-      repositories.add(ImmutableMap.of("uri", uri));
+    for (var repo : config.getList("map.repositories")) {
+      if (repo instanceof String uri)
+        registerRemoteMapSource(mapSourceFactories, Map.of("uri", uri));
+      else if (repo instanceof Map<?, ?> map) registerRemoteMapSource(mapSourceFactories, map);
     }
 
-    for (Map<?, ?> repository : repositories) {
-      registerRemoteMapSource(mapSourceFactories, repository);
-    }
-
-    for (String folder : folders) {
+    for (String folder : new TreeSet<>(config.getStringList("map.folders"))) {
       this.mapSourceFactories.add(new PathMapSourceFactory(Paths.get(folder)));
     }
 
@@ -174,9 +171,13 @@ public final class PGMConfig implements Config {
     this.showUnusedXml = parseBoolean(config.getString("map.show-unused-xml", "true"));
     this.enforceDevPhase = parseBoolean(config.getString("map.enforce-dev-phase", "false"));
 
-    this.startTime = parseDuration(config.getString("countdown.start", "30s"));
+    this.startTime = VariableDuration.parse(config.get("countdown.start"), "30s");
     this.huddleTime = parseDuration(config.getString("countdown.huddle", "0s"));
-    this.cycleTime = parseDuration(config.getString("countdown.cycle", "30s"));
+    this.cycleTime = VariableDuration.parse(config.get("countdown.cycle"), "30s");
+    this.preloadTime = VariableDuration.parse(
+        config.get("countdown.preload"),
+        // Fallback on the now legacy experiments
+        config.getString("experiments.match-preload-seconds", "0"));
     this.restartTime = parseDuration(config.getString("countdown.restart", "30s"));
 
     this.uptimeLimit = parseDuration(config.getString("restart.uptime", "1d"));
@@ -217,7 +218,7 @@ public final class PGMConfig implements Config {
     this.flagBeams = parseBoolean(config.getString("ui.flag-beams", "false"));
 
     this.verboseStats = parseBoolean(config.getString("stats.verbose", "true"));
-    this.statsShowAfter = parseDuration(config.getString("stats.show-after", "6s"));
+    this.statsShowAfter = VariableDuration.parse(config.get("stats.show-after"), "6s");
     this.statsShowBest = parseBoolean(config.getString("stats.show-best", "true"));
     this.statsShowOwn = parseBoolean(config.getString("stats.show-own", "true"));
     this.verboseItemSlot = parseInteger(config.getString("stats.item-slot", "7"));
@@ -507,7 +508,12 @@ public final class PGMConfig implements Config {
 
   @Override
   public Duration getStartTime() {
-    return startTime;
+    return startTime.getDefault();
+  }
+
+  @Override
+  public Duration getStartTime(Match match) {
+    return startTime.getDuration(match);
   }
 
   @Override
@@ -517,7 +523,17 @@ public final class PGMConfig implements Config {
 
   @Override
   public Duration getCycleTime() {
-    return cycleTime;
+    return cycleTime.getDefault();
+  }
+
+  @Override
+  public Duration getCycleTime(Match match) {
+    return cycleTime.getDuration(match);
+  }
+
+  @Override
+  public Duration getPreloadTime(Match match) {
+    return preloadTime.getDuration(match);
   }
 
   @Override
@@ -656,7 +672,12 @@ public final class PGMConfig implements Config {
 
   @Override
   public Duration showStatsAfter() {
-    return statsShowAfter;
+    return statsShowAfter.getDefault();
+  }
+
+  @Override
+  public Duration showStatsAfter(Match match) {
+    return statsShowAfter.getDuration(match);
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -178,7 +178,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
 
     if (!loadInitialMaps()) {
       logger.warning("No maps found, adding default repository as a fallback.");
-      PGMConfig.registerRemoteMapSource(mapSourceFactories, PGMConfig.DEFAULT_REMOTE_REPO);
+      mapSourceFactories.add(PGMConfig.parseGit(PGMConfig.DEFAULT_REMOTE_REPO));
       if (!loadInitialMaps()) {
         logger.severe("No maps were loaded in time, PGM will be disabled");
         getServer().getPluginManager().disablePlugin(this);

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -18,6 +18,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.permissions.Permission;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.map.factory.MapSourceFactory;
+import tc.oc.pgm.api.match.Match;
 
 /** A configuration for server owners to modify {@link PGM}. */
 public interface Config {
@@ -83,6 +84,14 @@ public interface Config {
   Duration getStartTime();
 
   /**
+   * Gets a duration to wait before starting a match.
+   *
+   * @param match The match.
+   * @return A duration.
+   */
+  Duration getStartTime(Match match);
+
+  /**
    * Gets a duration to give teams to "strategize" before the match starts.
    *
    * @return A duration, if non-positive or null then skips this phase.
@@ -95,6 +104,22 @@ public interface Config {
    * @return A duration, if zero then cycles immediately, if negative does not auto-cycle.
    */
   Duration getCycleTime();
+
+  /**
+   * Gets a duration to wait before cycling to another match.
+   *
+   * @param match The match.
+   * @return A duration.
+   */
+  Duration getCycleTime(Match match);
+
+  /**
+   * Gets how much earlier to start preloading the next match.
+   *
+   * @param match The match.
+   * @return A duration.
+   */
+  Duration getPreloadTime(Match match);
 
   /**
    * Gets a duration to wait before restarting the server.
@@ -269,6 +294,12 @@ public interface Config {
 
   /** @return How many ticks should wait until showing stats */
   Duration showStatsAfter();
+
+  /**
+   * @param match The match.
+   * @return How many ticks should wait until showing stats
+   */
+  Duration showStatsAfter(Match match);
 
   /** @return If stats on match end should shown high scores */
   boolean showBestStats();

--- a/core/src/main/java/tc/oc/pgm/api/VariableDuration.java
+++ b/core/src/main/java/tc/oc/pgm/api/VariableDuration.java
@@ -1,0 +1,53 @@
+package tc.oc.pgm.api;
+
+import static tc.oc.pgm.util.text.TextParser.parseDuration;
+
+import java.time.Duration;
+import org.bukkit.configuration.ConfigurationSection;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.util.VariableDurationImpl;
+import tc.oc.pgm.util.text.TextException;
+
+/** A duration that can vary based on the number of players and the length of the match. */
+public interface VariableDuration {
+  /**
+   * Gets the duration for the given match.
+   *
+   * @param match The match.
+   * @return The duration.
+   */
+  Duration getDuration(Match match);
+
+  /**
+   * Gets the default duration.
+   *
+   * @return The default duration.
+   */
+  Duration getDefault();
+
+  /**
+   * Parses a variable duration from the given object.
+   *
+   * @param object The object to parse (String or ConfigurationSection).
+   * @param def The default duration string if the object is null.
+   * @return The parsed variable duration.
+   * @throws TextException If the object is not a valid variable duration.
+   */
+  static VariableDuration parse(Object object, String def) throws TextException {
+    return switch (object) {
+      case ConfigurationSection cs -> VariableDurationImpl.parse(cs);
+      case String str -> VariableDurationImpl.of(parseDuration(str));
+      case null, default -> VariableDurationImpl.of(parseDuration(def));
+    };
+  }
+
+  /**
+   * Creates a variable duration that always returns the same value.
+   *
+   * @param duration The duration.
+   * @return The variable duration.
+   */
+  static VariableDuration constant(Duration duration) {
+    return VariableDurationImpl.of(duration);
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/api/VariableDuration.java
+++ b/core/src/main/java/tc/oc/pgm/api/VariableDuration.java
@@ -36,8 +36,8 @@ public interface VariableDuration {
   static VariableDuration parse(Object object, String def) throws TextException {
     return switch (object) {
       case ConfigurationSection cs -> VariableDurationImpl.parse(cs);
-      case String str -> VariableDurationImpl.of(parseDuration(str));
-      case null, default -> VariableDurationImpl.of(parseDuration(def));
+      case null -> VariableDurationImpl.of(parseDuration(def));
+      default -> VariableDurationImpl.of(parseDuration(object.toString()));
     };
   }
 

--- a/core/src/main/java/tc/oc/pgm/api/map/MapOrder.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapOrder.java
@@ -5,8 +5,8 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 
 /**
- * A provider of {@link MapInfo} ordering order. It is responsible for providing the next map the
- * server should play.
+ * A provider of {@link MapInfo} ordering. It is responsible for providing the next map the server
+ * should play.
  */
 public interface MapOrder {
 
@@ -40,6 +40,16 @@ public interface MapOrder {
    */
   default Duration getCycleTime() {
     return PGM.get().getConfiguration().getCycleTime();
+  }
+
+  /**
+   * Returns the duration used for cycles in {@link tc.oc.pgm.cycle.CycleMatchModule}.
+   *
+   * @param match The match.
+   * @return The cycle duration
+   */
+  default Duration getCycleTime(Match match) {
+    return PGM.get().getConfiguration().getCycleTime(match);
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleCountdown.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleCountdown.java
@@ -3,7 +3,6 @@ package tc.oc.pgm.cycle;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 
-import com.google.common.collect.Range;
 import java.time.Duration;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
@@ -15,33 +14,19 @@ import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.factory.MatchFactory;
 import tc.oc.pgm.countdowns.MatchCountdown;
-import tc.oc.pgm.util.text.TextException;
-import tc.oc.pgm.util.text.TextParser;
 
 public class CycleCountdown extends MatchCountdown {
 
-  // Number of seconds before a cycle occurs to start loading the next match.
+  // How early to early-load the next match.
   // This eases stress on the main thread when handling lots of players.
-  private int preloadSecs;
+  private final Duration preload;
 
   private MapInfo nextMap;
   private MatchFactory nextMatch;
 
   public CycleCountdown(Match match) {
     super(match, BossBar.Color.BLUE);
-
-    try {
-      this.preloadSecs =
-          TextParser.parseInteger(
-              PGM.get()
-                  .getConfiguration()
-                  .getExperiments()
-                  .getOrDefault("match-preload-seconds", "")
-                  .toString(),
-              Range.atLeast(0));
-    } catch (TextException t) {
-      // No-op, since this is experimental
-    }
+    this.preload = PGM.get().getConfiguration().getPreloadTime(match);
   }
 
   @Override
@@ -54,10 +39,9 @@ public class CycleCountdown extends MatchCountdown {
           mapName != null ? translatable("map.cycledMap", mapName) : translatable("map.cycled");
     } else {
       Component secs = secondsRemaining(NamedTextColor.DARK_RED);
-      cycleComponent =
-          mapName != null
-              ? translatable("map.cycleMap", mapName, secs)
-              : translatable("map.cycle", secs);
+      cycleComponent = mapName != null
+          ? translatable("map.cycleMap", mapName, secs)
+          : translatable("map.cycle", secs);
     }
 
     return cycleComponent.color(NamedTextColor.DARK_AQUA);
@@ -65,7 +49,7 @@ public class CycleCountdown extends MatchCountdown {
 
   private void checkSetNext() {
     final MapOrder mapOrder = PGM.get().getMapOrder();
-    if (remaining.getSeconds() <= preloadSecs) {
+    if (remaining.compareTo(preload) <= 0) {
       if (nextMatch != null) return;
 
       nextMap = mapOrder.popNextMap();

--- a/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/cycle/CycleMatchModule.java
@@ -34,7 +34,7 @@ public class CycleMatchModule implements MatchModule, Listener {
   }
 
   public void startCountdown(@Nullable Duration duration) {
-    if (duration == null) duration = PGM.get().getConfiguration().getCycleTime();
+    if (duration == null) duration = PGM.get().getConfiguration().getCycleTime(match);
     // In case the cycle config is set to -1 used to disable autocycle
     if (duration.isNegative()) duration = Duration.ofSeconds(30);
     match.finish();
@@ -61,7 +61,7 @@ public class CycleMatchModule implements MatchModule, Listener {
     mapOrder.matchEnded(match);
 
     if (!RestartManager.isQueued()) {
-      Duration duration = mapOrder.getCycleTime();
+      Duration duration = mapOrder.getCycleTime(match);
 
       if (!duration.isNegative()) {
         startCountdown(duration);

--- a/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -307,6 +307,15 @@ public class MapPoolManager implements MapOrder {
     return PGM.get().getConfiguration().getCycleTime();
   }
 
+  @Override
+  public Duration getCycleTime(Match match) {
+    Duration cycleTime;
+    if (activeMapPool != null && !(cycleTime = activeMapPool.getCycleTime(match)).isNegative()) {
+      return cycleTime;
+    }
+    return PGM.get().getConfiguration().getCycleTime(match);
+  }
+
   private boolean shouldRevert(Match match) {
     return match.getPlayers().stream()
             .noneMatch(mp -> mp.getBukkit().hasPermission(Permissions.STAFF))

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/MapPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/MapPool.java
@@ -1,11 +1,10 @@
 package tc.oc.pgm.rotation.pools;
 
-import static tc.oc.pgm.util.text.TextParser.parseDuration;
-
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import org.bukkit.configuration.ConfigurationSection;
+import tc.oc.pgm.api.VariableDuration;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapOrder;
 import tc.oc.pgm.api.match.Match;
@@ -20,7 +19,7 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
   protected final boolean enabled;
   protected final List<MapInfo> maps;
   protected final int players;
-  protected final Duration cycleTime;
+  protected final VariableDuration cycleTime;
 
   protected final boolean dynamic;
 
@@ -30,15 +29,14 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
       MapPoolManager manager,
       ConfigurationSection section,
       MapParser maps) {
-    this(
-        type,
-        name,
-        manager,
-        section.getBoolean("enabled"),
-        section.getInt("players"),
-        section.getBoolean("dynamic", true),
-        parseDuration(section.getString("cycle-time", "-1s")),
-        maps.getMaps());
+    this.type = type;
+    this.name = name;
+    this.manager = manager;
+    this.enabled = section.getBoolean("enabled");
+    this.players = section.getInt("players");
+    this.dynamic = section.getBoolean("dynamic", true);
+    this.cycleTime = VariableDuration.parse(section.get("cycle-time"), "-1s");
+    this.maps = Collections.unmodifiableList(maps.getMaps());
   }
 
   MapPool(
@@ -56,7 +54,7 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
     this.enabled = enabled;
     this.players = players;
     this.dynamic = dynamic;
-    this.cycleTime = cycleTime;
+    this.cycleTime = VariableDuration.constant(cycleTime);
     this.maps = Collections.unmodifiableList(maps);
   }
 
@@ -90,7 +88,12 @@ public abstract class MapPool implements MapOrder, Comparable<MapPool> {
 
   @Override
   public Duration getCycleTime() {
-    return cycleTime;
+    return cycleTime.getDefault();
+  }
+
+  @Override
+  public Duration getCycleTime(Match match) {
+    return cycleTime.getDuration(match);
   }
 
   /**

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
@@ -14,6 +14,7 @@ import net.objecthunter.exp4j.ExpressionContext;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.MemoryConfiguration;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.VariableDuration;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
@@ -33,6 +34,8 @@ public class VotingPool extends MapPool {
   // The algorithm used to pick the maps for next vote.
   public final MapVotePicker mapPicker;
 
+  private final VariableDuration pollDelay;
+
   // The current rating of maps. Eventually should be persisted elsewhere.
   private final Map<MapInfo, VoteData> mapScores;
 
@@ -47,6 +50,7 @@ public class VotingPool extends MapPool {
     super(type, name, manager, section, parser);
     this.constants = new VoteConstants(section, maps.size());
     this.mapPicker = MapVotePicker.of(manager, constants, section);
+    this.pollDelay = VariableDuration.parse(section.get("poll-delay"), "5s");
     this.mapScores = buildMapScores(parser::getWeight);
   }
 
@@ -76,6 +80,7 @@ public class VotingPool extends MapPool {
     super(type, name, manager, enabled, players, dynamic, cycleTime, maps);
     this.constants = new VoteConstants(new MemoryConfiguration(), maps.size());
     this.mapPicker = MapVotePicker.of(manager, constants, null);
+    this.pollDelay = VariableDuration.constant(Duration.ofSeconds(5));
     this.mapScores = buildMapScores(m -> 1);
   }
 
@@ -143,6 +148,7 @@ public class VotingPool extends MapPool {
   @Override
   public void matchEnded(Match match) {
     tickScores(match);
+    Duration delay = pollDelay.getDuration(match);
     match
         .getExecutor(MatchScope.LOADED)
         .schedule(
@@ -155,8 +161,8 @@ public class VotingPool extends MapPool {
               currentPoll = new MapPoll(
                   match, mapPicker.getMaps(match.getMap(), manager.getVoteOptions(), mapScores));
             },
-            5,
-            TimeUnit.SECONDS);
+            delay.toMillis(),
+            TimeUnit.MILLISECONDS);
   }
 
   public record VoteConstants(

--- a/core/src/main/java/tc/oc/pgm/start/StartMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/start/StartMatchModule.java
@@ -52,7 +52,7 @@ public class StartMatchModule implements MatchModule, Listener {
   private StartMatchModule(Match match) {
     this.match = match;
     this.unreadyBar = bossBar(space(), 1, BossBar.Color.RED, BossBar.Overlay.PROGRESS);
-    this.autoStart = !PGM.get().getConfiguration().getStartTime().isNegative();
+    this.autoStart = !PGM.get().getConfiguration().getStartTime(match).isNegative();
   }
 
   @Override
@@ -198,7 +198,7 @@ public class StartMatchModule implements MatchModule, Listener {
   private boolean startCountdown(
       @Nullable Duration duration, @Nullable Duration huddle, boolean force) {
     final Config config = PGM.get().getConfiguration();
-    if (duration == null) duration = config.getStartTime();
+    if (duration == null) duration = config.getStartTime(match);
     // In case the start config is set to -1 used to disable autostart
     if (duration.isNegative()) duration = Duration.ofSeconds(30);
     if (huddle == null) huddle = config.getHuddleTime();

--- a/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/stats/StatsMatchModule.java
@@ -95,7 +95,6 @@ public class StatsMatchModule implements MatchModule, Listener {
   private final List<StatType.OfFormula> formulaStats;
 
   private final boolean verboseStats = PGM.get().getConfiguration().showVerboseStats();
-  private final Duration showAfter = PGM.get().getConfiguration().showStatsAfter();
   private final boolean bestStats = PGM.get().getConfiguration().showBestStats();
   private final boolean ownStats = PGM.get().getConfiguration().showOwnStats();
   private final int verboseItemSlot = PGM.get().getConfiguration().getVerboseItemSlot();
@@ -265,7 +264,8 @@ public class StatsMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onMatchEnd(MatchFinishEvent event) {
-    if (allPlayerStats.isEmpty() || showAfter.isNegative()) return;
+    Duration delay = PGM.get().getConfiguration().showStatsAfter(match);
+    if (allPlayerStats.isEmpty() || delay.isNegative()) return;
 
     // Try to ensure that usernames for all relevant offline players will be loaded in the cache
     // when the inventory GUI is created. If usernames needs to be resolved using the mojang api
@@ -281,7 +281,7 @@ public class StatsMatchModule implements MatchModule, Listener {
         .getExecutor(MatchScope.LOADED)
         .schedule(
             () -> match.callEvent(new MatchStatsEvent(match, bestStats, ownStats)),
-            showAfter.toMillis(),
+            delay.toMillis(),
             TimeUnit.MILLISECONDS);
   }
 

--- a/core/src/main/java/tc/oc/pgm/util/VariableDurationImpl.java
+++ b/core/src/main/java/tc/oc/pgm/util/VariableDurationImpl.java
@@ -1,0 +1,68 @@
+package tc.oc.pgm.util;
+
+import static tc.oc.pgm.util.text.TextParser.parseDuration;
+
+import com.google.common.collect.Range;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import tc.oc.pgm.api.VariableDuration;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.util.range.Ranges;
+import tc.oc.pgm.util.text.TextException;
+import tc.oc.pgm.util.text.TextParser;
+
+public record VariableDurationImpl(Duration duration, List<Rule> rules)
+    implements VariableDuration {
+  public VariableDurationImpl {
+    rules = List.copyOf(rules);
+  }
+
+  private record Rule(Duration duration, Range<Integer> players, Range<Duration> matchLength) {}
+
+  @Override
+  public Duration getDuration(Match match) {
+    int onlinePlayers = Bukkit.getOnlinePlayers().size();
+    Duration matchLength = match.getDuration();
+    for (Rule rule : rules) {
+      if (rule.players.contains(onlinePlayers) && rule.matchLength.contains(matchLength)) {
+        return rule.duration;
+      }
+    }
+    return duration;
+  }
+
+  @Override
+  public Duration getDefault() {
+    return duration;
+  }
+
+  public static VariableDuration of(Duration duration) throws TextException {
+    return new VariableDurationImpl(duration, List.of());
+  }
+
+  public static VariableDuration parse(ConfigurationSection section) throws TextException {
+    Duration defaultDuration = parseDuration(section.getString("default", "30s"));
+    List<Rule> rules = new ArrayList<>();
+    for (var ruleMap : section.getMapList("rules")) {
+      var duration = parseDuration(String.valueOf(ruleMap.get("duration")));
+      var players = parseRange(ruleMap, "players", TextParser::parseInteger);
+      var matchLength = parseRange(ruleMap, "match-length", TextParser::parseDuration);
+      rules.add(new Rule(duration, players, matchLength));
+    }
+    return new VariableDurationImpl(defaultDuration, rules);
+  }
+
+  private static <T extends Comparable<T>> Range<T> parseRange(
+      Map<?, ?> cfg, String key, Function<String, T> parser) throws TextException {
+    var min = cfg.get("min-" + key);
+    var max = cfg.get("max-" + key);
+    return Ranges.createClosedRange(
+        min == null ? null : parser.apply(String.valueOf(min)),
+        max == null ? null : parser.apply(String.valueOf(max)));
+  }
+}

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -48,11 +48,21 @@ map:
 #  "1m5s" = 1 minute and 5 seconds
 #  "0s"   = immediately
 #  -1     = disabled
+# Additionally, some fields support variable durations, such as:
+# cycle:
+#   default: "30s"
+#   rules:
+#     - duration: "15s"
+#       max-players: 15
+#       max-match-length: "5m"
+#     - duration: "60s"
+#       min-match-length: "60m"
 #
 # See the examples above for how to format durations.
 countdown:
-  start: "30s"    # After a match cycles or /start
-  cycle: "30s"    # After a match ends or /cycle
+  start: "30s"    # After a match cycles or /start (supports variable durations)
+  cycle: "30s"    # After a match ends or /cycle (supports variable durations)
+  preload: "5s"   # Before a cycle ends to start loading the next match (supports variable durations)
   huddle: -1      # Before a match starts (only recommended for "ranked" matches)
   restart: "30s"  # After a restart countdown is queued or /qr
 
@@ -111,7 +121,7 @@ ui:
 # Changes how stats are shown.
 stats:
   verbose: true   # Enable more detailed stats?
-  show-after: 6s  # How long to wait after the match ends to show stats?
+  show-after: 6s  # How long to wait after the match ends to show stats? (supports variable durations)
   show-best: true # Should show best players stats?
   show-own: true  # Should show each players own stats?
   item-slot: 7    # In what slot should we place the verbose stats item?

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -23,8 +23,11 @@ pools:
     dynamic: true
     players: 1
     
-    # How long should a map cycle last?
+    # How long should a map cycle last? (supports variable durations)
     cycle-time: "15s"
+
+    # Voted pool only: how long to wait after match end to show votebook (supports variable durations)
+    poll-delay: "5s"
 
     # Map variants to use, in order, if they exist
     variants:

--- a/util/src/main/java/tc/oc/pgm/util/range/Ranges.java
+++ b/util/src/main/java/tc/oc/pgm/util/range/Ranges.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.util.range;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
+import org.jspecify.annotations.Nullable;
 
 /** Some {@link Range} utils ripped from ProjectAres :) */
 public class Ranges {
@@ -48,5 +49,23 @@ public class Ranges {
     return range.lowerBoundType() == BoundType.CLOSED && range.upperBoundType() == BoundType.CLOSED
         ? range
         : Range.closed(needMinimum(range), needMaximum(range));
+  }
+
+  public static <T extends Comparable<T>> Range<T> createClosedRange(
+      @Nullable T lower, @Nullable T upper) {
+    return createRange(lower, BoundType.CLOSED, upper, BoundType.CLOSED);
+  }
+
+  public static <T extends Comparable<T>> Range<T> createRange(
+      @Nullable T lower, BoundType lowerBound, @Nullable T upper, BoundType upperBound) {
+    if (lower != null && upper != null) {
+      return Range.range(lower, lowerBound, upper, upperBound);
+    } else if (lower != null) {
+      return Range.downTo(lower, lowerBound);
+    } else if (upper != null) {
+      return Range.upTo(upper, upperBound);
+    } else {
+      return Range.all();
+    }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/XMLUtils.java
@@ -488,21 +488,12 @@ public final class XMLUtils {
   public static <T extends Comparable<T>> Range<T> parseRange(
       Node node, @Nullable T lower, BoundType lowerBound, @Nullable T upper, BoundType upperBound)
       throws InvalidXMLException {
-    if (lower != null && upper != null) {
-      if (lower.compareTo(upper) > 0) {
-        throw new InvalidXMLException(
-            "range lower bound (" + lower + ") cannot be greater than upper bound (" + upper + ")",
-            node);
-      }
-
-      return Range.range(lower, lowerBound, upper, upperBound);
-    } else if (lower != null) {
-      return Range.downTo(lower, lowerBound);
-    } else if (upper != null) {
-      return Range.upTo(upper, upperBound);
-    } else {
-      return Range.all();
+    if (lower != null && upper != null && lower.compareTo(upper) > 0) {
+      throw new InvalidXMLException(
+          "range lower bound (" + lower + ") cannot be greater than upper bound (" + upper + ")",
+          node);
     }
+    return Ranges.createRange(lower, lowerBound, upper, upperBound);
   }
 
   /**


### PR DESCRIPTION
Allows multiple configs to support either a fixed duration, or a list of different durations based on the current playerount or match length.

Allows for longer cycle after a long match, shorter cycles on lower playercount times, etc