### PR TITLE
Add config for current map vote book weighting

### DIFF
--- a/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
@@ -177,7 +177,7 @@ public class VotingPool extends MapPool {
       Formula<Match> scoreAfterPlay,
       int minCooldown,
       int minutesPerDay,
-      boolean excludeUsingCurrentMap) {
+      boolean useCurrentMap) {
     private VoteConstants(ConfigurationSection section, int mapAmount) {
       this(
           section.getInt("vote-options", MapVotePicker.MAX_VOTE_OPTIONS), // Show 5 maps
@@ -192,7 +192,7 @@ public class VotingPool extends MapPool {
               .map(m -> new Context(m.getDuration())),
           section.getInt("cooldown.min-length", 30),
           section.getInt("cooldown.minutes-per-day", 30),
-          section.getBoolean("exclude-using-current-map", true));
+          section.getBoolean("score.use-current-map", true));
     }
 
     public double afterVoteScore(double score) {

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
@@ -177,7 +177,7 @@ public class VotingPool extends MapPool {
       Formula<Match> scoreAfterPlay,
       int minCooldown,
       int minutesPerDay,
-      boolean excludeCurrentGamemode) {
+      boolean excludeUsingCurrentMap) {
     private VoteConstants(ConfigurationSection section, int mapAmount) {
       this(
           section.getInt("vote-options", MapVotePicker.MAX_VOTE_OPTIONS), // Show 5 maps
@@ -192,7 +192,7 @@ public class VotingPool extends MapPool {
               .map(m -> new Context(m.getDuration())),
           section.getInt("cooldown.min-length", 30),
           section.getInt("cooldown.minutes-per-day", 30),
-          section.getBoolean("exclude-current-gamemode", true));
+          section.getBoolean("exclude-using-current-map", true));
     }
 
     public double afterVoteScore(double score) {

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
@@ -175,9 +175,9 @@ public class VotingPool extends MapPool {
       double scoreAfterVoteMax,
       double scoreMinToVote,
       Formula<Match> scoreAfterPlay,
+      boolean useCurrentMap,
       int minCooldown,
-      int minutesPerDay,
-      boolean useCurrentMap) {
+      int minutesPerDay) {
     private VoteConstants(ConfigurationSection section, int mapAmount) {
       this(
           section.getInt("vote-options", MapVotePicker.MAX_VOTE_OPTIONS), // Show 5 maps
@@ -190,9 +190,9 @@ public class VotingPool extends MapPool {
           section.getDouble("score.min-for-vote", 0.01), // To even be voted, need at least 1%
           Formula.of(section.getString("score.after-playing"), Context.variables(), c -> 0)
               .map(m -> new Context(m.getDuration())),
+          section.getBoolean("score.use-current-map", true),
           section.getInt("cooldown.min-length", 30),
-          section.getInt("cooldown.minutes-per-day", 30),
-          section.getBoolean("score.use-current-map", true));
+          section.getInt("cooldown.minutes-per-day", 30));
     }
 
     public double afterVoteScore(double score) {

--- a/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/pools/VotingPool.java
@@ -176,7 +176,8 @@ public class VotingPool extends MapPool {
       double scoreMinToVote,
       Formula<Match> scoreAfterPlay,
       int minCooldown,
-      int minutesPerDay) {
+      int minutesPerDay,
+      boolean excludeCurrentGamemode) {
     private VoteConstants(ConfigurationSection section, int mapAmount) {
       this(
           section.getInt("vote-options", MapVotePicker.MAX_VOTE_OPTIONS), // Show 5 maps
@@ -190,7 +191,8 @@ public class VotingPool extends MapPool {
           Formula.of(section.getString("score.after-playing"), Context.variables(), c -> 0)
               .map(m -> new Context(m.getDuration())),
           section.getInt("cooldown.min-length", 30),
-          section.getInt("cooldown.minutes-per-day", 30));
+          section.getInt("cooldown.minutes-per-day", 30),
+          section.getBoolean("exclude-current-gamemode", true));
     }
 
     public double afterVoteScore(double score) {

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
@@ -104,7 +104,8 @@ public class MapVotePicker {
       @Nullable MapInfo prevMap, @Nullable List<MapInfo> selected, Map<MapInfo, VoteData> scores) {
     if (selected == null) selected = new ArrayList<>();
 
-    List<MapInfo> previousMaps = prependedUnmodifiableList(prevMap, selected);
+    List<MapInfo> previousMaps =
+        prependedUnmodifiableList(constants.excludeCurrentGamemode() ? prevMap : null, selected);
     while (selected.size() < constants.voteOptions()) {
       MapInfo map = getMap(previousMaps, scores);
 

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
@@ -105,7 +105,7 @@ public class MapVotePicker {
     if (selected == null) selected = new ArrayList<>();
 
     List<MapInfo> previousMaps =
-        prependedUnmodifiableList(constants.excludeUsingCurrentMap() ? prevMap : null, selected);
+        prependedUnmodifiableList(constants.useCurrentMap() ? prevMap : null, selected);
     while (selected.size() < constants.voteOptions()) {
       MapInfo map = getMap(previousMaps, scores);
 

--- a/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
+++ b/core/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
@@ -105,7 +105,7 @@ public class MapVotePicker {
     if (selected == null) selected = new ArrayList<>();
 
     List<MapInfo> previousMaps =
-        prependedUnmodifiableList(constants.excludeCurrentGamemode() ? prevMap : null, selected);
+        prependedUnmodifiableList(constants.excludeUsingCurrentMap() ? prevMap : null, selected);
     while (selected.size() < constants.voteOptions()) {
       MapInfo map = getMap(previousMaps, scores);
 

--- a/core/src/main/resources/map-pools.yml
+++ b/core/src/main/resources/map-pools.yml
@@ -52,6 +52,9 @@ pools:
       # After the map plays, reset the score to:
       # Supports a formula with play_minutes
       after-playing: 0
+      # If the map that just played should count towards the vote's weighting, making
+      # it (or its gamemode, depending on the formula used) less likely to be picked again.
+      use-current-map: true
 
     # Voted pool only: make maps be excluded from votes if they recently played for long
     cooldown:


### PR DESCRIPTION
PR [#1581](https://github.com/PGMDev/PGM/pull/1581) introduced `prevMap` to `MapVotePicker.getMaps()`, prepending the current map to the "previous maps" list so that maps sharing its gamemode receive reduced weight in the vote. This was always-on with no way to disable it.

Forcing gamemode diversity sounds good on paper, but some gamemodes are more popular than others and penalising them in the vote takes away player choice. The vote picker already tries to pick varied maps, so a bit of gamemode overlap between the current map and the next vote is not really a problem.

Some pool types don't need this logic at all either. In arcade-style pools, a map's gamemode tag is often a poor reflection of how it actually plays, so gamemode-based exclusion does more harm than good.

Adds `excludeCurrentGamemode` to `VoteConstants`, backed by config key `exclude-current-gamemode` (default: `true`). The check lives inside `MapVotePicker.getMaps()`, which owns `VoteConstants` and all other weighting rules. `VotingPool` always passes `match.getMap()` and the picker decides whether to use it.

```yaml
exclude-current-gamemode: true   # default, reduces weight for maps sharing a gamemode with the current map
exclude-current-gamemode: false  # current map's gamemode is not considered, gamemode weighting still applies across vote candidates
```

Creating this PR as a start for discussion, it would be nice to run tests with this disabled for some period.