### PR TITLE
Emulate PlayerOnGroundEvent in modern from movement packets

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/ModernPlatform.java
@@ -15,6 +15,7 @@ import tc.oc.pgm.platform.modern.listeners.PlayerTracker;
 import tc.oc.pgm.platform.modern.listeners.RecipeUnlocker;
 import tc.oc.pgm.platform.modern.listeners.SpawnEggUseListener;
 import tc.oc.pgm.platform.modern.listeners.TntListener;
+import tc.oc.pgm.platform.modern.packets.OnGroundListener;
 import tc.oc.pgm.platform.modern.packets.PacketManipulations;
 import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.platform.Supports;
@@ -22,6 +23,7 @@ import tc.oc.pgm.util.platform.Supports;
 @Supports(value = PAPER, minVersion = "1.21.11", priority = HIGHEST)
 public class ModernPlatform implements Platform.Manifest {
   private PacketManipulations packetManipulations;
+  private OnGroundListener onGroundListener;
 
   @Override
   public void onEnable(Plugin plugin) {
@@ -39,7 +41,8 @@ public class ModernPlatform implements Platform.Manifest {
             new RecipeUnlocker(),
             new SpawnEggUseListener(),
             new TntListener(),
-            new ModernBlockPhysicsListener())
+            new ModernBlockPhysicsListener(),
+            onGroundListener = new OnGroundListener())
         .forEach(l -> Bukkit.getServer().getPluginManager().registerEvents(l, plugin));
 
     new ModernBlockTransformListener(plugin).registerEvents();
@@ -63,6 +66,11 @@ public class ModernPlatform implements Platform.Manifest {
     if (packetManipulations != null) {
       packetManipulations.unregister();
       packetManipulations = null;
+    }
+
+    if (onGroundListener != null) {
+      onGroundListener.unregister();
+      onGroundListener = null;
     }
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
@@ -22,7 +22,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockDamageEvent;
-import org.bukkit.event.entity.EntityPoseChangeEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -37,7 +36,6 @@ import tc.oc.pgm.util.event.entity.PotionEffectAddEvent;
 import tc.oc.pgm.util.event.entity.PotionEffectRemoveEvent;
 import tc.oc.pgm.util.event.player.PlayerAttackEntityEvent;
 import tc.oc.pgm.util.event.player.PlayerLocaleChangeEvent;
-import tc.oc.pgm.util.event.player.PlayerOnGroundEvent;
 import tc.oc.pgm.util.event.player.PlayerSkinPartsChangeEvent;
 import tc.oc.pgm.util.event.player.PlayerSpawnLocationEvent;
 
@@ -54,12 +52,6 @@ public class ModernListener implements Listener {
       BlockFallEvent pgmEvent = new BlockFallEvent(event.getLocation().getBlock(), fb);
       handleCall(pgmEvent, event);
     }
-  }
-
-  @EventHandler(ignoreCancelled = true)
-  public void onPlayerOnGround(EntityPoseChangeEvent event) {
-    if (event.getEntity() instanceof Player p)
-      handleCall(new PlayerOnGroundEvent(p, p.isOnGround()), event);
   }
 
   @EventHandler(ignoreCancelled = true)

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/OnGroundListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/packets/OnGroundListener.java
@@ -1,0 +1,146 @@
+package tc.oc.pgm.platform.modern.packets;
+
+import com.destroystokyo.paper.event.player.PlayerJumpEvent;
+import com.github.retrooper.packetevents.event.PacketListenerCommon;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerFlying;
+import io.papermc.paper.event.player.PlayerFailMoveEvent;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.jspecify.annotations.NullMarked;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.util.event.player.PlayerOnGroundEvent;
+import tc.oc.pgm.util.nms.packets.PacketEventsUtil;
+
+@NullMarked
+@SuppressWarnings("deprecation")
+public class OnGroundListener implements Listener {
+
+  private final PacketListenerCommon listener;
+  private final Map<UUID, Boolean> pendingOnGround = new ConcurrentHashMap<>();
+  private final Map<UUID, Boolean> lastOnGround = new ConcurrentHashMap<>();
+
+  public OnGroundListener() {
+    this.listener = PacketEventsUtil.registerReceive(
+        PacketListenerPriority.MONITOR,
+        Map.of(
+            PacketType.Play.Client.PLAYER_FLYING, this::handlePlayerMovement,
+            PacketType.Play.Client.PLAYER_POSITION, this::handlePlayerMovement,
+            PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION, this::handlePlayerMovement,
+            PacketType.Play.Client.PLAYER_ROTATION, this::handlePlayerMovement));
+  }
+
+  public void unregister() {
+    PacketEventsUtil.unregister(listener);
+    pendingOnGround.clear();
+    lastOnGround.clear();
+  }
+
+  private void handlePlayerMovement(PacketReceiveEvent event) {
+    if (event.isCancelled()) return;
+
+    Player player = event.getPlayer();
+    if (player == null) return;
+
+    var wrapper = new WrapperPlayClientPlayerFlying(event);
+    boolean onGround = wrapper.isOnGround();
+    UUID playerId = player.getUniqueId();
+    pendingOnGround.put(playerId, onGround);
+    Bukkit.getScheduler().runTask(PGM.get(), () -> validate(playerId, onGround));
+  }
+
+  private void validate(UUID playerId, boolean onGround) {
+    if (!pendingOnGround.remove(playerId, onGround)) return;
+
+    Player player = Bukkit.getPlayer(playerId);
+    if (player == null) {
+      removeAll(playerId);
+      return;
+    }
+
+    emitIfChanged(player, onGround);
+  }
+
+  private void emitIfChanged(Player player, boolean onGround) {
+    UUID playerId = player.getUniqueId();
+    if (!player.isOnline()) {
+      removeAll(playerId);
+      return;
+    }
+
+    boolean currentOnGround = player.isOnGround();
+    Boolean previousOnGround = lastOnGround.put(playerId, currentOnGround);
+
+    if (player.isInsideVehicle() || player.isSleeping()) return;
+    if (currentOnGround != onGround) return;
+    if (previousOnGround == null || previousOnGround == onGround) return;
+
+    new PlayerOnGroundEvent(player, onGround).callEvent();
+  }
+
+  private void removeAll(UUID playerId) {
+    pendingOnGround.remove(playerId);
+    lastOnGround.remove(playerId);
+  }
+
+  private void resetPending(Player player) {
+    UUID playerId = player.getUniqueId();
+    pendingOnGround.remove(playerId);
+
+    if (player.isOnline()) {
+      lastOnGround.put(playerId, player.isOnGround());
+    } else {
+      lastOnGround.remove(playerId);
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerJoin(PlayerJoinEvent event) {
+    lastOnGround.put(event.getPlayer().getUniqueId(), event.getPlayer().isOnGround());
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerQuit(PlayerQuitEvent event) {
+    removeAll(event.getPlayer().getUniqueId());
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerFailMove(PlayerFailMoveEvent event) {
+    if (!event.isAllowed()) {
+      resetPending(event.getPlayer());
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerJump(PlayerJumpEvent event) {
+    if (event.isCancelled()) {
+      resetPending(event.getPlayer());
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerMove(PlayerMoveEvent event) {
+    if (event instanceof PlayerTeleportEvent) return;
+
+    if (event.isCancelled()) {
+      resetPending(event.getPlayer());
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerTeleport(PlayerTeleportEvent event) {
+    resetPending(event.getPlayer());
+  }
+}


### PR DESCRIPTION
`EntityPoseChangeEvent` isn't necessarily an ideal replacement for SportPaper's `PlayerOnGroundEvent`, but it's not really possible to replicate that one-to-one without modifying Paper, and given the age of that API it seems like there would be a reason it is not in Spigot or Paper by now. This PR combines a PacketEvents movement packets listener with Bukkit event listeners to try to approximate the behaviour of `PlayerOnGroundEvent` more closely.

This should see some more focused testing in production-level scenarios, but the goal is to attempt to address incorrect kill credits in modern.