### PR TITLE
ci: update actions in the pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - id: checkout
       name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - id: setup-java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,11 @@ jobs:
       with:
         java-version: 21
         distribution: temurin
-    # Configures gradle with caching
+    # Configures gradle with caching. Intentionally pinned to v5.0.2 instead of v6
+    # to benefit from better caching without having to agree to a commercial license,
+    # along with having to trust a 2 MB obfuscated JS blob.
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
-      with:
-        cache-provider: basic
+      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
     # Run "gradlew publish" for origin/dev and "gradlew build" for PRs or elsewhere
     - name: Execute Gradle ${{ (github.repository == 'PGMDev/PGM' && github.ref == 'refs/heads/dev') && 'Publish' || 'Build' }}
       run: ./gradlew ${{ (github.repository == 'PGMDev/PGM' && github.ref == 'refs/heads/dev') && 'publish' || 'build' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,20 @@ jobs:
     steps:
     - id: checkout
       name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - id: setup-java
       name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 21
         distribution: temurin
     # Configures gradle with caching
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-provider: basic
     # Run "gradlew publish" for origin/dev and "gradlew build" for PRs or elsewhere
     - name: Execute Gradle ${{ (github.repository == 'PGMDev/PGM' && github.ref == 'refs/heads/dev') && 'Publish' || 'Build' }}
       run: ./gradlew ${{ (github.repository == 'PGMDev/PGM' && github.ref == 'refs/heads/dev') && 'publish' || 'build' }}
@@ -33,8 +35,9 @@ jobs:
         GITHUB_TOKEN: ${{ (github.repository == 'PGMDev/PGM' && github.ref == 'refs/heads/dev') && secrets.GITHUB_TOKEN || '' }}
     - id: artifact
       name: Upload Jar
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: PGM.jar
         path: build/libs/PGM.jar
         if-no-files-found: error
+        archive: false


### PR DESCRIPTION
Updates actions in the CI pipeline to their latest versions to get rid of the Node.js v20 EOL warning. A couple of things to note:
- The .jar artifact is no longer zipped, allowing people to download PGM builds with less friction
- ~~The v6 of the `setup-gradle` action has changed their caching mechanism to a [proprietary license](https://github.com/gradle/actions/releases/tag/v6.0.0). Currently, this PR opts into the "basic" caching mechanism (released later on), which is open source, but well… basic and isn't as granular as the (now) proprietary component. Although – per their words – the proprietary caching mechanism is free to use with public repositories (and thus probably OK to use), I'm keeping this as a draft until the way to go is decided.~~
  The `setup-gradle` action has been pinned to v5.0.2, which supports Node.js v24 and is the last version before the licensing changes. This should give us some time, during which PGM can use better caching (compared to v6 basic caching) under the MIT license (thus doesn't require agreeing to the commercial license and PGM having to trust a 2 MB obfuscated JavaScript blob) until it goes EOL in 2028.