### PR TITLE
Cleanup and encapsulate method parsing

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -7,10 +7,8 @@ import static net.kyori.adventure.text.Component.empty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -86,7 +84,7 @@ public class ActionParser {
   private final boolean legacy;
   private final FeatureDefinitionContext features;
   private final XMLFluentParser parser;
-  private final Map<String, Method> methodParsers;
+  private final MethodParsers<Action<?>> methodParsers;
   private final ReplacementParser replacementParser;
 
   public ActionParser(MapFactory factory) {
@@ -94,8 +92,8 @@ public class ActionParser {
     this.legacy = !factory.getProto().isNoOlderThan(MapProtos.ACTION_REVAMP);
     this.features = factory.getFeatures();
     this.parser = factory.getParser();
-    this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
-    replacementParser = new ReplacementParser(factory);
+    this.methodParsers = MethodParsers.byNameParser(this, "action");
+    this.replacementParser = new ReplacementParser(factory, false);
   }
 
   public <B extends Filterable<?>> Action<? super B> parseProperty(
@@ -134,7 +132,7 @@ public class ActionParser {
   }
 
   public Set<String> actionTypes() {
-    return methodParsers.keySet();
+    return methodParsers.methods().keySet();
   }
 
   private boolean maybeReference(Element el, boolean property) {
@@ -206,23 +204,10 @@ public class ActionParser {
     }
   }
 
-  protected Method getParserFor(Element el) {
-    return methodParsers.get(el.getName().toLowerCase());
-  }
-
   @SuppressWarnings("unchecked")
   private <T, B extends Filterable<?>> Action<T> parseDynamic(Element el, Class<B> scope)
       throws InvalidXMLException {
-    Method parser = getParserFor(el);
-    if (parser != null) {
-      try {
-        return (Action<T>) parser.invoke(this, el, scope);
-      } catch (Exception e) {
-        throw InvalidXMLException.coerce(e, new Node(el));
-      }
-    } else {
-      throw new InvalidXMLException("Unknown action type: " + el.getName(), el);
-    }
+    return (Action<T>) methodParsers.parse(el, scope);
   }
 
   private <B extends Filterable<?>> Class<B> parseScope(Element el, Class<B> scope)

--- a/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/replacements/ReplacementParser.java
@@ -4,11 +4,9 @@ import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.text;
 
 import com.google.common.collect.Range;
-import java.lang.reflect.Method;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Set;
 import net.kyori.adventure.text.Component;
 import org.jdom2.Element;
@@ -29,44 +27,27 @@ import tc.oc.pgm.util.xml.XMLFluentParser;
 
 public class ReplacementParser {
   private static final NumberFormat DEFAULT_FORMAT = NumberFormat.getIntegerInstance();
-  private final Map<String, Method> methodParsers =
-      MethodParsers.getMethodParsersForClass(getClass());
+  private final MethodParsers<Replacement> methodParsers;
   private final FeatureDefinitionContext features;
   private final XMLFluentParser parser;
   private final boolean isTopLevel;
 
   public ReplacementParser(MapFactory factory, boolean topLevel) {
-    features = factory.getFeatures();
-    parser = factory.getParser();
-    isTopLevel = topLevel;
-  }
-
-  public ReplacementParser(MapFactory factory) {
-    this(factory, false);
+    this.methodParsers = MethodParsers.byNameParser(this, "replacement");
+    this.features = factory.getFeatures();
+    this.parser = factory.getParser();
+    this.isTopLevel = topLevel;
   }
 
   public <B extends Filterable<?>> Replacement parse(Element el, @Nullable Class<B> scope)
       throws InvalidXMLException {
-    Method parser = getParserFor(el);
-    if (parser != null) {
-      try {
-        var replacement = (Replacement) parser.invoke(this, el, scope);
-        if (scope != null) replacement.validate(scope, new Node(el));
-        return replacement;
-      } catch (Exception e) {
-        throw InvalidXMLException.coerce(e, new Node(el));
-      }
-    } else {
-      throw new InvalidXMLException("Unknown replacement type: " + el.getName(), el);
-    }
+    var replacement = methodParsers.parse(el, scope);
+    if (scope != null) replacement.validate(scope, new Node(el));
+    return replacement;
   }
 
   public Set<String> replacementTypes() {
-    return methodParsers.keySet();
-  }
-
-  protected Method getParserFor(Element el) {
-    return methodParsers.get(el.getName().toLowerCase());
+    return methodParsers.methods().keySet();
   }
 
   private <B extends Filterable<?>> Class<B> parseScope(Element el, Class<B> scope)

--- a/core/src/main/java/tc/oc/pgm/compass/CompassParser.java
+++ b/core/src/main/java/tc/oc/pgm/compass/CompassParser.java
@@ -1,7 +1,5 @@
 package tc.oc.pgm.compass;
 
-import java.lang.reflect.Method;
-import java.util.Map;
 import net.kyori.adventure.text.Component;
 import org.jdom2.Element;
 import tc.oc.pgm.api.filter.Filter;
@@ -22,29 +20,16 @@ public class CompassParser {
 
   private final FeatureDefinitionContext features;
   private final FilterParser filters;
-  private final Map<String, Method> methodParsers;
+  private final MethodParsers<CompassTarget<?>> methodParsers;
 
   public CompassParser(MapFactory factory) {
     this.features = factory.getFeatures();
     this.filters = factory.getFilters();
-    this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
-  }
-
-  protected Method getParserFor(Element el) {
-    return methodParsers.get(el.getName().toLowerCase());
+    this.methodParsers = MethodParsers.byNameParser(this, "compass tracker");
   }
 
   public CompassTarget<?> parseCompassTarget(Element el) throws InvalidXMLException {
-    Method parser = getParserFor(el);
-    if (parser != null) {
-      try {
-        return (CompassTarget<?>) parser.invoke(this, el);
-      } catch (Exception e) {
-        throw InvalidXMLException.coerce(e, new Node(el));
-      }
-    } else {
-      throw new InvalidXMLException("Unknown compass tracker type: " + el.getName(), el);
-    }
+    return methodParsers.parse(el);
   }
 
   @MethodParser("player")

--- a/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
+++ b/core/src/main/java/tc/oc/pgm/filters/parse/FilterParser.java
@@ -4,11 +4,9 @@ import static tc.oc.pgm.filters.PlatformFilters.PLATFORM_FILTERS;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.LivingEntity;
@@ -99,7 +97,7 @@ import tc.oc.pgm.variables.Variable;
 
 public abstract class FilterParser implements XMLParser<Filter, FilterDefinition> {
 
-  protected final Map<String, Method> methodParsers;
+  protected final MethodParsers<Filter> methodParsers;
   protected final MapFactory factory;
   protected final XMLFluentParser parser;
   protected final FeatureDefinitionContext features;
@@ -109,7 +107,10 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
     this.parser = factory.getParser();
     this.features = factory.getFeatures();
 
-    this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
+    this.methodParsers = MethodParsers.<Filter>byNameParser(this, "filter").withFallback(el -> {
+      if (factory.getRegions().isRegion(el)) return factory.getRegions().parse(el);
+      throw new InvalidXMLException("Unknown filter type: " + el.getName(), el);
+    });
   }
 
   @Override
@@ -143,7 +144,8 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
   public abstract Filter parseReference(Node node, String id) throws InvalidXMLException;
 
   public boolean isFilter(Element el) {
-    return methodParsers.containsKey(el.getName()) || factory.getRegions().isRegion(el);
+    return methodParsers.methods().containsKey(el.getName())
+        || factory.getRegions().isRegion(el);
   }
 
   public void parseFilterChildren(Element parent) throws InvalidXMLException {
@@ -152,23 +154,8 @@ public abstract class FilterParser implements XMLParser<Filter, FilterDefinition
     }
   }
 
-  protected Method getParserFor(Element el) {
-    return methodParsers.get(el.getName().toLowerCase());
-  }
-
   protected Filter parseDynamic(Element el) throws InvalidXMLException {
-    Method parser = getParserFor(el);
-    if (parser != null) {
-      try {
-        return (Filter) parser.invoke(this, el);
-      } catch (Exception e) {
-        throw InvalidXMLException.coerce(e, new Node(el));
-      }
-    } else if (factory.getRegions().isRegion(el)) {
-      return factory.getRegions().parse(el);
-    } else {
-      throw new InvalidXMLException("Unknown filter type: " + el.getName(), el);
-    }
+    return methodParsers.parse(el);
   }
 
   protected List<Filter> parseChildren(Element parent) throws InvalidXMLException {

--- a/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
+++ b/core/src/main/java/tc/oc/pgm/regions/RegionParser.java
@@ -1,9 +1,7 @@
 package tc.oc.pgm.regions;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.bukkit.util.Vector;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
@@ -21,13 +19,13 @@ import tc.oc.pgm.util.xml.XMLUtils;
 
 public abstract class RegionParser implements XMLParser<Region, RegionDefinition> {
 
-  protected final Map<String, Method> methodParsers;
+  protected final MethodParsers<Region> methodParsers;
   protected final MapFactory factory;
   protected final XMLFluentParser parser;
 
   public RegionParser(MapFactory factory) {
     this.factory = factory;
-    this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
+    this.methodParsers = MethodParsers.byNameParser(this, "region");
     this.parser = factory.getParser();
   }
 
@@ -97,25 +95,12 @@ public abstract class RegionParser implements XMLParser<Region, RegionDefinition
     return parseRequiredProperty(el, name);
   }
 
-  protected Method getMethodParser(String regionName) {
-    return methodParsers.get(regionName);
-  }
-
   public boolean isRegion(Element el) {
-    return methodParsers.containsKey(el.getName());
+    return methodParsers.methods().containsKey(el.getName());
   }
 
   protected Region parseDynamic(Element el) throws InvalidXMLException {
-    Method parser = this.getMethodParser(el.getName());
-    try {
-      return (Region) parser.invoke(this, el);
-    } catch (Exception e) {
-      if (e.getCause() instanceof InvalidXMLException) {
-        throw (InvalidXMLException) e.getCause();
-      } else {
-        throw new InvalidXMLException("Unknown error parsing region: " + e.getMessage(), el, e);
-      }
-    }
+    return methodParsers.parse(el);
   }
 
   @MethodParser("half")

--- a/core/src/main/java/tc/oc/pgm/util/MethodParsers.java
+++ b/core/src/main/java/tc/oc/pgm/util/MethodParsers.java
@@ -1,21 +1,80 @@
 package tc.oc.pgm.util;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import org.jdom2.Element;
+import tc.oc.pgm.util.function.ThrowingFunction;
+import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.Node;
 
-public class MethodParsers {
-  public static Map<String, Method> getMethodParsersForClass(Class<?> cls) {
-    Map<String, Method> parsers = Maps.newHashMap();
+public record MethodParsers<T>(
+    Object actualParser,
+    Function<Element, String> keyExtractor,
+    Map<String, Method> methods,
+    ThrowingFunction<Element, T, InvalidXMLException> fallback) {
+  private static final Map<Class<?>, Map<String, Method>> METHOD_CACHE = new ConcurrentHashMap<>();
 
-    for (Method method : cls.getMethods()) {
-      MethodParser parser = method.getAnnotation(MethodParser.class);
-      if (parser != null) {
-        parsers.put(parser.value(), method);
-      }
+  public T parse(Element el) throws InvalidXMLException {
+    var key = keyExtractor.apply(el);
+    Method parser = key == null ? null : methods.get(key.toLowerCase(Locale.ROOT));
+    if (parser == null) return fallback.apply(el);
+    try {
+      //noinspection unchecked
+      return (T) parser.invoke(actualParser, el);
+    } catch (Exception e) {
+      throw InvalidXMLException.coerce(e, new Node(el));
     }
+  }
 
-    return ImmutableMap.copyOf(parsers);
+  public T parse(Element el, Object... additionalParams) throws InvalidXMLException {
+    var key = keyExtractor.apply(el);
+    Method parser = key == null ? null : methods.get(key.toLowerCase(Locale.ROOT));
+    if (parser == null) return fallback.apply(el);
+    try {
+      Object[] params = new Object[additionalParams.length + 1];
+      params[0] = el;
+      System.arraycopy(additionalParams, 0, params, 1, additionalParams.length);
+      //noinspection unchecked
+      return (T) parser.invoke(actualParser, params);
+    } catch (Exception e) {
+      throw InvalidXMLException.coerce(e, new Node(el));
+    }
+  }
+
+  public MethodParsers<T> withFallback(ThrowingFunction<Element, T, InvalidXMLException> fallback) {
+    return new MethodParsers<>(actualParser, keyExtractor, methods, fallback);
+  }
+
+  private static <T> MethodParsers<T> of(
+      Object actualParser, Function<Element, String> keyExtractor, String name) {
+    return new MethodParsers<>(
+        actualParser, keyExtractor, getMethodParsersForClass(actualParser.getClass()), el -> {
+          throw new InvalidXMLException("Unknown " + name + " type: " + keyExtractor.apply(el), el);
+        });
+  }
+
+  public static <T> MethodParsers<T> byNameParser(Object actualParser, String type) {
+    return of(actualParser, Element::getName, type);
+  }
+
+  public static <T> MethodParsers<T> byAttrParser(Object actualParser, String attribute) {
+    return of(actualParser, el -> el.getAttributeValue(attribute), attribute);
+  }
+
+  private static Map<String, Method> getMethodParsersForClass(Class<?> cls) {
+    return METHOD_CACHE.computeIfAbsent(cls, key -> {
+      Map<String, Method> parsers = new HashMap<>();
+      for (Method method : key.getMethods()) {
+        MethodParser parser = method.getAnnotation(MethodParser.class);
+        if (parser != null) {
+          parsers.put(parser.value().toLowerCase(Locale.ROOT), method);
+        }
+      }
+      return Map.copyOf(parsers);
+    });
   }
 }

--- a/core/src/main/java/tc/oc/pgm/variables/VariableParser.java
+++ b/core/src/main/java/tc/oc/pgm/variables/VariableParser.java
@@ -1,9 +1,7 @@
 package tc.oc.pgm.variables;
 
 import com.google.common.collect.Range;
-import java.lang.reflect.Method;
 import java.util.Locale;
-import java.util.Map;
 import java.util.regex.Pattern;
 import org.jdom2.Element;
 import tc.oc.pgm.api.filter.Filterables;
@@ -42,11 +40,11 @@ public class VariableParser {
   public static final Pattern VARIABLE_ID = Pattern.compile("[A-Za-z_][\\w.]*");
 
   private final MapFactory factory;
-  private final Map<String, Method> methodParsers;
+  private final MethodParsers<Variable<?>> methodParsers;
 
   public VariableParser(MapFactory factory) {
     this.factory = factory;
-    this.methodParsers = MethodParsers.getMethodParsersForClass(getClass());
+    this.methodParsers = MethodParsers.byNameParser(this, "variable");
   }
 
   public Variable<?> parse(Element el) throws InvalidXMLException {
@@ -56,16 +54,7 @@ public class VariableParser {
           "Variable IDs must start with a letter or underscore and can only include letters, digits or underscores.",
           el);
 
-    Method parser = methodParsers.get(el.getName().toLowerCase());
-    if (parser != null) {
-      try {
-        return (Variable<?>) parser.invoke(this, el);
-      } catch (Exception e) {
-        throw InvalidXMLException.coerce(e, new Node(el));
-      }
-    } else {
-      throw new InvalidXMLException("Unknown variable type: " + el.getName(), el);
-    }
+    return methodParsers.parse(el);
   }
 
   @MethodParser("variable")


### PR DESCRIPTION
Cleans up method parsing to provider a cleaner API to consumers that doesn't involve them manually needing to invoke, as well adding caching for methods so that not every parser (for every map) needs to re-scan the class for method parsers.

This is a part from a larger set of changes towards flexibilizing projectile parsing to support things like #1686 and #1502 , but since it stands on its own i'd rather merge it separately and earlier.