### PR TITLE
Fix paste structure placement offset

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,12 +8,20 @@ plugins {
 
 dependencies {
     compileOnly("dev.pgm.paper:paper-api:1.8_1.21.11-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    testImplementation("org.junit.jupiter:junit-jupiter:6.0.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     implementation(project(":util"))
     runtimeOnly(project(":platform-sportpaper")) { exclude("*") }
     runtimeOnly(project(":platform-modern")) { exclude("*") }
 }
 
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform {
+        includeEngines("junit-jupiter")
+    }
+}
 
 tasks.named<ShadowJar>("shadowJar") {
     manifest {

--- a/core/src/main/java/tc/oc/pgm/structure/Structure.java
+++ b/core/src/main/java/tc/oc/pgm/structure/Structure.java
@@ -60,7 +60,7 @@ public class Structure implements Feature<StructureDefinition> {
   }
 
   public void placeAbsolute(BlockVector vector, boolean update) {
-    vector.subtract(getRegion().getBounds().getBlockMin());
+    vector.subtract(getDefinition().getOrigin());
     place(vector, update);
   }
 }

--- a/core/src/test/java/tc/oc/pgm/structure/StructureTest.java
+++ b/core/src/test/java/tc/oc/pgm/structure/StructureTest.java
@@ -1,0 +1,65 @@
+package tc.oc.pgm.structure;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.bukkit.util.BlockVector;
+import org.bukkit.util.Vector;
+import org.junit.jupiter.api.Test;
+import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.regions.CuboidRegion;
+import tc.oc.pgm.snapshot.WorldSnapshot;
+
+public final class StructureTest {
+
+  @Test
+  public void placeAbsoluteAlignsDefaultOriginWithTarget() {
+    Region region = new CuboidRegion(new Vector(5, 0, 5), new Vector(6, 1, 6));
+    StructureDefinition definition =
+        new StructureDefinition("test-structure", null, region, true, false);
+    RecordingWorldSnapshot snapshot = new RecordingWorldSnapshot();
+    Structure structure = new Structure(definition, null, snapshot);
+
+    structure.placeAbsolute(new BlockVector(5, 0, 5), false);
+
+    assertBlockCoordinates(0, 0, 0, snapshot.offset);
+  }
+
+  @Test
+  public void placeAbsoluteAlignsConfiguredOriginWithTarget() {
+    Region region = new CuboidRegion(new Vector(5, 0, 5), new Vector(6, 1, 6));
+    StructureDefinition definition =
+        new StructureDefinition("test-structure", new Vector(4, -1, 4), region, true, false);
+    RecordingWorldSnapshot snapshot = new RecordingWorldSnapshot();
+    Structure structure = new Structure(definition, null, snapshot);
+
+    structure.placeAbsolute(new BlockVector(5, 0, 5), false);
+
+    assertBlockCoordinates(1, 1, 1, snapshot.offset);
+  }
+
+  private static void assertBlockCoordinates(
+      int expectedX, int expectedY, int expectedZ, BlockVector actual) {
+    assertAll(
+        () -> assertEquals(expectedX, actual.getBlockX()),
+        () -> assertEquals(expectedY, actual.getBlockY()),
+        () -> assertEquals(expectedZ, actual.getBlockZ()));
+  }
+
+  private static final class RecordingWorldSnapshot extends WorldSnapshot {
+
+    private BlockVector offset;
+
+    private RecordingWorldSnapshot() {
+      super(null);
+    }
+
+    @Override
+    public void saveRegion(Region region) {}
+
+    @Override
+    public void placeBlocks(Region region, BlockVector offset, boolean update) {
+      this.offset = offset.clone();
+    }
+  }
+}


### PR DESCRIPTION
# Fix paste structure placement offset

Fixes #1526.

## Root cause

Absolute placement currently subtracts `Bounds.getBlockMin()`, which represents
block centers at half coordinates. Subtracting that from an integer destination
produces `-0.5` components, which floor to a one-block negative offset when the
snapshot reads block coordinates.

The structure definition's `origin` is the documented destination reference
point and defaults to the low corner of the declared region. Using that origin
also avoids re-anchoring `air="false"` structures to the first captured non-air
block. If leading air separates that block from the declared origin, the
corrected offset can be larger than one block.

## Summary

- calculate absolute structure placement from the structure's configured
  origin, matching the existing dynamic-structure calculation
- add focused regression coverage for both default and explicit structure
  origins
- enable JUnit tests in the core module using the same setup as the util module

## Coordination

This branch is based on
`825df5fe3df9f1bdbfc840a19ae44d0f339f2f85`. Open PRs #1648 and #1712 modify
the same core dependency block while migrating Paper and JUnit versions. If
either lands first, this change must be rebased and its test dependencies
aligned with the updated util-module convention.

PR #1682 also touches `Structure.java`, but only appends an independent
`findMismatch` method; that method already uses the same definition-origin
calculation.

## Testing

- base plus test only: both tests failed for the expected placement offsets,
  comprising six failed coordinate assertions
- patched
  `./gradlew :core:test --tests tc.oc.pgm.structure.StructureTest`: 2 tests,
  0 failures, 0 errors, 0 skipped
- `./gradlew spotlessCheck`: passed
- `./gradlew build`: passed repository-wide (49 actionable tasks)

Live-server coverage was not run. In particular, the `air="false"` filtered
world-capture path is validated by the documented origin semantics and shared
dynamic-structure calculation, but not by a real Bukkit world integration test.
