### PR TITLE
Add flexibility to projectile entities

### DIFF
--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileDefinition.java
@@ -2,54 +2,44 @@ package tc.oc.pgm.projectile;
 
 import java.time.Duration;
 import java.util.List;
-import org.bukkit.entity.Entity;
 import org.bukkit.potion.PotionEffect;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
-import tc.oc.pgm.util.material.BlockMaterialData;
+import tc.oc.pgm.projectile.projectiles.PgmProjectile;
 
 public class ProjectileDefinition extends SelfIdentifyingFeatureDefinition {
-  protected @Nullable String name;
-  protected @Nullable Double damage;
-  protected @Nullable Float power;
-  protected double velocity;
-  protected ClickAction clickAction;
-  protected Class<? extends Entity> projectile;
-  protected List<PotionEffect> potion;
-  protected Filter destroyFilter;
-  protected Duration coolDown;
-  protected boolean throwable;
-  protected boolean precise;
-  protected BlockMaterialData blockMaterial;
+  protected final @Nullable String name;
+  protected final @Nullable Double damage;
+  protected final double velocity;
+  protected final ClickAction clickAction;
+  protected final PgmProjectile projectile;
+  protected final List<PotionEffect> potion;
+  protected final Filter destroyFilter;
+  protected final Duration coolDown;
+  protected final boolean throwable;
 
   public ProjectileDefinition(
       @Nullable String id,
       @Nullable String name,
       @Nullable Double damage,
-      @Nullable Float power,
       double velocity,
       ClickAction clickAction,
-      Class<? extends Entity> entity,
+      PgmProjectile projectile,
       List<PotionEffect> potion,
       Filter destroyFilter,
       Duration coolDown,
-      boolean throwable,
-      boolean precise,
-      BlockMaterialData blockMaterial) {
+      boolean throwable) {
     super(id);
     this.name = name;
     this.damage = damage;
-    this.power = power;
     this.velocity = velocity;
     this.clickAction = clickAction;
-    this.projectile = entity;
+    this.projectile = projectile;
     this.potion = potion;
     this.destroyFilter = destroyFilter;
     this.coolDown = coolDown;
     this.throwable = throwable;
-    this.precise = precise;
-    this.blockMaterial = blockMaterial;
   }
 
   public @Nullable String getName() {

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileMatchModule.java
@@ -4,13 +4,11 @@ import static tc.oc.pgm.util.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Explosive;
-import org.bukkit.entity.FallingBlock;
-import org.bukkit.entity.Fireball;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -46,7 +44,6 @@ import tc.oc.pgm.filters.query.PlayerBlockQuery;
 import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
 import tc.oc.pgm.util.inventory.InventoryUtils;
-import tc.oc.pgm.util.nms.NMSHacks;
 
 @ListenerScope(MatchScope.RUNNING)
 public class ProjectileMatchModule implements MatchModule, Listener {
@@ -60,7 +57,7 @@ public class ProjectileMatchModule implements MatchModule, Listener {
 
   private final Match match;
   private final ImmutableSet<ProjectileDefinition> projectileDefinitions;
-  private final HashMap<UUID, ProjectileCooldowns> projectileCooldowns = new HashMap<>();
+  private final Map<UUID, ProjectileCooldowns> projectileCooldowns = new HashMap<>();
 
   private static final String DEFINITION_KEY = "projectileDefinition";
 
@@ -88,34 +85,17 @@ public class ProjectileMatchModule implements MatchModule, Listener {
 
       if (this.isCooldownActive(player, projectileDefinition)) return;
 
-      boolean realProjectile = Projectile.class.isAssignableFrom(projectileDefinition.projectile);
       Vector velocity =
           player.getEyeLocation().getDirection().multiply(projectileDefinition.velocity);
       Entity projectile;
       try {
         assertTrue(launchingDefinition.get() == null, "nested projectile launch");
         launchingDefinition.set(projectileDefinition);
-        if (realProjectile) {
-          projectile = player.launchProjectile(
-              projectileDefinition.projectile.asSubclass(Projectile.class), velocity);
-          if (projectile instanceof Fireball fireball && projectileDefinition.precise) {
-            NMSHacks.NMS_HACKS.setFireballDirection(fireball, velocity);
-          }
-        } else {
-          if (FallingBlock.class.isAssignableFrom(projectileDefinition.projectile)) {
-            projectile =
-                projectileDefinition.blockMaterial.spawnFallingBlock(player.getEyeLocation());
-          } else {
-            projectile =
-                player.getWorld().spawn(player.getEyeLocation(), projectileDefinition.projectile);
-          }
-          projectile.setVelocity(velocity);
+        projectile = projectileDefinition.projectile.spawn(player, velocity);
+        if (projectile != null) {
+          projectile.setMetadata(
+              "projectileDefinition", new FixedMetadataValue(PGM.get(), projectileDefinition));
         }
-        if (projectileDefinition.power != null && projectile instanceof Explosive) {
-          ((Explosive) projectile).setYield(projectileDefinition.power);
-        }
-        projectile.setMetadata(
-            "projectileDefinition", new FixedMetadataValue(PGM.get(), projectileDefinition));
       } finally {
         launchingDefinition.remove();
       }
@@ -123,7 +103,7 @@ public class ProjectileMatchModule implements MatchModule, Listener {
       // If the entity implements Projectile, it will have already generated a
       // ProjectileLaunchEvent.
       // Otherwise, we fire our custom event.
-      if (!realProjectile) {
+      if (projectile != null && !(projectile instanceof Projectile)) {
         EntityLaunchEvent launchEvent = new EntityLaunchEvent(projectile, event.getPlayer());
         match.callEvent(launchEvent);
         if (launchEvent.isCancelled()) {

--- a/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/ProjectileModule.java
@@ -10,7 +10,9 @@ import java.util.Set;
 import java.util.logging.Logger;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Explosive;
 import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Fireball;
 import org.bukkit.potion.PotionEffect;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -20,11 +22,11 @@ import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.filters.FilterModule;
-import tc.oc.pgm.filters.parse.FilterParser;
-import tc.oc.pgm.kits.KitParser;
-import tc.oc.pgm.util.material.BlockMaterialData;
+import tc.oc.pgm.projectile.projectiles.EntityProjectile;
+import tc.oc.pgm.projectile.projectiles.PgmProjectile;
+import tc.oc.pgm.util.MethodParsers;
 import tc.oc.pgm.util.xml.InvalidXMLException;
-import tc.oc.pgm.util.xml.Node;
+import tc.oc.pgm.util.xml.XMLFluentParser;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class ProjectileModule implements MapModule<ProjectileMatchModule> {
@@ -49,54 +51,79 @@ public class ProjectileModule implements MapModule<ProjectileMatchModule> {
     public ProjectileModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
       Set<ProjectileDefinition> projectiles = new HashSet<>();
-      KitParser kitParser = factory.getKits();
-      FilterParser filterParser = factory.getFilters();
+      var parser = factory.getParser();
+      var projParser = new ProjectileParser(parser);
 
-      for (Element projectileElement :
+      for (Element el :
           XMLUtils.flattenElements(doc.getRootElement(), "projectiles", "projectile")) {
-        String id = XMLUtils.getRequiredAttribute(projectileElement, "id").getValue();
-        String name = projectileElement.getAttributeValue("name");
-        Double damage = XMLUtils.parseNumber(
-            projectileElement.getAttribute("damage"), Double.class, (Double) null);
-        double velocity = XMLUtils.parseNumber(
-            Node.fromChildOrAttr(projectileElement, "velocity"), Double.class, 1.0);
-        ClickAction clickAction = XMLUtils.parseEnum(
-            Node.fromAttr(projectileElement, "click"), ClickAction.class, ClickAction.BOTH);
-        Class<? extends Entity> entity =
-            XMLUtils.parseEntityTypeAttribute(projectileElement, "projectile", Arrow.class);
-        BlockMaterialData blockMaterial = entity.isAssignableFrom(FallingBlock.class)
-            ? XMLUtils.parseBlockMaterialData(Node.fromAttr(projectileElement, "material"))
-            : null;
-        Float power = XMLUtils.parseNumber(
-            Node.fromChildOrAttr(projectileElement, "power"), Float.class, null);
-        List<PotionEffect> potionKit = kitParser.parsePotions(projectileElement);
-        Filter destroyFilter =
-            filterParser.parseFilterProperty(projectileElement, "destroy-filter");
-        Duration coolDown = XMLUtils.parseDuration(projectileElement.getAttribute("cooldown"));
-        boolean throwable =
-            XMLUtils.parseBoolean(projectileElement.getAttribute("throwable"), true);
-        boolean precise = XMLUtils.parseBoolean(projectileElement.getAttribute("precise"), true);
+        String id = parser.string(el, "id").required();
+        String name = parser.string(el, "name").orNull();
+        Double damage = parser.parseDouble(el, "damage").orNull();
+        double velocity = parser.parseDouble(el, "velocity").optional(1.0);
+        var clickAction =
+            parser.parseEnum(ClickAction.class, el, "click").optional(ClickAction.BOTH);
+        var projectile = projParser.parseDynamic(el);
+        List<PotionEffect> potionKit = factory.getKits().parsePotions(el);
+        Filter destroyFilter = parser.filter(el, "destroy-filter").orNull();
+        Duration coolDown = parser.duration(el, "cooldown").attr().orNull();
+        boolean throwable = parser.parseBool(el, "throwable").attr().optional(true);
 
         ProjectileDefinition projectileDefinition = new ProjectileDefinition(
             id,
             name,
             damage,
-            power,
             velocity,
             clickAction,
-            entity,
+            projectile,
             potionKit,
             destroyFilter,
             coolDown,
-            throwable,
-            precise,
-            blockMaterial);
+            throwable);
 
-        factory.getFeatures().addFeature(projectileElement, projectileDefinition);
+        factory.getFeatures().addFeature(el, projectileDefinition);
         projectiles.add(projectileDefinition);
       }
 
       return projectiles.isEmpty() ? null : new ProjectileModule(ImmutableSet.copyOf(projectiles));
+    }
+  }
+
+  private static class ProjectileParser {
+    private final XMLFluentParser parser;
+    private final MethodParsers<PgmProjectile> methodParsers;
+
+    private ProjectileParser(XMLFluentParser parser) {
+      this.parser = parser;
+      this.methodParsers = MethodParsers.<PgmProjectile>byAttrParser(this, "projectile")
+          .withFallback(this::parsePlainEntity);
+    }
+
+    public PgmProjectile parseDynamic(Element el) throws InvalidXMLException {
+      return methodParsers.parse(el);
+    }
+
+    /*@MethodParser("bridge-egg")
+    public PgmProjectile parseBridgeEgg(Element el) throws InvalidXMLException {
+      // TODO: implement actual parsing and the feature, this is just an example.
+      //  Should return a new PgmProjectile type.
+      return new EntityProjectile(Egg.class, null, null, false);
+    }*/
+
+    public PgmProjectile parsePlainEntity(Element el) throws InvalidXMLException {
+      var entity = parser
+          .<Class<? extends Entity>>node(XMLUtils::parseEntityType, el, "projectile")
+          .optional(Arrow.class);
+      var blockMaterial = entity.isAssignableFrom(FallingBlock.class)
+          ? parser.blockMaterialData(el, "material").required()
+          : null;
+      var power = entity.isAssignableFrom(Explosive.class)
+          ? parser.parseFloat(el, "power").orNull()
+          : null;
+      var precise = entity.isAssignableFrom(Fireball.class)
+          ? parser.parseBool(el, "precise").attr().optional(true)
+          : false;
+
+      return new EntityProjectile(entity, blockMaterial, power, precise);
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/projectile/projectiles/EntityProjectile.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/projectiles/EntityProjectile.java
@@ -1,0 +1,37 @@
+package tc.oc.pgm.projectile.projectiles;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Explosive;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.util.Vector;
+import tc.oc.pgm.util.material.BlockMaterialData;
+import tc.oc.pgm.util.nms.NMSHacks;
+
+public record EntityProjectile(
+    Class<? extends Entity> entity, BlockMaterialData blockMaterial, Float power, boolean precise)
+    implements PgmProjectile {
+
+  public Entity spawn(Player player, Vector velocity) {
+    Entity projectile;
+    if (Projectile.class.isAssignableFrom(entity)) {
+      projectile = player.launchProjectile(entity.asSubclass(Projectile.class), velocity);
+      if (projectile instanceof Fireball fireball && precise) {
+        NMSHacks.NMS_HACKS.setFireballDirection(fireball, velocity);
+      }
+    } else {
+      if (FallingBlock.class.isAssignableFrom(entity)) {
+        projectile = blockMaterial.spawnFallingBlock(player.getEyeLocation());
+      } else {
+        projectile = player.getWorld().spawn(player.getEyeLocation(), entity);
+      }
+      projectile.setVelocity(velocity);
+    }
+    if (power != null && projectile instanceof Explosive) {
+      ((Explosive) projectile).setYield(power);
+    }
+    return projectile;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/projectile/projectiles/PgmProjectile.java
+++ b/core/src/main/java/tc/oc/pgm/projectile/projectiles/PgmProjectile.java
@@ -1,0 +1,12 @@
+package tc.oc.pgm.projectile.projectiles;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import org.jspecify.annotations.Nullable;
+
+public interface PgmProjectile {
+
+  @Nullable
+  Entity spawn(Player player, Vector velocity);
+}

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -1,5 +1,7 @@
 package tc.oc.pgm.util.xml;
 
+import static tc.oc.pgm.util.material.MaterialUtils.MATERIAL_UTILS;
+
 import com.google.common.collect.Range;
 import java.time.Duration;
 import java.util.function.Function;
@@ -21,6 +23,7 @@ import tc.oc.pgm.kits.Kit;
 import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.util.function.ThrowingFunction;
+import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.math.Formula;
 import tc.oc.pgm.util.text.TextException;
 import tc.oc.pgm.util.text.TextFormatter;
@@ -150,6 +153,15 @@ public class XMLFluentParser {
       @Override
       protected Material parse(Node node) throws InvalidXMLException {
         return XMLUtils.parseMaterial(node);
+      }
+    };
+  }
+
+  public Builder.Generic<BlockMaterialData> blockMaterialData(Element el, String... prop) {
+    return new Builder.Generic<>(el, prop) {
+      @Override
+      protected BlockMaterialData parse(Node node) throws InvalidXMLException {
+        return MATERIAL_UTILS.parseBlockMaterialData(node.getValueNormalize(), node);
       }
     };
   }


### PR DESCRIPTION
migrates projectiles to not be directly a Class<? extends Entity> type, but rather an interface that can later be expanded to support differing types of custom projectiles, like #1502 and #1686 are implementing, as well as possible future ones like a ray projectile (quake)