### PR TITLE
Implement a tracker for end crystals

### DIFF
--- a/core/src/main/java/tc/oc/pgm/tracker/TrackerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/TrackerMatchModule.java
@@ -9,6 +9,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
@@ -27,6 +28,7 @@ import tc.oc.pgm.tracker.trackers.CactiTracker;
 import tc.oc.pgm.tracker.trackers.CombatLogTracker;
 import tc.oc.pgm.tracker.trackers.DeathTracker;
 import tc.oc.pgm.tracker.trackers.DispenserTracker;
+import tc.oc.pgm.tracker.trackers.EndCrystalTracker;
 import tc.oc.pgm.tracker.trackers.EntityTracker;
 import tc.oc.pgm.tracker.trackers.FallTracker;
 import tc.oc.pgm.tracker.trackers.FallingBlockTracker;
@@ -36,6 +38,7 @@ import tc.oc.pgm.tracker.trackers.ProjectileTracker;
 import tc.oc.pgm.tracker.trackers.SpleefTracker;
 import tc.oc.pgm.tracker.trackers.TNTTracker;
 
+@NullMarked
 public class TrackerMatchModule implements MatchModule {
 
   private final EntityTracker entityTracker;
@@ -79,6 +82,7 @@ public class TrackerMatchModule implements MatchModule {
     match.addListener(blockTracker, MatchScope.RUNNING);
     match.addListener(fallingBlockTracker, MatchScope.RUNNING);
     match.addListener(cactiTracker, MatchScope.RUNNING);
+    match.addListener(new EndCrystalTracker(this, match), MatchScope.RUNNING);
     match.addListener(new DispenserTracker(this, match), MatchScope.RUNNING);
     match.addListener(new TNTTracker(this, match), MatchScope.RUNNING);
     match.addListener(new SpleefTracker(this), MatchScope.RUNNING);
@@ -155,7 +159,7 @@ public class TrackerMatchModule implements MatchModule {
     return null;
   }
 
-  public TrackerInfo resolveInfo(Entity entity) {
+  public @Nullable TrackerInfo resolveInfo(Entity entity) {
     return entityTracker.resolveInfo(entity);
   }
 
@@ -168,7 +172,7 @@ public class TrackerMatchModule implements MatchModule {
     return entityTracker.getOwner(entity);
   }
 
-  public TrackerInfo resolveInfo(Block block) {
+  public @Nullable TrackerInfo resolveInfo(Block block) {
     return blockTracker.resolveInfo(block);
   }
 

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/EndCrystalTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/EndCrystalTracker.java
@@ -1,0 +1,28 @@
+package tc.oc.pgm.tracker.trackers;
+
+import org.bukkit.entity.EnderCrystal;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.jspecify.annotations.NullMarked;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.ParticipantState;
+import tc.oc.pgm.tracker.TrackerMatchModule;
+import tc.oc.pgm.tracker.info.EntityInfo;
+
+@NullMarked
+public class EndCrystalTracker extends AbstractTracker<EntityInfo> {
+  public EndCrystalTracker(TrackerMatchModule tmm, Match match) {
+    super(EntityInfo.class, tmm, match);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onCrystalDamage(EntityDamageByEntityEvent event) {
+    if (!(event.getEntity() instanceof EnderCrystal crystal)) return;
+
+    ParticipantState owner = entities().getOwner(event.getDamager());
+    if (owner == null) return;
+
+    entities().trackEntity(crystal, new EntityInfo(crystal, owner));
+  }
+}

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernModuleRegistrar.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/ModernModuleRegistrar.java
@@ -4,6 +4,7 @@ import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
 import tc.oc.pgm.api.Modules;
 import tc.oc.pgm.platform.modern.modules.kits.ModernKitMatchModule;
+import tc.oc.pgm.platform.modern.modules.tracker.ModernTrackerMatchModule;
 import tc.oc.pgm.platform.modern.modules.trim.TrimMatchModule;
 import tc.oc.pgm.platform.modern.modules.trim.TrimModule;
 import tc.oc.pgm.platform.modern.modules.waypoint.WaypointMatchModule;
@@ -17,6 +18,7 @@ public class ModernModuleRegistrar implements Modules.ModuleRegistrar {
         ModernEventFilterMatchModule.class, new ModernEventFilterMatchModule.Factory());
     modules.register(ModernKitMatchModule.class, new ModernKitMatchModule.Factory());
     modules.register(ModernMobsMatchModule.class, new ModernMobsMatchModule.Factory());
+    modules.register(ModernTrackerMatchModule.class, new ModernTrackerMatchModule.Factory());
     modules.register(TrimModule.class, TrimMatchModule.class, new TrimModule.Factory());
     modules.register(WaypointMatchModule.class, WaypointMatchModule::new);
   }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/tracker/ModernTrackerMatchModule.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/modules/tracker/ModernTrackerMatchModule.java
@@ -1,0 +1,94 @@
+package tc.oc.pgm.platform.modern.modules.tracker;
+
+import java.util.Collection;
+import java.util.List;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.DamageSource;
+import org.bukkit.craftbukkit.damage.CraftDamageSource;
+import org.bukkit.craftbukkit.entity.CraftEnderCrystal;
+import org.bukkit.entity.EnderCrystal;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityPlaceEvent;
+import org.jspecify.annotations.NullMarked;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.match.factory.MatchModuleFactory;
+import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.api.player.ParticipantState;
+import tc.oc.pgm.events.ListenerScope;
+import tc.oc.pgm.platform.modern.listeners.TntListener;
+import tc.oc.pgm.tracker.TrackerMatchModule;
+import tc.oc.pgm.tracker.info.EntityInfo;
+
+@NullMarked
+@ListenerScope(MatchScope.RUNNING)
+public class ModernTrackerMatchModule implements MatchModule, Listener {
+
+  public static class Factory implements MatchModuleFactory<ModernTrackerMatchModule> {
+    @Override
+    public Collection<Class<? extends MatchModule>> getSoftDependencies() {
+      return List.of(TrackerMatchModule.class);
+    }
+
+    @Override
+    public ModernTrackerMatchModule createMatchModule(Match match) throws ModuleLoadException {
+      return new ModernTrackerMatchModule(match);
+    }
+  }
+
+  private final Match match;
+  private final TrackerMatchModule tmm;
+
+  public ModernTrackerMatchModule(Match match) {
+    this.match = match;
+    this.tmm = match.needModule(TrackerMatchModule.class);
+  }
+
+  /**
+   * causingEntity needs to be null to ensure self-damage is not negated when friendly fire is
+   * disabled. We have to do something similar for TNT, see {@link TntListener#onTntSpawn}; however,
+   * as causingEntity is private and final, we have to cancel the original event and replace the end
+   * crystal's DamageSource and then call hurtServer.
+   */
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void onCrystalDamage(EntityDamageByEntityEvent event) {
+    if (!(event.getEntity() instanceof EnderCrystal crystal)) return;
+    // Only intercept when a player has damaged the end crystal
+    if (!(event.getDamageSource().getCausingEntity() instanceof Player)) return;
+
+    ParticipantState owner = tmm.getEntityTracker().getOwner(event.getDamager());
+    if (owner == null) return;
+
+    var nmsCrystal = ((CraftEnderCrystal) crystal).getHandle();
+    var handle = ((CraftDamageSource) event.getDamageSource()).getHandle();
+
+    // Reconstruct the damage source one-to-one, but setting causingEntity as null
+    var damageSource = new DamageSource(
+        handle.typeHolder(), handle.getDirectEntity(), null, handle.sourcePositionRaw());
+    var knownCause = handle.knownCause();
+    if (knownCause != null) damageSource = damageSource.knownCause(knownCause);
+    if (handle.isCritical()) damageSource = damageSource.critical();
+
+    event.setCancelled(true);
+    nmsCrystal.hurtServer(
+        (ServerLevel) nmsCrystal.level(), damageSource, (float) event.getDamage());
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onCrystalPlace(EntityPlaceEvent event) {
+    if (!(event.getEntity() instanceof EnderCrystal crystal)) return;
+
+    Player player = event.getPlayer();
+    if (player == null) return;
+
+    ParticipantState placer = match.getParticipantState(player);
+    if (placer == null) return;
+
+    tmm.getEntityTracker().trackEntity(crystal, new EntityInfo(crystal, placer));
+  }
+}


### PR DESCRIPTION
Hooks end crystals into PGM's pre-existing trackers to credit the player who detonates and end crystal via any means (projectile, melee hit, etc.), falling back on the player who placed the end crystal on modern only, since end crystals can't be placed on legacy.

This also resolves an issue where players could not damage themselves with end crystals even if `self="false"` on `entity explosion` in `<disabledamage/>`; unfortunately this uses reflection, and is a similar issue to the one we work around for TNT in modern's `TntListener`.