### PR TITLE
fix(SpreadPointProvider): fail gracefully if no good points are provided

### DIFF
--- a/core/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
+++ b/core/src/main/java/tc/oc/pgm/points/SpreadPointProvider.java
@@ -55,6 +55,7 @@ public class SpreadPointProvider extends AggregatePointProvider {
       }
     }
 
+    if (bestPoints.isEmpty()) return null;
     int index = match.getRandom().nextInt(bestPoints.size());
     return bestPoints.get(index);
   }


### PR DESCRIPTION
Prevents the following exception:
```
[11:59:50 ERROR]: [PGM.MatchImpl] [MatchImpl] Could not tick tc.oc.pgm.spawns.SpawnMatchModule@57dad91 in match #4
java.lang.IllegalArgumentException: bound must be positive
	at java.base/java.util.Random.nextInt(Random.java:557) ~[?:?]
	at PGM.jar//tc.oc.pgm.points.SpreadPointProvider.getPoint(SpreadPointProvider.java:58) ~[?:?]
	at PGM.jar//tc.oc.pgm.spawns.Spawn.getSpawn(Spawn.java:29) ~[?:?]
	at PGM.jar//tc.oc.pgm.spawns.states.Spawning.trySpawn(Spawning.java:96) ~[?:?]
	at PGM.jar//tc.oc.pgm.spawns.states.Spawning.tick(Spawning.java:82) ~[?:?]
	at PGM.jar//tc.oc.pgm.spawns.SpawnMatchModule.lambda$tick$17(SpawnMatchModule.java:380) ~[?:?]
	at com.google.common.collect.RegularImmutableMap.forEach(RegularImmutableMap.java:293) ~[guava-33.5.0-jre.jar:?]
	at PGM.jar//tc.oc.pgm.spawns.SpawnMatchModule.tick(SpawnMatchModule.java:379) ~[?:?]
	at PGM.jar//tc.oc.pgm.match.MatchImpl$TickableTask.run(MatchImpl.java:781) ~[?:?]
```

that may happen if the underlying region is small and requires safe spread spawns.