### PR TITLE
Fix one filter operator not correctly evaluating allow

### DIFF
--- a/core/src/main/java/tc/oc/pgm/filters/operator/OneFilter.java
+++ b/core/src/main/java/tc/oc/pgm/filters/operator/OneFilter.java
@@ -12,17 +12,18 @@ public class OneFilter extends MultiFilterFunction {
   @Override
   public QueryResponse query(Query query) {
     // returns true if exactly one of the filters match
+    boolean hasAllow = false;
     QueryResponse response = QueryResponse.ABSTAIN;
     for (Filter filter : this.filters) {
       QueryResponse filterResponse = filter.query(query);
       if (filterResponse == QueryResponse.ALLOW) {
-        if (response == QueryResponse.ALLOW) {
+        if (hasAllow) {
           return QueryResponse.DENY;
-        } else {
-          response = filterResponse;
         }
-      } else if (filterResponse == QueryResponse.DENY) {
-        response = filterResponse;
+        hasAllow = true;
+        response = QueryResponse.ALLOW;
+      } else if (filterResponse == QueryResponse.DENY && !hasAllow) {
+        response = QueryResponse.DENY;
       }
     }
     return response;


### PR DESCRIPTION
Currently the `<one> ... </one>` filter operator only returns allow if the last child allows and the proceeding child denies or all siblings abstain. This does not achieve the filter's purpose of returning allow when only one child allows, as demonstrated in this video.

https://github.com/user-attachments/assets/965c0994-2b49-4e81-b990-00bdd1b3cedf

This PR corrects this behaviour to do what it says on the tin.

https://github.com/user-attachments/assets/247e5056-f506-4545-8128-fab58a22d89c

[Demo map](https://github.com/user-attachments/files/29847256/one_filter.zip)

