### PR TITLE
Address potential memory leaks in modern

### DIFF
--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernNMSHacks.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernNMSHacks.java
@@ -64,7 +64,6 @@ import org.bukkit.entity.Firework;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerPickupArrowEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
-import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.generator.WorldInfo;
@@ -330,7 +329,6 @@ public class ModernNMSHacks implements NMSHacks {
     console.initWorld(serverLevel, primaryLevelData, primaryLevelData.worldGenOptions());
     serverLevel.setSpawnSettings(true);
     console.prepareLevel(serverLevel);
-    server.getPluginManager().callEvent(new WorldLoadEvent(serverLevel.getWorld()));
     return serverLevel.getWorld();
   }
 

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernBlockPhysicsListener.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/listeners/ModernBlockPhysicsListener.java
@@ -4,11 +4,14 @@ import com.destroystokyo.paper.event.block.BlockDestroyEvent;
 import com.destroystokyo.paper.event.server.ServerTickEndEvent;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.state.BlockState;
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.data.CraftBlockData;
@@ -16,13 +19,14 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.FluidLevelChangeEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
 import org.jspecify.annotations.NullMarked;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.listeners.BlockPhysicsListener;
 
 @NullMarked
 public class ModernBlockPhysicsListener extends BlockPhysicsListener {
-  private final Set<Chunk> loadingChunks = new HashSet<>();
+  private final Set<LoadingChunk> loadingChunks = new HashSet<>();
 
   @EventHandler(priority = EventPriority.LOWEST)
   public void onFluidLevelChange(FluidLevelChangeEvent event) {
@@ -32,19 +36,26 @@ public class ModernBlockPhysicsListener extends BlockPhysicsListener {
   @EventHandler(priority = EventPriority.MONITOR)
   public void onChunkLoad(ChunkLoadEvent event) {
     if (Match.isMatchWorld(event.getWorld())) {
-      loadingChunks.add(event.getChunk());
+      loadingChunks.add(LoadingChunk.of(event.getChunk()));
     }
   }
 
   @EventHandler
   public void onTickEnd(ServerTickEndEvent event) {
-    loadingChunks.removeIf(chunk -> chunk.getLoadLevel() != Chunk.LoadLevel.BORDER);
+    loadingChunks.removeIf(chunk -> !chunk.isLoading());
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onWorldUnload(WorldUnloadEvent event) {
+    UUID worldId = event.getWorld().getUID();
+    loadingChunks.removeIf(chunk -> chunk.worldId().equals(worldId));
   }
 
   @EventHandler(priority = EventPriority.LOWEST)
   public void onBlockDestroy(BlockDestroyEvent event) {
     Block block = event.getBlock();
-    boolean loading = !loadingChunks.isEmpty() && loadingChunks.contains(block.getChunk());
+    boolean loading =
+        !loadingChunks.isEmpty() && loadingChunks.contains(LoadingChunk.of(block.getChunk()));
 
     if (!loading && allowPhysics(block.getWorld())) return;
 
@@ -84,6 +95,19 @@ public class ModernBlockPhysicsListener extends BlockPhysicsListener {
 
     if (updated != state) {
       block.setBlockData(CraftBlockData.createData(updated), false);
+    }
+  }
+
+  private record LoadingChunk(UUID worldId, int x, int z) {
+    private static LoadingChunk of(Chunk chunk) {
+      return new LoadingChunk(chunk.getWorld().getUID(), chunk.getX(), chunk.getZ());
+    }
+
+    private boolean isLoading() {
+      World world = Bukkit.getWorld(worldId);
+      return world != null
+          && world.isChunkLoaded(x, z)
+          && world.getChunkAt(x, z).getLoadLevel() != Chunk.LoadLevel.ENTITY_TICKING;
     }
   }
 }

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/OnlinePlayerMapAdapter.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/OnlinePlayerMapAdapter.java
@@ -7,7 +7,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.plugin.Plugin;
 
 /** Uses {@link ListeningMapAdapter} to guarantee that the map only contains online players. */
@@ -29,6 +31,19 @@ public class OnlinePlayerMapAdapter<V> extends ListeningMapAdapter<Player, V> im
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerQuit(PlayerQuitEvent event) {
     this.remove(event.getPlayer());
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+    V value = this.remove(event.getPlayer());
+    if (value != null) {
+      this.put(event.getPlayer(), value);
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  public void onWorldUnload(WorldUnloadEvent event) {
+    this.keySet().removeIf(player -> player.getWorld().equals(event.getWorld()));
   }
 
   @Override


### PR DESCRIPTION
1. Remove a duplicate `WorldLoadEvent` call; this happens in `prepareLevel` already. Not likely to be a memory leak though, but still an unnecessary duplicate event call.
2. Use `OnlinePlayerUUIDMapAdapter` in `AfkTracker` to avoid holding direct, stale `Player` references in previous match worlds, which would prevent them from unloading fully.
3. Replace direct `Chunk` references in `ModernBlockPhysicsListener` with a world UUID and chunk coordinate record, and ensure proper cleanup occurs by listening on `WorldUnloadEvent` to remove chunks in unloaded worlds from the tracking set.