### PR TITLE
fix: properly enforce import restrictions

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import de.skuzzle.restrictimports.gradle.RestrictImports
+
 plugins {
     `java-library`
     id("com.diffplug.spotless")
@@ -75,13 +77,20 @@ spotless {
     }
 }
 
-restrictImports {
-    group {
+tasks {
+    // Bypass inability to have two groups with same base packages inside the import restriction plugin
+    val restrictJavaxAnnotations = register<RestrictImports>("restrictJavaxAnnotations") {
+        group = "verification"
         reason = "Use org.jspecify.annotations to add annotations, or org.jetbrains.annotations if needed"
         bannedImports = listOf("javax.annotation.**")
     }
-    group {
+    val restrictAsserts = register<RestrictImports>("restrictAsserts") {
+        group = "verification"
         reason = "Use tc.oc.pgm.util.Assert to add assertions"
         bannedImports = listOf("com.google.common.base.Preconditions.**", "java.util.Objects.requireNonNull")
+    }
+    // Enforce the import restrictions
+    check {
+        dependsOn(restrictJavaxAnnotations, restrictAsserts)
     }
 }

--- a/core/src/main/java/tc/oc/pgm/events/PlayerChangePartyEvent.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerChangePartyEvent.java
@@ -2,8 +2,8 @@ package tc.oc.pgm.events;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.bukkit.event.HandlerList;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.join.JoinRequest;

--- a/core/src/main/java/tc/oc/pgm/events/PlayerPartyChangeEventBase.java
+++ b/core/src/main/java/tc/oc/pgm/events/PlayerPartyChangeEventBase.java
@@ -1,6 +1,6 @@
 package tc.oc.pgm.events;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;


### PR DESCRIPTION
When PGM migrated over to Gradle, it turns out the import restriction rules had never been enforced at all! 💀 

This PR:
- makes sure the import restrictions are enforced
- fixes a configuration issue that prevents the default restrictImports task from working
  - since for some reason, the groups inside the restrictImports block cannot affect the same package sets (the default `./gradlew restrictImports` task against current dev branch complains), this has to be split up into two tasks
  - this could probably be grouped back into a single task that would depend on the underlying split tasks?
- fixes up offending code