### PR TITLE
Fix minor modern material parsing bugs

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialParser.java
@@ -131,7 +131,7 @@ class ModernMaterialParser {
     Set<Material> materials = new HashSet<>(16);
     materials.add(main);
     materials.add(alt);
-    for (byte i = 3; i < 16; i++) {
+    for (byte i = 2; i < 16; i++) {
       md.setData(i);
       materials.add(UNSAFE.fromLegacy(md));
     }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/material/ModernMaterialUtils.java
@@ -158,7 +158,7 @@ public class ModernMaterialUtils implements MaterialUtils {
 
     @Override
     public MaterialMatcher.Builder visit(Material material) {
-      return add(material, true);
+      return add(material, material.isLegacy());
     }
 
     @Override


### PR DESCRIPTION
- When flattening a legacy material, we were checking `material:0`, `material:1`, and if they're different, then checking `material:3` to `:15`, but that's explicitly skipping `:2`, the result was that it was not possible to create a monument for magenta stained clay unless using `stained clay:2` since parsing with metadata skipped flattening, any attempt to use `magenta terracotta` would fail.
- In modern all materials are always being flattened, so `red_wool` got turned into legacy `wool` then mapped into its 16 variants (well, except magenta due to the above bug). I've changed it so only legacy names (eg: `wool`) will perform flattening.