### PR TITLE
Cleanup spawner module, fixes a few bugs

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/actions/TeleportAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/TeleportAction.java
@@ -33,9 +33,8 @@ public class TeleportAction extends AbstractAction<MatchPlayer> {
 
   @Override
   public void trigger(MatchPlayer player) {
-    var location = this.region
-        .map(r -> r.getRandom(player.getMatch()).toLocation(player.getWorld()))
-        .orElseGet(player::getLocation);
+    var location =
+        this.region.map(r -> r.getRandomLoc(player.getMatch())).orElseGet(player::getLocation);
 
     xformula.ifPresent(f -> location.setX(f.applyAsDouble(player)));
     yformula.ifPresent(f -> location.setY(f.applyAsDouble(player)));

--- a/core/src/main/java/tc/oc/pgm/api/region/Region.java
+++ b/core/src/main/java/tc/oc/pgm/api/region/Region.java
@@ -143,6 +143,10 @@ public interface Region extends TypedFilter<LocationQuery> {
     return getStatic(match).getRandom(match.getRandom());
   }
 
+  default Location getRandomLoc(Match match) {
+    return getStatic(match).getRandom(match.getRandom()).toLocation(match.getWorld());
+  }
+
   /** Does this region contain a finite number of blocks? */
   default boolean isBlockBounded() {
     return false;

--- a/core/src/main/java/tc/oc/pgm/enderchest/EnderChestMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/enderchest/EnderChestMatchModule.java
@@ -54,7 +54,7 @@ public class EnderChestMatchModule implements MatchModule, Listener {
     boolean dropped = false;
     for (Dropoff dropoff : dropoffs) {
       if (dropoff.getFilter().query(oldParty).isAllowed()) {
-        drop(enderchest, dropoff.getRegion().getRandom(match).toLocation(match.getWorld()));
+        drop(enderchest, dropoff.getRegion().getRandomLoc(match));
         dropped = true;
         break;
       }

--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -2,27 +2,28 @@ package tc.oc.pgm.spawner;
 
 import static tc.oc.pgm.util.bukkit.Effects.EFFECTS;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import java.util.Objects;
-import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.entity.ItemMergeEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
-import org.bukkit.metadata.Metadatable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.match.Tickable;
-import tc.oc.pgm.api.match.event.MatchFinishEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.time.Tick;
-import tc.oc.pgm.util.TimeUtils;
+import tc.oc.pgm.controlpoint.RegionPlayerTracker;
+import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
-import tc.oc.pgm.util.bukkit.OnlinePlayerMapAdapter;
-import tc.oc.pgm.util.event.PlayerCoarseMoveEvent;
 
 public class Spawner implements Listener, Tickable {
 
@@ -30,115 +31,110 @@ public class Spawner implements Listener, Tickable {
 
   private final Match match;
   private final SpawnerDefinition definition;
-  private final OnlinePlayerMapAdapter<MatchPlayer> players;
+  private final RegionPlayerTracker playerTracker;
 
-  private long lastTick;
-  private long currentDelay;
+  private long canSpawnAt;
   private long spawnedEntities;
 
   public Spawner(SpawnerDefinition definition, Match match) {
     this.definition = definition;
     this.match = match;
-    this.lastTick = match.getTick().tick;
-    this.players = new OnlinePlayerMapAdapter<>(PGM.get());
-    calculateDelay();
+    this.playerTracker = new RegionPlayerTracker(match, definition.playerRegion);
+  }
+
+  public void registerEvents() {
+    match.addListener(this, MatchScope.RUNNING);
+    match.addTickable(this, MatchScope.RUNNING);
+    match.addListener(this.playerTracker, MatchScope.RUNNING);
+  }
+
+  public void unregisterEvents() {
+    HandlerList.unregisterAll(this);
+    HandlerList.unregisterAll(this.playerTracker);
   }
 
   @Override
   public void tick(Match match, Tick tick) {
-    if (!canSpawn()) return;
-    if (match.getTick().tick - lastTick >= currentDelay) {
-      for (Spawnable spawnable : definition.objects) {
-        final Location location =
-            definition.spawnRegion.getRandom(match).toLocation(match.getWorld());
-        spawnable.spawn(location, match);
-        EFFECTS.spawnFlame(match.getWorld(), location);
-        spawnedEntities += spawnable.getSpawnCount();
-      }
-      calculateDelay();
+    var now = match.getTick().tick;
+    if (now < this.canSpawnAt || spawnedEntities >= definition.maxEntities) return;
+    if (!definition.matchFilter.response(match) || !anyPlayerAllows()) return;
+
+    for (Spawnable spawnable : definition.objects) {
+      var location = definition.spawnRegion.getRandomLoc(match);
+      spawnable.spawn(location, match);
+      EFFECTS.spawnFlame(match.getWorld(), location);
+      spawnedEntities += spawnable.getSpawnCount();
     }
+    canSpawnAt = now + calculateDelay();
   }
 
-  private void calculateDelay() {
-    if (definition.minDelay == definition.maxDelay) {
-      currentDelay = TimeUtils.toTicks(definition.delay);
-    } else {
-      long maxDelay = TimeUtils.toTicks(definition.maxDelay);
-      long minDelay = TimeUtils.toTicks(definition.minDelay);
-      currentDelay = (long) (match.getRandom().nextDouble() * (maxDelay - minDelay)
-          + minDelay); // Picks a random tick duration between minDelay and maxDelay
-    }
-    lastTick = match.getTick().tick;
+  private long calculateDelay() {
+    long delay = definition.minDelay;
+    if (definition.maxDelay != delay)
+      delay += (long) ((definition.maxDelay - delay) * match.getRandom().nextDouble());
+    return delay;
   }
 
-  private boolean canSpawn() {
-    if (spawnedEntities >= definition.maxEntities || players.isEmpty()) return false;
-    for (MatchPlayer player : players.values()) {
-      if (definition.playerFilter.query(player).isAllowed()) return true;
+  private boolean anyPlayerAllows() {
+    var filter = definition.playerFilter;
+    if (filter == StaticFilter.ALLOW) return !playerTracker.getPlayers().isEmpty();
+
+    for (MatchPlayer player : playerTracker.getPlayers()) {
+      if (filter.query(player).isAllowed()) return true;
     }
     return false;
   }
 
   @EventHandler(priority = EventPriority.HIGHEST)
   public void onItemMerge(ItemMergeEvent event) {
-    boolean entityTracked = event.getEntity().hasMetadata(METADATA_KEY);
-    boolean targetTracked = event.getTarget().hasMetadata(METADATA_KEY);
-    if (!entityTracked && !targetTracked) return; // None affected
-    if (entityTracked && targetTracked) {
-      String entitySpawnerId =
-          MetadataUtils.getMetadataValue(event.getEntity(), METADATA_KEY, PGM.get());
-      String targetSpawnerId =
-          MetadataUtils.getMetadataValue(event.getTarget(), METADATA_KEY, PGM.get());
-      if (Objects.equals(entitySpawnerId, targetSpawnerId)) return; // Same spawner, allow merge
+    var entityMeta = MetadataUtils.getMetadataValue(event.getEntity(), METADATA_KEY, PGM.get());
+    var targetMeta = MetadataUtils.getMetadataValue(event.getTarget(), METADATA_KEY, PGM.get());
+    if (entityMeta == null && targetMeta == null) return; // Not spawner related
+    if (!Objects.equals(entityMeta, targetMeta)) {
+      event.setCancelled(true); // Different spawners, prevent merging
     }
-    event.setCancelled(true);
   }
 
-  private void handleEntityRemoveEvent(Metadatable metadatable, int amount) {
-    if (metadatable.hasMetadata(METADATA_KEY)) {
-      if (Objects.equals(
-          MetadataUtils.getMetadataValue(metadatable, METADATA_KEY, PGM.get()),
-          definition.getId())) {
-        spawnedEntities -= amount;
-        spawnedEntities = Math.max(0, spawnedEntities);
+  private void handleEntityRemoveEvent(Entity entity, boolean affectCount) {
+    var metadata = MetadataUtils.getMetadataValue(entity, METADATA_KEY, PGM.get());
+    if (Objects.equals(definition.getId(), metadata)) {
+      entity.removeMetadata(METADATA_KEY, PGM.get());
+      if (affectCount) {
+        int removedEntities = entity instanceof Item item ? item.getItemStack().getAmount() : 1;
+        spawnedEntities = Math.max(0, spawnedEntities - removedEntities);
       }
     }
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onEntityDeath(EntityDeathEvent event) {
-    handleEntityRemoveEvent(event.getEntity(), 1);
+    handleEntityRemoveEvent(event.getEntity(), true);
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onItemDespawn(ItemDespawnEvent event) {
-    handleEntityRemoveEvent(event.getEntity(), event.getEntity().getItemStack().getAmount());
+    handleEntityRemoveEvent(event.getEntity(), true);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onItemMergeRecover(ItemMergeEvent event) {
+    // Entity merging does not affect count.
+    // We do need to remove the meta so the remove from world doesn't subtract.
+    handleEntityRemoveEvent(event.getEntity(), false);
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onEntityRemove(EntityRemoveFromWorldEvent event) {
+    handleEntityRemoveEvent(event.getEntity(), true);
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPotionSplash(PotionSplashEvent event) {
-    handleEntityRemoveEvent(event.getEntity(), 1);
+    handleEntityRemoveEvent(event.getEntity(), true);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerPickup(PlayerPickupItemEvent event) {
-    handleEntityRemoveEvent(event.getItem(), event.getItem().getItemStack().getAmount());
-  }
-
-  @EventHandler(priority = EventPriority.MONITOR)
-  public void onPlayerMove(PlayerCoarseMoveEvent event) {
-    final MatchPlayer player = match.getParticipant(event.getPlayer());
-    if (player == null) return;
-    if (definition.playerRegion.contains(event.getPlayer())) {
-      players.putIfAbsent(event.getPlayer(), player);
-    } else {
-      players.remove(event.getPlayer());
-    }
-  }
-
-  @EventHandler(priority = EventPriority.MONITOR)
-  public void onMatchEnd(MatchFinishEvent event) {
-    this.players.clear();
-    this.players.disable();
+    handleEntityRemoveEvent(event.getItem(), true);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
@@ -8,14 +8,16 @@ import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
+import tc.oc.pgm.util.TimeUtils;
 
 @FeatureInfo(name = "spawner")
 public class SpawnerDefinition extends SelfIdentifyingFeatureDefinition {
   public final Region spawnRegion;
   public final Region playerRegion;
   public final int maxEntities;
-  public final Duration minDelay, maxDelay, delay;
+  public final long minDelay, maxDelay;
   public final List<Spawnable> objects;
+  public final Filter matchFilter;
   public final Filter playerFilter;
 
   public SpawnerDefinition(
@@ -23,8 +25,8 @@ public class SpawnerDefinition extends SelfIdentifyingFeatureDefinition {
       List<Spawnable> objects,
       Region spawnRegion,
       Region playerRegion,
+      Filter matchFilter,
       Filter playerFilter,
-      Duration delay,
       Duration minDelay,
       Duration maxDelay,
       int maxEntities) {
@@ -32,10 +34,10 @@ public class SpawnerDefinition extends SelfIdentifyingFeatureDefinition {
     this.spawnRegion = spawnRegion;
     this.playerRegion = playerRegion;
     this.maxEntities = maxEntities;
-    this.minDelay = minDelay;
-    this.maxDelay = maxDelay;
-    this.delay = delay;
+    this.minDelay = TimeUtils.toTicks(minDelay);
+    this.maxDelay = TimeUtils.toTicks(maxDelay);
     this.objects = objects;
+    this.matchFilter = matchFilter;
     this.playerFilter = playerFilter;
   }
 

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerMatchModule.java
@@ -3,24 +3,28 @@ package tc.oc.pgm.spawner;
 import java.util.List;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
-import tc.oc.pgm.api.match.MatchScope;
 
 public class SpawnerMatchModule implements MatchModule {
 
   private final Match match;
-  private final List<SpawnerDefinition> definitions;
+  private final List<Spawner> spawners;
 
-  public SpawnerMatchModule(Match match, List<SpawnerDefinition> definitions) {
+  public SpawnerMatchModule(Match match, List<Spawner> spawners) {
     this.match = match;
-    this.definitions = definitions;
+    this.spawners = spawners;
   }
 
   @Override
   public void load() {
-    for (SpawnerDefinition definition : definitions) {
-      Spawner spawner = new Spawner(definition, match);
-      match.addListener(spawner, MatchScope.RUNNING);
-      match.addTickable(spawner, MatchScope.RUNNING);
+    for (Spawner spawner : spawners) {
+      spawner.registerEvents();
+    }
+  }
+
+  @Override
+  public void unload() {
+    for (Spawner spawner : this.spawners) {
+      spawner.unregisterEvents();
     }
   }
 }

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -14,7 +14,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Wither;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
-import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import tc.oc.pgm.api.filter.Filter;
@@ -26,29 +25,37 @@ import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.entity.SpawnableEntity;
 import tc.oc.pgm.filters.FilterModule;
 import tc.oc.pgm.filters.matcher.StaticFilter;
-import tc.oc.pgm.filters.parse.FilterParser;
-import tc.oc.pgm.kits.KitParser;
 import tc.oc.pgm.regions.RegionModule;
-import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.spawner.objects.SpawnableItem;
 import tc.oc.pgm.spawner.objects.SpawnableMob;
 import tc.oc.pgm.spawner.objects.SpawnablePotion;
 import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.xml.InheritingElement;
 import tc.oc.pgm.util.xml.InvalidXMLException;
+import tc.oc.pgm.util.xml.XMLFluentParser;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public class SpawnerModule implements MapModule<SpawnerMatchModule> {
 
+  private static final Duration DEFAULT_DELAY = Duration.ofSeconds(10);
   private static final int SPLASH_BIT = 0x4000;
   private static final Set<Class<? extends LivingEntity>> EXCLUDED_MOB_TYPES =
       Set.of(Wither.class, EnderDragon.class);
 
-  private final List<SpawnerDefinition> spawnerDefinitions = new ArrayList<>();
+  private final List<SpawnerDefinition> definitions;
+
+  public SpawnerModule(List<SpawnerDefinition> definitions) {
+    this.definitions = definitions;
+  }
 
   @Override
   public SpawnerMatchModule createMatchModule(Match match) {
-    return new SpawnerMatchModule(match, spawnerDefinitions);
+    List<Spawner> spawners = new ArrayList<>(this.definitions.size());
+    for (SpawnerDefinition definition : this.definitions) {
+      spawners.add(new Spawner(definition, match));
+    }
+
+    return new SpawnerMatchModule(match, spawners);
   }
 
   public static class Factory implements MapModuleFactory<SpawnerModule> {
@@ -60,50 +67,53 @@ public class SpawnerModule implements MapModule<SpawnerMatchModule> {
     @Override
     public SpawnerModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
-      SpawnerModule spawnerModule = new SpawnerModule();
-      RegionParser regionParser = factory.getRegions();
-      KitParser kitParser = factory.getKits();
-      FilterParser filterParser = factory.getFilters();
+      XMLFluentParser parser = factory.getParser();
       AtomicInteger spawnerIdSerial = new AtomicInteger(1);
 
-      for (Element spawnerEl :
-          XMLUtils.flattenElements(doc.getRootElement(), "spawners", "spawner")) {
-        String id = spawnerEl.getAttributeValue("id");
-        Region spawnRegion = regionParser.parseRequiredRegionProperty(spawnerEl, "spawn-region");
-        Region playerRegion = regionParser.parseRequiredRegionProperty(spawnerEl, "player-region");
-        Attribute delayAttr = spawnerEl.getAttribute("delay");
-        Attribute minDelayAttr = spawnerEl.getAttribute("min-delay");
-        Attribute maxDelayAttr = spawnerEl.getAttribute("max-delay");
+      List<SpawnerDefinition> spawners = new ArrayList<>();
+      for (Element el : XMLUtils.flattenElements(doc.getRootElement(), "spawners", "spawner")) {
+        String id = parser
+            .string(el, "id")
+            .optional(() -> SpawnerDefinition.makeDefaultId(null, spawnerIdSerial));
+        Region spawnRegion = parser.region(el, "spawn-region").randomPoints().required();
+        Region playerRegion = parser.region(el, "player-region").orEverywhere();
 
-        if (id == null) id = SpawnerDefinition.makeDefaultId(null, spawnerIdSerial);
+        Duration parsedMinDelay = parser.duration(el, "min-delay").orNull();
+        Duration parsedMaxDelay = parser.duration(el, "max-delay").orNull();
+        Duration delay = parser
+            .duration(el, "delay")
+            .validate((d, n) -> {
+              if (parsedMinDelay != null || parsedMaxDelay != null)
+                throw new InvalidXMLException(
+                    "'min-delay' and 'max-delay' cannot be combined with 'delay'", n);
+            })
+            .optional(DEFAULT_DELAY);
 
-        if ((minDelayAttr != null || maxDelayAttr != null) && delayAttr != null) {
-          throw new InvalidXMLException(
-              "Attribute 'minDelay' and 'maxDelay' cannot be combined with 'delay'", spawnerEl);
+        Duration minDelay = parsedMinDelay != null ? parsedMinDelay : delay;
+        Duration maxDelay = parsedMaxDelay != null ? parsedMaxDelay : delay;
+
+        if (maxDelay.compareTo(minDelay) < 0) {
+          throw new InvalidXMLException("Max-delay must be longer or equal to min-delay", el);
         }
 
-        Duration delay = XMLUtils.parseDuration(delayAttr, Duration.ofSeconds(10));
-        Duration minDelay = XMLUtils.parseDuration(minDelayAttr, delay);
-        Duration maxDelay = XMLUtils.parseDuration(maxDelayAttr, delay);
+        int maxEntities = parser.parseInt(el, "max-entities").optional(Integer.MAX_VALUE);
+        Filter filter = parser.filter(el, "filter").orAllow();
 
-        if (maxDelay.compareTo(minDelay) <= 0 && minDelayAttr != null && maxDelayAttr != null) {
-          throw new InvalidXMLException("Max-delay must be longer than min-delay", spawnerEl);
-        }
-
-        int maxEntities = XMLUtils.parseNumber(
-            spawnerEl.getAttribute("max-entities"), Integer.class, Integer.MAX_VALUE);
-        Filter playerFilter =
-            filterParser.parseFilterProperty(spawnerEl, "filter", StaticFilter.ALLOW);
+        // Supporting both independently would require a proto bump; however we
+        // can use respondsTo as an optimization to handle it as a match-only filter.
+        boolean isMatchFilter = filter.respondsTo(Match.class);
+        Filter playerFilter = isMatchFilter ? StaticFilter.ALLOW : filter;
+        Filter matchFilter = isMatchFilter ? filter : StaticFilter.ALLOW;
 
         List<Spawnable> objects = new ArrayList<>();
-        for (Element itemEl : XMLUtils.getChildren(spawnerEl, "item")) {
-          ItemStack stack = kitParser.parseItem(itemEl, false);
+        for (Element itemEl : XMLUtils.getChildren(el, "item")) {
+          ItemStack stack = parser.item(itemEl).required();
           SpawnableItem item = new SpawnableItem(stack, id);
           objects.add(item);
         }
 
-        for (Element potionEl : XMLUtils.getChildren(spawnerEl, "potion")) {
-          short dmg = XMLUtils.parseNumber(potionEl.getAttribute("damage"), Short.class, (short) 0);
+        for (Element potionEl : XMLUtils.getChildren(el, "potion")) {
+          short dmg = parser.parseShort(potionEl, "damage").optional((short) 0);
           ItemStack potion =
               MaterialData.item(Material.POTION, (short) (dmg | SPLASH_BIT)).toItemStack(1);
           PotionMeta meta = (PotionMeta) potion.getItemMeta();
@@ -112,13 +122,13 @@ public class SpawnerModule implements MapModule<SpawnerMatchModule> {
                 XMLUtils.parsePotionEffect(new InheritingElement(potionChild)), false);
           }
           if (!meta.hasCustomEffects()) {
-            throw new InvalidXMLException("Expected child effects, but found none", spawnerEl);
+            throw new InvalidXMLException("Expected child effects, but found none", el);
           }
           potion.setItemMeta(meta);
           objects.add(new SpawnablePotion(potion, id));
         }
 
-        for (Element mobEl : XMLUtils.getChildren(spawnerEl, "mob")) {
+        for (Element mobEl : XMLUtils.getChildren(el, "mob")) {
           objects.add(parseMob(mobEl, id));
         }
 
@@ -127,16 +137,16 @@ public class SpawnerModule implements MapModule<SpawnerMatchModule> {
             objects,
             spawnRegion,
             playerRegion,
+            matchFilter,
             playerFilter,
-            delay,
             minDelay,
             maxDelay,
             maxEntities);
-        factory.getFeatures().addFeature(spawnerEl, spawnerDefinition);
-        spawnerModule.spawnerDefinitions.add(spawnerDefinition);
+        factory.getFeatures().addFeature(el, spawnerDefinition);
+        spawners.add(spawnerDefinition);
       }
 
-      return spawnerModule.spawnerDefinitions.isEmpty() ? null : spawnerModule;
+      return spawners.isEmpty() ? null : new SpawnerModule(spawners);
     }
 
     private static SpawnableMob parseMob(Element mobEl, String spawnerId)

--- a/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/XMLFluentParser.java
@@ -125,6 +125,10 @@ public class XMLFluentParser {
     return number(Float.class, el, prop);
   }
 
+  public NumberBuilder<Short> parseShort(Element el, String... prop) {
+    return number(Short.class, el, prop);
+  }
+
   public <T extends Number & Comparable<T>> NumberBuilder<T> number(
       Class<T> cls, Element el, String... prop) {
     return new NumberBuilder<>(cls, el, prop);

--- a/core/src/main/java/tc/oc/pgm/util/xml/parsers/RegionBuilder.java
+++ b/core/src/main/java/tc/oc/pgm/util/xml/parsers/RegionBuilder.java
@@ -6,13 +6,16 @@ import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.regions.BlockBoundedValidation;
+import tc.oc.pgm.regions.EmptyRegion;
+import tc.oc.pgm.regions.EverywhereRegion;
 import tc.oc.pgm.regions.RandomPointsValidation;
 import tc.oc.pgm.regions.RegionParser;
 import tc.oc.pgm.regions.StaticValidation;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 import tc.oc.pgm.util.xml.Node;
 
-public abstract class RegionBuilder<T extends Region> extends Builder<T, RegionBuilder<T>> {
+public abstract sealed class RegionBuilder<T extends Region> extends Builder<T, RegionBuilder<T>>
+    permits RegionBuilder.OfRegion, RegionBuilder.OfStatic {
   protected final RegionParser regions;
   private boolean children = false;
 
@@ -42,6 +45,16 @@ public abstract class RegionBuilder<T extends Region> extends Builder<T, RegionB
     return this;
   }
 
+  @SuppressWarnings("unchecked")
+  public T orEverywhere() throws InvalidXMLException {
+    return optional((T) EverywhereRegion.INSTANCE);
+  }
+
+  @SuppressWarnings("unchecked")
+  public T orNowhere() throws InvalidXMLException {
+    return optional((T) EmptyRegion.INSTANCE);
+  }
+
   protected Region parseRegion(Node node) throws InvalidXMLException {
     if (children && node.isElement()) {
       return regions.parseChildren(node.getElement());
@@ -55,7 +68,7 @@ public abstract class RegionBuilder<T extends Region> extends Builder<T, RegionB
     return this;
   }
 
-  public static class OfRegion extends RegionBuilder<Region> {
+  public static final class OfRegion extends RegionBuilder<Region> {
     public OfRegion(RegionParser regions, Element el, String... prop) {
       super(regions, el, prop);
     }
@@ -66,7 +79,7 @@ public abstract class RegionBuilder<T extends Region> extends Builder<T, RegionB
     }
   }
 
-  public static class OfStatic extends RegionBuilder<Region.Static> {
+  public static final class OfStatic extends RegionBuilder<Region.Static> {
 
     public OfStatic(RegionParser regions, Element el, String... prop) {
       super(regions, el, prop);

--- a/util/src/main/java/tc/oc/pgm/util/event/PlayerItemTransferEvent.java
+++ b/util/src/main/java/tc/oc/pgm/util/event/PlayerItemTransferEvent.java
@@ -3,6 +3,7 @@ package tc.oc.pgm.util.event;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -79,5 +80,16 @@ public class PlayerItemTransferEvent extends ItemTransferEvent {
     return reason == Reason.PLACE
         || reason == Reason.DROP
         || (reason == Reason.TRANSFER && getTo() != null && getTo().getHolder() != this.player);
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
   }
 }


### PR DESCRIPTION
Fixes a bunch of minor and less minor issues with spawners:
 - Instead of spawners rolling their own player tracking, reuse the existing player tracker from controlpoints
   - This fixes things like dead players within spawner range still counting towards activating spawners until they moved again, or even if they joined obs so long as they did not move.
 - There were ways for entities to vanish without being "uncounted" from spawned entities, leading to spawners which would never spawn items again.
   - Some of these include making the item go into the void, or being picked up by hoppers or hopper minecarts
   - Coincidentally, also found a bug in player transfer item event (missing event handlers) which caused handling of hopper picking up items to fail, as listeners for player transfer events were registered to the item transfer event, and failed to cast to the right type to get the player for dynamic filters.
 - The region was forced to be specified, even when "everywhere" is a sane default and is used in several maps
 - The filter is a "player-filter", meaning it was tested for every player until one passed. 
   - This is unnecessary most of the times!
   - Many maps are never filtering on players themselves, they filter for match time or some variable that is also match global, since they basically use everywhere regions for the players anyways.
   - Made it so PGM tries to figure out if it really needs to check each player, or if it can get away with just checking the match.
   - The filter default is "always" (as it already was) which can also be optimized away in checking for individual players.
 - Setting min-delay and max-delay to the same number, would make the default delay (10s) be used instead.
   - On the definition, instead of minDelay, maxDelay and delay, we just have min and max. If they're the same, it won't be random.
   - On the parsing side, specifying delay means setting min and max to the same. They're still mutually exclusive.
 - Spawners were checking all the players for the filter even when the spawner was on cooldown.
   - Order of checks in the tick is now more optimized to skip checking filters whenever possible and short-circuit earlier.
 - Pgm didn't check that the spawn region supported random points at parse time. It would still break if it ever tried to spawn.