### PR TITLE
Schedule post kit apply fix at most once per tick

### DIFF
--- a/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
+++ b/core/src/main/java/tc/oc/pgm/match/MatchPlayerImpl.java
@@ -81,6 +81,7 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
   private final AtomicBoolean protocolReady;
   private final AtomicInteger protocolVersion;
   private final AfkTracker.Activity activity;
+  private long lastKitTick = 0;
 
   public MatchPlayerImpl(Match match, Player player) {
     this.logger = ClassLogger.get(
@@ -372,17 +373,21 @@ public class MatchPlayerImpl implements MatchPlayer, Comparable<MatchPlayer> {
       }
     }
 
-    match
-        .getExecutor(MatchScope.LOADED)
-        .schedule(
-            () -> {
-              final Player bukkit = getBukkit();
-              if (bukkit.isOnline() && !isDead() && bukkit.getMaxHealth() < 20) {
-                bukkit.setHealth(Math.min(bukkit.getHealth(), bukkit.getMaxHealth()));
-              }
-            },
-            TimeUtils.TICK,
-            TimeUnit.MILLISECONDS);
+    var currTick = match.getTick().tick;
+    if (currTick > lastKitTick) {
+      lastKitTick = currTick;
+      match
+          .getExecutor(MatchScope.LOADED)
+          .schedule(
+              () -> {
+                final Player bukkit = getBukkit();
+                if (bukkit.isOnline() && !isDead() && bukkit.getMaxHealth() < 20) {
+                  bukkit.setHealth(Math.min(bukkit.getHealth(), bukkit.getMaxHealth()));
+                }
+              },
+              TimeUtils.TICK,
+              TimeUnit.MILLISECONDS);
+    }
   }
 
   @Override


### PR DESCRIPTION
Turns out if you give 470 kits to 60 players in one tick, you get 28k scheduled tasks that bukkit has to work its way thru, and scheduling isn't that cheap. This lowers it to one per player per tick at most.