### PR TITLE
Add support for multiple username APIs

### DIFF
--- a/core/src/main/java/tc/oc/pgm/PGMConfig.java
+++ b/core/src/main/java/tc/oc/pgm/PGMConfig.java
@@ -47,6 +47,7 @@ import tc.oc.pgm.map.source.GitMapSourceFactory;
 import tc.oc.pgm.map.source.PathMapSourceFactory;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 import tc.oc.pgm.util.text.TextException;
+import tc.oc.pgm.util.usernames.ApiUsernameResolver;
 
 public final class PGMConfig implements Config {
 
@@ -125,6 +126,10 @@ public final class PGMConfig implements Config {
 
   // groups.*
   private final List<Group> groups;
+
+  // username-resolvers.*
+  private final List<UsernameResolverType> usernameResolvers;
+  private final List<ApiUsernameResolver> customUsernameResolvers;
 
   // experiments.*
   private final Map<String, Object> experiments;
@@ -234,6 +239,22 @@ public final class PGMConfig implements Config {
 
     this.vanish = parseBoolean(config.getString("vanish", "true"));
 
+    this.usernameResolvers = new ArrayList<>();
+    this.customUsernameResolvers = new ArrayList<>();
+    for (var resolver : config.getMapList("username-resolvers")) {
+      var type = parseEnum(String.valueOf(resolver.get("type")), UsernameResolverType.class);
+      if (type == UsernameResolverType.CUSTOM) {
+        customUsernameResolvers.add(new ApiUsernameResolver(
+            getOrDefault(resolver, "name", "custom"),
+            getOrDefault(resolver, "uri", ""),
+            parseBoolean(getOrDefault(resolver, "single-threaded", "true")),
+            getOrDefault(resolver, "json-path", "username")));
+      } else if (usernameResolvers.contains(type)) {
+        throw new IllegalArgumentException("Username resolver already exists for type " + type);
+      }
+      usernameResolvers.add(type);
+    }
+
     final ConfigurationSection section = config.getConfigurationSection("groups");
     this.groups = new ArrayList<>();
     if (section != null) {
@@ -258,15 +279,11 @@ public final class PGMConfig implements Config {
       ImmutableMap.of("uri", "https://github.com/PGMDev/Maps", "path", "default-maps");
 
   public static GitMapSourceFactory parseGit(Map<?, ?> repository) {
-    final URI uri = parseUri(String.valueOf(repository.get("uri")));
+    final URI uri = parseUri(getOrDefault(repository, "uri", null));
 
-    String branch = String.valueOf(repository.get("branch"));
-    if (branch.isEmpty() || branch.equals("null")) {
-      branch = null;
-    }
-
-    String path = String.valueOf(repository.get("path"));
-    if (path.isEmpty() || path.equals("null")) {
+    String branch = getOrDefault(repository, "branch", null);
+    String path = getOrDefault(repository, "path", null);
+    if (path == null) {
       String normalizedPath = Normalizer.normalize(
               uri.getHost() + uri.getPath(), Normalizer.Form.NFD)
           .replaceAll("[^A-Za-z0-9_]", "-")
@@ -285,6 +302,12 @@ public final class PGMConfig implements Config {
     }
 
     return new GitMapSourceFactory(base, children, uri, branch);
+  }
+
+  private static String getOrDefault(Map<?, ?> map, String key, String defaultValue) {
+    var value = map.get(key);
+    if (value == null) return defaultValue;
+    return value.toString();
   }
 
   // TODO: Can be removed after 1.0 release
@@ -716,6 +739,16 @@ public final class PGMConfig implements Config {
   @Override
   public boolean isVanishEnabled() {
     return vanish;
+  }
+
+  @Override
+  public List<UsernameResolverType> getUsernameResolvers() {
+    return usernameResolvers;
+  }
+
+  @Override
+  public List<ApiUsernameResolver> getCustomUsernameResolvers() {
+    return customUsernameResolvers;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -5,6 +5,7 @@ import fr.minuskube.inv.InventoryManager;
 import java.io.File;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -85,6 +86,7 @@ import tc.oc.pgm.util.usernames.BukkitUsernameResolver;
 import tc.oc.pgm.util.usernames.ElectroidApiUsernameResolver;
 import tc.oc.pgm.util.usernames.MojangApiUsernameResolver;
 import tc.oc.pgm.util.usernames.PlayerDbApiUsernameResolver;
+import tc.oc.pgm.util.usernames.UsernameResolver;
 import tc.oc.pgm.util.usernames.UsernameResolvers;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
@@ -171,12 +173,7 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
       return;
     }
 
-    UsernameResolvers.setResolvers(
-        new BukkitUsernameResolver(),
-        new SqlUsernameResolver((SQLDatastore) datastore),
-        new PlayerDbApiUsernameResolver(),
-        new MojangApiUsernameResolver(),
-        new ElectroidApiUsernameResolver());
+    setupUsernameResolvers();
 
     datastore = new CacheDatastore(datastore);
 
@@ -254,6 +251,33 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
 
     registerListeners();
     registerCommands();
+  }
+
+  private void setupUsernameResolvers() {
+    var custom = config.getCustomUsernameResolvers().iterator();
+    var types = config.getUsernameResolvers();
+    if (types.isEmpty()) {
+      PGM.get()
+          .getLogger()
+          .warning("No username resolvers were configured, falling back to defaults.");
+      var nonCustom = EnumSet.allOf(Config.UsernameResolverType.class);
+      nonCustom.remove(Config.UsernameResolverType.CUSTOM);
+      types = List.copyOf(nonCustom);
+    }
+
+    List<UsernameResolver> resolvers = new ArrayList<>();
+    for (var type : types) {
+      resolvers.add(
+          switch (type) {
+            case BUKKIT -> new BukkitUsernameResolver();
+            case SQL -> new SqlUsernameResolver((SQLDatastore) datastore);
+            case PLAYER_DB -> new PlayerDbApiUsernameResolver();
+            case MOJANG -> new MojangApiUsernameResolver();
+            case ELECTROID -> new ElectroidApiUsernameResolver();
+            case CUSTOM -> custom.next();
+          });
+    }
+    UsernameResolvers.setResolvers(resolvers.toArray(UsernameResolver[]::new));
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -174,9 +174,9 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     UsernameResolvers.setResolvers(
         new BukkitUsernameResolver(),
         new SqlUsernameResolver((SQLDatastore) datastore),
-        new ElectroidApiUsernameResolver(),
         new PlayerDbApiUsernameResolver(),
-        new MojangApiUsernameResolver());
+        new MojangApiUsernameResolver(),
+        new ElectroidApiUsernameResolver());
 
     datastore = new CacheDatastore(datastore);
 

--- a/core/src/main/java/tc/oc/pgm/PGMPlugin.java
+++ b/core/src/main/java/tc/oc/pgm/PGMPlugin.java
@@ -81,8 +81,10 @@ import tc.oc.pgm.util.platform.Platform;
 import tc.oc.pgm.util.tablist.TablistResizer;
 import tc.oc.pgm.util.text.TextException;
 import tc.oc.pgm.util.text.TextTranslations;
-import tc.oc.pgm.util.usernames.ApiUsernameResolver;
 import tc.oc.pgm.util.usernames.BukkitUsernameResolver;
+import tc.oc.pgm.util.usernames.ElectroidApiUsernameResolver;
+import tc.oc.pgm.util.usernames.MojangApiUsernameResolver;
+import tc.oc.pgm.util.usernames.PlayerDbApiUsernameResolver;
 import tc.oc.pgm.util.usernames.UsernameResolvers;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
@@ -172,7 +174,9 @@ public class PGMPlugin extends JavaPlugin implements PGM, Listener {
     UsernameResolvers.setResolvers(
         new BukkitUsernameResolver(),
         new SqlUsernameResolver((SQLDatastore) datastore),
-        new ApiUsernameResolver());
+        new ElectroidApiUsernameResolver(),
+        new PlayerDbApiUsernameResolver(),
+        new MojangApiUsernameResolver());
 
     datastore = new CacheDatastore(datastore);
 

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -19,6 +19,7 @@ import org.bukkit.permissions.Permission;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.map.factory.MapSourceFactory;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.util.usernames.ApiUsernameResolver;
 
 /** A configuration for server owners to modify {@link PGM}. */
 public interface Config {
@@ -512,6 +513,19 @@ public interface Config {
    * @return If vanish is enabled.
    */
   boolean isVanishEnabled();
+
+  List<UsernameResolverType> getUsernameResolvers();
+
+  List<ApiUsernameResolver> getCustomUsernameResolvers();
+
+  enum UsernameResolverType {
+    BUKKIT,
+    SQL,
+    PLAYER_DB,
+    MOJANG,
+    ELECTROID,
+    CUSTOM
+  }
 
   /**
    * Gets experimental configuration settings that are not yet stable.

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -233,6 +233,28 @@ database-max-connections: 5
 # Enable the simple vanish manager, disable if you want other plugins to handle this
 vanish: true
 
+# Resolvers pgm should use to convert uuid -> username, mainly for map author names
+# The defined order will be respected by pgm, if one fails or doesn't
+# give a valid answer, the next is checked.
+username-resolvers:
+  # Resolve using bukkit directly first, heavily recommended
+  - type: BUKKIT
+  # Resolve using pgm's SQL table, used as a cache, heavily recommended
+  - type: SQL
+  # See https://playerdb.co, recommended
+  - type: PLAYER_DB
+  # Official minecraft API, heavily rate-limited, but reliable
+  - type: MOJANG
+  # See https://github.com/Electroid/mojang-api, outdated
+  - type: ELECTROID
+  # You may add custom apis of your own, as long as they respond with JSON.
+  # The following is an example of how you'd setup player-db
+#  - type: CUSTOM
+#    name: "playerdb-copy" # Used for debug/logs
+#    uri: "https://playerdb.co/api/player/minecraft/{uuid}" # Template for the uri to hit
+#    single-threaded: false # Optional, use true for rate-limited APIs, ensures non-overlapping requests.
+#    json-path: "data.player.username" # dot-separated JSON object properties, does not support arrays.
+
 # Experimental features that are not yet stable.
 experiments:
   # Enable payload preview. This is not fully finished and xml syntax is likely to change at a later time.

--- a/util/src/main/java/tc/oc/pgm/util/usernames/AbstractBatchingUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/AbstractBatchingUsernameResolver.java
@@ -13,16 +13,13 @@ public abstract class AbstractBatchingUsernameResolver extends AbstractUsernameR
 
   @Override
   public synchronized CompletableFuture<UsernameResponse> resolve(UUID uuid) {
-    CompletableFuture<UsernameResponse> response =
-        futures.computeIfAbsent(
-            uuid,
-            key -> {
-              if (currentBatch != null) currentBatch.add(uuid);
-              return createFuture(uuid);
-            });
-
-    if (currentBatch == null) getExecutor().execute(() -> process(uuid, response));
-
+    var response = futures.get(uuid);
+    if (response == null) {
+      var newFuture = response = createFuture(uuid);
+      futures.put(uuid, newFuture);
+      if (currentBatch != null) currentBatch.add(uuid);
+      else getExecutor().execute(() -> process(uuid, newFuture));
+    }
     return response;
   }
 

--- a/util/src/main/java/tc/oc/pgm/util/usernames/AbstractBatchingUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/AbstractBatchingUsernameResolver.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import org.bukkit.Bukkit;
 
 public abstract class AbstractBatchingUsernameResolver extends AbstractUsernameResolver
     implements UsernameResolver {
@@ -33,12 +32,12 @@ public abstract class AbstractBatchingUsernameResolver extends AbstractUsernameR
     List<UUID> batch = currentBatch;
     currentBatch = null;
     if (batch != null && !batch.isEmpty()) {
-      Bukkit.getLogger().info(LOG_PREFIX + "Batch resolving " + batch.size() + " uuids");
+      info("Batch resolving " + batch.size() + " uuids");
 
       return CompletableFuture.runAsync(
           () -> {
             process(batch);
-            Bukkit.getLogger().info(LOG_PREFIX + "Done resolving " + batch.size() + " uuids");
+            info("Done resolving " + batch.size() + " uuids");
           },
           getExecutor());
     } else {

--- a/util/src/main/java/tc/oc/pgm/util/usernames/AbstractUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/AbstractUsernameResolver.java
@@ -5,16 +5,19 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
 
 public abstract class AbstractUsernameResolver implements UsernameResolver {
+  protected static final Executor EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
 
   protected final String LOG_PREFIX = "[" + getClass().getSimpleName() + "] ";
   protected final Map<UUID, CompletableFuture<UsernameResponse>> futures =
       new ConcurrentHashMap<>();
 
   protected Executor getExecutor() {
-    return ForkJoinPool.commonPool();
+    return EXECUTOR;
   }
 
   @Override
@@ -42,6 +45,18 @@ public abstract class AbstractUsernameResolver implements UsernameResolver {
   protected void complete(UUID uuid, UsernameResponse response) {
     CompletableFuture<UsernameResponse> future = futures.get(uuid);
     if (future != null) future.complete(response);
+  }
+
+  protected String logPrefix() {
+    return LOG_PREFIX;
+  }
+
+  protected void info(String message) {
+    Bukkit.getLogger().log(Level.INFO, logPrefix() + message);
+  }
+
+  protected void warn(String message, Throwable t) {
+    Bukkit.getLogger().log(Level.WARNING, logPrefix() + message, t);
   }
 
   protected abstract void process(UUID uuid, CompletableFuture<UsernameResponse> future);

--- a/util/src/main/java/tc/oc/pgm/util/usernames/ApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/ApiUsernameResolver.java
@@ -4,6 +4,7 @@ import static tc.oc.pgm.util.Assert.assertNotNull;
 import static tc.oc.pgm.util.Assert.assertTrue;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.net.NoRouteToHostException;
@@ -19,13 +20,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Level;
-import org.bukkit.Bukkit;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import org.bukkit.plugin.Plugin;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 
 /** Utility to resolve Minecraft usernames from an external HTTP API. */
-public abstract class ApiUsernameResolver extends AbstractBatchingUsernameResolver {
+public class ApiUsernameResolver extends AbstractBatchingUsernameResolver {
   private static final int HTTP_OK = 200;
   private static final int HTTP_TOO_MANY_REQUESTS = 429;
 
@@ -46,18 +47,35 @@ public abstract class ApiUsernameResolver extends AbstractBatchingUsernameResolv
     }
   }
 
+  private final String logPrefix;
   private final String path;
   private final HttpClient httpClient;
+  private final Executor executor;
+  private final String[] jsonPath;
 
   private long backoffMs = MIN_BACKOFF;
 
-  public ApiUsernameResolver(String path) {
+  public ApiUsernameResolver(String name, String path, boolean singleThreaded, String jsonPath) {
     assertTrue(path.contains("{uuid}"));
+    this.logPrefix = "[ApiUsernameResolver:" + name + "] ";
     this.path = path;
     this.httpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(10))
         .followRedirects(HttpClient.Redirect.ALWAYS)
         .build();
+    this.executor =
+        singleThreaded ? Executors.newSingleThreadExecutor() : AbstractUsernameResolver.EXECUTOR;
+    this.jsonPath = jsonPath.split("\\.");
+  }
+
+  @Override
+  protected Executor getExecutor() {
+    return executor;
+  }
+
+  @Override
+  protected String logPrefix() {
+    return logPrefix;
   }
 
   @Override
@@ -66,9 +84,9 @@ public abstract class ApiUsernameResolver extends AbstractBatchingUsernameResolv
     try {
       name = resolveSync(uuid, 5);
     } catch (Throwable t) {
-      Bukkit.getLogger().log(Level.WARNING, "Could not resolve username for " + uuid, t);
+      warn("Could not resolve username for " + uuid, t);
     } finally {
-      future.complete(UsernameResponse.of(name, ApiUsernameResolver.class));
+      future.complete(UsernameResponse.of(name, getClass()));
     }
   }
 
@@ -100,20 +118,17 @@ public abstract class ApiUsernameResolver extends AbstractBatchingUsernameResolv
             || t instanceof UnknownHostException
             || t instanceof NoRouteToHostException) {
           stopped = true;
-          Bukkit.getLogger().log(Level.WARNING, LOG_PREFIX + "Stopped resolving usernames", t);
+          warn("Stopped resolving usernames", t);
         }
       } finally {
         complete(id, UsernameResponse.of(name, now, getClass()));
       }
     }
 
-    if (!errors.isEmpty()) {
-      Bukkit.getLogger()
-          .log(
-              Level.WARNING,
-              LOG_PREFIX + "Could not resolve " + errors.size() + " usernames",
-              errors.values().iterator().next());
-    }
+    if (!errors.isEmpty())
+      warn(
+          "Could not resolve " + errors.size() + " usernames",
+          errors.values().iterator().next());
   }
 
   private String resolveSync(UUID id, int maxRetries) throws Exception {
@@ -151,5 +166,12 @@ public abstract class ApiUsernameResolver extends AbstractBatchingUsernameResolv
   }
 
   // Each API impl has to decide how to extract the username
-  protected abstract String getUsername(JsonObject response);
+  protected String getUsername(JsonObject response) {
+    JsonElement curr = response;
+    for (String s : jsonPath) {
+      if (curr == null || !curr.isJsonObject()) return null;
+      curr = curr.getAsJsonObject().get(s);
+    }
+    return curr.getAsString();
+  }
 }

--- a/util/src/main/java/tc/oc/pgm/util/usernames/ApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/ApiUsernameResolver.java
@@ -1,18 +1,18 @@
 package tc.oc.pgm.util.usernames;
 
 import static tc.oc.pgm.util.Assert.assertNotNull;
+import static tc.oc.pgm.util.Assert.assertTrue;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
 import java.net.NoRouteToHostException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,14 +24,15 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import tc.oc.pgm.util.bukkit.BukkitUtils;
 
-/**
- * Utility to resolve Minecraft usernames from an external API.
- *
- * @link https://github.com/Electroid/mojang-api
- */
-public final class ApiUsernameResolver extends AbstractBatchingUsernameResolver {
+/** Utility to resolve Minecraft usernames from an external HTTP API. */
+public abstract class ApiUsernameResolver extends AbstractBatchingUsernameResolver {
+  private static final int HTTP_OK = 200;
+  private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
   private static final Gson GSON = new Gson();
   private static final int MAX_SEQUENTIAL_FAILURES = 5;
+  private static final int MIN_BACKOFF = 5_000;
+  private static final int MAX_BACKOFF = 60_000;
   private static String userAgent = "PGM";
 
   static {
@@ -45,11 +46,25 @@ public final class ApiUsernameResolver extends AbstractBatchingUsernameResolver 
     }
   }
 
+  private final String path;
+  private final HttpClient httpClient;
+
+  private long backoffMs = MIN_BACKOFF;
+
+  public ApiUsernameResolver(String path) {
+    assertTrue(path.contains("{uuid}"));
+    this.path = path;
+    this.httpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .followRedirects(HttpClient.Redirect.ALWAYS)
+        .build();
+  }
+
   @Override
   protected void process(UUID uuid, CompletableFuture<UsernameResponse> future) {
     String name = null;
     try {
-      name = resolveSync(uuid);
+      name = resolveSync(uuid, 5);
     } catch (Throwable t) {
       Bukkit.getLogger().log(Level.WARNING, "Could not resolve username for " + uuid, t);
     } finally {
@@ -74,17 +89,21 @@ public final class ApiUsernameResolver extends AbstractBatchingUsernameResolver 
 
       String name = null;
       try {
-        name = resolveSync(id);
-        fails = 0;
+        name = resolveSync(id, 5);
+        if (name != null) {
+          backoffMs = backoff(0.95d, true);
+          fails = 0;
+        }
       } catch (Throwable t) {
         errors.put(id, t);
         if (++fails > MAX_SEQUENTIAL_FAILURES
             || t instanceof UnknownHostException
             || t instanceof NoRouteToHostException) {
           stopped = true;
+          Bukkit.getLogger().log(Level.WARNING, LOG_PREFIX + "Stopped resolving usernames", t);
         }
       } finally {
-        complete(id, UsernameResponse.of(name, now, ApiUsernameResolver.class));
+        complete(id, UsernameResponse.of(name, now, getClass()));
       }
     }
 
@@ -97,19 +116,40 @@ public final class ApiUsernameResolver extends AbstractBatchingUsernameResolver 
     }
   }
 
-  private static String resolveSync(UUID id) throws IOException, URISyntaxException {
-    final URI uri = new URI("https://api.ashcon.app/mojang/v2/user/" + assertNotNull(id));
-    final HttpURLConnection url = (HttpURLConnection) uri.toURL().openConnection();
-    url.setRequestMethod("GET");
-    url.setRequestProperty("User-Agent", userAgent);
-    url.setRequestProperty("Accept", "application/json");
-    url.setInstanceFollowRedirects(true);
-    url.setConnectTimeout(10000);
-    url.setReadTimeout(10000);
+  private String resolveSync(UUID id, int maxRetries) throws Exception {
+    var response = httpClient.send(buildRequest(id), HttpResponse.BodyHandlers.ofString());
 
-    try (final BufferedReader br =
-        new BufferedReader(new InputStreamReader(url.getInputStream(), StandardCharsets.UTF_8))) {
-      return GSON.fromJson(br, JsonObject.class).get("username").getAsString();
-    }
+    return switch (response.statusCode()) {
+      case HTTP_OK -> getUsername(GSON.fromJson(response.body(), JsonObject.class));
+      case HTTP_TOO_MANY_REQUESTS -> {
+        if (maxRetries > 1) {
+          backoffMs = backoff(2d, true);
+          var jitter = (Math.random() * 0.5d);
+          Thread.sleep(backoff(1d + jitter, false));
+          yield resolveSync(id, maxRetries - 1);
+        }
+        throw new IOException("Too many requests");
+      }
+      default -> null;
+    };
   }
+
+  private long backoff(double scaling, boolean clamp) {
+    long backoff = (long) (backoffMs * scaling);
+    if (clamp) backoff = Math.clamp(backoff, MIN_BACKOFF, MAX_BACKOFF);
+    return backoff;
+  }
+
+  protected HttpRequest buildRequest(UUID uuid) throws Exception {
+    return HttpRequest.newBuilder()
+        .GET()
+        .uri(new URI(path.replace("{uuid}", assertNotNull(uuid).toString())))
+        .header("User-Agent", userAgent)
+        .header("Accept", "application/json")
+        .timeout(Duration.ofSeconds(10))
+        .build();
+  }
+
+  // Each API impl has to decide how to extract the username
+  protected abstract String getUsername(JsonObject response);
 }

--- a/util/src/main/java/tc/oc/pgm/util/usernames/ElectroidApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/ElectroidApiUsernameResolver.java
@@ -1,0 +1,23 @@
+package tc.oc.pgm.util.usernames;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Resolves using electroid's mojang-api
+ *
+ * @link <a href="https://github.com/Electroid/mojang-api">Github</a>
+ * @link <a
+ *     href="https://api.ashcon.app/mojang/v2/user/853c80ef-3c37-49fd-aa49-938b674adae6">Example
+ *     response</a>
+ */
+public class ElectroidApiUsernameResolver extends ApiUsernameResolver {
+
+  public ElectroidApiUsernameResolver() {
+    super("https://api.ashcon.app/mojang/v2/user/{uuid}");
+  }
+
+  protected String getUsername(JsonObject response) {
+    var name = response.get("username");
+    return name == null ? null : name.getAsString();
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/usernames/ElectroidApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/ElectroidApiUsernameResolver.java
@@ -1,7 +1,5 @@
 package tc.oc.pgm.util.usernames;
 
-import com.google.gson.JsonObject;
-
 /**
  * Resolves using electroid's mojang-api
  *
@@ -13,11 +11,6 @@ import com.google.gson.JsonObject;
 public class ElectroidApiUsernameResolver extends ApiUsernameResolver {
 
   public ElectroidApiUsernameResolver() {
-    super("https://api.ashcon.app/mojang/v2/user/{uuid}");
-  }
-
-  protected String getUsername(JsonObject response) {
-    var name = response.get("username");
-    return name == null ? null : name.getAsString();
+    super("electroid", "https://api.ashcon.app/mojang/v2/user/{uuid}", false, "username");
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/usernames/MojangApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/MojangApiUsernameResolver.java
@@ -1,9 +1,5 @@
 package tc.oc.pgm.util.usernames;
 
-import com.google.gson.JsonObject;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-
 /**
  * Resolves using mojang's official minecraft api
  *
@@ -13,21 +9,11 @@ import java.util.concurrent.Executors;
  *     response</a>
  */
 public class MojangApiUsernameResolver extends ApiUsernameResolver {
-  // Given the known rate-limit, pin everything to a single thread and make resolving wait
-  private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
-
   public MojangApiUsernameResolver() {
-    super("https://api.minecraftservices.com/minecraft/profile/lookup/{uuid}");
-  }
-
-  @Override
-  protected Executor getExecutor() {
-    return EXECUTOR;
-  }
-
-  @Override
-  protected String getUsername(JsonObject response) {
-    var name = response.get("name");
-    return name == null ? null : name.getAsString();
+    super(
+        "mojang",
+        "https://api.minecraftservices.com/minecraft/profile/lookup/{uuid}",
+        true,
+        "name");
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/usernames/MojangApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/MojangApiUsernameResolver.java
@@ -1,0 +1,34 @@
+package tc.oc.pgm.util.usernames;
+
+import com.google.gson.JsonObject;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Resolves using mojang's official minecraft api
+ *
+ * @link <a href="https://minecraft.wiki/w/Mojang_API">Mojang API on minecraft.wiki</a>
+ * @link <a
+ *     href="https://api.minecraftservices.com/minecraft/profile/lookup/853c80ef-3c37-49fd-aa49-938b674adae6">Example
+ *     response</a>
+ */
+public class MojangApiUsernameResolver extends ApiUsernameResolver {
+  // Given the known rate-limit, pin everything to a single thread and make resolving wait
+  private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+
+  public MojangApiUsernameResolver() {
+    super("https://api.minecraftservices.com/minecraft/profile/lookup/{uuid}");
+  }
+
+  @Override
+  protected Executor getExecutor() {
+    return EXECUTOR;
+  }
+
+  @Override
+  protected String getUsername(JsonObject response) {
+    var name = response.get("name");
+    return name == null ? null : name.getAsString();
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/usernames/MojangApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/MojangApiUsernameResolver.java
@@ -1,7 +1,6 @@
 package tc.oc.pgm.util.usernames;
 
 import com.google.gson.JsonObject;
-
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 

--- a/util/src/main/java/tc/oc/pgm/util/usernames/PlayerDbApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/PlayerDbApiUsernameResolver.java
@@ -1,7 +1,5 @@
 package tc.oc.pgm.util.usernames;
 
-import com.google.gson.JsonObject;
-
 /**
  * Resolves using PlayerDb
  *
@@ -13,18 +11,10 @@ import com.google.gson.JsonObject;
  */
 public class PlayerDbApiUsernameResolver extends ApiUsernameResolver {
   public PlayerDbApiUsernameResolver() {
-    super("https://playerdb.co/api/player/minecraft/{uuid}");
-  }
-
-  @Override
-  protected String getUsername(JsonObject response) {
-    var success = response.get("success");
-    if (success == null || !success.getAsBoolean()) return null;
-    var data = response.getAsJsonObject("data");
-    if (data == null) return null;
-    var player = data.getAsJsonObject("player");
-    if (player == null) return null;
-    var username = player.get("username");
-    return username == null ? null : username.getAsString();
+    super(
+        "playerdb",
+        "https://playerdb.co/api/player/minecraft/{uuid}",
+        false,
+        "data.player.username");
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/usernames/PlayerDbApiUsernameResolver.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/PlayerDbApiUsernameResolver.java
@@ -1,0 +1,30 @@
+package tc.oc.pgm.util.usernames;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Resolves using PlayerDb
+ *
+ * @link <a href="https://github.com/nodecraft/playerdb">Github</a>
+ * @link <a href="https://playerdb.co">Website</a>
+ * @link <a
+ *     href="https://playerdb.co/api/player/minecraft/853c80ef-3c37-49fd-aa49-938b674adae6">Example
+ *     response</a>
+ */
+public class PlayerDbApiUsernameResolver extends ApiUsernameResolver {
+  public PlayerDbApiUsernameResolver() {
+    super("https://playerdb.co/api/player/minecraft/{uuid}");
+  }
+
+  @Override
+  protected String getUsername(JsonObject response) {
+    var success = response.get("success");
+    if (success == null || !success.getAsBoolean()) return null;
+    var data = response.getAsJsonObject("data");
+    if (data == null) return null;
+    var player = data.getAsJsonObject("player");
+    if (player == null) return null;
+    var username = player.get("username");
+    return username == null ? null : username.getAsString();
+  }
+}

--- a/util/src/main/java/tc/oc/pgm/util/usernames/UsernameResolvers.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/UsernameResolvers.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public interface UsernameResolvers {
 
   AtomicReference<UsernameResolver> INSTANCE =
-      new AtomicReference<>(of(new BukkitUsernameResolver(), new ElectroidApiUsernameResolver()));
+      new AtomicReference<>(of(new BukkitUsernameResolver(), new PlayerDbApiUsernameResolver()));
 
   static UsernameResolver get() {
     return INSTANCE.get();

--- a/util/src/main/java/tc/oc/pgm/util/usernames/UsernameResolvers.java
+++ b/util/src/main/java/tc/oc/pgm/util/usernames/UsernameResolvers.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public interface UsernameResolvers {
 
   AtomicReference<UsernameResolver> INSTANCE =
-      new AtomicReference<>(of(new BukkitUsernameResolver(), new ApiUsernameResolver()));
+      new AtomicReference<>(of(new BukkitUsernameResolver(), new ElectroidApiUsernameResolver()));
 
   static UsernameResolver get() {
     return INSTANCE.get();


### PR DESCRIPTION
Instead of relying on just electroid's api for username resolving, pgm adopts 3 different supported apis for resolving.
Support for ratelimiting is not tied specifically to mojang's api and can work for any ratelimited api.
Could offer support for config-based apis, or at least allow configuring if you want to enable/disable a specific resolver.