### PR TITLE
<launch-projectile/> action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -27,6 +27,7 @@ import tc.oc.pgm.action.actions.EnchantItemAction;
 import tc.oc.pgm.action.actions.ExposedAction;
 import tc.oc.pgm.action.actions.FillAction;
 import tc.oc.pgm.action.actions.KillEntitiesAction;
+import tc.oc.pgm.action.actions.LaunchProjectileAction;
 import tc.oc.pgm.action.actions.MessageAction;
 import tc.oc.pgm.action.actions.OpenShop;
 import tc.oc.pgm.action.actions.PasteStructureAction;
@@ -61,6 +62,7 @@ import tc.oc.pgm.filters.operator.AllFilter;
 import tc.oc.pgm.flag.FlagDefinition;
 import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.modules.WeatherMatchModule;
+import tc.oc.pgm.projectile.ProjectileDefinition;
 import tc.oc.pgm.shops.Shop;
 import tc.oc.pgm.shops.ShopModule;
 import tc.oc.pgm.shops.menu.Payable;
@@ -564,5 +566,17 @@ public class ActionParser {
     return MatchPlayer.class.isAssignableFrom(scope)
         ? new ScheduleAction.Player(after, (Action<? super MatchPlayer>) action)
         : new ScheduleAction<>(scope, after, action);
+  }
+
+  @MethodParser("launch-projectile")
+  public <T extends Filterable<?>> LaunchProjectileAction<T> parseProjectile(Element el, Class<T> scope)
+      throws InvalidXMLException {
+    scope = parseScope(el, scope);
+    var projectile = parser.reference(ProjectileDefinition.class, el, "id").required();
+    var origin = parser.vector(el, "origin").required();
+    var destination = parser.vector(el, "destination").required();
+    Filter damageFilter = parser.filter(el, "damage-filter").orNull();
+
+    return new LaunchProjectileAction(scope, projectile, origin, destination, damageFilter);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -19,6 +19,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 import org.jdom2.Element;
 import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.action.actions.ActionNode;
@@ -569,14 +570,32 @@ public class ActionParser {
   }
 
   @MethodParser("launch-projectile")
-  public <T extends Filterable<?>> LaunchProjectileAction<T> parseProjectile(Element el, Class<T> scope)
-      throws InvalidXMLException {
+  public <T extends Filterable<?>> LaunchProjectileAction<T> parseProjectile(
+      Element el, Class<T> scope) throws InvalidXMLException {
     scope = parseScope(el, scope);
-    var projectile = parser.reference(ProjectileDefinition.class, el, "id").required();
+    var projectile =
+        parser.reference(ProjectileDefinition.class, el, "projectile").required();
     var origin = parser.vector(el, "origin").required();
-    var destination = parser.vector(el, "destination").required();
+    Vector toward = XMLUtils.parseVector(Node.fromAttr(el, "toward"));
+    Node yawNode = Node.fromAttr(el, "yaw");
+    Node pitchNode = Node.fromAttr(el, "pitch");
+    float yaw = XMLUtils.parseNumber(yawNode, Float.class, 0F);
+    float pitch = XMLUtils.parseNumber(pitchNode, Float.class, 0F);
+    if (toward != null) {
+      if (yawNode != null) {
+        throw new InvalidXMLException("'toward' and 'yaw' cannot both be defined", el);
+      }
+      if (pitchNode != null) {
+        throw new InvalidXMLException("'toward' and 'pitch' cannot both be defined", el);
+      }
+    }
+    if (toward == null && yawNode == null && pitchNode == null) {
+      throw new InvalidXMLException("Either 'toward' or 'pitch/yaw' must be defined", el);
+    }
+
     Filter damageFilter = parser.filter(el, "damage-filter").orNull();
 
-    return new LaunchProjectileAction(scope, projectile, origin, destination, damageFilter);
+    return new LaunchProjectileAction<>(
+        scope, projectile, origin, toward, yaw, pitch, damageFilter);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/LaunchProjectileAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/LaunchProjectileAction.java
@@ -1,8 +1,11 @@
 package tc.oc.pgm.action.actions;
 
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.Vector;
 import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.match.Match;
@@ -10,33 +13,28 @@ import tc.oc.pgm.filters.Filterable;
 import tc.oc.pgm.projectile.ProjectileDefinition;
 
 public class LaunchProjectileAction<T extends Filterable<?>> extends AbstractAction<T> {
-  private final Match match;
   private final FeatureReference<ProjectileDefinition> projectileReference;
-  private Vector origin;
-  private final Vector destination;
+  private final Vector origin;
+  private final @Nullable Vector toward;
+  private final float yaw;
+  private final float pitch;
   private final Filter damageFilter;
 
   public LaunchProjectileAction(
       Class<T> scope,
-      Match match,
       FeatureReference<ProjectileDefinition> projectileReference,
       Vector origin,
-      Vector destination,
+      @Nullable Vector toward,
+      float yaw,
+      float pitch,
       @Nullable Filter damageFilter) {
     super(scope);
-    this.match = match;
     this.projectileReference = projectileReference;
     this.origin = origin;
-    this.destination = destination;
+    this.toward = toward;
+    this.yaw = yaw;
+    this.pitch = pitch;
     this.damageFilter = damageFilter;
-  }
-
-  public Vector getOrigin() {
-    return origin;
-  }
-
-  public Vector getDestination() {
-    return destination;
   }
 
   public @Nullable Filter getDamageFilter() {
@@ -44,18 +42,23 @@ public class LaunchProjectileAction<T extends Filterable<?>> extends AbstractAct
   }
 
   @Override
-  public void trigger (T t) {
-    ProjectileDefinition projectile = projectileReference.get();
-    Vector direction = destination.clone().subtract(origin.normalize());
-//    double velocity = direction.multiply(projectile.velocity);
-    Location loc = new Location(match.getWorld(), 0, 0, 0);
-//    boolean realProjectile = Projectile.class.isAssignableFrom(projectile.projectile);
-//
-//
-//    Entity entity
-//    if (realProjectile) {
-//      entity = spawn
-//    }
-//    Entity entity = loc.getWorld().spawnEntity(loc, projectile.getEntityType())
+  public void trigger(T t) {
+    Match match = t.getMatch();
+    ProjectileDefinition def = projectileReference.get();
+
+    Vector dir;
+    if (toward != null) {
+      dir = toward.clone().subtract(origin).normalize();
+    } else {
+      Location dirLoc = new Location(null, 0, 0, 0, yaw, pitch);
+      dir = dirLoc.getDirection();
+    }
+    dir.multiply(def.getVelocity());
+    Location loc = origin.toLocation(match.getWorld());
+
+    Entity proj = match.getWorld().spawn(loc, def.getProjectile());
+    proj.setVelocity(dir);
+    proj.setMetadata("projectileDefinition", new FixedMetadataValue(PGM.get(), def));
+    proj.setMetadata("launchProjectile", new FixedMetadataValue(PGM.get(), this));
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/actions/LaunchProjectileAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/LaunchProjectileAction.java
@@ -1,0 +1,61 @@
+package tc.oc.pgm.action.actions;
+
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.projectile.ProjectileDefinition;
+
+public class LaunchProjectileAction<T extends Filterable<?>> extends AbstractAction<T> {
+  private final Match match;
+  private final FeatureReference<ProjectileDefinition> projectileReference;
+  private Vector origin;
+  private final Vector destination;
+  private final Filter damageFilter;
+
+  public LaunchProjectileAction(
+      Class<T> scope,
+      Match match,
+      FeatureReference<ProjectileDefinition> projectileReference,
+      Vector origin,
+      Vector destination,
+      @Nullable Filter damageFilter) {
+    super(scope);
+    this.match = match;
+    this.projectileReference = projectileReference;
+    this.origin = origin;
+    this.destination = destination;
+    this.damageFilter = damageFilter;
+  }
+
+  public Vector getOrigin() {
+    return origin;
+  }
+
+  public Vector getDestination() {
+    return destination;
+  }
+
+  public @Nullable Filter getDamageFilter() {
+    return damageFilter;
+  }
+
+  @Override
+  public void trigger (T t) {
+    ProjectileDefinition projectile = projectileReference.get();
+    Vector direction = destination.clone().subtract(origin.normalize());
+//    double velocity = direction.multiply(projectile.velocity);
+    Location loc = new Location(match.getWorld(), 0, 0, 0);
+//    boolean realProjectile = Projectile.class.isAssignableFrom(projectile.projectile);
+//
+//
+//    Entity entity
+//    if (realProjectile) {
+//      entity = spawn
+//    }
+//    Entity entity = loc.getWorld().spawnEntity(loc, projectile.getEntityType())
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -82,6 +82,8 @@ import tc.oc.pgm.modules.ItemDestroyMatchModule;
 import tc.oc.pgm.modules.ItemDestroyModule;
 import tc.oc.pgm.modules.ItemKeepMatchModule;
 import tc.oc.pgm.modules.ItemKeepModule;
+import tc.oc.pgm.modules.LaunchProjectileMatchModule;
+import tc.oc.pgm.modules.LaunchProjectileModule;
 import tc.oc.pgm.modules.MapmakerMatchModule;
 import tc.oc.pgm.modules.MobsMatchModule;
 import tc.oc.pgm.modules.MobsModule;
@@ -313,6 +315,10 @@ public final class Modules {
         new FallingBlocksModule.Factory());
     register(FlagModule.class, FlagMatchModule.class, new FlagModule.Factory());
     register(ProjectileModule.class, ProjectileMatchModule.class, new ProjectileModule.Factory());
+    register(
+        LaunchProjectileModule.class,
+        LaunchProjectileMatchModule.class,
+        new LaunchProjectileModule.Factory());
     register(ConsumableModule.class, ConsumableMatchModule.class, new ConsumableModule.Factory());
     register(
         DiscardPotionBottlesModule.class,

--- a/core/src/main/java/tc/oc/pgm/modules/LaunchProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/LaunchProjectileMatchModule.java
@@ -1,0 +1,48 @@
+package tc.oc.pgm.modules;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import tc.oc.pgm.action.actions.LaunchProjectileAction;
+import tc.oc.pgm.api.filter.Filter;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+import tc.oc.pgm.api.match.MatchScope;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.ListenerScope;
+
+@ListenerScope(MatchScope.RUNNING)
+public class LaunchProjectileMatchModule implements MatchModule, Listener {
+
+  private static final String METADATA_KEY = "launchProjectile";
+  private final Match match;
+
+  public LaunchProjectileMatchModule(Match match) {
+    this.match = match;
+  }
+
+  @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+  public void onDamage(EntityDamageByEntityEvent event) {
+    Entity damager = event.getDamager();
+    if (!damager.hasMetadata(METADATA_KEY)) return;
+
+    LaunchProjectileAction<?> action =
+        (LaunchProjectileAction<?>) damager.getMetadata(METADATA_KEY).getFirst().value();
+
+    if (!(event.getEntity() instanceof Player player)) return;
+
+    MatchPlayer victim = match.getPlayer(player);
+    if (victim == null) return;
+
+    Filter damageFilter = action.getDamageFilter();
+    if (damageFilter == null) return;
+
+    if (!damageFilter.query(victim).isAllowed()) {
+      event.setCancelled(true);
+      damager.remove();
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/modules/LaunchProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/modules/LaunchProjectileModule.java
@@ -1,0 +1,25 @@
+package tc.oc.pgm.modules;
+
+import java.util.logging.Logger;
+import org.jdom2.Document;
+import tc.oc.pgm.api.map.MapModule;
+import tc.oc.pgm.api.map.factory.MapFactory;
+import tc.oc.pgm.api.map.factory.MapModuleFactory;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+
+public class LaunchProjectileModule implements MapModule<LaunchProjectileMatchModule> {
+
+  @Override
+  public LaunchProjectileMatchModule createMatchModule(Match match) {
+    return new LaunchProjectileMatchModule(match);
+  }
+
+  public static class Factory implements MapModuleFactory<LaunchProjectileModule> {
+    @Override
+    public LaunchProjectileModule parse(MapFactory factory, Logger logger, Document doc)
+        throws InvalidXMLException {
+      return new LaunchProjectileModule();
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
@@ -52,6 +52,14 @@ public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
     this.blockMaterial = blockMaterial;
   }
 
+  public Class<? extends Entity> getProjectile() {
+    return projectile;
+  }
+
+  public Double getVelocity() {
+    return velocity;
+  }
+
   public @Nullable String getName() {
     return name;
   }


### PR DESCRIPTION
This PR introduces a new action type ```<launch-projectile/>```. The XML looks like this:
```xml
<projectiles>
    <projectile id="test-arrow" projectile="Arrow" damage="80" destroy-filter="stone"/>
    <projectile id="lazer" name="lazer" projectile="Snowball" velocity="3.5" damage="50" throwable="false" cooldown="5s"/>
</projectiles>
<actions>
    <action id="test-action" scope="match" expose="true">
        <!-- Using toward attribute -->
        <launch-projectile projectile="test-arrow" origin="0,0,0" toward="5,5,5"/>
        <!-- Using yaw/pitch attributes instead -->
        <launch-projectile projectile="test-arrow" origin="0,0,0" yaw="45" pitch="22.5"/>
        <!-- Will only kill blue players -->
        <launch-projectile projectile="lazer" origin="0,0,0" toward="5,5,5" damage-filter="blue-team"/> 
    </action>
</actions>
```

(**NOTE:** ```toward="x,y,z"``` _is the direction the projectile will be fired towards once spawned in. It does not mean the projectile will travel until it hits that exact point_)

With ```<launch-projectile/>``` it would be nice to be able to launch custom fireworks, but at the moment custom fireworks can only be used for kits. My first thought was that ```<firework/>``` could live inside of ```<projectiles></projectiles>``` where it would then be given an id to be used for ```<launch-projectile projectile="firework-id" .../>```, but I'm not entirely sure and this sounds like it could become a proto bump.