### PR TITLE
Resolve material data parsing inconsistencies

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
@@ -73,9 +73,29 @@ class ModernMaterialParser {
 
   public static ItemMaterialData parseItem(String text, short dmg, Node node)
       throws InvalidXMLException {
-    var res = Adapter.PGM_ITEM.visit(parseLegacyMaterial(text, node), dmg);
-    validateItem(res.getItemType(), node);
-    return res;
+    String[] pieces = text.split(":");
+    if (pieces.length > 2) {
+      throw new InvalidXMLException("Invalid material pattern '" + text + "'.", node);
+    }
+
+    Material material = parseLegacyMaterial(pieces[0], node);
+    short mdData = pieces.length == 2 ? XMLUtils.parseNumber(node, pieces[1], Short.class) : 0;
+    if (mdData != dmg && mdData != 0 && dmg != 0) {
+      throw new InvalidXMLException(
+          "Mismatching damage, parsed '" + text + ":" + dmg + "' but should be '" + text + ":"
+              + mdData + "'",
+          node);
+    }
+    short data = dmg != 0 ? dmg : mdData;
+
+    if (data != 0 && !material.isLegacy() && !canUseMeta(material)) {
+      throw new InvalidXMLException(
+          "Material '" + material + "' cannot have a damage/meta value of " + data, node);
+    }
+
+    var md = Adapter.PGM_ITEM.visit(material, data);
+    validateItem(md.getItemType(), node);
+    return md;
   }
 
   public static Material parseMaterial(String text, Node node) throws InvalidXMLException {
@@ -175,15 +195,15 @@ class ModernMaterialParser {
     }
 
     Material material = parseLegacyMaterial(pieces[0], node);
-    if (pieces.length == 1) {
-      return adapter.visit(material);
-    } else {
-      try {
-        return adapter.visit(material, XMLUtils.parseNumber(node, pieces[1], Short.class));
-      } catch (NumberFormatException e) {
-        throw new InvalidXMLException("Invalid damage value: " + pieces[1], node, e);
-      }
-    }
+    return pieces.length == 1
+        ? adapter.visit(material)
+        : adapter.visit(material, XMLUtils.parseNumber(node, pieces[1], Short.class));
+  }
+
+  private static boolean canUseMeta(Material material) {
+    return material.getMaxDurability() > 0
+        || material == Material.POTION
+        || material == Material.SPLASH_POTION;
   }
 
   private static Material upgrade(Material material, short data) {

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialParser.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialParser.java
@@ -20,6 +20,26 @@ class SpMaterialParser {
     return parse(text, node, false, Adapter.PGM_ITEM);
   }
 
+  public static SpMaterialData parseItem(String text, short dmg, Node node)
+      throws InvalidXMLException {
+    SpMaterialData md = parseItem(text, node);
+    short mdData = md.getData();
+    if (mdData != dmg && mdData != 0 && dmg != 0) {
+      throw new InvalidXMLException(
+          "Mismatching damage, parsed '" + text + ":" + dmg + "' but should be '" + text + ":"
+              + mdData + "'",
+          node);
+    }
+    short data = dmg != 0 ? dmg : mdData;
+
+    if (dmg != 0 && isModernName(text) && !canUseMeta(md.getItemType())) {
+      throw new InvalidXMLException(
+          "Material '" + md.getItemType() + "' cannot have a damage/meta value of " + data, node);
+    }
+
+    return new SpMaterialData(md.getItemType(), data);
+  }
+
   public static SpMaterialData parseBlock(String text, Node node) throws InvalidXMLException {
     return parse(text, node, false, Adapter.PGM_BLOCK);
   }
@@ -70,6 +90,14 @@ class SpMaterialParser {
 
   private static String normalize(String text) {
     return text.toUpperCase(Locale.ROOT).replaceAll("\\s+", "_").replaceAll("\\W", "");
+  }
+
+  private static boolean isModernName(String text) {
+    return ModernMaterialNames.get(normalize(text)) != null;
+  }
+
+  private static boolean canUseMeta(Material material) {
+    return material.getMaxDurability() > 0 || material == Material.POTION;
   }
 
   interface Adapter<T> {

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/material/SpMaterialUtils.java
@@ -109,15 +109,7 @@ public class SpMaterialUtils implements MaterialUtils {
   @Override
   public ItemMaterialData parseItemMaterialData(String text, short dmg, @Nullable Node node)
       throws InvalidXMLException {
-    var md = SpMaterialParser.parseItem(text, node);
-    short mdData = md.getData();
-    if (mdData != dmg && mdData != 0 && dmg != 0)
-      throw new InvalidXMLException(
-          "Mismatching damage, parsed '" + text + ":" + dmg + "' but should be '" + text + ":"
-              + md.getData() + "'",
-          node);
-
-    if (mdData != dmg && dmg != 0) md = new SpMaterialData(md.getItemType(), dmg);
+    var md = SpMaterialParser.parseItem(text, dmg, node);
     validateItem(md.getItemType(), node);
     return md;
   }


### PR DESCRIPTION
This became noticeable when we loaded The Funky Queen to OCC; things defined like "stained glass:15" weren't parsed on modern correctly while being supported on SportPaper. It probably makes sense to support this given that `damage` in modern tends to refer to actual durability status of the item when relevant.