### PR TITLE
Shop xml changes and bump proto

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/map/MapProtos.java
+++ b/core/src/main/java/tc/oc/pgm/api/map/MapProtos.java
@@ -52,4 +52,7 @@ public interface MapProtos {
 
   // Make more singletons have built-in default ids
   Version FEATURE_SINGLETON_IDS_2 = new Version(1, 5, 1);
+
+  // Shop categories are features; shopkeepers accept mob properties
+  Version SHOP_CATEGORY_FEATURES = new Version(1, 5, 2);
 }

--- a/core/src/main/java/tc/oc/pgm/entity/SpawnableEntity.java
+++ b/core/src/main/java/tc/oc/pgm/entity/SpawnableEntity.java
@@ -17,14 +17,14 @@ import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public record SpawnableEntity(
-    Class<? extends LivingEntity> entityType, List<Consumer<Entity>> properties, Kit kit) {
+    Class<? extends Entity> entityType, List<Consumer<Entity>> properties, Kit kit) {
 
   public Entity spawn(Location location) {
-    LivingEntity entity = location.getWorld().spawn(location, entityType);
+    Entity entity = location.getWorld().spawn(location, entityType);
     for (var property : properties) {
       property.accept(entity);
     }
-    kit.apply(entity);
+    if (entity instanceof LivingEntity living) kit.apply(living);
     return entity;
   }
 

--- a/core/src/main/java/tc/oc/pgm/shops/Shop.java
+++ b/core/src/main/java/tc/oc/pgm/shops/Shop.java
@@ -5,7 +5,9 @@ import static net.kyori.adventure.text.Component.translatable;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 import tc.oc.pgm.kits.ItemKit;
@@ -15,12 +17,14 @@ import tc.oc.pgm.shops.menu.Category;
 import tc.oc.pgm.shops.menu.Icon;
 import tc.oc.pgm.util.bukkit.Sounds;
 
+@FeatureInfo(name = "shop")
 public class Shop extends SelfIdentifyingFeatureDefinition {
 
   private final String name;
-  private final ImmutableList<Category> categories;
+  private final ImmutableList<Supplier<Category>> categories;
+  private ImmutableList<Category> resolvedCategories;
 
-  public Shop(String id, String name, List<Category> categories) {
+  public Shop(String id, String name, List<Supplier<Category>> categories) {
     super(id);
     this.name = name != null ? name : id;
     this.categories = ImmutableList.copyOf(categories);
@@ -31,11 +35,15 @@ public class Shop extends SelfIdentifyingFeatureDefinition {
   }
 
   public List<Category> getCategories() {
-    return categories;
+    if (resolvedCategories == null) {
+      resolvedCategories =
+          ImmutableList.copyOf(categories.stream().map(Supplier::get).toList());
+    }
+    return resolvedCategories;
   }
 
   public List<Category> getVisibleCategories(MatchPlayer player) {
-    return categories.stream()
+    return getCategories().stream()
         .filter(c -> c.getFilter().query(player).isAllowed())
         .toList();
   }

--- a/core/src/main/java/tc/oc/pgm/shops/ShopKeeper.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopKeeper.java
@@ -3,6 +3,8 @@ package tc.oc.pgm.shops;
 import static tc.oc.pgm.util.bukkit.BukkitUtils.colorize;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 
+import java.util.List;
+import java.util.function.Consumer;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
@@ -10,6 +12,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.points.PointProvider;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
@@ -21,18 +24,24 @@ public class ShopKeeper {
   private final String name;
   private final PointProvider location;
   private final Class<? extends Entity> type;
-  private final Shop shop;
+  private final List<Consumer<Entity>> properties;
+  private final FeatureReference<Shop> shop;
 
   public ShopKeeper(
-      @Nullable String name, PointProvider location, Class<? extends Entity> type, Shop shop) {
+      @Nullable String name,
+      PointProvider location,
+      Class<? extends Entity> type,
+      List<Consumer<Entity>> properties,
+      FeatureReference<Shop> shop) {
     this.name = name;
     this.location = location;
     this.type = type;
+    this.properties = properties;
     this.shop = shop;
   }
 
   public Shop getShop() {
-    return shop;
+    return shop.get();
   }
 
   public Class<? extends Entity> getType() {
@@ -52,10 +61,13 @@ public class ShopKeeper {
     Entity keeper = loc.getWorld().spawn(loc, type);
     keeper.setCustomName(getName());
     keeper.setCustomNameVisible(true);
-    keeper.setMetadata(METADATA_KEY, new FixedMetadataValue(PGM.get(), shop.getId()));
     if (keeper instanceof LivingEntity livingEntity) {
       livingEntity.setRemoveWhenFarAway(false);
     }
+    for (Consumer<Entity> property : properties) {
+      property.accept(keeper);
+    }
+    keeper.setMetadata(METADATA_KEY, new FixedMetadataValue(PGM.get(), getShop().getId()));
     NMS_HACKS.freezeEntity(keeper);
   }
 

--- a/core/src/main/java/tc/oc/pgm/shops/ShopKeeper.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopKeeper.java
@@ -3,7 +3,6 @@ package tc.oc.pgm.shops;
 import static tc.oc.pgm.util.bukkit.BukkitUtils.colorize;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 
-import java.util.List;
 import java.util.function.Consumer;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -14,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.feature.FeatureReference;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.entity.SpawnableEntity;
 import tc.oc.pgm.points.PointProvider;
 import tc.oc.pgm.util.bukkit.MetadataUtils;
 
@@ -23,20 +23,17 @@ public class ShopKeeper {
 
   private final String name;
   private final PointProvider location;
-  private final Class<? extends Entity> type;
-  private final List<Consumer<Entity>> properties;
+  private final SpawnableEntity entity;
   private final FeatureReference<Shop> shop;
 
   public ShopKeeper(
       @Nullable String name,
       PointProvider location,
-      Class<? extends Entity> type,
-      List<Consumer<Entity>> properties,
+      SpawnableEntity entity,
       FeatureReference<Shop> shop) {
     this.name = name;
     this.location = location;
-    this.type = type;
-    this.properties = properties;
+    this.entity = entity;
     this.shop = shop;
   }
 
@@ -45,7 +42,7 @@ public class ShopKeeper {
   }
 
   public Class<? extends Entity> getType() {
-    return type;
+    return entity.entityType();
   }
 
   public String getName() {
@@ -58,13 +55,13 @@ public class ShopKeeper {
     Location loc = location.getPoint(match, null);
     loc.getWorld().getChunkAt(loc); // Load chunk
 
-    Entity keeper = loc.getWorld().spawn(loc, type);
+    Entity keeper = loc.getWorld().spawn(loc, entity.entityType());
     keeper.setCustomName(getName());
     keeper.setCustomNameVisible(true);
     if (keeper instanceof LivingEntity livingEntity) {
       livingEntity.setRemoveWhenFarAway(false);
     }
-    for (Consumer<Entity> property : properties) {
+    for (Consumer<Entity> property : entity.properties()) {
       property.accept(keeper);
     }
     keeper.setMetadata(METADATA_KEY, new FixedMetadataValue(PGM.get(), getShop().getId()));

--- a/core/src/main/java/tc/oc/pgm/shops/ShopMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopMatchModule.java
@@ -4,11 +4,13 @@ import static tc.oc.pgm.shops.ShopKeeper.isKeeper;
 
 import java.util.Map;
 import java.util.Set;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.vehicle.VehicleDamageEvent;
 import org.bukkit.event.vehicle.VehicleDestroyEvent;
@@ -48,6 +50,12 @@ public class ShopMatchModule implements MatchModule, Listener {
     if (isKeeper(event.getEntity())) {
       event.setCancelled(true);
     }
+  }
+
+  // Armor stands never fire PlayerInteractEntityEvent
+  @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+  public void onClickArmorStandKeeper(PlayerInteractAtEntityEvent event) {
+    if (event.getRightClicked() instanceof ArmorStand) onClickShopKeeper(event);
   }
 
   @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)

--- a/core/src/main/java/tc/oc/pgm/shops/ShopModule.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopModule.java
@@ -36,6 +36,7 @@ import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.entity.MobProperties;
+import tc.oc.pgm.entity.SpawnableEntity;
 import tc.oc.pgm.kits.ItemKit;
 import tc.oc.pgm.kits.KitNode;
 import tc.oc.pgm.kits.OverflowWarningKit;
@@ -132,7 +133,8 @@ public class ShopModule implements MapModule<ShopMatchModule> {
             : List.of();
         PointProvider location = pointParser.parseSingle(shopkeeper, new PointProviderAttributes());
 
-        keepers.add(new ShopKeeper(name, location, mob, properties, shop));
+        keepers.add(new ShopKeeper(
+            name, location, new SpawnableEntity(mob, properties, KitNode.EMPTY), shop));
       }
 
       return shops.isEmpty() ? null : new ShopModule(shops, keepers);

--- a/core/src/main/java/tc/oc/pgm/shops/ShopModule.java
+++ b/core/src/main/java/tc/oc/pgm/shops/ShopModule.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -21,18 +23,19 @@ import org.bukkit.entity.Villager;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import tc.oc.pgm.action.Action;
 import tc.oc.pgm.action.ActionModule;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.map.MapModule;
+import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.entity.MobProperties;
 import tc.oc.pgm.kits.ItemKit;
 import tc.oc.pgm.kits.KitNode;
 import tc.oc.pgm.kits.OverflowWarningKit;
@@ -82,20 +85,28 @@ public class ShopModule implements MapModule<ShopMatchModule> {
       PointParser pointParser = new PointParser(factory);
       Map<String, Shop> shops = Maps.newHashMap();
       Set<ShopKeeper> keepers = Sets.newHashSet();
+      boolean shopFeatures = factory.getProto().isNoOlderThan(MapProtos.SHOP_CATEGORY_FEATURES);
 
       // Parse Shops
       for (Element shop : XMLUtils.flattenElements(doc.getRootElement(), "shops")) {
-        String shopId = XMLUtils.getRequiredAttribute(shop, "id").getValue();
-        String shopName = XMLUtils.getNullableAttribute(shop, "name");
-        List<Category> categories = Lists.newArrayList();
+        if ("category".equals(shop.getName())) {
+          parseCategory(shop, factory, true);
+          continue;
+        }
+
+        String shopId = parser.string(shop, "id").attr().required();
+        String shopName = parser.string(shop, "name").attr().orNull();
+        List<Supplier<Category>> categories = Lists.newArrayList();
 
         for (Element category : XMLUtils.getChildren(shop, "category")) {
-          Attribute categoryId = XMLUtils.getRequiredAttribute(category, "id");
-          ItemStack categoryIcon = applyItemFlags(parser.item(category).required());
-          List<Icon> icons = parseIcons(category, parser);
-          Filter filter = parser.filter(category, "filter").orAllow();
-
-          categories.add(new Category(categoryId.getValue(), categoryIcon, filter, icons));
+          if (isCategoryReference(category)) {
+            var reference =
+                parser.reference(Category.class, category, "id").attr().required();
+            categories.add(reference::get);
+          } else {
+            Category parsed = parseCategory(category, factory, shopFeatures);
+            categories.add(() -> parsed);
+          }
         }
 
         if (categories.isEmpty()) {
@@ -109,33 +120,51 @@ public class ShopModule implements MapModule<ShopMatchModule> {
 
       // Parse Shopkeepers
       for (Element shopkeeper : XMLUtils.flattenElements(doc.getRootElement(), "shopkeepers")) {
-        Attribute shopAttr = XMLUtils.getRequiredAttribute(shopkeeper, "shop");
-
-        String shopId = shopAttr.getValue();
-        String name = XMLUtils.getNullableAttribute(shopkeeper, "name");
-        Class<? extends Entity> mob =
-            XMLUtils.parseEntityTypeAttribute(shopkeeper, "mob", Villager.class);
+        var shop = parser.reference(Shop.class, shopkeeper, "shop").required();
+        String name = parser.string(shopkeeper, "name").attr().orNull();
+        Class<? extends Entity> mob = parser
+            .node(XMLUtils::parseEntityType, shopkeeper, "mob")
+            .attr()
+            .optional(Villager.class);
+        List<Consumer<Entity>> properties = shopFeatures
+            ? MobProperties.MOB_PROPERTIES.parseAttributes(
+                mob, shopkeeper, "shop", "name", "mob", "yaw", "pitch", "angle", "safe", "outdoors")
+            : List.of();
         PointProvider location = pointParser.parseSingle(shopkeeper, new PointProviderAttributes());
 
-        Shop shop = shops.get(shopId);
-
-        if (shop == null) {
-          throw new InvalidXMLException(
-              "No shop with id '" + shopId + "' could be found", shopkeeper);
-        }
-
-        keepers.add(new ShopKeeper(name, location, mob, shop));
+        keepers.add(new ShopKeeper(name, location, mob, properties, shop));
       }
 
       return shops.isEmpty() ? null : new ShopModule(shops, keepers);
     }
   }
 
-  private static List<Icon> parseIcons(Element category, XMLFluentParser parser)
+  private static boolean isCategoryReference(Element el) {
+    return el.getChildren().isEmpty()
+        && el.getAttributes().size() == 1
+        && el.getAttribute("id") != null;
+  }
+
+  private static Category parseCategory(Element el, MapFactory factory, boolean register)
+      throws InvalidXMLException {
+    var parser = factory.getParser();
+    String id = parser.string(el, "id").attr().required();
+    ItemStack icon = applyItemFlags(parser.item(el).required());
+    Filter filter = parser.filter(el, "filter").orAllow();
+    PaymentDefaults defaults = PaymentDefaults.parse(el, parser);
+    List<Icon> icons = parseIcons(el, parser, defaults);
+
+    Category category = new Category(id, icon, filter, icons);
+    if (register) factory.getFeatures().addFeature(el, category);
+    return category;
+  }
+
+  private static List<Icon> parseIcons(
+      Element category, XMLFluentParser parser, PaymentDefaults defaults)
       throws InvalidXMLException {
     List<Icon> icons = Lists.newArrayList();
     for (Element icon : XMLUtils.getChildren(category, "item")) {
-      icons.add(parseIcon(icon, parser));
+      icons.add(parseIcon(icon, parser, defaults));
     }
 
     if (icons.size() > Category.MAX_ICONS) {
@@ -150,10 +179,11 @@ public class ShopModule implements MapModule<ShopMatchModule> {
     return icons;
   }
 
-  private static Icon parseIcon(Element icon, XMLFluentParser parser) throws InvalidXMLException {
+  private static Icon parseIcon(Element icon, XMLFluentParser parser, PaymentDefaults defaults)
+      throws InvalidXMLException {
     boolean stackable = false;
 
-    List<Payment> payments = parsePayments(icon, parser);
+    List<Payment> payments = parsePayments(icon, parser, defaults);
 
     ItemStack item = parser.item(icon).required();
     Filter filter = parser.filter(icon, "filter").orAllow();
@@ -173,12 +203,17 @@ public class ShopModule implements MapModule<ShopMatchModule> {
 
   public static List<Payment> parsePayments(Element parent, XMLFluentParser parser)
       throws InvalidXMLException {
+    return parsePayments(parent, parser, null);
+  }
+
+  private static List<Payment> parsePayments(
+      Element parent, XMLFluentParser parser, PaymentDefaults defaults) throws InvalidXMLException {
     List<Payment> payments = Lists.newArrayList();
     for (Element payment : XMLUtils.getChildren(parent, "payment")) {
-      payments.add(parsePayment(payment, parser));
+      payments.add(parsePayment(payment, parser, defaults));
     }
     if (payments.isEmpty()) {
-      payments.add(parsePayment(parent, parser));
+      payments.add(parsePayment(parent, parser, defaults));
     }
     if (payments.size()
         != payments.stream().map(Payment::getCurrency).distinct().count()) {
@@ -190,9 +225,18 @@ public class ShopModule implements MapModule<ShopMatchModule> {
 
   public static Payment parsePayment(Element el, XMLFluentParser parser)
       throws InvalidXMLException {
+    return parsePayment(el, parser, null);
+  }
+
+  private static Payment parsePayment(Element el, XMLFluentParser parser, PaymentDefaults defaults)
+      throws InvalidXMLException {
     Integer price = parser.parseInt(el, "price").optional(0);
     Material currency = price <= 0 ? null : parser.material(el, "currency").orNull();
-    ChatColor color = parser.parseEnum(ChatColor.class, el, "color").optional(ChatColor.GOLD);
+    if (currency == null && price > 0 && defaults != null) currency = defaults.currency();
+
+    ChatColor defaultColor =
+        defaults != null && defaults.color() != null ? defaults.color() : ChatColor.GOLD;
+    ChatColor color = parser.parseEnum(ChatColor.class, el, "color").optional(defaultColor);
 
     ItemStack item = parser.item(el, "item").child().orNull();
     if (currency == null && item == null && price > 0) {
@@ -200,6 +244,14 @@ public class ShopModule implements MapModule<ShopMatchModule> {
     }
 
     return new Payment(currency, price, color, item);
+  }
+
+  private record PaymentDefaults(Material currency, ChatColor color) {
+    static PaymentDefaults parse(Element el, XMLFluentParser parser) throws InvalidXMLException {
+      return new PaymentDefaults(
+          parser.material(el, "currency").attr().orNull(),
+          parser.parseEnum(ChatColor.class, el, "payment-color").attr().orNull());
+    }
   }
 
   private static ItemStack applyItemFlags(ItemStack stack) {

--- a/core/src/main/java/tc/oc/pgm/shops/menu/Category.java
+++ b/core/src/main/java/tc/oc/pgm/shops/menu/Category.java
@@ -4,28 +4,26 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.bukkit.inventory.ItemStack;
+import tc.oc.pgm.api.feature.FeatureInfo;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.features.SelfIdentifyingFeatureDefinition;
 
-public class Category {
+@FeatureInfo(name = "category")
+public class Category extends SelfIdentifyingFeatureDefinition {
 
   // Max amount of icons a category can hold
   public static final int MAX_ICONS = 28;
 
-  private final String id;
   private final ItemStack categoryIcon;
   private final ImmutableList<Icon> icons;
   private final Filter filter;
 
   public Category(String id, ItemStack categoryIcon, Filter filter, List<Icon> icons) {
-    this.id = id;
+    super(id);
     this.categoryIcon = categoryIcon;
     this.filter = filter;
     this.icons = ImmutableList.copyOf(icons);
-  }
-
-  public String getId() {
-    return id;
   }
 
   public ItemStack getCategoryIcon() {
@@ -37,10 +35,9 @@ public class Category {
   }
 
   public ImmutableList<Icon> getVisibleIcons(MatchPlayer player) {
-    return ImmutableList.copyOf(
-        icons.stream()
-            .filter(icon -> icon.getFilter().query(player).isAllowed())
-            .collect(Collectors.toList()));
+    return ImmutableList.copyOf(icons.stream()
+        .filter(icon -> icon.getFilter().query(player).isAllowed())
+        .collect(Collectors.toList()));
   }
 
   public Filter getFilter() {

--- a/util/src/main/java/tc/oc/pgm/util/xml/InheritingElement.java
+++ b/util/src/main/java/tc/oc/pgm/util/xml/InheritingElement.java
@@ -44,8 +44,9 @@ public class InheritingElement extends LocatedElement {
       setAttribute(attribute.clone());
     }
 
-    if (getParent() instanceof Element) {
-      for (Attribute attribute : ((Element) el.getParent()).getAttributes()) {
+    // Root attributes (proto, etc.) are map metadata, not inheritable defaults
+    if (getParent() instanceof Element parent && !parent.isRootElement()) {
+      for (Attribute attribute : parent.getAttributes()) {
         if (getAttribute(attribute.getName()) == null) {
           setAttribute(attribute.clone());
         }
@@ -111,15 +112,13 @@ public class InheritingElement extends LocatedElement {
 
   public Iterable<Element> getChildren(Set<String> names) {
     boolean visitingAllowed = visitingAllowed();
-    return Iterables.filter(
-        super.getChildren(),
-        el -> {
-          if (names.contains(el.getName())) {
-            if (visitingAllowed) ((InheritingElement) el).setVisited();
-            return true;
-          }
-          return false;
-        });
+    return Iterables.filter(super.getChildren(), el -> {
+      if (names.contains(el.getName())) {
+        if (visitingAllowed) ((InheritingElement) el).setVisited();
+        return true;
+      }
+      return false;
+    });
   }
 
   @Override


### PR DESCRIPTION
Bumps the proto to 1.5.2

- register shop `<category>` as features
- Allow referencing categories
- ids for categories must now be unique though (why it has a proto bump)
- Fix armor stand shop keepers
- Add support for some mob properties on shopkeepers

Example:
```xml
<shops>
  <!-- e.g. from an include -->
  <category id="ammo" name="Ammo" material="arrow" currency="gold nugget" payment-color="aqua">
    <item price="1" material="arrow" amount="16"/>
    <item price="3" currency="emerald" material="tnt"/>
  </category>

  <shop id="main">
    <category id="ammo"/>
  </shop>
</shops>
```


