### PR TITLE
Don't modify bow projectiles if unspecified in xml

### DIFF
--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileMatchModule.java
@@ -19,6 +19,7 @@ import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.match.Match;
@@ -35,21 +36,21 @@ import tc.oc.pgm.util.bukkit.Sounds;
 public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
 
   private final Match match;
-  private final Class<? extends Entity> cls;
+  private final @Nullable Class<? extends Entity> cls;
   private final float velocityMod;
   private final Set<PotionEffect> potionEffects;
   private final Filter pickupFilter;
 
   public ModifyBowProjectileMatchModule(
       Match match,
-      Class<? extends Entity> cls,
+      @Nullable Class<? extends Entity> cls,
       float velocityMod,
       Set<PotionEffect> effects,
       Filter pickupFilter) {
     this.match = match;
     this.cls = cls;
     this.velocityMod = velocityMod;
-    potionEffects = effects;
+    this.potionEffects = effects;
     this.pickupFilter = pickupFilter;
   }
 
@@ -58,8 +59,8 @@ public class ModifyBowProjectileMatchModule implements MatchModule, Listener {
     Plugin plugin = PGM.get();
     Entity newProjectile;
 
-    if (this.cls == Arrow.class && event.getProjectile() instanceof Arrow) {
-      // Don't change the projectile if it's an Arrow and the custom entity type is also Arrow
+    if (this.cls == null) {
+      // Don't replace the projectile, keep the original
       newProjectile = event.getProjectile();
     } else {
       // Replace the projectile

--- a/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/ModifyBowProjectileModule.java
@@ -3,11 +3,11 @@ package tc.oc.pgm.modules;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
-import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.potion.PotionEffect;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
 import tc.oc.pgm.api.map.factory.MapFactory;
@@ -19,19 +19,19 @@ import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class ModifyBowProjectileModule implements MapModule<ModifyBowProjectileMatchModule> {
-  protected final Class<? extends Entity> cls;
+  protected final @Nullable Class<? extends Entity> cls;
   protected final float velocityMod;
   protected final Set<PotionEffect> potionEffects;
   protected final Filter pickupFilter;
 
   public ModifyBowProjectileModule(
-      Class<? extends Entity> cls,
+      @Nullable Class<? extends Entity> cls,
       float velocityMod,
       Set<PotionEffect> effects,
       Filter pickupFilter) {
     this.cls = cls;
     this.velocityMod = velocityMod;
-    potionEffects = effects;
+    this.potionEffects = effects;
     this.pickupFilter = pickupFilter;
   }
 
@@ -48,7 +48,7 @@ public class ModifyBowProjectileModule implements MapModule<ModifyBowProjectileM
       FilterParser filters = factory.getFilters();
 
       boolean changed = false;
-      Class<? extends Entity> projectile = Arrow.class;
+      Class<? extends Entity> projectile = null;
       float velocityMod = 1;
       Set<PotionEffect> potionEffects = new HashSet<>();
       Filter pickupFilter = StaticFilter.ALLOW;


### PR DESCRIPTION
Fixes #1600, all projectiles shot are still replaced if you specify a replacement, but just adding a velocityMod or a pickup-filter will no longer cause all projectiles to be replaced with arrows