### PR TITLE
fix: don't send legacy color codes through `player()` component

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.api;
 
+import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.newline;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
@@ -20,6 +21,7 @@ import org.bukkit.permissions.Permission;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.map.factory.MapSourceFactory;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.usernames.ApiUsernameResolver;
 
 /** A configuration for server owners to modify {@link PGM}. */
@@ -472,6 +474,9 @@ public interface Config {
       if ((prefix ? getPrefixOverride() : getSuffixOverride()) != null) {
         return prefix ? getPrefixOverride() : getSuffixOverride();
       }
+      String flairText = prefix ? getPrefix() : getSuffix();
+      if (StringUtils.isNullOrEmpty(flairText)) return empty();
+
       TextComponent.Builder hover = text();
       boolean addNewline = false;
       if (getDisplayName() != null && !getDisplayName().isEmpty()) {
@@ -494,10 +499,9 @@ public interface Config {
         hover.append(clickLink);
       }
 
-      TextComponent.Builder component = text()
-          .append(LegacyComponentSerializer.legacySection()
-              .deserialize(prefix ? getPrefix() : getSuffix()))
-          .hoverEvent(showText(hover.build()));
+      TextComponent.Builder component =
+          LegacyComponentSerializer.legacySection().deserialize(flairText).toBuilder()
+              .hoverEvent(showText(hover.build()));
 
       if (getClickLink() != null && !getClickLink().isEmpty()) {
         component.clickEvent(openUrl(getClickLink()));

--- a/core/src/main/java/tc/oc/pgm/api/Config.java
+++ b/core/src/main/java/tc/oc/pgm/api/Config.java
@@ -15,6 +15,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.permissions.Permission;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.map.factory.MapSourceFactory;
@@ -468,7 +469,7 @@ public interface Config {
     Component getSuffixOverride();
 
     default Component getComponent(boolean prefix) {
-      if (prefix ? getPrefixOverride() != null : getSuffixOverride() != null) {
+      if ((prefix ? getPrefixOverride() : getSuffixOverride()) != null) {
         return prefix ? getPrefixOverride() : getSuffixOverride();
       }
       TextComponent.Builder hover = text();
@@ -494,7 +495,8 @@ public interface Config {
       }
 
       TextComponent.Builder component = text()
-          .append(text(prefix ? getPrefix() : getSuffix()))
+          .append(LegacyComponentSerializer.legacySection()
+              .deserialize(prefix ? getPrefix() : getSuffix()))
           .hoverEvent(showText(hover.build()));
 
       if (getClickLink() != null && !getClickLink().isEmpty()) {


### PR DESCRIPTION
Fixes a practically invisible oversight where the code path for getting a component for a flair from the config file would emit components with legacy color codes, later on being sent over to players using the `player()` component.

This behavior is obscured by both the Minecraft client (legacy and modern alike) for players, and by `adventure-plaform-bukkit` which falls through to legacy string-based `sendMessage` API for consoles. 

It may be observed, for example, by swapping `adventure-platform-bukkit` on a modern server to an alternative ABI-compatible implementation that proxies Adventure calls through the PGM's component renderer directly to Paper's Adventure implementation:

<img width="1083" height="353" alt="image" src="https://github.com/user-attachments/assets/bb79de69-9b25-49d5-8558-64b985007a37" />
