### PR TITLE
Add permission to bypass team switch cooldowns

### DIFF
--- a/core/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/core/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -25,6 +25,7 @@ public interface Permissions {
   String JOIN_CHOOSE = JOIN + ".choose"; // Can choose which team to join
   String JOIN_FULL = ROOT + ".full"; // Can join a team or server if it is full
   String JOIN_FORCE = JOIN + ".force"; // Can force other players onto teams
+  String JOIN_BYPASS = JOIN + ".bypass-time"; // Can bypass time penalties when joining a team
   String VOTE = ROOT + ".vote"; // Can user vote in map pools
   String EXTRA_VOTE = VOTE + ".extra"; // User vote in map pools count as double
   String LEAVE = ROOT + ".leave"; // Can join observers willingly

--- a/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
+++ b/core/src/main/java/tc/oc/pgm/spawns/SpawnMatchModule.java
@@ -27,6 +27,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jspecify.annotations.Nullable;
 import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.filter.Filter;
 import tc.oc.pgm.api.filter.query.Query;
 import tc.oc.pgm.api.match.Match;
@@ -160,6 +161,7 @@ public class SpawnMatchModule implements MatchModule, Listener, Tickable {
     // Direct joins (old party is null) are always forced, but shouldn't skip penalty
     if (event.getRequest().has(JoinRequest.Flag.FORCE) && event.getOldParty() != null) return 0;
     if (event.getNewParty() == null || !event.getNewParty().isParticipating()) return 0;
+    if (event.getPlayer().getBukkit().hasPermission(Permissions.JOIN_BYPASS)) return 0;
 
     ParticipationData data = participationData.getIfPresent(event.getPlayer().getId());
     return data == null ? 0 : data.getJoinTick(event.getNewParty() instanceof Team t ? t : null);


### PR DESCRIPTION
This PR adds a new permission node `pgm.join.bypass-time` which when granted, allows a player to bypass the team switch penalty cooldown. Given there may be different server setups, you may want staff members to be able to switch teams for various reasons without being forced to rely solely on the `/team force` command. 

Tested locally and works as expected ✅

Please let me know if there are any suggestions or changes you'd like made but this is a fairly simple change so 👍