### PR TITLE
Allow hunger module to turn off depletion and replenishment

### DIFF
--- a/core/src/main/java/tc/oc/pgm/hunger/HungerMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/hunger/HungerMatchModule.java
@@ -13,12 +13,19 @@ import tc.oc.pgm.events.ListenerScope;
 @ListenerScope(MatchScope.RUNNING)
 public class HungerMatchModule implements MatchModule, Listener {
 
-  public HungerMatchModule(Match match) {}
+  private final boolean preventDepletion;
+  private final boolean preventReplenishment;
+
+  public HungerMatchModule(Match match, boolean depletion, boolean replenishment) {
+    this.preventDepletion = !depletion;
+    this.preventReplenishment = !replenishment;
+  }
 
   @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
   public void handleHungerChange(final FoodLevelChangeEvent event) {
-    if (event.getEntity() instanceof Player) {
-      int oldFoodLevel = ((Player) event.getEntity()).getFoodLevel();
+    if (!(event.getEntity() instanceof Player p)) return;
+    int oldFoodLevel = p.getFoodLevel();
+    if (event.getFoodLevel() < oldFoodLevel ? preventDepletion : preventReplenishment) {
       event.setFoodLevel(oldFoodLevel);
     }
   }

--- a/core/src/main/java/tc/oc/pgm/hunger/HungerModule.java
+++ b/core/src/main/java/tc/oc/pgm/hunger/HungerModule.java
@@ -10,32 +10,37 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.util.xml.InvalidXMLException;
 
 public class HungerModule implements MapModule<HungerMatchModule> {
+  private final boolean depletion;
+  private final boolean replenishment;
+
+  public HungerModule(boolean depletion, boolean replenishment) {
+    this.depletion = depletion;
+    this.replenishment = replenishment;
+  }
 
   @Override
   public HungerMatchModule createMatchModule(Match match) {
-    return new HungerMatchModule(match);
+    return new HungerMatchModule(match, depletion, replenishment);
   }
 
   public static class Factory implements MapModuleFactory<HungerModule> {
     @Override
     public HungerModule parse(MapFactory factory, Logger logger, Document doc)
         throws InvalidXMLException {
-      boolean on = true;
+      var parser = factory.getParser();
 
-      for (Element hungerRootElement : doc.getRootElement().getChildren("hunger")) {
-        Element hungerDepletionElement = hungerRootElement.getChild("depletion");
-        if (hungerDepletionElement != null) {
-          if (hungerDepletionElement.getValue().equalsIgnoreCase("off")) {
-            on = false;
-          }
-        }
+      boolean depletion = true;
+      Boolean replenishment = null; // Optional, will default to depletion
+
+      for (Element hungerEl : doc.getRootElement().getChildren("hunger")) {
+        depletion = parser.parseBool(hungerEl, "depletion").optional(depletion);
+        replenishment = parser.parseBool(hungerEl, "replenishment").optional(replenishment);
       }
 
-      if (!on) {
-        return new HungerModule();
-      } else {
-        return null;
-      }
+      // Legacy behavior, replenishment defaults to depletion
+      if (replenishment == null) replenishment = depletion;
+
+      return depletion && replenishment ? null : new HungerModule(depletion, replenishment);
     }
   }
 }


### PR DESCRIPTION
```xml
<hunger>
  <depletion>off</depletion> <!-- Can't lose hunger (eg: sprinting) -->
  <replenishment>on</replenishment> <!-- Can gain hunger (eg: eating) -->
</hunger>
```
allows for depletion and replenishment to be configured separately in PGM. By default, for backwards compatibility purposes, replenishment defaults to the same as depletion.

The syntax was also extended and brought more in line with the rest of pgm, so things like this work too:
```xml
<hunger depletion="true" replenishment="false"/> <!-- Can lose hunger, but not gain it -->
```