### PR TITLE
Mob Tagging + Summon Action

### DIFF
--- a/core/src/main/java/tc/oc/pgm/action/ActionModule.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionModule.java
@@ -15,6 +15,7 @@ import tc.oc.pgm.api.map.factory.MapModuleFactory;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchModule;
 import tc.oc.pgm.api.module.exception.ModuleLoadException;
+import tc.oc.pgm.entity.TaggedMobMatchModule;
 import tc.oc.pgm.filters.FilterMatchModule;
 import tc.oc.pgm.itemmeta.ItemModifyModule;
 import tc.oc.pgm.util.xml.InvalidXMLException;
@@ -39,7 +40,7 @@ public class ActionModule implements MapModule<ActionMatchModule> {
   @Nullable
   @Override
   public Collection<Class<? extends MatchModule>> getHardDependencies() {
-    return ImmutableList.of(FilterMatchModule.class);
+    return ImmutableList.of(FilterMatchModule.class, TaggedMobMatchModule.class);
   }
 
   @Nullable

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -35,6 +35,7 @@ import tc.oc.pgm.action.actions.ScheduleAction;
 import tc.oc.pgm.action.actions.ScopeSwitchAction;
 import tc.oc.pgm.action.actions.SetVariableAction;
 import tc.oc.pgm.action.actions.SoundAction;
+import tc.oc.pgm.action.actions.SummonAction;
 import tc.oc.pgm.action.actions.TakePaymentAction;
 import tc.oc.pgm.action.actions.TeamAliasAction;
 import tc.oc.pgm.action.actions.TeleportAction;
@@ -50,6 +51,8 @@ import tc.oc.pgm.api.map.MapProtos;
 import tc.oc.pgm.api.map.factory.MapFactory;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.entity.SpawnableEntity;
+import tc.oc.pgm.entity.TaggedMob;
 import tc.oc.pgm.features.FeatureDefinitionContext;
 import tc.oc.pgm.features.XMLFeatureReference;
 import tc.oc.pgm.filters.Filterable;
@@ -549,5 +552,33 @@ public class ActionParser {
     return MatchPlayer.class.isAssignableFrom(scope)
         ? new ScheduleAction.Player(after, (Action<? super MatchPlayer>) action)
         : new ScheduleAction<>(scope, after, action);
+  }
+
+  @MethodParser("summon")
+  public <T extends Filterable<?>> SummonAction<T> parseSummon(Element el, Class<T> scope)
+      throws InvalidXMLException {
+    scope = parseScope(el, scope);
+
+    var entity = parser.reference(TaggedMob.class, el, "entity").optional().orElse(null);
+    Element mobEl = el.getChild("mob");
+
+    if (entity != null && mobEl != null) {
+      throw new InvalidXMLException("Cannot specify both 'entity-id' and 'mob' elements", el);
+    }
+
+    if (entity == null && mobEl == null) {
+      throw new InvalidXMLException("Either 'entity' or a 'mob' element is required", el);
+    }
+
+    SpawnableEntity mob = mobEl != null ? SpawnableEntity.parse(mobEl) : null;
+
+    var xFormula = parser.formula(scope, el, "x").required();
+    var yFormula = parser.formula(scope, el, "y").required();
+    var zFormula = parser.formula(scope, el, "z").required();
+    var pitchFormula = parser.formula(scope, el, "pitch").optional();
+    var yawFormula = parser.formula(scope, el, "yaw").optional();
+
+    return new SummonAction<>(
+        scope, entity, mob, xFormula, yFormula, zFormula, pitchFormula, yawFormula);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/action/ActionParser.java
+++ b/core/src/main/java/tc/oc/pgm/action/ActionParser.java
@@ -563,7 +563,7 @@ public class ActionParser {
     Element mobEl = el.getChild("mob");
 
     if (entity != null && mobEl != null) {
-      throw new InvalidXMLException("Cannot specify both 'entity-id' and 'mob' elements", el);
+      throw new InvalidXMLException("Cannot specify both 'entity' and 'mob' elements", el);
     }
 
     if (entity == null && mobEl == null) {

--- a/core/src/main/java/tc/oc/pgm/action/actions/SummonAction.java
+++ b/core/src/main/java/tc/oc/pgm/action/actions/SummonAction.java
@@ -1,0 +1,68 @@
+package tc.oc.pgm.action.actions;
+
+import java.util.Optional;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.feature.FeatureReference;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.entity.SpawnableEntity;
+import tc.oc.pgm.entity.TaggedMob;
+import tc.oc.pgm.entity.TaggedMobMatchModule;
+import tc.oc.pgm.filters.Filterable;
+import tc.oc.pgm.util.math.Formula;
+
+public class SummonAction<B extends Filterable<?>> extends AbstractAction<B> {
+
+  private final @Nullable FeatureReference<TaggedMob> entity;
+  private final @Nullable SpawnableEntity mob;
+  private final Formula<B> xformula;
+  private final Formula<B> yformula;
+  private final Formula<B> zformula;
+  private final Optional<Formula<B>> pitchFormula;
+  private final Optional<Formula<B>> yawFormula;
+
+  public SummonAction(
+      Class<B> scope,
+      @Nullable FeatureReference<TaggedMob> entity,
+      @Nullable SpawnableEntity mob,
+      Formula<B> xformula,
+      Formula<B> yformula,
+      Formula<B> zformula,
+      Optional<Formula<B>> pitchFormula,
+      Optional<Formula<B>> yawFormula) {
+    super(scope);
+    this.entity = entity;
+    this.mob = mob;
+    this.xformula = xformula;
+    this.yformula = yformula;
+    this.zformula = zformula;
+    this.pitchFormula = pitchFormula;
+    this.yawFormula = yawFormula;
+  }
+
+  @Override
+  public void trigger(B b) {
+    Match match = b.getMatch();
+    double x = xformula.apply(b);
+    double y = yformula.apply(b);
+    double z = zformula.apply(b);
+    float pitch = pitchFormula.map(f -> (float) f.apply(b)).orElse(0f);
+    float yaw = yawFormula.map(f -> (float) f.apply(b)).orElse(0f);
+
+    if (entity != null) {
+      entity.get().spawn(match, x, y, z, pitch, yaw);
+      return;
+    }
+
+    if (mob != null) {
+      Entity spawned = mob.spawn(new Location(match.getWorld(), x, y, z, pitch, yaw));
+
+      if (mob.id() != null && spawned instanceof LivingEntity le) {
+        match.needModule(TaggedMobMatchModule.class).track(mob.id(), le);
+      }
+      return;
+    }
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/api/Modules.java
+++ b/core/src/main/java/tc/oc/pgm/api/Modules.java
@@ -42,6 +42,7 @@ import tc.oc.pgm.destroyable.DestroyableModule;
 import tc.oc.pgm.doublejump.DoubleJumpMatchModule;
 import tc.oc.pgm.enderchest.EnderChestMatchModule;
 import tc.oc.pgm.enderchest.EnderChestModule;
+import tc.oc.pgm.entity.TaggedMobMatchModule;
 import tc.oc.pgm.fallingblocks.FallingBlocksMatchModule;
 import tc.oc.pgm.fallingblocks.FallingBlocksModule;
 import tc.oc.pgm.ffa.FreeForAllMatchModule;
@@ -333,5 +334,6 @@ public final class Modules {
     // MatchModules only used if required as a dependency by other modules
     registerDependencyOnly(SnapshotMatchModule.class, new SnapshotMatchModule.Factory());
     registerDependencyOnly(HologramMatchModule.class, HologramMatchModule::new);
+    registerDependencyOnly(TaggedMobMatchModule.class, TaggedMobMatchModule::new);
   }
 }

--- a/core/src/main/java/tc/oc/pgm/entity/SpawnableEntity.java
+++ b/core/src/main/java/tc/oc/pgm/entity/SpawnableEntity.java
@@ -12,7 +12,7 @@ import tc.oc.pgm.util.xml.Node;
 import tc.oc.pgm.util.xml.XMLUtils;
 
 public record SpawnableEntity(
-    Class<? extends LivingEntity> entityType, List<Consumer<Entity>> properties) {
+    Class<? extends LivingEntity> entityType, List<Consumer<Entity>> properties, String id) {
 
   public Entity spawn(Location location) {
     Entity entity = location.getWorld().spawn(location, entityType);
@@ -24,8 +24,9 @@ public record SpawnableEntity(
 
   public static SpawnableEntity parse(Element el) throws InvalidXMLException {
     var type = parseType(Node.fromRequiredAttr(el, "type"));
+    String id = el.getAttributeValue("id");
     return new SpawnableEntity(
-        type, MobProperties.MOB_PROPERTIES.parseAttributes(type, el, "type"));
+        type, MobProperties.MOB_PROPERTIES.parseAttributes(type, el, "type", "id"), id);
   }
 
   private static Class<? extends LivingEntity> parseType(Node typeNode) throws InvalidXMLException {

--- a/core/src/main/java/tc/oc/pgm/entity/TaggedMob.java
+++ b/core/src/main/java/tc/oc/pgm/entity/TaggedMob.java
@@ -1,0 +1,11 @@
+package tc.oc.pgm.entity;
+
+import org.bukkit.entity.LivingEntity;
+import tc.oc.pgm.api.feature.FeatureDefinition;
+import tc.oc.pgm.api.match.Match;
+
+public interface TaggedMob extends FeatureDefinition {
+  String getId();
+
+  LivingEntity spawn(Match match, double x, double y, double z, float pitch, float yaw);
+}

--- a/core/src/main/java/tc/oc/pgm/entity/TaggedMobMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/entity/TaggedMobMatchModule.java
@@ -1,0 +1,68 @@
+package tc.oc.pgm.entity;
+
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.SetMultimap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchModule;
+
+public class TaggedMobMatchModule implements MatchModule, Listener {
+
+  private final Match match;
+  private final SetMultimap<String, LivingEntity> instances = HashMultimap.create();
+  private final Map<UUID, String> byEntity = new HashMap<>();
+
+  public TaggedMobMatchModule(Match match) {
+    this.match = match;
+  }
+
+  public void track(String id, LivingEntity le) {
+    instances.put(id, le);
+    byEntity.put(le.getUniqueId(), id);
+  }
+
+  public void untrack(LivingEntity le) {
+    String id = byEntity.remove(le.getUniqueId());
+
+    if (id != null) {
+      instances.remove(id, le);
+    }
+  }
+
+  public Set<LivingEntity> get(String id) {
+    return instances.get(id);
+  }
+
+  public @Nullable String getId(LivingEntity le) {
+    return byEntity.get(le.getUniqueId());
+  }
+
+  public void forEach(String id, Consumer<LivingEntity> consumer) {
+    for (LivingEntity le : ImmutableSet.copyOf(instances.get(id))) {
+      consumer.accept(le);
+    }
+  }
+
+  @EventHandler
+  public void onDeath(EntityDeathEvent event) {
+    untrack(event.getEntity());
+  }
+
+  @EventHandler
+  public void onRemoval(EntityRemoveFromWorldEvent event) {
+    if (event.getEntity() instanceof LivingEntity le) {
+      untrack(le);
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a system for assigning an ID to a LivingEntity. I also added a new action that lets you summon in a LivingEntity on demand. I created this in order to address issues Pablo raised in https://github.com/PGMDev/PGM/pull/1706. 

```xml
<actions>
    <action id="" scope="match">
        <!-- Using a mob child -->
        <summon x="5" y="5" z="5" pitch="90" yaw="45">
            <mob id="test-mob" type="Zombie" baby="true" can-pickup-items="false"/>  
        </summon>
        
        <!-- Using a pre-defined mob ID -->
        <summon entity="test-mob" x="5" y="5" z="5"/>
    </action>
</actions>
```

Ideally down the road something like a mob module would be created so mobs could be defined and then called with a summon action or spawners. I just need this to be approved for mannequins so I can rebase this into that PR so I can continue working. 