### PR TITLE
Add isEmpty check to Region.getChunkPositions

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/region/Region.java
+++ b/core/src/main/java/tc/oc/pgm/api/region/Region.java
@@ -181,6 +181,7 @@ public interface Region extends TypedFilter<LocationQuery> {
 
   default Stream<ChunkVector> getChunkPositions() {
     final Bounds bounds = getBounds();
+    if (bounds.isEmpty()) return Stream.empty();
     if (!bounds.isBlockFinite()) {
       throw new UnsupportedOperationException(
           "Cannot enumerate chunks in unbounded region type " + getClass().getSimpleName());

--- a/core/src/main/java/tc/oc/pgm/structure/Structure.java
+++ b/core/src/main/java/tc/oc/pgm/structure/Structure.java
@@ -26,6 +26,17 @@ public class Structure implements Feature<StructureDefinition> {
           b -> b.getType() != Material.AIR,
           match.getMap().getProto());
 
+    if (region.getBounds().isEmpty()) {
+      match
+          .getLogger()
+          .warning("No blocks found in structure "
+              + definition.getId()
+              + "; it will be empty"
+              + (definition.includeAir()
+                  ? ""
+                  : " (set air=\"true\" to capture air, or check its region)"));
+    }
+
     snapshot.saveRegion(region);
     if (definition.clearSource()) snapshot.removeBlocks(region, new BlockVector(), false);
   }


### PR DESCRIPTION
Fixes bug:
```java
java.lang.IllegalStateException: Trying to create chunk out of reasonable bounds: [134217727, 134217727]
  at net.minecraft.server.level.GenerationChunkHolder.<init>(GenerationChunkHolder.java:35)
  at net.minecraft.server.level.ChunkHolder.<init>(ChunkHolder.java:147)
...
  at net.minecraft.world.level.Level.getChunk(Level.java:1031)
  at org.bukkit.craftbukkit.CraftWorld.getChunkAt(CraftWorld.java:374)
  at PGM.jar//tc.oc.pgm.util.chunk.ChunkVector.getChunk(ChunkVector.java:81)
  at PGM.jar//tc.oc.pgm.snapshot.WorldSnapshot.lambda$saveSnapshot$0(WorldSnapshot.java:64)
  at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1228)
  at PGM.jar//tc.oc.pgm.snapshot.WorldSnapshot.saveSnapshot(WorldSnapshot.java:63)
  at PGM.jar//tc.oc.pgm.snapshot.WorldSnapshot.lambda$saveRegion$1(WorldSnapshot.java:83)
 ...
  at PGM.jar//tc.oc.pgm.snapshot.WorldSnapshot.saveRegion(WorldSnapshot.java:83)
  at PGM.jar//tc.oc.pgm.structure.Structure.<init>(Structure.java:29)
  at PGM.jar//tc.oc.pgm.structure.StructureMatchModule.load(StructureMatchModule.java:47)
  at PGM.jar//tc.oc.pgm.match.MatchImpl$ModuleLoader.createModule(MatchImpl.java:839)
```

added a warning log for empty structures.