### PR TITLE
fix: give `/team shuffle` flags a proper long name

### DIFF
--- a/core/src/main/java/tc/oc/pgm/command/TeamCommand.java
+++ b/core/src/main/java/tc/oc/pgm/command/TeamCommand.java
@@ -66,8 +66,8 @@ public final class TeamCommand {
       Match match,
       CommandSender sender,
       TeamMatchModule teams,
-      @Flag("a") boolean all,
-      @Flag("f") boolean force) {
+      @Flag(value = "all", aliases = "a") boolean all,
+      @Flag(value = "force", aliases = "f") boolean force) {
     if (match.isRunning() && !force) {
       throw exception("match.shuffle.err");
     }


### PR DESCRIPTION
For some reason, the Cloud `@Flag` annotation considers the value of the annotation a long flag name even if the flag name is a single character, resulting in the command for shuffling everyone (including observers) having an odd syntax of `/team shuffle --a --f`. This PR gives the flags a long name with the short forms as aliases which are parsed correctly as short flags.