### PR TITLE
Fix FFA npe on visibility change

### DIFF
--- a/core/src/main/java/tc/oc/pgm/ffa/FreeForAllMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/ffa/FreeForAllMatchModule.java
@@ -136,14 +136,8 @@ public class FreeForAllMatchModule implements MatchModule, Listener, JoinHandler
 
   public void setNameTagVisibility(@Nullable NameTagVisibility nameTagVisibility) {
     this.nameTagVisibility = nameTagVisibility;
-
-    if (smm == null) {
-      smm = match.needModule(ScoreboardMatchModule.class);
-    }
-
-    tributes.forEach((uuid, tribute) -> {
-      smm.updatePartyScoreboardTeam(tribute);
-    });
+    if (smm == null) smm = match.needModule(ScoreboardMatchModule.class);
+    tributes.forEach((uuid, tribute) -> smm.updatePartyScoreboardTeam(tribute));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/scoreboard/ScoreboardMatchModule.java
@@ -33,6 +33,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
 import tc.oc.pgm.ffa.FreeForAllMatchModule;
+import tc.oc.pgm.ffa.Tribute;
 import tc.oc.pgm.teams.TeamMatchModule;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.named.NameStyle;
@@ -74,6 +75,8 @@ public class ScoreboardMatchModule implements MatchModule, Listener {
   }
 
   protected void updatePartyScoreboardTeam(Party party, Team team, boolean forObservers) {
+    // Tributes may be created but not populated, in which cases the scoreboard team is null.
+    if (party instanceof Tribute t && t.getPlayer() == null && team == null) return;
     match.getLogger().fine("Updating scoreboard team " + toString(team) + " for party " + party);
 
     team.setDisplayName(


### PR DESCRIPTION
fixes the following NPE:
```
[PGM] Exception running task from plugin PGM v0.16-SNAPSHOT (git-866a21d1)
java.lang.NullPointerException: Cannot invoke "org.bukkit.scoreboard.Team.setDisplayName(String)" because "team" is null
	at tc.oc.pgm.scoreboard.ScoreboardMatchModule.updatePartyScoreboardTeam(ScoreboardMatchModule.java:79)
	at tc.oc.pgm.scoreboard.ScoreboardMatchModule.updatePartyScoreboardTeam(ScoreboardMatchModule.java:227)
	at tc.oc.pgm.ffa.FreeForAllMatchModule.lambda$setNameTagVisibility$0(FreeForAllMatchModule.java:145)
	at java.base/java.util.HashMap.forEach(HashMap.java:1430)
	at tc.oc.pgm.ffa.FreeForAllMatchModule.setNameTagVisibility(FreeForAllMatchModule.java:144)
	at tc.oc.pgm.ffa.FreeForAllMatchModule.lambda$onMatchLoad$0(FreeForAllMatchModule.java:162)
```

Having looked into it, the issue is `getTribute(player)` causes the tribute to get created and added to a Map<Player, Tribute>, which is what we iterate to update team visibility. 
However, the actual scoreboard team is only created whenever the player *joins* the tribute team, which could be cancelled leaving orphaned tributes that will fail to update the team, because there isn't one. Its safe to ignore updating tributes with no players, whenever the team gets created later it will do so with the right settings anyways.