### PR TITLE
Add minimum respawn delay config option

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -359,6 +359,7 @@ public interface Config {
     FULL_REJOIN,
     REJOIN_MULTIPLIER,
     REJOIN_MAX,
+    REJOIN_MIN,
     SWITCH
   }
 

--- a/core/src/main/java/tc/oc/pgm/spawns/ParticipationData.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/ParticipationData.java
@@ -33,7 +33,9 @@ class ParticipationData {
     TimePenalty penalty = getPenalty(newTeam);
     Duration timeOff = getDuration(penalty);
     if (penalty == TimePenalty.REJOIN_MULTIPLIER) {
-      timeOff = TimeUtils.min(timeOff.multipliedBy(rejoins), getDuration(TimePenalty.REJOIN_MAX));
+      timeOff = TimeUtils.max(
+          TimeUtils.min(timeOff.multipliedBy(rejoins), getDuration(TimePenalty.REJOIN_MAX)),
+          getDuration(TimePenalty.REJOIN_MIN));
     }
     return lastLeaveTick + TimeUtils.toTicks(timeOff);
   }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -94,8 +94,9 @@ gameplay:
     full-rejoin: 30s       # Rejoining when your team was full and is still full
     rejoin-multiplier: 10s # Increased penalty for every additional rejoin, up to max
     rejoin-max: 30s        # Max time penalty for repeated rejoins
+    rejoin-min: 0s         # Min time penalty for repeated rejoins
     switch: 30s            # Plainly switching teams
-  
+
 # Changes map voting mechanics.
 votes:
   # Players can gain extra votes based on the permission "pgm.vote.extra.#".


### PR DESCRIPTION
Currently players would need to leave/join twice to be given a time plenty (built in leeway).

This works in public scenarios but in scenarios where you may not want to be so lenient a `rejoin-min` can be set.