### PR TITLE
Ensure ListeningMapAdapter does not re-enable after disabling

### DIFF
--- a/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/inventory/ViewInventoryMatchModule.java
@@ -67,8 +67,8 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
 
   private final Match match;
 
-  private final Map<Player, InventoryTrackerEntry> monitoredInventories;
-  private final Map<Player, Instant> updateQueue;
+  private final OnlinePlayerMapAdapter<InventoryTrackerEntry> monitoredInventories;
+  private final OnlinePlayerMapAdapter<Instant> updateQueue;
 
   public ViewInventoryMatchModule(Match match) {
     this.match = match;
@@ -249,8 +249,8 @@ public class ViewInventoryMatchModule implements MatchModule, Listener {
 
   @Override
   public void unload() {
-    monitoredInventories.clear();
-    updateQueue.clear();
+    monitoredInventories.disable();
+    updateQueue.disable();
   }
 
   public boolean canPreviewInventory(Player viewer, Player holder) {

--- a/core/src/main/java/tc/oc/pgm/tracker/TrackerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/TrackerMatchModule.java
@@ -47,6 +47,7 @@ public class TrackerMatchModule implements MatchModule {
   private final FireTracker fireTracker;
   private final FallingBlockTracker fallingBlockTracker;
   private final CactiTracker cactiTracker;
+  private final CombatLogTracker combatLogTracker;
 
   private final Set<DamageResolver> damageResolvers = new LinkedHashSet<>();
   private final Match match;
@@ -59,6 +60,7 @@ public class TrackerMatchModule implements MatchModule {
     fireTracker = new FireTracker(this, match);
     fallingBlockTracker = new FallingBlockTracker(this, match);
     cactiTracker = new CactiTracker(this, match);
+    combatLogTracker = new CombatLogTracker(this);
 
     // Damage resolvers - order is important!
     damageResolvers.add(fallTracker);
@@ -82,14 +84,19 @@ public class TrackerMatchModule implements MatchModule {
     match.addListener(blockTracker, MatchScope.RUNNING);
     match.addListener(fallingBlockTracker, MatchScope.RUNNING);
     match.addListener(cactiTracker, MatchScope.RUNNING);
+    match.addListener(combatLogTracker, MatchScope.RUNNING);
     match.addListener(new EndCrystalTracker(this, match), MatchScope.RUNNING);
     match.addListener(new DispenserTracker(this, match), MatchScope.RUNNING);
     match.addListener(new TNTTracker(this, match), MatchScope.RUNNING);
     match.addListener(new SpleefTracker(this), MatchScope.RUNNING);
     match.addListener(new OwnedMobTracker(this, match), MatchScope.RUNNING);
     match.addListener(new ProjectileTracker(this, match), MatchScope.RUNNING);
-    match.addListener(new CombatLogTracker(this), MatchScope.RUNNING);
     match.addListener(new DeathTracker(this), MatchScope.RUNNING);
+  }
+
+  @Override
+  public void unload() {
+    combatLogTracker.unload();
   }
 
   public EntityTracker getEntityTracker() {

--- a/core/src/main/java/tc/oc/pgm/tracker/trackers/CombatLogTracker.java
+++ b/core/src/main/java/tc/oc/pgm/tracker/trackers/CombatLogTracker.java
@@ -7,7 +7,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -63,9 +62,14 @@ public class CombatLogTracker implements Listener {
       @Nullable Block blockDamager,
       boolean alreadyDamaged) {}
 
-  private final Map<Player, Damage> recentDamage = new OnlinePlayerMapAdapter<>(PGM.get());
+  private final OnlinePlayerMapAdapter<Damage> recentDamage =
+      new OnlinePlayerMapAdapter<>(PGM.get());
 
   public CombatLogTracker(TrackerMatchModule tmm) {}
+
+  public void unload() {
+    recentDamage.disable();
+  }
 
   private static boolean hasFireResistance(LivingEntity entity) {
     for (PotionEffect effect : entity.getActivePotionEffects()) {

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/ListeningMapAdapter.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/ListeningMapAdapter.java
@@ -129,7 +129,9 @@ public abstract class ListeningMapAdapter<K, V> extends ForwardingMap<K, V> impl
    * called.
    */
   public void disable() {
+    this.lazyEnable = false;
     if (this.enabled) {
+      this.enabled = false;
       this.clear();
       HandlerList.unregisterAll(this);
     }


### PR DESCRIPTION
Ensure disabled `ListeningMapAdapter`s do not get re-enabled.
Disable 3 `ListeningMapAdapter` instance on unload from `ViewInventoryMatchModule` and `CombatLogTracker`