### PR TITLE
Check joining team type in PickerMatchModule

### DIFF
--- a/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/picker/PickerMatchModule.java
@@ -137,7 +137,7 @@ public class PickerMatchModule implements MatchModule, Listener {
   }
 
   private boolean hasJoined(MatchPlayer joining) {
-    return joining.isParticipating()
+    return !(joining.getParty() instanceof ObserverParty)
         || match.needModule(JoinMatchModule.class).isQueuedToJoin(joining);
   }
 


### PR DESCRIPTION
Currently players are not given the "leave" helmet before the match starts as `isParticipating` on a team will check if the match is running and assumes that they are not participating unless it is. 

This change switches it to an negative instance of `ObserverParty` check which passes in cases where the leave helmet is needed.