### PR TITLE
fix: remap ender pearl entity to ender pearl item

### DIFF
--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMinecraftTranslator.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMinecraftTranslator.java
@@ -29,6 +29,7 @@ public class SpMinecraftTranslator implements MinecraftComponent.MinecraftTransl
     return switch (entityType) {
       case MINECART_TNT -> getTranslationKey(Material.EXPLOSIVE_MINECART);
       case EGG -> getTranslationKey(Material.EGG);
+      case ENDER_PEARL -> getTranslationKey(Material.ENDER_PEARL);
       // Not fully correct, but whatever
       case FISHING_HOOK -> getTranslationKey(Material.FISHING_ROD);
       default -> ENTITY_TYPE_FORMAT.formatted(entityType.getName());


### PR DESCRIPTION
Remaps ender pearl entities to the ender pearl item as ender pearls can kill, and they don't have a translation on 1.8.