### PR TITLE
Address some loose ends with spawners

### DIFF
--- a/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/kits/KitMatchModule.java
@@ -30,6 +30,7 @@ import tc.oc.pgm.filters.FilterMatchModule;
 import tc.oc.pgm.kits.tag.Grenade;
 import tc.oc.pgm.kits.tag.ItemTags;
 import tc.oc.pgm.util.event.ItemTransferEvent;
+import tc.oc.pgm.util.event.PlayerItemTransferEvent;
 import tc.oc.pgm.util.inventory.Slot;
 
 @ListenerScope(MatchScope.RUNNING)
@@ -173,6 +174,15 @@ public class KitMatchModule implements MatchModule, Listener {
 
   @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
   public void checkItemTransfer(ItemTransferEvent event) {
+    checkTransfer(event);
+  }
+
+  @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+  public void checkPlayerItemTransfer(PlayerItemTransferEvent event) {
+    checkTransfer(event);
+  }
+
+  private void checkTransfer(ItemTransferEvent event) {
     if (event.getReason() == ItemTransferEvent.Reason.PLACE && isUnshareable(event.getItem())) {
       event.setCancelled(true);
     }

--- a/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
+++ b/core/src/main/java/tc/oc/pgm/spawner/Spawner.java
@@ -1,6 +1,7 @@
 package tc.oc.pgm.spawner;
 
 import static tc.oc.pgm.util.bukkit.Effects.EFFECTS;
+import static tc.oc.pgm.util.bukkit.MiscUtils.MISC_UTILS;
 
 import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import java.util.Objects;
@@ -11,9 +12,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
-import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.entity.ItemMergeEvent;
-import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.filter.Filter;
@@ -29,6 +28,7 @@ import tc.oc.pgm.util.bukkit.MetadataUtils;
 public class Spawner implements Listener, Tickable {
 
   public static final String METADATA_KEY = "spawner";
+  private static final int MAX_MERGE_SIZE = 64;
 
   private final Match match;
   private final SpawnerDefinition definition;
@@ -100,10 +100,10 @@ public class Spawner implements Listener, Tickable {
     }
   }
 
-  private void handleEntityRemoveEvent(Entity entity, boolean affectCount) {
+  private void handleEntityRemoveEvent(Entity entity, boolean affectCount, boolean stopTracking) {
     var metadata = MetadataUtils.getMetadataValue(entity, METADATA_KEY, PGM.get());
     if (Objects.equals(definition.getId(), metadata)) {
-      entity.removeMetadata(METADATA_KEY, PGM.get());
+      if (stopTracking) entity.removeMetadata(METADATA_KEY, PGM.get());
       if (affectCount) {
         int removedEntities = entity instanceof Item item ? item.getItemStack().getAmount() : 1;
         spawnedEntities = Math.max(0, spawnedEntities - removedEntities);
@@ -113,33 +113,31 @@ public class Spawner implements Listener, Tickable {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onEntityDeath(EntityDeathEvent event) {
-    handleEntityRemoveEvent(event.getEntity(), true);
-  }
-
-  @EventHandler(priority = EventPriority.MONITOR)
-  public void onItemDespawn(ItemDespawnEvent event) {
-    handleEntityRemoveEvent(event.getEntity(), true);
+    handleEntityRemoveEvent(event.getEntity(), true, true);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onItemMergeRecover(ItemMergeEvent event) {
     // Entity merging does not affect count.
     // We do need to remove the meta so the remove from world doesn't subtract.
-    handleEntityRemoveEvent(event.getEntity(), false);
+    // Partial merges still do need to be tracked, however
+    var from = event.getEntity().getItemStack();
+    var to = event.getTarget().getItemStack();
+    int space = Math.min(to.getMaxStackSize(), MAX_MERGE_SIZE) - to.getAmount();
+    if (space < from.getAmount()) return;
+    handleEntityRemoveEvent(event.getEntity(), false, true);
   }
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onEntityRemove(EntityRemoveFromWorldEvent event) {
-    handleEntityRemoveEvent(event.getEntity(), true);
-  }
-
-  @EventHandler(priority = EventPriority.MONITOR)
-  public void onPotionSplash(PotionSplashEvent event) {
-    handleEntityRemoveEvent(event.getEntity(), true);
+    // When an item is removed by chunk unloads, it's not actually gone and
+    // is still relevant to the spawner.
+    if (!MISC_UTILS.isEntityDestroyed(event)) return;
+    handleEntityRemoveEvent(event.getEntity(), true, true);
   }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerPickup(PlayerPickupItemEvent event) {
-    handleEntityRemoveEvent(event.getItem(), true);
+    handleEntityRemoveEvent(event.getItem(), true, event.getRemaining() == 0);
   }
 }

--- a/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
+++ b/platform/platform-modern/src/main/java/tc/oc/pgm/platform/modern/impl/ModernMiscUtil.java
@@ -2,6 +2,7 @@ package tc.oc.pgm.platform.modern.impl;
 
 import static tc.oc.pgm.util.platform.Supports.Variant.PAPER;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import java.nio.file.Path;
 import java.util.List;
 import net.kyori.adventure.key.Key;
@@ -14,6 +15,7 @@ import org.bukkit.Location;
 import org.bukkit.Registry;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.entity.CraftEntity;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
 import org.bukkit.enchantments.Enchantment;
@@ -126,6 +128,14 @@ public class ModernMiscUtil implements MiscUtils {
   public boolean isDestructiveExplosion(EntityExplodeEvent ev) {
     return ev.getExplosionResult() == ExplosionResult.DESTROY
         || ev.getExplosionResult() == ExplosionResult.DESTROY_WITH_DECAY;
+  }
+
+  @Override
+  public boolean isEntityDestroyed(EntityRemoveFromWorldEvent ev) {
+    // When an entity is removed by chunk unloading, dimension change,
+    // or with its player, it is not actually destroyed.
+    var reason = ((CraftEntity) ev.getEntity()).getHandle().getRemovalReason();
+    return reason != null && reason.shouldDestroy();
   }
 
   @Override

--- a/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMiscUtil.java
+++ b/platform/platform-sportpaper/src/main/java/tc/oc/pgm/platform/sportpaper/impl/SpMiscUtil.java
@@ -4,6 +4,7 @@ import static net.kyori.adventure.key.Key.key;
 import static tc.oc.pgm.util.platform.Supports.Priority.HIGH;
 import static tc.oc.pgm.util.platform.Supports.Variant.SPORTPAPER;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -117,6 +118,12 @@ public class SpMiscUtil implements MiscUtils {
   public boolean isDestructiveExplosion(EntityExplodeEvent ev) {
     // All explosions in 1.8 are destructive
     return true;
+  }
+
+  @Override
+  public boolean isEntityDestroyed(EntityRemoveFromWorldEvent ev) {
+    // When an entity is removed by chunk unloading, it's not destroyed
+    return ev.getEntity().isDead();
   }
 
   @Override

--- a/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
+++ b/util/src/main/java/tc/oc/pgm/util/bukkit/MiscUtils.java
@@ -1,5 +1,6 @@
 package tc.oc.pgm.util.bukkit;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import java.nio.file.Path;
 import java.util.List;
 import net.kyori.adventure.key.Key;
@@ -58,6 +59,8 @@ public interface MiscUtils {
   boolean isPowerEnchanted(Projectile proj);
 
   boolean isDestructiveExplosion(EntityExplodeEvent ev);
+
+  boolean isEntityDestroyed(EntityRemoveFromWorldEvent ev);
 
   Entity getFakePickupEntity(PlayerPickupItemEvent ev);
 }


### PR DESCRIPTION
Follow up relevant to #1702, #1709, and #1717

1. Handler list addition to `PlayerItemTransferEvent` made it no longer inherit the one from `ItemTransferEvent`, so add an event handler for it to `KitMatchModule` to keep previous behaviour.
2. Remove redundant listeners from `Spawner`; `EntityRemoveFromWorldEvent` covers what we were listening for in `onPotionSplash` and `onItemDespawn`
3. Keep tracking partial merges in `onItemMergeRecover`, and only stop tracking on player pickup if nothing is remaining to be picked up.
4. Don't count unloaded chunks as actually removed items in `onEntityRemove` as this would probably break spawner item tracking if the spawner is somehow in an unloaded chunk.