### PR TITLE
Fix incorrect spawner entity count tracking

### DIFF
--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -121,7 +121,7 @@ public class Spawner implements Listener, Tickable {
     handleEntityRemoveEvent(event.getEntity(), true);
   }
 
-  @EventHandler(priority = EventPriority.MONITOR)
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onItemMergeRecover(ItemMergeEvent event) {
     // Entity merging does not affect count.
     // We do need to remove the meta so the remove from world doesn't subtract.


### PR DESCRIPTION
`Spawner#onItemMerge` cancels item merges for items coming out of different spawners, however, `Spawner#onItemMergeRecover` proceeds with stripping the metadata from the source item regardless of outcome. This results in the amount of spawned items in the spawner never going down when affected items get eventually picked up by a player, causing spawners with `max-entities` set to eventually halt entirely.

This commit makes `Spawner#onItemMergeRecover` ignore cancelled item merge events, making the spawners work correctly.