### PR TITLE
Resolve several participant-observer barrier issues on modern

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/EventFilterMatchModule.java
@@ -101,7 +101,7 @@ public class EventFilterMatchModule implements MatchModule, Listener {
     return cancel(event, !player.canInteract(), player.getBukkit().getWorld(), player, null);
   }
 
-  boolean cancelUnlessInteracting(Cancellable event, Entity entity) {
+  public boolean cancelUnlessInteracting(Cancellable event, Entity entity) {
     if (!(entity instanceof Player)) {
       return false;
     }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernEventFilterMatchModule.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernEventFilterMatchModule.java
@@ -1,0 +1,58 @@
+package tc.oc.pgm.platform.modern.modules;
+
+import io.papermc.paper.event.entity.EntityKnockbackEvent;
+import java.util.Collection;
+import java.util.List;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.GenericGameEvent;
+import org.jspecify.annotations.NullMarked;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.match.factory.MatchModuleFactory;
+import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.modules.EventFilterMatchModule;
+
+@NullMarked
+@ListenerScope(MatchScope.LOADED)
+public class ModernEventFilterMatchModule implements MatchModule, Listener {
+
+  public static class Factory implements MatchModuleFactory<ModernEventFilterMatchModule> {
+    @Override
+    public Collection<Class<? extends MatchModule>> getSoftDependencies() {
+      return List.of(EventFilterMatchModule.class);
+    }
+
+    @Override
+    public ModernEventFilterMatchModule createMatchModule(Match match) throws ModuleLoadException {
+      return new ModernEventFilterMatchModule(match);
+    }
+  }
+
+  private final EventFilterMatchModule efmm;
+
+  public ModernEventFilterMatchModule(Match match) {
+    this.efmm = match.needModule(EventFilterMatchModule.class);
+  }
+
+  // Prevent observers from triggering sculk sensors and sculk shriekers
+  @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+  public void onGameEvent(GenericGameEvent event) {
+    Entity entity = event.getEntity();
+    if (entity instanceof Player) efmm.cancelUnlessInteracting(event, entity);
+  }
+
+  // Prevent observers from receiving explosion knockback
+  @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+  public void onKnockback(EntityKnockbackEvent event) {
+    if (event.getCause() != EntityKnockbackEvent.Cause.EXPLOSION) return;
+
+    Entity entity = event.getEntity();
+    if (entity instanceof Player) efmm.cancelUnlessInteracting(event, entity);
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernMobsMatchModule.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernMobsMatchModule.java
@@ -1,0 +1,61 @@
+package tc.oc.pgm.platform.modern.modules;
+
+import java.util.Collection;
+import java.util.List;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.match.event.MatchFinishEvent;
+import tc.oc.pgm.api.match.factory.MatchModuleFactory;
+import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.events.PlayerChangePartyEvent;
+import tc.oc.pgm.modules.MobsMatchModule;
+
+@NullMarked
+@ListenerScope(MatchScope.LOADED)
+public class ModernMobsMatchModule implements MatchModule, Listener {
+
+  public static class Factory implements MatchModuleFactory<ModernMobsMatchModule> {
+    @Override
+    public Collection<Class<? extends MatchModule>> getSoftDependencies() {
+      return List.of(MobsMatchModule.class);
+    }
+
+    @Override
+    public ModernMobsMatchModule createMatchModule(Match match) throws ModuleLoadException {
+      return new ModernMobsMatchModule();
+    }
+  }
+
+  // If a player leaves a team and becomes an observer, remove
+  // them as a target for any mob that exists in the match.
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onPartyChange(PlayerChangePartyEvent event) {
+    if (event.getNewParty() == null || !event.getNewParty().isObserving()) return;
+    event.addHandler(() -> clearMobTargets(event.getMatch(), event.getPlayer().getBukkit()));
+  }
+
+  // Remove match participants as mob targets on match end
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onMatchFinish(MatchFinishEvent event) {
+    clearMobTargets(event.getMatch(), null);
+  }
+
+  private void clearMobTargets(Match match, @Nullable Player targetPlayer) {
+    for (var entity : match.getWorld().getLivingEntities()) {
+      if (entity instanceof Mob mob
+          && mob.getTarget() instanceof Player target
+          && (targetPlayer == null || targetPlayer.equals(target))) {
+        mob.setTarget(null);
+      }
+    }
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernModuleRegistrar.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernModuleRegistrar.java
@@ -13,7 +13,10 @@ import tc.oc.pgm.util.platform.Supports;
 public class ModernModuleRegistrar implements Modules.ModuleRegistrar {
   @Override
   public void registerModules(Modules modules) {
+    modules.register(
+        ModernEventFilterMatchModule.class, new ModernEventFilterMatchModule.Factory());
     modules.register(ModernKitMatchModule.class, new ModernKitMatchModule.Factory());
+    modules.register(ModernMobsMatchModule.class, new ModernMobsMatchModule.Factory());
     modules.register(TrimModule.class, TrimMatchModule.class, new TrimModule.Factory());
     modules.register(WaypointMatchModule.class, WaypointMatchModule::new);
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/kits/ModernKitMatchModule.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/kits/ModernKitMatchModule.java
@@ -8,10 +8,13 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.match.factory.MatchModuleFactory;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.kits.KitMatchModule;
 
+@ListenerScope(MatchScope.RUNNING)
 public class ModernKitMatchModule implements MatchModule, Listener {
 
   public static class Factory implements MatchModuleFactory<ModernKitMatchModule> {


### PR DESCRIPTION
1. Prevent observers from triggering sculk sensors and sculk shriekers
2. Cancel knockback from explosions for observers
3. Remove match participants as mob targets if they leave the team and go to observers, or once the match ends