### PR TITLE
Deduplicate core/destroyable logic and optimize large destroyables

### DIFF
--- a/core/src/main/java/tc/oc/pgm/core/Core.java
+++ b/core/src/main/java/tc/oc/pgm/core/Core.java
@@ -1,22 +1,18 @@
 package tc.oc.pgm.core;
 
-import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.format.Style.style;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Collections;
 import java.util.Set;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
@@ -27,21 +23,18 @@ import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.goals.Contribution;
 import tc.oc.pgm.goals.IncrementalGoal;
 import tc.oc.pgm.goals.ModeChangeGoal;
-import tc.oc.pgm.goals.TouchableGoal;
+import tc.oc.pgm.goals.OwnedTouchableGoal;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.modes.ModeUtils;
 import tc.oc.pgm.regions.CuboidRegion;
 import tc.oc.pgm.regions.FiniteBlockRegion;
-import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.material.MaterialMatcher;
 import tc.oc.pgm.util.material.Materials;
-import tc.oc.pgm.util.named.NameStyle;
 
-// TODO: Consider making Core extend Destroyable
-public class Core extends TouchableGoal<CoreFactory>
+public class Core extends OwnedTouchableGoal<CoreFactory>
     implements IncrementalGoal<CoreFactory>, ModeChangeGoal<CoreFactory> {
 
   private static final MaterialMatcher LAVA_BLOCKS =
@@ -56,7 +49,6 @@ public class Core extends TouchableGoal<CoreFactory>
   protected MaterialMatcher material;
   protected int leak = 0;
   protected boolean leaked = false;
-  protected Iterable<Location> proximityLocations;
 
   public Core(CoreFactory definition, Match match) {
     super(definition, match);
@@ -89,46 +81,9 @@ public class Core extends TouchableGoal<CoreFactory>
     this.isShared = match.getCompetitors().stream().filter(this::canComplete).count() != 1;
   }
 
-  // Remove @Nullable
   @Override
-  public @NotNull Team getOwner() {
-    Team owner = super.getOwner();
-    if (owner == null) {
-      throw new IllegalStateException("core " + getId() + " has no owner");
-    }
-    return owner;
-  }
-
-  @Override
-  public boolean getDeferTouches() {
-    return true;
-  }
-
-  @Override
-  public Component getTouchMessage(@Nullable ParticipantState toucher, boolean self) {
-    // Core has same touch messages as Destroyable
-    if (toucher == null) {
-      return translatable(
-          "destroyable.touch.owned", empty(), getComponentName(), getOwner().getName());
-    } else if (self) {
-      return translatable(
-          "destroyable.touch.owned.you", empty(), getComponentName(), getOwner().getName());
-    } else {
-      return translatable(
-          "destroyable.touch.owned.player",
-          toucher.getName(NameStyle.COLOR),
-          getComponentName(),
-          getOwner().getName());
-    }
-  }
-
-  @Override
-  public Iterable<Location> getProximityLocations(ParticipantState player) {
-    if (proximityLocations == null) {
-      proximityLocations = Collections.singleton(
-          casingRegion.getBounds().getCenterPoint().toLocation(this.getMatch().getWorld()));
-    }
-    return proximityLocations;
+  protected Region getProximityRegion() {
+    return this.casingRegion;
   }
 
   @Override
@@ -172,7 +127,7 @@ public class Core extends TouchableGoal<CoreFactory>
 
   @Override
   public boolean isShared() {
-    return isShared;
+    return this.isShared;
   }
 
   @Override
@@ -205,7 +160,7 @@ public class Core extends TouchableGoal<CoreFactory>
     return StringUtils.percentage(this.getCompletion());
   }
 
-  @NotNull
+  @NonNull
   @Override
   public String renderPreciseCompletion() {
     return this.leak + "/" + this.leakRequired;
@@ -239,7 +194,7 @@ public class Core extends TouchableGoal<CoreFactory>
 
   @Override
   public boolean isObjectiveMaterial(Block block) {
-    return material.matches(block.getState());
+    return this.material.matches(block.getState());
   }
 
   @Override
@@ -248,7 +203,7 @@ public class Core extends TouchableGoal<CoreFactory>
   }
 
   public ImmutableList<Contribution> getContributions() {
-    Set<ParticipantState> touchers = getTouchingPlayers();
+    Set<ParticipantState> touchers = this.getTouchingPlayers();
     ImmutableList.Builder<Contribution> builder = ImmutableList.builder();
     for (MatchPlayerState player : touchers) {
       builder.add(new Contribution(player, 1d / touchers.size()));

--- a/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/Destroyable.java
@@ -1,17 +1,16 @@
 package tc.oc.pgm.destroyable;
 
-import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.format.Style.style;
 import static tc.oc.pgm.util.nms.NMSHacks.NMS_HACKS;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +35,7 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.MatchPlayerState;
 import tc.oc.pgm.api.player.ParticipantState;
+import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.blockdrops.BlockDrops;
 import tc.oc.pgm.blockdrops.BlockDropsMatchModule;
 import tc.oc.pgm.blockdrops.BlockDropsRuleSet;
@@ -43,13 +43,12 @@ import tc.oc.pgm.events.FeatureChangeEvent;
 import tc.oc.pgm.fireworks.FireworkMatchModule;
 import tc.oc.pgm.goals.IncrementalGoal;
 import tc.oc.pgm.goals.ModeChangeGoal;
-import tc.oc.pgm.goals.TouchableGoal;
+import tc.oc.pgm.goals.OwnedTouchableGoal;
 import tc.oc.pgm.goals.events.GoalCompleteEvent;
 import tc.oc.pgm.goals.events.GoalStatusChangeEvent;
 import tc.oc.pgm.modes.Mode;
 import tc.oc.pgm.modes.ModeUtils;
 import tc.oc.pgm.regions.FiniteBlockRegion;
-import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.util.StringUtils;
 import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.bukkit.Sounds;
@@ -57,10 +56,11 @@ import tc.oc.pgm.util.collection.DefaultMapAdapter;
 import tc.oc.pgm.util.material.BlockMaterialData;
 import tc.oc.pgm.util.material.MaterialData;
 import tc.oc.pgm.util.material.MaterialMatcher;
-import tc.oc.pgm.util.named.NameStyle;
 
-public class Destroyable extends TouchableGoal<DestroyableFactory>
+public class Destroyable extends OwnedTouchableGoal<DestroyableFactory>
     implements IncrementalGoal<DestroyableFactory>, ModeChangeGoal<DestroyableFactory> {
+
+  private static final Duration SPARK_COOLDOWN = Duration.ofMillis(75);
 
   // Block replacement rules in this ruleset will be used to calculate destroyable health
   protected BlockDropsRuleSet blockDropsRuleSet;
@@ -73,7 +73,6 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
   // The percentage of blocks that must be broken for the entire Destroyable to be destroyed.
   protected double destructionRequired;
 
-  protected final Duration SPARK_COOLDOWN = Duration.ofMillis(75);
   protected Instant lastSparkTime;
 
   /**
@@ -95,19 +94,20 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
    *
    * <p>This map will have en entry for every destroyable world for every block. If there are no
    * custom block replacement rules affecting this destroyable, this will be null;
+   *
+   * <p>Keyed by {@link BlockVectors#encodePos encoded position} so that lookups on the block-change
+   * hot path don't have to allocate a {@link BlockVector}.
    */
-  protected Map<BlockVector, Map<BlockMaterialData, Integer>> blockMaterialHealth;
+  protected Long2ObjectMap<Map<BlockMaterialData, Integer>> blockMaterialHealth;
 
   protected final List<DestroyableHealthChange> events = Lists.newArrayList();
   protected ImmutableList<DestroyableContribution> contributions;
-
-  protected Iterable<Location> proximityLocations;
 
   public Destroyable(DestroyableFactory definition, Match match) {
     super(definition, match);
 
     this.materialPattern = definition.getMaterials();
-    this.materials = materialPattern.getPossibleBlocks();
+    this.materials = this.materialPattern.getPossibleBlocks();
     this.destructionRequired = definition.getDestructionRequired();
 
     this.blockRegion = FiniteBlockRegion.fromWorld(
@@ -128,47 +128,9 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     this.isShared = match.getCompetitors().stream().filter(this::canComplete).count() != 1;
   }
 
-  // Remove @Nullable
   @Override
-  public @NonNull Team getOwner() {
-    Team owner = super.getOwner();
-    if (owner == null) {
-      throw new IllegalStateException("destroyable " + getId() + " has no owner");
-    }
-    return owner;
-  }
-
-  @Override
-  public boolean getDeferTouches() {
-    return true;
-  }
-
-  @Override
-  public Component getTouchMessage(@Nullable ParticipantState toucher, boolean self) {
-    if (toucher == null) {
-      return translatable(
-          "destroyable.touch.owned", empty(), getComponentName(), getOwner().getName());
-    } else if (self) {
-      return translatable(
-          "destroyable.touch.owned.you", empty(), getComponentName(), getOwner().getName());
-    } else {
-      return translatable(
-          "destroyable.touch.owned.player",
-          toucher.getName(NameStyle.COLOR),
-          getComponentName(),
-          getOwner().getName());
-    }
-  }
-
-  @Override
-  public Iterable<Location> getProximityLocations(ParticipantState player) {
-    if (proximityLocations == null) {
-      proximityLocations = Collections.singleton(getBlockRegion()
-          .getBounds()
-          .getCenterPoint()
-          .toLocation(getOwner().getMatch().getWorld()));
-    }
-    return proximityLocations;
+  protected Region getProximityRegion() {
+    return this.blockRegion;
   }
 
   @Override
@@ -182,7 +144,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     // We only need blockMaterialHealth if there are destroyable blocks that are
     // replaced by other destroyable blocks when broken.
     if (this.isAffectedByBlockReplacementRules()) {
-      this.blockMaterialHealth = new HashMap<>();
+      this.blockMaterialHealth = new Long2ObjectOpenHashMap<>();
       this.buildMaterialHealthMap();
     } else {
       this.blockMaterialHealth = null;
@@ -221,7 +183,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     this.health = 0;
     Set<BlockMaterialData> visited = new HashSet<>();
     try {
-      for (Block block : blockRegion.getBlocks(match.getWorld())) {
+      for (Block block : this.blockRegion.getBlocks(match.getWorld())) {
         Map<BlockMaterialData, Integer> materialHealthMap = new HashMap<>();
         int blockMaxHealth = 0;
 
@@ -234,10 +196,10 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
           }
         }
 
-        this.blockMaterialHealth.put(
-            block.getLocation().toVector().toBlockVector(), materialHealthMap);
+        long pos = BlockVectors.encodePos(block);
+        this.blockMaterialHealth.put(pos, materialHealthMap);
         this.maxHealth += blockMaxHealth;
-        this.health += this.getBlockHealth(block.getState());
+        this.health += this.getBlockHealth(block.getState(), pos);
       }
     } catch (Indestructible ex) {
       this.health = this.maxHealth = Integer.MAX_VALUE;
@@ -284,16 +246,11 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
   }
 
   /** Return the number of breaks required to change the given block to a non-objective world */
-  public int getBlockHealth(BlockState blockState) {
-    if (!this.getBlockRegion().contains(blockState)) {
-      return 0;
-    }
-
+  private int getBlockHealth(BlockState blockState, long pos) {
     if (this.blockMaterialHealth == null) {
       return this.hasMaterial(MaterialData.block(blockState)) ? 1 : 0;
     } else {
-      Map<BlockMaterialData, Integer> materialHealthMap =
-          this.blockMaterialHealth.get(blockState.getLocation().toVector().toBlockVector());
+      Map<BlockMaterialData, Integer> materialHealthMap = this.blockMaterialHealth.get(pos);
       if (materialHealthMap == null) {
         return 0;
       }
@@ -302,8 +259,12 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
     }
   }
 
-  public int getBlockHealthChange(BlockState oldState, BlockState newState) {
-    return this.getBlockHealth(newState) - this.getBlockHealth(oldState);
+  /**
+   * Both states are the same block, so they share a single position and a single region check, done
+   * by the caller.
+   */
+  protected int getBlockHealthChange(BlockState oldState, BlockState newState, long pos) {
+    return this.getBlockHealth(newState, pos) - this.getBlockHealth(oldState, pos);
   }
 
   /**
@@ -313,14 +274,15 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
    * @param oldState State of the block before the change
    * @param newState State of the block after the change
    * @param player Player responsible for the change
+   * @param pos The {@link BlockVectors#encodePos encoded position} shared by both states
    * @return An object containing information about the change, including the health delta, or null
    *     if this Destroyable was not affected by the block change
    */
   public DestroyableHealthChange handleBlockChange(
-      BlockState oldState, BlockState newState, @Nullable ParticipantState player) {
-    if (this.isDestroyed() || !this.getBlockRegion().contains(oldState)) return null;
+      BlockState oldState, BlockState newState, @Nullable ParticipantState player, long pos) {
+    if (this.isDestroyed() || !this.getBlockRegion().contains(pos)) return null;
 
-    int deltaHealth = this.getBlockHealthChange(oldState, newState);
+    int deltaHealth = this.getBlockHealthChange(oldState, newState, pos);
     if (deltaHealth == 0) return null;
 
     this.addHealth(deltaHealth);
@@ -389,14 +351,15 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
    * @param oldState State of the block before the change
    * @param newState State of the block after the change
    * @param player Player responsible for the change
+   * @param pos The {@link BlockVectors#encodePos encoded position} shared by both states
    * @return A player-readable message explaining why the block change is not allowed, or null if it
    *     is allowed
    */
   public String testBlockChange(
-      BlockState oldState, BlockState newState, @Nullable ParticipantState player) {
-    if (this.isDestroyed() || !this.getBlockRegion().contains(oldState)) return null;
+      BlockState oldState, BlockState newState, @Nullable ParticipantState player, long pos) {
+    if (this.isDestroyed() || !this.getBlockRegion().contains(pos)) return null;
 
-    int deltaHealth = this.getBlockHealthChange(oldState, newState);
+    int deltaHealth = this.getBlockHealthChange(oldState, newState, pos);
     if (deltaHealth == 0) return null;
 
     if (deltaHealth < 0) {
@@ -421,7 +384,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
   }
 
   public boolean hasMaterial(MaterialData data) {
-    return materialPattern.matches(data);
+    return this.materialPattern.matches(data);
   }
 
   public void addHealth(int delta) {
@@ -511,7 +474,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
 
   @Override
   public TextColor renderSidebarLabelColor(@Nullable Competitor competitor, Party viewer) {
-    if (isShared && owner != null) return owner.getTextColor();
+    if (this.isShared && this.owner != null) return this.owner.getTextColor();
     return super.renderSidebarLabelColor(competitor, viewer);
   }
 
@@ -526,7 +489,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
 
   @Override
   public boolean isShared() {
-    return isShared;
+    return this.isShared;
   }
 
   @Override
@@ -593,7 +556,7 @@ public class Destroyable extends TouchableGoal<DestroyableFactory>
 
     for (Block block : this.getBlockRegion().getBlocks(match.getWorld())) {
       BlockState oldState = block.getState();
-      int oldHealth = this.getBlockHealth(oldState);
+      int oldHealth = this.getBlockHealth(oldState, BlockVectors.encodePos(block));
 
       if (oldHealth > 0) {
         newMaterial.applyTo(block, true);

--- a/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/destroyable/DestroyableMatchModule.java
@@ -22,6 +22,7 @@ import tc.oc.pgm.events.ListenerScope;
 import tc.oc.pgm.events.ParticipantBlockTransformEvent;
 import tc.oc.pgm.goals.ShowOption;
 import tc.oc.pgm.modes.ObjectiveModeChangeEvent;
+import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.material.MaterialData;
 
 @ListenerScope(MatchScope.RUNNING)
@@ -38,10 +39,9 @@ public class DestroyableMatchModule implements MatchModule, Listener {
     return destroyables;
   }
 
-  private boolean anyDestroyableAffected(BlockTransformEvent event) {
+  private boolean anyDestroyableAffected(long pos) {
     for (Destroyable destroyable : this.destroyables) {
-      if (!destroyable.isDestroyed()
-          && destroyable.getBlockRegion().contains(event.getNewState())) {
+      if (!destroyable.isDestroyed() && destroyable.getBlockRegion().contains(pos)) {
         return true;
       }
     }
@@ -54,9 +54,11 @@ public class DestroyableMatchModule implements MatchModule, Listener {
    */
   @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
   public void testBlockChange(BlockTransformEvent event) {
-    if (this.match.getWorld() != event.getWorld() || !this.anyDestroyableAffected(event)) {
-      return;
-    }
+    if (this.match.getWorld() != event.getWorld()) return;
+
+    // Both states are the same block, so one encoded position serves every region check below
+    long pos = BlockVectors.encodePos(event.getOldState());
+    if (!this.anyDestroyableAffected(pos)) return;
 
     ParticipantState player = ParticipantBlockTransformEvent.getPlayerState(event);
 
@@ -78,7 +80,7 @@ public class DestroyableMatchModule implements MatchModule, Listener {
 
     for (Destroyable destroyable : this.destroyables) {
       String reasonKey =
-          destroyable.testBlockChange(event.getOldState(), event.getNewState(), player);
+          destroyable.testBlockChange(event.getOldState(), event.getNewState(), player, pos);
       if (reasonKey != null) {
         event.setCancelled(translatable(reasonKey, destroyable.getComponentName()));
         return;
@@ -92,15 +94,13 @@ public class DestroyableMatchModule implements MatchModule, Listener {
    */
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void handleBlockChange(BlockTransformEvent event) {
-    if (this.match.getWorld() != event.getWorld() || !this.anyDestroyableAffected(event)) {
-      return;
-    }
+    if (this.match.getWorld() != event.getWorld()) return;
+
+    long pos = BlockVectors.encodePos(event.getOldState());
+    ParticipantState player = ParticipantBlockTransformEvent.getPlayerState(event);
 
     for (Destroyable destroyable : this.destroyables) {
-      destroyable.handleBlockChange(
-          event.getOldState(),
-          event.getNewState(),
-          ParticipantBlockTransformEvent.getPlayerState(event));
+      destroyable.handleBlockChange(event.getOldState(), event.getNewState(), player, pos);
     }
   }
 
@@ -113,10 +113,11 @@ public class DestroyableMatchModule implements MatchModule, Listener {
     MatchPlayer player = this.match.getPlayer(event.getPlayer());
     if (player == null) return;
 
+    long pos = BlockVectors.encodePos(block);
     for (Destroyable destroyable : this.destroyables) {
       if (player.getParty() == destroyable.getOwner()
           && !destroyable.isDestroyed()
-          && destroyable.getBlockRegion().contains(block)
+          && destroyable.getBlockRegion().contains(pos)
           && destroyable.hasMaterial(material)) {
 
         event.setCancelled(true);

--- a/core/src/main/java/tc/oc/pgm/flag/Flag.java
+++ b/core/src/main/java/tc/oc/pgm/flag/Flag.java
@@ -81,7 +81,6 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
   private final ItemStack bannerItem;
   private final ItemStack legacyBannerItem;
   private final AngleProvider bannerYawProvider;
-  private final @Nullable Team owner;
   private Set<Team> capturers;
   private Set<Team> controllers;
   private Set<Team> completers;
@@ -92,14 +91,6 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
       throws ModuleLoadException {
     super(definition, match);
     this.nets = nets;
-
-    TeamMatchModule tmm = match.getModule(TeamMatchModule.class);
-
-    if (definition.getOwner() != null && tmm != null) {
-      this.owner = tmm.getTeam(definition.getOwner());
-    } else {
-      this.owner = null;
-    }
 
     Banner banner = null;
     for (PointProvider point : definition.getDefaultPost().getFallback().getReturnPoints()) {
@@ -201,11 +192,6 @@ public class Flag extends TouchableGoal<FlagDefinition> implements Listener {
     return this.state instanceof Spawned
         ? Optional.of(((Spawned) state).getLocation())
         : Optional.empty();
-  }
-
-  /** Owner is defined in XML, and does not change during a match */
-  public @Nullable Team getOwner() {
-    return owner;
   }
 
   /** Controller is the owner of the {@link Post} the flag is at, which obviously can change */

--- a/core/src/main/java/tc/oc/pgm/goals/OwnedGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/OwnedGoal.java
@@ -1,7 +1,7 @@
 package tc.oc.pgm.goals;
 
 import org.bukkit.DyeColor;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.teams.Team;
 import tc.oc.pgm.teams.TeamMatchModule;
@@ -9,14 +9,13 @@ import tc.oc.pgm.teams.TeamMatchModule;
 /** A goal with an owning team. Match-time companion to {@link OwnedGoal} */
 public abstract class OwnedGoal<T extends OwnedGoalDefinition> extends SimpleGoal<T> {
 
-  protected final Team owner;
+  protected final @Nullable Team owner;
 
   public OwnedGoal(T definition, Match match) {
     super(definition, match);
+    TeamMatchModule tmm = match.getModule(TeamMatchModule.class);
     this.owner =
-        definition.getOwner() == null
-            ? null
-            : match.needModule(TeamMatchModule.class).getTeam(definition.getOwner());
+        (definition.getOwner() != null && tmm != null) ? tmm.getTeam(definition.getOwner()) : null;
   }
 
   public @Nullable Team getOwner() {

--- a/core/src/main/java/tc/oc/pgm/goals/OwnedTouchableGoal.java
+++ b/core/src/main/java/tc/oc/pgm/goals/OwnedTouchableGoal.java
@@ -1,0 +1,75 @@
+package tc.oc.pgm.goals;
+
+import static net.kyori.adventure.text.Component.empty;
+import static net.kyori.adventure.text.Component.translatable;
+
+import java.util.Collections;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Location;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.ParticipantState;
+import tc.oc.pgm.api.region.Region;
+import tc.oc.pgm.teams.Team;
+import tc.oc.pgm.util.named.NameStyle;
+
+/**
+ * A {@link TouchableGoal} that always belongs to exactly one {@link Team} and is defended by that
+ * team, i.e. cores and destroyables.
+ */
+public abstract class OwnedTouchableGoal<T extends ProximityGoalDefinition>
+    extends TouchableGoal<T> {
+
+  private Iterable<Location> proximityLocations;
+
+  public OwnedTouchableGoal(T definition, Match match) {
+    super(definition, match);
+  }
+
+  /** The region whose center players are measured against for proximity. */
+  protected abstract Region getProximityRegion();
+
+  @Override
+  public @NonNull Team getOwner() {
+    Team owner = super.getOwner();
+    if (owner == null) {
+      throw new IllegalStateException("goal " + this.getId() + " has no owner");
+    }
+    return owner;
+  }
+
+  @Override
+  public boolean getDeferTouches() {
+    return true;
+  }
+
+  @Override
+  public Component getTouchMessage(@Nullable ParticipantState toucher, boolean self) {
+    String key = "destroyable.touch.owned";
+    Component toucherName = empty();
+
+    if (toucher != null) {
+      if (self) {
+        key = "destroyable.touch.owned.you";
+      } else {
+        key = "destroyable.touch.owned.player";
+        toucherName = toucher.getName(NameStyle.COLOR);
+      }
+    }
+
+    return translatable(
+        key, toucherName, this.getComponentName(), this.getOwner().getName());
+  }
+
+  @Override
+  public Iterable<Location> getProximityLocations(ParticipantState player) {
+    if (this.proximityLocations == null) {
+      this.proximityLocations = Collections.singleton(getProximityRegion()
+          .getBounds()
+          .getCenterPoint()
+          .toLocation(getMatch().getWorld()));
+    }
+    return this.proximityLocations;
+  }
+}

--- a/core/src/main/java/tc/oc/pgm/regions/FiniteBlockRegion.java
+++ b/core/src/main/java/tc/oc/pgm/regions/FiniteBlockRegion.java
@@ -12,7 +12,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.region.Region;
 import tc.oc.pgm.api.region.RegionDefinition;
@@ -25,7 +25,7 @@ import tc.oc.pgm.util.block.BlockVectors;
 import tc.oc.pgm.util.material.MaterialMatcher;
 
 /**
- * Region represented by a list of single blocks. This will check if a point is inside the block at
+ * Region represented by a set of single blocks. This will check if a point is inside the block at
  * all.
  */
 public class FiniteBlockRegion implements RegionDefinition.HardStatic {
@@ -54,7 +54,11 @@ public class FiniteBlockRegion implements RegionDefinition.HardStatic {
 
   @Override
   public boolean contains(Vector point) {
-    return bounds.contains(point) && positions.contains(point.toBlockVector());
+    return this.bounds.contains(point) && this.positions.contains(point.toBlockVector());
+  }
+
+  public boolean contains(long encodedPos) {
+    return this.positions.contains(encodedPos);
   }
 
   @Override
@@ -84,16 +88,16 @@ public class FiniteBlockRegion implements RegionDefinition.HardStatic {
 
   @Override
   public Iterator<BlockVector> getBlockVectorIterator() {
-    return positions.iterator();
+    return this.positions.iterator();
   }
 
   @Override
   public Iterable<BlockVector> getBlockVectors() {
-    return positions;
+    return this.positions;
   }
 
   public int getBlockVolume() {
-    return positions.size();
+    return this.positions.size();
   }
 
   @Override

--- a/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
+++ b/core/src/main/java/tc/oc/pgm/wool/MonumentWool.java
@@ -14,7 +14,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Competitor;
 import tc.oc.pgm.api.party.Party;
@@ -56,9 +57,8 @@ public class MonumentWool extends TouchableGoal<MonumentWoolFactory>
         + this.definition + '}';
   }
 
-  // Remove @Nullable
   @Override
-  public Team getOwner() {
+  public @NonNull Team getOwner() {
     Team owner = super.getOwner();
     if (owner == null) {
       throw new IllegalStateException("wool " + getId() + " has no owner");


### PR DESCRIPTION
Address old `TODO: Consider making Core extend Destroyable` by not doing that as it's counter-productive, instead aiming to reduce duplicate code between `Core` and `Destroyable` by creating `OwnedTouchableGoal` and having both extend that instead.

Also seeks to resolve https://github.com/PGMDev/PGM/issues/768 by reusing an encoded block position rather than allocating a `BlockVector` repeatedly, and by storing per-block destroyable health as a map of these encoded positions.