### PR TITLE
Defer Spawner filter split to match creation

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -16,6 +16,7 @@ import org.bukkit.event.entity.ItemMergeEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchScope;
 import tc.oc.pgm.api.match.Tickable;
@@ -32,6 +33,8 @@ public class Spawner implements Listener, Tickable {
   private final Match match;
   private final SpawnerDefinition definition;
   private final RegionPlayerTracker playerTracker;
+  private final Filter matchFilter;
+  private final Filter playerFilter;
 
   private long canSpawnAt;
   private long spawnedEntities;
@@ -40,6 +43,9 @@ public class Spawner implements Listener, Tickable {
     this.definition = definition;
     this.match = match;
     this.playerTracker = new RegionPlayerTracker(match, definition.playerRegion);
+    boolean isMatchFilter = definition.filter.respondsTo(Match.class);
+    this.matchFilter = isMatchFilter ? definition.filter : StaticFilter.ALLOW;
+    this.playerFilter = isMatchFilter ? StaticFilter.ALLOW : definition.filter;
   }
 
   public void registerEvents() {
@@ -57,7 +63,7 @@ public class Spawner implements Listener, Tickable {
   public void tick(Match match, Tick tick) {
     var now = match.getTick().tick;
     if (now < this.canSpawnAt || spawnedEntities >= definition.maxEntities) return;
-    if (!definition.matchFilter.response(match) || !anyPlayerAllows()) return;
+    if (!matchFilter.response(match) || !anyPlayerAllows()) return;
 
     for (Spawnable spawnable : definition.objects) {
       var location = definition.spawnRegion.getRandomLoc(match);
@@ -76,11 +82,10 @@ public class Spawner implements Listener, Tickable {
   }
 
   private boolean anyPlayerAllows() {
-    var filter = definition.playerFilter;
-    if (filter == StaticFilter.ALLOW) return !playerTracker.getPlayers().isEmpty();
+    if (playerFilter == StaticFilter.ALLOW) return !playerTracker.getPlayers().isEmpty();
 
     for (MatchPlayer player : playerTracker.getPlayers()) {
-      if (filter.query(player).isAllowed()) return true;
+      if (playerFilter.query(player).isAllowed()) return true;
     }
     return false;
   }

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerDefinition.java
@@ -17,16 +17,14 @@ public class SpawnerDefinition extends SelfIdentifyingFeatureDefinition {
   public final int maxEntities;
   public final long minDelay, maxDelay;
   public final List<Spawnable> objects;
-  public final Filter matchFilter;
-  public final Filter playerFilter;
+  public final Filter filter;
 
   public SpawnerDefinition(
       String id,
       List<Spawnable> objects,
       Region spawnRegion,
       Region playerRegion,
-      Filter matchFilter,
-      Filter playerFilter,
+      Filter filter,
       Duration minDelay,
       Duration maxDelay,
       int maxEntities) {
@@ -37,8 +35,7 @@ public class SpawnerDefinition extends SelfIdentifyingFeatureDefinition {
     this.minDelay = TimeUtils.toTicks(minDelay);
     this.maxDelay = TimeUtils.toTicks(maxDelay);
     this.objects = objects;
-    this.matchFilter = matchFilter;
-    this.playerFilter = playerFilter;
+    this.filter = filter;
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/SpawnerModule.java
@@ -24,7 +24,6 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.entity.SpawnableEntity;
 import tc.oc.pgm.filters.FilterModule;
-import tc.oc.pgm.filters.matcher.StaticFilter;
 import tc.oc.pgm.regions.RegionModule;
 import tc.oc.pgm.spawner.objects.SpawnableItem;
 import tc.oc.pgm.spawner.objects.SpawnableMob;
@@ -99,12 +98,6 @@ public class SpawnerModule implements MapModule<SpawnerMatchModule> {
         int maxEntities = parser.parseInt(el, "max-entities").optional(Integer.MAX_VALUE);
         Filter filter = parser.filter(el, "filter").orAllow();
 
-        // Supporting both independently would require a proto bump; however we
-        // can use respondsTo as an optimization to handle it as a match-only filter.
-        boolean isMatchFilter = filter.respondsTo(Match.class);
-        Filter playerFilter = isMatchFilter ? StaticFilter.ALLOW : filter;
-        Filter matchFilter = isMatchFilter ? filter : StaticFilter.ALLOW;
-
         List<Spawnable> objects = new ArrayList<>();
         for (Element itemEl : XMLUtils.getChildren(el, "item")) {
           ItemStack stack = parser.item(itemEl).required();
@@ -133,15 +126,7 @@ public class SpawnerModule implements MapModule<SpawnerMatchModule> {
         }
 
         SpawnerDefinition spawnerDefinition = new SpawnerDefinition(
-            id,
-            objects,
-            spawnRegion,
-            playerRegion,
-            matchFilter,
-            playerFilter,
-            minDelay,
-            maxDelay,
-            maxEntities);
+            id, objects, spawnRegion, playerRegion, filter, minDelay, maxDelay, maxEntities);
         factory.getFeatures().addFeature(el, spawnerDefinition);
         spawners.add(spawnerDefinition);
       }


### PR DESCRIPTION
Fixes:
```bash
[02:42:22 INFO]: [PGM] <CommunityMaps>/arcade/standard/the_funky_queen: Unhandled java.lang.IllegalStateException, caused by: Cannot access unresolved FilterDefinition 'round-playing'
[02:42:22 WARN]: [PGM] Unhandled java.lang.IllegalStateException
java.lang.IllegalStateException: Cannot access unresolved FilterDefinition 'round-playing'
        at PGM.jar//tc.oc.pgm.features.XMLFeatureReference.get(XMLFeatureReference.java:93) ~[?:?]
        at PGM.jar//tc.oc.pgm.filters.XMLFilterReference.respondsTo(XMLFilterReference.java:34) ~[?:?]
        at PGM.jar//tc.oc.pgm.filters.operator.MultiFilterFunction.lambda$respondsTo$0(MultiFilterFunction.java:26) ~[?:?]
        at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90) ~[?:?]
        at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:1034) ~[?:?]
...
        at PGM.jar//tc.oc.pgm.filters.operator.MultiFilterFunction.respondsTo(MultiFilterFunction.java:26) ~[?:?]
        at PGM.jar//tc.oc.pgm.filters.operator.MultiFilterFunction.lambda$respondsTo$0(MultiFilterFunction.java:26) ~[?:?]
        at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90) ~[?:?]
...
        at PGM.jar//tc.oc.pgm.filters.operator.MultiFilterFunction.respondsTo(MultiFilterFunction.java:26) ~[?:?]
        at PGM.jar//tc.oc.pgm.filters.operator.MultiFilterFunction.lambda$respondsTo$0(MultiFilterFunction.java:26) ~[?:?]
...
        at PGM.jar//tc.oc.pgm.filters.operator.MultiFilterFunction.respondsTo(MultiFilterFunction.java:26) ~[?:?]
        at PGM.jar//tc.oc.pgm.spawner.SpawnerModule$Factory.parse(SpawnerModule.java:104) ~[?:?]
        at PGM.jar//tc.oc.pgm.spawner.SpawnerModule$Factory.parse(SpawnerModule.java:61) ~[?:?]
        at PGM.jar//tc.oc.pgm.map.MapFactoryImpl.createModule(MapFactoryImpl.java:75) ~[?:?]
        at PGM.jar//tc.oc.pgm.map.MapFactoryImpl.createModule(MapFactoryImpl.java:44) ~[?:?]
        at PGM.jar//tc.oc.pgm.api.module.ModuleGraph.load(ModuleGraph.java:159) ~[?:?]
        at PGM.jar//tc.oc.pgm.api.module.ModuleGraph.loadAll(ModuleGraph.java:47) ~[?:?]
        at PGM.jar//tc.oc.pgm.map.MapFactoryImpl.load(MapFactoryImpl.java:94) ~[?:?]
        at PGM.jar//tc.oc.pgm.map.MapLibraryImpl.loadMap(MapLibraryImpl.java:204) ~[?:?]
        at PGM.jar//tc.oc.pgm.map.MapLibraryImpl.loadMapSafe(MapLibraryImpl.java:244) ~[?:?]
        at PGM.jar//tc.oc.pgm.map.MapLibraryImpl.lambda$loadNewMaps$4(MapLibraryImpl.java:167) ~[?:?]
        ```