### PR TITLE
Send fake block updates when denying block break on modern

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernListener.java
@@ -10,6 +10,9 @@ import java.util.List;
 import net.minecraft.network.protocol.game.ServerboundPlayerLoadedPacket;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRules;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.TileState;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Player;
@@ -17,12 +20,16 @@ import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.entity.EntityPoseChangeEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.world.WorldLoadEvent;
+import org.jspecify.annotations.NullMarked;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.util.event.block.BlockFallEvent;
 import tc.oc.pgm.util.event.entity.EntityDespawnInVoidEvent;
@@ -38,6 +45,7 @@ import tc.oc.pgm.util.event.player.PlayerSpawnLocationEvent;
  * TODO: fix unsupported events: <br>
  * - EntityExtinguishEvent <br>
  */
+@NullMarked
 public class ModernListener implements Listener {
 
   @EventHandler(ignoreCancelled = true)
@@ -130,5 +138,38 @@ public class ModernListener implements Listener {
     var pgmEvent = new PlayerSpawnLocationEvent(event.getSpawnLocation());
     handleCall(pgmEvent, event);
     event.setSpawnLocation(pgmEvent.getSpawnLocation());
+  }
+
+  // When a player in legacy versions breaks a block but that break is denied,
+  // they do not receive a block update and thus the block is broken clientside.
+  // This sends a fake block update in that specific case.
+  private void resendBlock(Player player, Block block) {
+    player.sendBlockChange(block.getLocation(), block.getBlockData());
+
+    BlockState state = block.getState();
+    if (state instanceof TileState tileState) {
+      player.sendBlockUpdate(block.getLocation(), tileState);
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerInteract(PlayerInteractEvent event) {
+    if (event.getAction() != Action.LEFT_CLICK_BLOCK
+        || (event.useInteractedBlock() != Event.Result.DENY
+            && event.useItemInHand() != Event.Result.DENY)) {
+      return;
+    }
+
+    Block block = event.getClickedBlock();
+    if (block == null) return;
+
+    resendBlock(event.getPlayer(), block);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onBlockDamage(BlockDamageEvent event) {
+    if (!event.isCancelled()) return;
+
+    resendBlock(event.getPlayer(), event.getBlock());
   }
 }


### PR DESCRIPTION
On modern Paper, a player connected using ViaVersion and ViaBackwards on a client 1.18.2 or lower can try to break blocks as observer or as a player on a map where block breaking is denied, but rather than seeing the block return on denial of the block break, it remains broken clientside. This is fixable in ViaBackwards, but given packet changes in 1.18.2->1.19 doing so seems to be memory-expensive. 

This PR works around the issue in PGM instead, since this is a fairly niche problem.